### PR TITLE
Enable the site config to include own package feeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ export GLUON_CONFIGURE := $(GLUONDIR)/scripts/configure.pl
 
 
 feeds: FORCE
+	[ ! -f $(GLUON_SITEDIR)/modules ] || . $(GLUON_SITEDIR)/modules && for feed in $$GLUON_SITE_FEEDS; do echo src-link $$feed ../../packages/$$feed; done > feeds.conf
 	. $(GLUONDIR)/modules && for feed in $$GLUON_FEEDS; do echo src-link $$feed ../../packages/$$feed; done > feeds.conf
 	+$(GLUONMAKE) refresh_feeds V=s$(OPENWRT_VERBOSE)
 

--- a/scripts/modules.sh
+++ b/scripts/modules.sh
@@ -1,7 +1,8 @@
 . "$1"/modules
+[ ! -f "$1"/site/modules ] || . "$1"/site/modules
 
 GLUON_MODULES=openwrt
 
-for feed in $GLUON_FEEDS; do
+for feed in $GLUON_SITE_FEEDS $GLUON_FEEDS; do
 	GLUON_MODULES="$GLUON_MODULES packages/$feed"
 done


### PR DESCRIPTION
gluon may depend on some specific versions of specific feeds, like openwrt itself. Thus some feeds need to be included in the gluon repository itself.

But the site may wish to deploy own feeds, like for example ones containing tiny hackish packages which set some setting on every boot, send a message to the administrators or whatever. While real packages are desired to be managed in freifunk-gluon/gluon-packages, this kind of packages shouldn't find it's way into central repositories.

But using them is the site's choice, and right now that's a bit cumbersome if you still want to pull updated from the main gluon repo. Thus this patch.
