### PR TITLE
site/modules: fix generation of feeds.conf

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,8 +143,9 @@ export GLUON_CONFIGURE := $(GLUONDIR)/scripts/configure.pl
 
 
 feeds: FORCE
-	[ ! -f $(GLUON_SITEDIR)/modules ] || . $(GLUON_SITEDIR)/modules && for feed in $$GLUON_SITE_FEEDS; do echo src-link $$feed ../../packages/$$feed; done > feeds.conf
-	. $(GLUONDIR)/modules && for feed in $$GLUON_FEEDS; do echo src-link $$feed ../../packages/$$feed; done > feeds.conf
+	echo -n > feeds.conf
+	[ ! -f $(GLUON_SITEDIR)/modules ] || . $(GLUON_SITEDIR)/modules && for feed in $$GLUON_SITE_FEEDS; do echo src-link $$feed ../../packages/$$feed; done >> feeds.conf
+	. $(GLUONDIR)/modules && for feed in $$GLUON_FEEDS; do echo src-link $$feed ../../packages/$$feed; done >> feeds.conf
 	+$(GLUONMAKE) refresh_feeds V=s$(OPENWRT_VERBOSE)
 
 config: FORCE


### PR DESCRIPTION
With the previous patch, the second line writing to feeds.conf overwrote it, thus making the first line a noop.

This fixes it by first cleaning the file and then appending two times (or only one if there are note site/modules).
