### PR TITLE
Allow specifying a branch for a module

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -7,12 +7,13 @@ set -e
 for module in $GLUON_MODULES; do
 	var=$(echo $module | tr '[:lower:]/' '[:upper:]_')
 	eval repo=\${${var}_REPO}
+	eval branch=\${${var}_BRANCH}
 	eval commit=\${${var}_COMMIT}
 
 	mkdir -p "$1"/$module
 	cd "$1"/$module
 	git init
 
-	git checkout $commit 2>/dev/null || git fetch $repo
+	git checkout $commit 2>/dev/null || git fetch $repo $branch
 	git checkout -B base $commit
 done


### PR DESCRIPTION
If a given commit is not included in the master branch, the update script fails.
