### PR TITLE
docs: renaming gluon-luci-privatewifi into gluon-luci-private-wifi

### DIFF
--- a/docs/features/private-wlan.rst
+++ b/docs/features/private-wlan.rst
@@ -4,10 +4,9 @@ Private WLAN
 It is possible to set up a private WLAN that bridges the WAN port and is seperated from the mesh network.
 Please note that you should not enable ``mesh_on_wan`` simultaneously.
 
-The private WLAN can be enabled through the config mode if the package ``gluon-luci-privatewifi`` is installed.
-You may also enable a private WLAN using the command line:
+The private WLAN can be enabled through the config mode if the package ``gluon-luci-private-wifi`` is installed.
+You may also enable a private WLAN using the command line::
 
-  ::
   uci set wireless.wan_radio0=wifi-iface
   uci set wireless.wan_radio0.device=radio0
   uci set wireless.wan_radio0.network=wan
@@ -22,9 +21,8 @@ You may also enable a private WLAN using the command line:
 Please replace ``$SSID`` by the name of the WLAN and ``$KEY`` by your passphrase (8-63 characters).
 If you have two radios (e.g. 2.4 and 5 GHz) you need to do this for radio0 and radio1.
 
-It may also be disabled by running:
+It may also be disabled by running::
 
-  ::
   uci set wireless.wan_radio0.disabled=1
   uci commit
   wifi


### PR DESCRIPTION
as requested in https://github.com/freifunk-gluon/packages/pull/57
