### PR TITLE
Adding support for TL-WA850RE

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -60,6 +60,10 @@ $(eval $(call GluonModel,TLWDR4300,tl-wdr4300-v1-squashfs,tp-link-tl-wdr4300-v1)
 $(eval $(call GluonProfile,TLWA750))
 $(eval $(call GluonModel,TLWA750,tl-wa750re-v1-squashfs,tp-link-tl-wa750re-v1))
 
+# TL-WA850RE v1
+$(eval $(call GluonProfile,TLWA850))
+$(eval $(call GluonModel,TLWA850,tl-wa850re-v1-squashfs,tp-link-tl-wa850re-v1))
+
 # TL-WA901N/ND v2
 $(eval $(call GluonProfile,TLWA901))
 $(eval $(call GluonModel,TLWA901,tl-wa901nd-v2-squashfs,tp-link-tl-wa901n-nd-v2))


### PR DESCRIPTION
basic wifi meshing with neighbouring nodes
tested, with TL-WA750RE

client WLAN (if applicable)
works

client lan on LAN ports (if applicable)
n/a - only 1x Ethernet 

mesh-vpn on WAN port
works 

mesh-on-wan
Not tested

re-entering configmode by pressing the button for >3 seconds
works. 

entering failsafe mode
works 

whether the MAC address seen by Gluon is the one printed on the device
yes

Und folgende Kommandos:
tail /lib/gluon/core/sysconfig/*
brctl show
lua -e "print(require('platform_info').get_image_name())"

root@XXX:~# tail /lib/gluon/core/sysconfig/*
==> /lib/gluon/core/sysconfig/primary_mac <==
(macwieaufgerätaufgedruckt)
==> /lib/gluon/core/sysconfig/setup_ifname <==
eth0
==> /lib/gluon/core/sysconfig/wan_ifname <==
eth0

root@XXX:~# brctl show
bridge name bridge id       STP enabled interfaces
br-wan      7fff.(primarymac)   no      eth0
br-client       7fff.(primarymac)   no      bat0
                            wlan0-1

root@XXXX:~# lua -e "print(require('platform_info').get_image_name())"
tp-link-tl-wa850re-v1
