### PR TITLE
Site sample configuration: Linkfix timezones

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -20,7 +20,7 @@
   prefix6 = 'fdef:ffc0:3dd7::/64',
 
   -- Timezone of your community.
-  -- See http://wiki.openwrt.org/doc/uci/system#time.zones
+  -- See http://wiki.openwrt.org/doc/uci/system#time_zones
   timezone = 'CET-1CEST,M3.5.0,M10.5.0/3',
 
   -- List of NTP servers in your community.


### PR DESCRIPTION
Link to timezone configuration help had a wrong anchor
