### PR TITLE
Add Darmstadt to site.rst

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -213,6 +213,7 @@ This is a non-exhaustive list of site-repos from various communities:
 
 * `site-ffbs <https://github.com/ffbs/site-ffbs>`_ (Braunschweig)
 * `site-ffhb <https://github.com/FreifunkBremen/gluon-site-ffhb>`_ (Bremen)
+* `site-ffda <https://github.com/freifunk-darmstadt/site-ffda>`_ (Darmstadt)
 * `site-ffhh <https://github.com/freifunkhamburg/site-ffhh>`_ (Hamburg)
 * `site-ffhgw <https://github.com/lorenzo-greifswald/site-ffhgw>`_ (Greifswald)
 * `site-ffhl <https://github.com/freifunk-gluon/site-ffhl>`_ (Lübeck)


### PR DESCRIPTION
Add Darmstadts site configuration to the user documentation.
