### PR TITLE
docs: update supported devices, reorder them alphabetically and fix a mo...

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -41,6 +41,19 @@ Developer Documentation
 Supported Devices
 -----------------
 
+* Buffalo
+
+  - WZR-HP-AG300H / WZR-600DHP
+  - WZR-HP-G450H
+
+* D-Link
+
+  - DIR-825 (B1)
+
+* Linksys
+
+  - WRT160NL
+
 * TP-Link
 
   - CPE210 (v1)
@@ -52,6 +65,7 @@ Supported Devices
   - TL-MR3220 (v1)
   - TL-MR3420 (v1, v2)
   - TL-WA750RE (v1)
+  - TL-WA801N/ND (v2)
   - TL-WA850RE (v1)
   - TL-WA901N/ND (v2)
   - TL-WDR3500 (v1)
@@ -62,7 +76,6 @@ Supported Devices
   - TL-WR710N (v1)
   - TL-WR740N (v1, v3, v4)
   - TL-WR741N/ND (v1, v2, v4)
-  - TL-WR801N/ND (v2)
   - TL-WR841N/ND (v3, v5, v7, v8, v9)
   - TL-WR842N/ND (v1, v2)
   - TL-WR941N/ND (v2, v3, v4)
@@ -75,13 +88,6 @@ Supported Devices
   - UniFi AP
   - UniFi AP Outdoor
 
-* D-Link
-
-  - DIR-825 (B1)
-
-* Linksys
-
-  - WRT160NL
 
 Releases
 --------


### PR DESCRIPTION
...del name

WR801 should be WA801, also added the Buffalo models and sorted the list by vendor alphabetically.
