### PR TITLE
Adding support for D-Link DIR-615 C1

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -114,6 +114,10 @@ endif
 
 ## D-Link
 
+# D-Link DIR-615 rev. C1
+$(eval $(call GluonProfile,DIR615C1))
+$(eval $(call GluonModel,DIR615C1,dir-615-c1-squashfs,d-link-dir-615-rev-c1))
+
 # D-Link DIR-825 rev. B1
 $(eval $(call GluonProfile,DIR825B1))
 $(eval $(call GluonModel,DIR825B1,dir-825-b1-squashfs,d-link-dir-825-rev-b1))


### PR DESCRIPTION
Everything works as expected. Only the MAC-Address is off by one compared to the address on the sticker.