### PR TITLE
Add support for Netgear WNDR3700/3800

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -134,3 +134,11 @@ $(eval $(call GluonModel,WZRHPG450H,wzr-hp-g450h-squashfs,buffalo-wzr-hp-g450h))
 # WZR-HP-AG300H/WZR-600DHP
 $(eval $(call GluonProfile,WZRHPAG300H))
 $(eval $(call GluonModel,WZRHPAG300H,wzr-hp-ag300h-squashfs,buffalo-wzr-hp-ag300h-wzr-600dhp))
+
+## Netgear
+
+# WNDR3700v2/3800
+$(eval $(call GluonProfile,WNDR3700))
+$(eval $(call GluonProfileFactorySuffix,WNDR3700,.img))
+$(eval $(call GluonModel,WNDR3700,wndr3700v2-squashfs,netgear-wndr3700v2))
+$(eval $(call GluonModel,WNDR3700,wndr3800-squashfs,netgear-wndr3800))

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -140,5 +140,6 @@ $(eval $(call GluonModel,WZRHPAG300H,wzr-hp-ag300h-squashfs,buffalo-wzr-hp-ag300
 # WNDR3700v2/3800
 $(eval $(call GluonProfile,WNDR3700))
 $(eval $(call GluonProfileFactorySuffix,WNDR3700,.img))
+$(eval $(call GluonModel,WNDR3700,wndr3700-squashfs,netgear-wndr3700))
 $(eval $(call GluonModel,WNDR3700,wndr3700v2-squashfs,netgear-wndr3700v2))
 $(eval $(call GluonModel,WNDR3700,wndr3800-squashfs,netgear-wndr3800))


### PR DESCRIPTION
basic wifi meshing with neighbouring nodes
tested, with TL-WDR4300 (both bands working)

client WLAN (if applicable)
works

client lan on LAN ports (if applicable)
works

mesh-vpn on WAN port
works

mesh-on-wan
Not tested

re-entering configmode by pressing the button for >3 seconds
works

entering failsafe mode
works

whether the MAC address seen by Gluon is the one printed on the device
yes

lua -e "print(require('platform_info').get_image_name())"
netgear-wndr3700v2