### PR TITLE
site.rst -> Fix Göttingen

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -214,7 +214,7 @@ This is a non-exhaustive list of site-repos from various communities:
 * `site-ffbs <https://github.com/ffbs/site-ffbs>`_ (Braunschweig)
 * `site-ffhb <https://github.com/FreifunkBremen/gluon-site-ffhb>`_ (Bremen)
 * `site-ffda <https://github.com/freifunk-darmstadt/site-ffda>`_ (Darmstadt)
-* `site-ffgoe <https://github.com/freifunk-goettingen/site-ffgoe>`_(Göttingen)
+* `site-ffgoe <https://github.com/freifunk-goettingen/site-ffgoe>`_ (Göttingen)
 * `site-ffhh <https://github.com/freifunkhamburg/site-ffhh>`_ (Hamburg)
 * `site-ffhgw <https://github.com/lorenzo-greifswald/site-ffhgw>`_ (Greifswald)
 * `site-ffhl <https://github.com/freifunk-gluon/site-ffhl>`_ (Lübeck)


### PR DESCRIPTION
wrong formating due to a missing space