### PR TITLE
docs/site-example: cleanup

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -10,14 +10,14 @@
   hostname_prefix = 'freifunk',
 
   -- Name of the community.
-  site_name = 'Freifunk Lübeck',
+  site_name = 'Freifunk Entenhausen',
 
   -- Shorthand of the community.
-  site_code = 'ffhl',
+  site_code = 'ffxx',
 
   -- Prefixes used within the mesh. Both are required.
-  prefix4 = '10.130.0.0/20',
-  prefix6 = 'fdef:ffc0:3dd7::/64',
+  prefix4 = '10.xxx.0.0/20',
+  prefix6 = 'fdxx:xxxx:xxxx::/64',
 
   -- Timezone of your community.
   -- See http://wiki.openwrt.org/doc/uci/system#time_zones
@@ -25,7 +25,7 @@
 
   -- List of NTP servers in your community.
   -- Must be reachable using IPv6!
-  ntp_servers = {'1.ntp.services.ffhl'},
+  ntp_servers = {'1.ntp.services.ffxx'},
 
   -- Wireless regulatory domain of your community.
   regdom = 'DE',
@@ -36,7 +36,7 @@
     channel = 1,
 
     -- ESSID used for client network.
-    ssid = 'luebeck.freifunk.net',
+    ssid = 'entenhausen.freifunk.net',
 
     -- Specifies the channel width in 802.11n and 802.11ac mode.
     -- Possible values are:
@@ -46,8 +46,8 @@
     htmode = 'HT20',
 
     -- Adjust these values!
-    mesh_ssid = 'XX:XX:XX:XX:XX:XX',  -- ESSID used for mesh
-    mesh_bssid = 'XX:XX:XX:XX:XX:XX', -- BSSID used for mesh
+    mesh_ssid = 'xe:xx:xx:xx:xx:xx',  -- ESSID used for mesh
+    mesh_bssid = 'xe:xx:xx:xx:xx:xx', -- BSSID used for mesh
 
     -- Bitrate used for multicast/broadcast packets.
     mesh_mcast_rate = 12000,
@@ -57,11 +57,11 @@
   -- This should be equal to the 2.4 GHz variant, except
   -- for channel and htmode.
   wifi5 = {
-    ssid = 'luebeck.freifunk.net',
+    ssid = 'entenhausen.freifunk.net',
     channel = 44,
     htmode = 'HT20',
-    mesh_ssid = 'XX:XX:XX:XX:XX:XX',
-    mesh_bssid = 'XX:XX:XX:XX:XX:XX',
+    mesh_ssid = 'xx:xx:xx:xx:xx:xx',
+    mesh_bssid = 'xx:xx:xx:xx:xx:xx',
     mesh_mcast_rate = 12000,
   },
 
@@ -69,18 +69,18 @@
   -- connected to using a known IP address.
   next_node = {
     -- anycast IPs of all nodes
-    ip4 = '10.130.0.1',
-    ip6 = 'fdef:ffc0:3dd7::1',
+    ip4 = '10.xxx.0.xxx',
+    ip6 = 'fdxx:xxxx:xxxx::xxxx',
 
     -- anycast MAC of all nodes
-    mac = '16:41:95:40:f7:dc',
+    mac = 'xe:xx:xx:xx:xx:xx',
   },
 
   -- Refer to http://fastd.readthedocs.org/en/latest/ to better understand
   -- what these options do.
   fastd_mesh_vpn = {
     -- List of crypto-methods to use.
-    methods = {'salsa2012+gmac'},
+    methods = {'salsa2012+umac'},
     mtu = 1426,
     backbone = {
       -- Limit number of connected peers to reduce bandwidth.
@@ -88,15 +88,16 @@
 
       -- List of peers.
       peers = {
-        burgtor = {
-          key = '657af03e36ff1b8bbe5a5134982a4f110c8523a9a63293870caf548916a95a03',
+        peer1 = {
+          key = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
 
           -- This is a list, so you might add multiple entries.
-          remotes = {'ipv4 "burgtor.mesh.ffhl.chaotikum.org" port 10000'},
+          remotes = {'ipv4 "xxx.somehost.invalid" port xxxxxx'},
         },
-        holstentor = {
-          key = '8c660f7511bf101ea1b599fe53af20e1146cd923c9e9d2a3a0d534ee75af9067',
-          remotes = {'ipv4 "holstentor.mesh.ffhl.chaotikum.org" port 10000'},
+        peer2 = {
+          key = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+          -- You can also omit the ipv4 to allow both connection via ipv4 and ipv6
+          remotes = {'"xxx.somehost2.invalid" port xxxxx'},
         },
       },
     },
@@ -122,9 +123,9 @@
 
         -- List of public keys of maintainers.
         pubkeys = {
-                'daa19b44bbd7033965e02088127bad9516ba0fea8f34267a777144a23ec8900c', -- Linus
-                'a8dd60765b07330a4bbfdf8406102befca132881a4b65f3efda32cf2d5b362d9', -- Nils
-                '323bd3285c4e5547a89cd6da1f2aef67f1654b0928bbd5b104efc9dab2156d0b', -- NeoRaider
+                'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', -- Alice
+                'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', -- Bob
+                'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx', -- Mary
         },
       },
     },
@@ -159,25 +160,24 @@
   -- <%=sysconfig.primary_mac%> - the node's primary MAC
   config_mode = {
     msg_welcome = [[
-Willkommen zum Einrichtungsassistenten für deinen neuen Lübecker
+Willkommen zum Einrichtungsassistenten für deinen neuen Entenhausener
 Freifunk-Knoten. Fülle das folgende Formular deinen Vorstellungen
 entsprechend aus und sende es ab.
 ]],
     msg_pubkey = [[
 Dies ist der öffentliche Schlüssel deines Freifunk-Knotens. Erst nachdem
-er auf den Servern des Lübecker Freifunk-Projektes eingetragen wurde,
-kann sich dein Knoten mit dem Lübecker Mesh-VPN zu verbinden. Bitte
+er auf den Servern des Entenhausener Freifunk-Projektes eingetragen wurde,
+kann sich dein Knoten mit dem Entenhausener Mesh-VPN verbinden. Bitte
 schicke dazu diesen Schlüssel und den Namen deines Knotens
 (<em><%=hostname%></em>) an
-<a href="mailto:keys@luebeck.freifunk.net">keys@luebeck.freifunk.net</a>.
+<a href="mailto:keys@entenhausen.freifunk.net">keys@entenhausen.freifunk.net</a>.
 ]],
     msg_reboot = [[
 <p>
 Dein Knoten startet gerade neu und wird anschließend versuchen,
-sich anschließend mit anderen Freifunk-Knoten in seiner Nähe zu
-verbinden. Weitere Informationen zur
-Lübecker Freifunk-Community findest du auf
-<a href="https://luebeck.freifunk.net/">unserer Webseite</a>.
+sich mit anderen Freifunk-Knoten in seiner Nähe zu verbinden.
+Weitere Informationen zur Entenhausener Freifunk-Community
+findest du auf <a href="https://entenhausen.freifunk.net/">unserer Webseite</a>.
 </p>
 <p>
 Viel Spaß mit deinem Knoten und der Erkundung von Freifunk!

--- a/docs/site-example/site.mk
+++ b/docs/site-example/site.mk
@@ -9,11 +9,11 @@ GLUON_SITE_PACKAGES := \
 	gluon-alfred \
 	gluon-announced \
 	gluon-autoupdater \
-	gluon-config-mode-hostname \
 	gluon-config-mode-autoupdater \
-	gluon-config-mode-mesh-vpn \
-	gluon-config-mode-geo-location \
 	gluon-config-mode-contact-info \
+	gluon-config-mode-geo-location \
+	gluon-config-mode-hostname \
+	gluon-config-mode-mesh-vpn \
 	gluon-ebtables-filter-multicast \
 	gluon-ebtables-filter-ra-dhcp \
 	gluon-luci-admin \
@@ -23,9 +23,9 @@ GLUON_SITE_PACKAGES := \
 	gluon-mesh-vpn-fastd \
 	gluon-radvd \
 	gluon-status-page \
-	iwinfo \
+	haveged \
 	iptables \
-	haveged
+	iwinfo
 
 ##	DEFAULT_GLUON_RELEASE
 #		version string to use for images
@@ -33,7 +33,7 @@ GLUON_SITE_PACKAGES := \
 #			opkg compare-versions "$1" '>>' "$2"
 #		to decide if a version is newer or not.
 
-DEFAULT_GLUON_RELEASE := 0.4+0-exp$(shell date '+%Y%m%d')
+DEFAULT_GLUON_RELEASE := 0.6+exp$(shell date '+%Y%m%d')
 
 
 ##	GLUON_RELEASE


### PR DESCRIPTION
 - generalize, to make it more clear that the site config
   needs to be adapted to the local community.
 - remove some host names and public keys used in Lübeck
 - suggest private space mac adresses
 - change fastd method to salsa2012+umac, which is the recommended default
 - add config for a fastd peer reachable by both ipv4 and ipv6
 - order GLUON_SITE_PACKAGES alphabetically