### PR TITLE
Add support for ALLNET ALL0315N

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -129,3 +129,10 @@ $(eval $(call GluonModel,WZRHPG450H,wzr-hp-g450h-squashfs,buffalo-wzr-hp-g450h))
 # WZR-HP-AG300H/WZR-600DHP
 $(eval $(call GluonProfile,WZRHPAG300H))
 $(eval $(call GluonModel,WZRHPAG300H,wzr-hp-ag300h-squashfs,buffalo-wzr-hp-ag300h-wzr-600dhp))
+
+## Allnet
+
+# ALL0315N
+$(eval $(call GluonProfile,ALL0315N,uboot-envtools,rssileds))
+$(eval $(call GluonProfileFactorySuffix,ALL0315N,))
+$(eval $(call GluonModel,ALL0315N,all0315n-squashfs,allnet-all0315n))


### PR DESCRIPTION
Built, flashed and tested. SUCCESS.
This patch takes advantage of patch https://github.com/freifunk-gluon/gluon/commit/e93173c45cf4a48b4692ab6a23390f97f7b5832b which solved issue https://github.com/freifunk-gluon/gluon/issues/226 by introducing "GluonProfileFactorySuffix".