### PR TITLE
Add support for ALLNET ALL0315N

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -169,3 +169,10 @@ $(eval $(call GluonProfileFactorySuffix,WNDR3700,.img))
 $(eval $(call GluonModel,WNDR3700,wndr3700-squashfs,netgear-wndr3700))
 $(eval $(call GluonModel,WNDR3700,wndr3700v2-squashfs,netgear-wndr3700v2))
 $(eval $(call GluonModel,WNDR3700,wndr3800-squashfs,netgear-wndr3800))
+
+## Allnet
+
+# ALL0315N
+$(eval $(call GluonProfile,ALL0315N,uboot-envtools rssileds))
+$(eval $(call GluonProfileFactorySuffix,ALL0315N,))
+$(eval $(call GluonModel,ALL0315N,all0315n-squashfs,allnet-all0315n))


### PR DESCRIPTION
Built, flashed and successully tested. This patch takes advantage of patch freifunk-gluon@e93173c which solved issue freifunk-gluon#226 by introducing "GluonProfileFactorySuffix". Packages are separated by a space, not a comma. The ALL0315N initially has a OpenWRT based firmware and there is no need for a factory image. The sysupgrade can be flashed instantly.