### PR TITLE
Add support for GL-iNet devicAdd support for GL-iNet devicee

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -4,7 +4,7 @@
 
 # GL-iNet 1.0 ; BB is the 8MB version, works on 16M too
 $(eval $(call GluonProfile,GLINET))
-$(eval $(call GluonModel,GLINET,gl-inet-v1-squashfs,gl-inet-v1.0))
+$(eval $(call GluonModel,GLINET,gl-inet-v1-squashfs,gl-inet-v1))
 
 
 ## TP-Link

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -1,5 +1,12 @@
 # List of hardware profiles
 
+## GL-iNet
+
+# GL-iNet 1.0 ; BB is the 8MB version, works on 16M too
+$(eval $(call GluonProfile,GLINET))
+$(eval $(call GluonModel,GLINET,gl-inet-v1-squashfs,gl-inet-v1.0))
+
+
 ## TP-Link
 
 # CPE210/220/510/520


### PR DESCRIPTION
Adds support for GL-iNet devices.

http://wiki.openwrt.org/toh/gl-inet/gl-inet

With BB only 8MB firmware files, but they can be flashed on the newer 16MB devices without problems.
Can be bought here: https://www.gl-inet.nl/ and on amazon