### PR TITLE
add subject and body in default-mailto link

### DIFF
--- a/docs/site-example/i18n/de.po
+++ b/docs/site-example/i18n/de.po
@@ -23,7 +23,7 @@ msgstr ""
 "kann sich dein Knoten mit dem Entenhausener Mesh-VPN zu verbinden. Bitte "
 "schicke dazu diesen Schlüssel und den Namen deines Knotens "
 "(<em><%=hostname%></em>) an "
-"<a href=\"mailto:keys@entenhausen.freifunk.net\">keys@entenhausen.freifunk.net</a>."
+"<a href=\"mailto:keys@entenhausen.freifunk.net?subject=Bitte+den+Schlüssel+für+<%=hostname%>+eintragen&body=Bitte+tragt+den+schlüssel+für+meinen+neuen+Knoten+<%=hostname%>+ein:<%=key%>\">keys@entenhausen.freifunk.net</a>."
 
 msgid "gluon-config-mode:reboot"
 msgstr ""


### PR DESCRIPTION
Add a default subject and body that is transferred to your mail client as default text, so the user has to type less when creating the mail to send the fastd-key to the community mailinglist.   
I am not sure if the `<%=key?>` part works, maybe this has to be adapted, so the key is in the link