### PR TITLE
docs: site-example: change default batman-adv version to 15

### DIFF
--- a/docs/site-example/site.mk
+++ b/docs/site-example/site.mk
@@ -5,7 +5,7 @@
 #		The gluon-mesh-batman-adv-* package must come first because of the dependency resolution
 
 GLUON_SITE_PACKAGES := \
-	gluon-mesh-batman-adv-14 \
+	gluon-mesh-batman-adv-15 \
 	gluon-alfred \
 	gluon-announced \
 	gluon-autoupdater \


### PR DESCRIPTION
...refore we should change the example.

neoraider suggested that I change my own config to batman-adv-15, so therefore we should change the example.

he said that batman-adv-15 is stable enough now, so why not go with something more stable and newer. :D