### PR TITLE
fix: Fix handling of filenames with spaces

### DIFF
--- a/contrib/sign.sh
+++ b/contrib/sign.sh
@@ -18,23 +18,23 @@ See also
 EOHELP
 	exit 1
 fi
- 
-SECRET=$1
- 
-manifest=$2
-upper=$(mktemp)
-lower=$(mktemp)
- 
+
+SECRET="$1"
+
+manifest="$2"
+upper="$(mktemp)"
+lower="$(mktemp)"
+
 awk "BEGIN    { sep=0 }
      /^---\$/ { sep=1; next }
               { if(sep==0) print > \"$upper\";
                 else       print > \"$lower\"}" \
-    $manifest
- 
-ecdsasign $upper < $SECRET >> $lower
- 
-cat  $upper  > $manifest
-echo ---    >> $manifest
-cat  $lower >> $manifest
- 
-rm -f $upper $lower
+    "$manifest"
+
+ecdsasign "$upper" < "$SECRET" >> "$lower"
+
+cat  "$upper"  > "$manifest"
+echo ---      >> "$manifest"
+cat  "$lower" >> "$manifest"
+
+rm -f "$upper" "$lower"


### PR DESCRIPTION
When filenames contain spaces this might cause problems to create a proper signature.