### PR TITLE
Create 0005-reset-hop_penalty-to-previous-rating.patch

### DIFF
--- a/patches/packages/routing/0005-reset-hop_penalty-to-previous-rating.patch
+++ b/patches/packages/routing/0005-reset-hop_penalty-to-previous-rating.patch
@@ -1,0 +1,36 @@
+From 9781dd471e040a6bf40f6a2b1cdb20ade91d8749 Mon Sep 17 00:00:00 2001
+From: RubenKelevra <ruben@vfn-nrw.de>
+Date: Thu, 2 Apr 2015 17:36:15 +0200
+Subject: [PATCH] add patch which resets hop_penalty to previous rating
+
+
+diff --git a/batman-adv/patches/0002-reset-hop_penalty-to-previous-rating.patch b/batman-adv/patches/0002-reset-hop_penalty-to-previous-rating.patch
+new file mode 100644
+index 0000000..c77bf4e
+--- /dev/null
++++ b/batman-adv/patches/0002-reset-hop_penalty-to-previous-rating.patch
+@@ -0,0 +1,22 @@
++From 76a3f0d5c86a02134ff30cf38337196acb315b22 Mon Sep 17 00:00:00 2001
++From: RubenKelevra <ruben@vfn-nrw.de>
++Date: Thu, 2 Apr 2015 17:33:49 +0200
++Subject: [PATCH] reset hop_penalty to previous rating, which is well tested
++
++
++diff --git a/soft-interface.c b/soft-interface.c
++index 78d63e3..93c81c5 100644
++--- a/soft-interface.c
+++++ b/soft-interface.c
++@@ -756,7 +756,7 @@ static int batadv_softif_init_late(struct net_device *dev)
++        atomic_set(&bat_priv->gw.bandwidth_down, 100);
++        atomic_set(&bat_priv->gw.bandwidth_up, 20);
++        atomic_set(&bat_priv->orig_interval, 1000);
++-       atomic_set(&bat_priv->hop_penalty, 30);
+++       atomic_set(&bat_priv->hop_penalty, 15);
++ #ifdef CONFIG_BATMAN_ADV_DEBUG
++        atomic_set(&bat_priv->log_level, 0);
++ #endif
++--
++2.3.5
++
+--
+2.3.5


### PR DESCRIPTION
Batman-adv's default hop_penalty was changed from 15 to 30, which makes some large meshes with many hops unusable, because the TQ for the gateway drops below zero.

This patch restores the old behaviour which is well tested.