### PR TITLE
ar71xx-generic: add support for TP-Link TL-MR3220 v2

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -111,9 +111,10 @@ $(eval $(call GluonProfile,TLMR3040))
 $(eval $(call GluonModel,TLMR3040,tl-mr3040-v1,tp-link-tl-mr3040-v1))
 $(eval $(call GluonModel,TLMR3040,tl-mr3040-v2,tp-link-tl-mr3040-v2))
 
-# TL-MR3220 v1
+# TL-MR3220 v1, v2
 $(eval $(call GluonProfile,TLMR3220))
 $(eval $(call GluonModel,TLMR3220,tl-mr3220-v1,tp-link-tl-mr3220-v1))
+$(eval $(call GluonModel,TLMR3220,tl-mr3220-v2,tp-link-tl-mr3220-v2))
 
 # TL-MR3420 v1, v2
 $(eval $(call GluonProfile,TLMR3420))


### PR DESCRIPTION
This commit enables the support for the TP-Link TL-MR3220 v2 router.
All Gluon features tested successfully (MAC, WIFI, LAN/WAN ports, mesh, reset button, config mode, mesh-on-wan). Also a 4-weeks long-term test was passed.