### PR TITLE
make wireless-disable state survive updates and allow site option

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -54,6 +54,8 @@
 
     -- (optional) mesh VLAN on 802.11 ad-hoc interface (1-4095)
     -- mesh_vlan = 14,
+    -- client_disabled = true,
+    -- mesh_disabled = false,
   },
 
   -- Wireless configuration for 5 GHz interfaces.
@@ -67,6 +69,8 @@
     mesh_bssid = 'xx:xx:xx:xx:xx:xx',
     mesh_mcast_rate = 12000,
     -- mesh_vlan = 14,
+    -- client_disabled = true,
+    -- mesh_disabled = false,
   },
 
   -- The next node feature allows clients to always reach the node it is

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -67,7 +67,9 @@ wifi24
     ``htmode``, the adhoc ssid ``mesh_ssid`` used between devices, the adhoc
     bssid ``mesh_bssid`` and the adhoc multicast rate ``mesh_mcast_rate``.
     Optionally ``mesh_vlan`` can be used to setup VLAN on top of the 802.11
-    ad-hoc interface.
+    ad-hoc interface. The options``mesh_disabled`` and ``client_disabled``
+    are optional, too. They allow to disable the SSID by default, e.g. for
+    preconfigured node. This only affects first configuraton.
     Combined in an dictionary, e.g.:
     ::
 
@@ -78,6 +80,8 @@ wifi24
          mesh_ssid = 'ff:ff:ff:ee:ba:be',
          mesh_bssid = 'ff:ff:ff:ee:ba:be',
          mesh_mcast_rate = 12000,
+         client_disabled = true,
+         mesh_disabled = false,
        },
 
 wifi5

--- a/package/gluon-mesh-batman-adv-core/check_site.lua
+++ b/package/gluon-mesh-batman-adv-core/check_site.lua
@@ -8,6 +8,8 @@ for _, config in ipairs({'wifi24', 'wifi5'}) do
    need_string_match(config .. '.mesh_bssid', '^%x[02468aAcCeE]:%x%x:%x%x:%x%x:%x%x:%x%x$')
    need_number(config .. '.mesh_mcast_rate')
    need_number(config .. '.mesh_vlan', false)
+   need_number(config .. '.client_disabled', false)
+   need_number(config .. '.mesh_disabled', false)
 end
 
 need_boolean('mesh_on_wan', false)

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
@@ -16,6 +16,21 @@ local function configure_radio(radio, index, config)
   local client = 'client_' .. radio
   local mesh = 'mesh_' .. radio
 
+  local disable_state_client = false
+  local disable_state_mesh = false
+
+  if uci:get('wireless', client) then
+    disable_state_client = uci:get_bool('wireless', client, "disabled")
+  elseif config.client_disabled then
+    disable_state_client = true
+  end
+
+  if uci:get('wireless', mesh) then
+    disable_state_mesh = uci:get_bool('wireless', mesh, "disabled")
+  elseif config.mesh_disabled then
+    disable_state_mesh = true
+  end
+
   local client_ifname
   local mesh_ifname
   local radio_suffix = radio:match('^radio(%d+)$')
@@ -33,6 +48,7 @@ local function configure_radio(radio, index, config)
 		ssid = config.ssid,
 		macaddr = util.generate_mac(2, index),
 		ifname = client_ifname,
+		disabled = disable_state_client and 1 or 0,
 	      }
   )
 
@@ -72,6 +88,7 @@ local function configure_radio(radio, index, config)
 		macaddr = util.generate_mac(3, index),
 		mcast_rate = config.mesh_mcast_rate,
 		ifname = mesh_ifname,
+		disabled = disable_state_mesh and 1 or 0,
 	      }
   )
 end


### PR DESCRIPTION
This Option allows the "disabled"-option in "/etc/config/wireless" to survive updates or specify it in the site.conf.

The new code looks, weather the network is disabled, if not it looks for the site-option. In case none of those options is set it enables the network.

The site-options have to look like this, both options can be true or false.
```
client_disabled = true,
mesh_disabled = false,
```
