### PR TITLE
remove broken flag for Netgear WNDRMACv2

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -184,8 +184,8 @@ $(eval $(call GluonModel,WNDR3700,wndr3700v2,netgear-wndr3700v2))
 $(eval $(call GluonModel,WNDR3700,wndr3800,netgear-wndr3800))
 ifeq ($(BROKEN),1)
 $(eval $(call GluonModel,WNDR3700,wndrmac,netgear-wndrmac)) # BROKEN: untested
-$(eval $(call GluonModel,WNDR3700,wndrmacv2,netgear-wndrmacv2)) # BROKEN: untested
 endif
+$(eval $(call GluonModel,WNDR3700,wndrmacv2,netgear-wndrmacv2))
 
 ## Allnet
 


### PR DESCRIPTION
Signed-off-by: Alex Eickhoff <alex@artbanause.de>


WNDRMACv2
Router Firmware Version
V1.0.0.20


Flashed via Netgear Web-Config
Gluon Master 0b6a0be15299d6e5ebdb607c2ab66b590f97c623

* basic wifi meshing with neighbouring nodes
 * Tested with TP-Link TL-WDR3600 v1

* client WLAN (if applicable)
 * [x]

* client lan on LAN ports (if applicable)
 * [x]

* mesh-vpn on WAN port
 * [X]

* mesh-on-wan
 * [X]   

* re-entering configmode by pressing the button for >3 seconds
 * Power Led is blinking slowly
 * [*]                                               

* entering failsafe mode                    
                                    
* whether the MAC address seen by Gluon is the one printed on the device
 * [x]                       
      
* lua -e "print(require('platform_info').get_image_name())"
 * netgear-wndrmacv2                     
      

           