### PR TITLE
nodeinfo: mesh interface classes (wireless, tunnel, other)

### DIFF
--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/mesh/bat0/interfaces
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/mesh/bat0/interfaces
@@ -1,0 +1,52 @@
+local list = util.exec('batctl if')
+
+local wireless = {}
+local tunnel = {}
+local other = {}
+
+local function get_address(t, ifname)
+  pcall(
+    function()
+      table.insert(t, util.trim(fs.readfile('/sys/class/net/' .. ifname .. '/address')))
+    end
+  )
+end
+
+local function is_wireless(ifname)
+  local type = fs.stat('/sys/class/net/' .. ifname .. '/wireless', 'type')
+
+  return type == 'directory'
+end
+
+local function is_tuntap(ifname)
+  local type = fs.stat('/sys/class/net/' .. ifname .. '/tun_flags', 'type')
+
+  return type == 'regular'
+end
+
+local function nil_table(t)
+  if next(t) ~= nil then
+    return t
+  else
+    return nil
+  end
+end
+
+for _, line in ipairs(util.split(list)) do
+  local ifname = line:match('^(.-):')
+  if ifname ~= nil then
+    if is_wireless(ifname) then
+      get_address(wireless, ifname)
+    elseif is_tuntap(ifname) then
+      get_address(tunnel, ifname)
+    else
+      get_address(other, ifname)
+    end
+  end
+end
+
+return {
+  wireless = nil_table(wireless),
+  tunnel = nil_table(tunnel),
+  other = nil_table(other)
+}

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/status
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/status
@@ -22,9 +22,23 @@ function neighbours(ifname)
   for _, line in ipairs(util.split(info)) do
     local data = json.decode(line)
     if data then
-      if data["network"] and data["network"]["mesh_interfaces"] then
-        for _, mac in ipairs(data["network"]["mesh_interfaces"]) do
-          macs[mac] = data
+      local function add_macs(list)
+        if list then
+          for _, mac in ipairs(list) do
+            macs[mac] = data
+          end
+        end
+      end
+
+      if data["network"] then
+        add_macs(data["network"]["mesh_interfaces"])
+
+        if data["network"]["mesh"] and data["network"]["mesh"]["bat0"] and
+           data["network"]["mesh"]["bat0"]["interfaces"] then
+          local interfaces = data["network"]["mesh"]["bat0"]["interfaces"]
+          add_macs(interfaces["other"])
+          add_macs(interfaces["wireless"])
+          add_macs(interfaces["tunnel"])
         end
       end
     end


### PR DESCRIPTION
This will introduce a new nodeinfo object, network.mesh.bat0.interfaces,
containing any of the the following subordinated objects:

- wireless
- tunnel
- other

Each of these objects contains a (possibly empty) list of MAC addresses
(lowercase, colon-notation) corresponding to a interface of the given
class. Combined with a batman graph it is thus possible to mark
sub-graphs as "wireless" or "vpn".

The previously used object mesh_intefaces is superseded by this new
object structure and mesh_interfaces will be removed in a future Gluon
release.