### PR TITLE
gluon-mesh-batman-adv-core: fix the data types in the check_site.lua

### DIFF
--- a/package/gluon-mesh-batman-adv-core/check_site.lua
+++ b/package/gluon-mesh-batman-adv-core/check_site.lua
@@ -8,8 +8,8 @@ for _, config in ipairs({'wifi24', 'wifi5'}) do
    need_string_match(config .. '.mesh_bssid', '^%x[02468aAcCeE]:%x%x:%x%x:%x%x:%x%x:%x%x$')
    need_number(config .. '.mesh_mcast_rate')
    need_number(config .. '.mesh_vlan', false)
-   need_number(config .. '.client_disabled', false)
-   need_number(config .. '.mesh_disabled', false)
+   need_boolean(config .. '.client_disabled', false)
+   need_boolean(config .. '.mesh_disabled', false)
 end
 
 need_boolean('mesh_on_wan', false)


### PR DESCRIPTION
As we changed the ```check_site.lua``` I forgot to change the data types of the ```mesh_disabled``` and the ```client_disabled``` lines. This mistake stopped gluon from compiling, when using this options. This PR fixes the data types to boolean.