### PR TITLE
docs/autoupdater: depends on ipv6 reachable update-servers

### DIFF
--- a/docs/features/autoupdater.rst
+++ b/docs/features/autoupdater.rst
@@ -54,7 +54,7 @@ We suggest to have following directory tree accessible via http:
                     sysupgrade/
                     factory/
 
-The server should be available via IPv6.
+The server must be available via IPv6.
 
 Command Line
 ------------


### PR DESCRIPTION
Change the modal verb to avoid confusion, as this is not really optional if one wants to use the autoupdater, as nodes without IPv4 connectivity (which can only be gained via WAN) are left out.