### PR TITLE
gluon-status-page: API

### DIFF
--- a/package/gluon-status-page/Makefile
+++ b/package/gluon-status-page/Makefile
@@ -12,7 +12,7 @@ define Package/gluon-status-page
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Adds a status page showing information about the node.
-  DEPENDS:=+gluon-core +gluon-neighbour-info +uhttpd
+  DEPENDS:=+gluon-core +uhttpd +gluon-neighbour-info +gluon-announce +libiwinfo-lua
 endef
 
 define Package/gluon-status-page/description

--- a/package/gluon-status-page/files/lib/gluon/announce/nodeinfo.d/software/status-page
+++ b/package/gluon-status-page/files/lib/gluon/announce/nodeinfo.d/software/status-page
@@ -1,0 +1,1 @@
+return { api = 1 }

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/dyn/neighbours-batadv
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/dyn/neighbours-batadv
@@ -1,0 +1,32 @@
+#!/usr/bin/lua
+
+local json = require 'luci.json'
+local nixio = require 'nixio'
+
+function neighbours()
+  local neighbours = {}
+  local list = io.lines("/sys/kernel/debug/batman_adv/bat0/originators")
+  for line in list do
+    local mac1, lastseen, tq, mac2, ifname =
+      line:match("^([0-9a-f:]+) +(%d+%.%d+)s +%( *(%d+)%) +([0-9a-f:]+) +%[ *(.-)%]")
+
+    if mac1 ~= nil and mac1 == mac2 then
+      neighbours[mac1] = { tq = tonumber(tq)
+                         , lastseen = tonumber(lastseen)
+                         , ifname = ifname
+                         }
+    end
+  end
+
+  return neighbours
+end
+
+io.write("Access-Control-Allow-Origin: *\n")
+io.write("Content-type: text/event-stream\n\n")
+
+while true do
+  local neighbours = json.encode(neighbours())
+  io.write("data: " .. neighbours .. "\n\n")
+  io.flush()
+  nixio.nanosleep(1, 0)
+end

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/dyn/neighbours-nodeinfo
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/dyn/neighbours-nodeinfo
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo 'Access-Control-Allow-Origin: *'
+
+batctl if | cut -d: -f1 | grep -qxF "$QUERY_STRING" || exit 1
+
+exec /usr/bin/gluon-neighbour-info -s -i "$QUERY_STRING" -d ff02::2:1001 -p 1001 -r nodeinfo

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/dyn/stations
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/dyn/stations
@@ -1,0 +1,52 @@
+#!/usr/bin/lua
+
+util = require 'luci.util'
+json = require 'luci.json'
+nixio = require 'nixio'
+iwinfo = require 'iwinfo'
+
+function badrequest()
+  io.write("Status: 400 Bad Request\n\n")
+  os.exit(1)
+end
+
+function get_stations(iw, ifname)
+  local stations = {}
+
+  for k, v in pairs(iw.assoclist(ifname)) do
+    stations[k:lower()] = {signal = v.signal, noise = v.noise, inactive = v.inactive}
+  end
+
+  return stations
+end
+
+local ifname = os.getenv("QUERY_STRING")
+
+if ifname == nil then badrequest() end
+
+local list = util.exec('batctl if')
+local found = false
+for _, line in ipairs(util.split(list)) do
+  if ifname == line:match('^(.-):') then
+    found = true
+    break
+  end
+end
+
+if found == false then badrequest() end
+
+local wifitype = iwinfo.type(ifname)
+
+if wifitype == nil then badrequest() end
+
+local iw = iwinfo[wifitype]
+
+io.write("Access-Control-Allow-Origin: *\n")
+io.write("Content-type: text/event-stream\n\n")
+
+while true do
+  local stations = json.encode(get_stations(iw, ifname))
+  io.write("data: " .. stations .. "\n\n")
+  io.flush()
+  nixio.nanosleep(0, 150e6)
+end

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/dyn/statistics
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/dyn/statistics
@@ -1,0 +1,18 @@
+#!/usr/bin/lua
+
+local announce = require 'gluon.announce'
+local json = require 'luci.json'
+local util = require 'luci.util'
+local nixio = require 'nixio'
+
+local announce_dir = '/lib/gluon/announce/statistics.d/'
+
+io.write("Access-Control-Allow-Origin: *\n")
+io.write("Content-type: text/event-stream\n\n")
+
+while true do
+  local data = json.encode(announce.collect_dir(announce_dir))
+  io.write("data: " .. data .. "\n\n")
+  io.flush()
+  nixio.nanosleep(1, 0)
+end

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/interfaces
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/interfaces
@@ -1,0 +1,24 @@
+#!/usr/bin/lua
+
+util = require 'luci.util'
+json = require 'luci.json'
+fs = require 'nixio.fs'
+
+io.write("Access-Control-Allow-Origin: *\n")
+io.write("Content-type: application/json\n\n")
+
+list = util.exec('batctl if')
+
+interfaces = {}
+
+for _, line in ipairs(util.split(list)) do
+  ifname = line:match('^(.-):')
+  if ifname ~= nil then
+    pcall(function()
+      local address = util.trim(fs.readfile('/sys/class/net/' .. ifname .. '/address'))
+      interfaces[ifname] = { address = address }
+    end)
+  end
+end
+
+io.write(json.encode(interfaces))

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/nodeinfo
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/nodeinfo
@@ -1,0 +1,15 @@
+#!/usr/bin/lua
+
+local announce = require 'gluon.announce'
+local json = require 'luci.json'
+local util = require 'luci.util'
+local nixio = require 'nixio'
+
+local announce_dir = '/lib/gluon/announce/nodeinfo.d/'
+
+io.write("Access-Control-Allow-Origin: *\n")
+io.write("Content-type: application/json\n\n")
+
+local data = json.encode(announce.collect_dir(announce_dir))
+io.write(data)
+io.flush()

--- a/package/gluon-status-page/files/lib/gluon/upgrade/500-status-page
+++ b/package/gluon-status-page/files/lib/gluon/upgrade/500-status-page
@@ -9,5 +9,7 @@ uci batch <<-EOF
 
 	set uhttpd.main.home=/lib/gluon/status-page/www
 
+	set uhttpd.main.max_requests=12
+
 	commit uhttpd
 EOF


### PR DESCRIPTION
This adds the API used for the new status page. It doesn't yet add the frontend but it will allow the frontend running on other nodes to access data from this node. The total number of concurrent connections is limited to 12, limiting the number of users to about 2 or 3 (~4 connections per user).

Later versions of the should probably convert scripts to pure C to further reduce load.