### PR TITLE
Altitude in meters above streetlevel

### DIFF
--- a/package/gluon-config-mode-geo-location/i18n/de.po
+++ b/package/gluon-config-mode-geo-location/i18n/de.po
@@ -27,7 +27,7 @@ msgid "Longitude"
 msgstr "Längengrad"
 
 msgid "Altitude"
-msgstr "Höhenmeter über Normalnull"
+msgstr "Höhenmeter über dem Boden"
 
 msgid "Show node on the map"
 msgstr "Knoten auf der Karte anzeigen"


### PR DESCRIPTION
It is not easy to determine the exact altitude above NN. In openstreetmap the streetlevel already has the altitude information, so the altitude a user can determine by himself would be the altitude above streetlevel. For scripts that would plot these coordinates the altitudes can simply be added to the base level. 
 