### PR TITLE
gluon-core: add script for node-info at login

### DIFF
--- a/package/gluon-core/files/etc/profile
+++ b/package/gluon-core/files/etc/profile
@@ -1,0 +1,16 @@
+#!/bin/sh
+[ -f /etc/banner ] && cat /etc/banner && /lib/gluon/node-info
+
+export PATH=/usr/bin:/usr/sbin:/bin:/sbin
+export HOME=$(grep -e "^${USER:-root}:" /etc/passwd | cut -d ":" -f 6)
+export HOME=${HOME:-/root}
+export PS1='\u@\h:\w\$ '
+
+[ -x /bin/more ] || alias more=less
+[ -x /usr/bin/vim ] && alias vi=vim || alias vim=vi
+
+[ -z "$KSH_VERSION" -o \! -s /etc/mkshrc ] || . /etc/mkshrc
+
+[ -x /usr/bin/arp ] || arp() { cat /proc/net/arp; }
+[ -x /usr/bin/ldd ] || ldd() { LD_TRACE_LOADED_OBJECTS=1 $*; }
+

--- a/package/gluon-core/files/lib/gluon/info.d/core
+++ b/package/gluon-core/files/lib/gluon/info.d/core
@@ -1,0 +1,9 @@
+#!/usr/bin/lua
+local util = require("luci.util")
+local sys = require("luci.sys")
+
+local hours = math.floor(sys.uptime() / 3600)
+local minutes = math.floor(sys.uptime() / 60) - (hours * 60)
+
+io.write(" your nodes uptime: " .. hours.. " hours, ".. minutes  .. " minutes\n")
+io.write(" " .. string.rep("-",53) .."\n")

--- a/package/gluon-core/files/lib/gluon/node-info
+++ b/package/gluon-core/files/lib/gluon/node-info
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+for script in /lib/gluon/info.d/*; do
+	"$script"
+done

--- a/package/gluon-mesh-vpn-fastd/files/lib/gluon/info.d/fastd
+++ b/package/gluon-mesh-vpn-fastd/files/lib/gluon/info.d/fastd
@@ -1,0 +1,64 @@
+#!/usr/bin/lua
+
+local util = require("luci.util")
+local fs = require("nixio.fs")
+local ltn12 = require 'luci.ltn12'
+local sys = require("luci.sys")
+local json = require("luci.json")
+local nixio = require 'nixio'
+local platform_info = require("platform_info")
+
+
+local stat, fastd_status = pcall(
+  function()
+    local fastd_sock = nixio.socket('unix', 'stream')
+    assert(fastd_sock:connect('/var/run/fastd.mesh_vpn.socket'))
+
+    decoder = json.Decoder()
+    ltn12.pump.all(ltn12.source.file(fastd_sock), decoder:sink())
+    return decoder:get()
+  end
+)
+
+io.write(" fastd")
+
+if stat then
+
+  local running_hours = math.floor((fastd_status.uptime/1000) / 3600)
+  local running_minutes = math.floor((fastd_status.uptime/1000) / 60) - (running_hours * 60)
+  io.write(string.format(" is running for %i hours and %i minutes.\n", running_hours, running_minutes))
+
+  local peers = 0
+  local connections = 0
+
+  for key, peer in pairs(fastd_status.peers) do
+    peers = peers+1
+
+    if peer.connection then
+      connections = connections+1
+    end
+  end
+
+  io.write(string.format(" Connected to %i out of %i peers\n", connections, peers))
+  local x = 0
+  for key, peer in pairs(fastd_status.peers) do
+    
+    if peer.connection then
+      local connection_hours = math.floor((peer.connection.established/1000) / 3600)
+      local connection_minutes = math.floor((peer.connection.established/1000) / 60) - (connection_hours * 60)
+      local peername = string.gsub(peer.name, "mesh_vpn_", " ")
+      peername = string.gsub(peername, "_", " ")
+
+      x = 1
+      io.write(string.format("%s: ",peername))
+      io.write(string.format("connected for %i:%i hours\n", connection_hours, connection_minutes))
+    end
+  end
+  if (x==0) then
+    io.write(" no Connections\n")
+  end
+else
+  io.write(" is not running\n")
+end
+
+io.write(" " .. string.rep("-",53) .."\n")


### PR DESCRIPTION
# general idea
In the IRC-Channel we came up with an idea to let the node throw out some useful information on login via command-line to make it easier to debug a node. In the following picture you can see a proof-of-concept version of the idea. It contains the core-information and the fastd-information.

![node-info](http://linux-nerds.de/stuff/node-info2.png)

# how it works
With this pull request come three important files an directories: ```/etc/profiles```, ```/lib/gluon/node-info``` and ```/lib/gluon/info.d```.
```/etc/profiles``` is called at login and is modified to call ```/lib/gluon/node-info```, which again calls every script in the directory ```/lib/gluon/info.d```. This allows other packages (like fastd) to provide a script into the directory, which is executed at login to display the current status of the service.
Because the info-scripts (except ```core```) are provided by the packages there is no need to write code and check weather a package is installed or not.

# ToDo-list
- [x] rework the code for ```core``` to make the uptime look prettier
- [ ] provide scripts for all packages, where info is useful
- [ ] define a maximum width for a line

This pull request can be merged, but some commits for more scripts will follow anyway.