### PR TITLE
updated openwrt commit, to include openssl patch

### DIFF
--- a/modules
+++ b/modules
@@ -1,7 +1,7 @@
 GLUON_FEEDS='openwrt gluon routing luci'
 
 OPENWRT_REPO=git://git.openwrt.org/14.07/openwrt.git
-OPENWRT_COMMIT=179bab8b1700d74b28cc6cd25322f9a1ad670107
+OPENWRT_COMMIT=d70e69464ec00006b26ac684e808a6118dd4177a
 
 PACKAGES_OPENWRT_REPO=git://github.com/openwrt/packages.git
 PACKAGES_OPENWRT_COMMIT=01fcd1f29174a56d6ddb59901ed8c67ea42c3a8f


### PR DESCRIPTION
As Gluon currently won't build if the openssl*.tar.gz is missing under openwrt/dl


mkdir -p /var/lib/jenkins/workspace/gluon/gluon/build/ar71xx-generic/openwrt/dl
/var/lib/jenkins/workspace/gluon/gluon/build/ar71xx-generic/openwrt/scripts/download.pl "/var/lib/jenkins/workspace/gluon/gluon/build/ar71xx-generic/openwrt/dl" "openssl-1.0.2a.tar.gz" "a06c547dac9044161a477211049f60ef" "http://www.openssl.org/source/" "ftp://ftp.funet.fi/pub/crypt/mirrors/ftp.openssl.org/source" "ftp://ftp.sunet.se/pub/security/tools/net/openssl/source/"
--2015-06-14 00:52:06--  http://www.openssl.org/source/openssl-1.0.2a.tar.gz
Resolving www.openssl.org (www.openssl.org)... 194.97.150.234
Connecting to www.openssl.org (www.openssl.org)|194.97.150.234|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2015-06-14 00:52:06 ERROR 404: Not Found.

Download failed.
--2015-06-14 00:52:06--  ftp://ftp.funet.fi/pub/crypt/mirrors/ftp.openssl.org/source/openssl-1.0.2a.tar.gz
           => `-'
Resolving ftp.funet.fi (ftp.funet.fi)... 2001:708:10:9::20:2, 193.166.3.2
Connecting to ftp.funet.fi (ftp.funet.fi)|2001:708:10:9::20:2|:21... connected.
Logging in as anonymous ... Logged in!
==> SYST ... done.    ==> PWD ... done.
==> TYPE I ... done.  ==> CWD (1) /pub/crypt/mirrors/ftp.openssl.org/source ... 
No such directory `pub/crypt/mirrors/ftp.openssl.org/source'.

Download failed.
--2015-06-14 00:52:08--  ftp://ftp.sunet.se/pub/security/tools/net/openssl/source/openssl-1.0.2a.tar.gz
           => `-'
Resolving ftp.sunet.se (ftp.sunet.se)... 2001:6b0:19::64, 194.71.11.69
Connecting to ftp.sunet.se (ftp.sunet.se)|2001:6b0:19::64|:21... connected.
Logging in as anonymous ... Logged in!
==> SYST ... done.    ==> PWD ... done.
==> TYPE I ... done.  ==> CWD (1) /pub/security/tools/net/openssl/source ... done.
==> SIZE openssl-1.0.2a.tar.gz ... done.
==> EPSV ... done.    ==> RETR openssl-1.0.2a.tar.gz ... 
No such file `openssl-1.0.2a.tar.gz'.

Download failed.
--2015-06-14 00:52:08--  http://mirror2.openwrt.org/sources/openssl-1.0.2a.tar.gz
Resolving mirror2.openwrt.org (mirror2.openwrt.org)... 46.4.11.11
Connecting to mirror2.openwrt.org (mirror2.openwrt.org)|46.4.11.11|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2015-06-14 00:52:08 ERROR 404: Not Found.

Download failed.
--2015-06-14 00:52:08--  http://downloads.openwrt.org/sources/openssl-1.0.2a.tar.gz
Resolving downloads.openwrt.org (downloads.openwrt.org)... 78.24.191.177
Connecting to downloads.openwrt.org (downloads.openwrt.org)|78.24.191.177|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2015-06-14 00:52:09 ERROR 404: Not Found.

Download failed.
