### PR TITLE
gluon-announce, ...: don't output empty lists where not appropriate

### DIFF
--- a/package/gluon-announce/files/usr/lib/lua/gluon/announce.lua
+++ b/package/gluon-announce/files/usr/lib/lua/gluon/announce.lua
@@ -3,6 +3,7 @@
 module('gluon.announce', package.seeall)
 
 fs = require 'nixio.fs'
+json = require 'luci.json'
 uci = require('luci.model.uci').cursor()
 util = require 'luci.util'
 
@@ -15,7 +16,7 @@ local function collect_entry(entry)
 end
 
 function collect_dir(dir)
-	local ret = {}
+	local ret = { [json.null] = true }
 
 	for entry in fs.dir(dir) do
 		if entry:sub(1, 1) ~= '.' then

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/neighbours.d/batadv
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/neighbours.d/batadv
@@ -1,7 +1,3 @@
-local json = require 'luci.json'
-local util = require 'luci.util'
-local fs = require 'nixio.fs'
-
 local ifname_address_cache = {}
 
 function ifname2address(ifname)
@@ -26,7 +22,7 @@ function batadv()
     if mac1 ~= nil and mac1 == mac2 then
       ifaddress = ifname2address(ifname)
       if interfaces[ifaddress] == nil then
-        interfaces[ifaddress] = { neighbours = {} }
+        interfaces[ifaddress] = { neighbours = { [json.null] = true } }
       end
 
       interfaces[ifaddress].neighbours[mac1] = { tq = tonumber(tq)
@@ -35,7 +31,9 @@ function batadv()
     end
   end
 
-  return interfaces
+  if next(interfaces) then
+    return interfaces
+  end
 end
 
 return batadv()

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/neighbours.d/wifi
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/neighbours.d/wifi
@@ -1,6 +1,3 @@
-local json = require 'luci.json'
-local util = require 'luci.util'
-local fs = require 'nixio.fs'
 local iwinfo = require 'iwinfo'
 
 function neighbours(iface)
@@ -12,7 +9,9 @@ function neighbours(iface)
                           }
   end
 
-  return stations
+  if next(stations) then
+    return stations
+  end
 end
 
 function interfaces()
@@ -38,4 +37,6 @@ for address, iface in pairs(interfaces()) do
   wifi[address] = { neighbours = neighbours(iface) }
 end
 
-return wifi
+if next(wifi) then
+  return wifi
+end

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/mesh/bat0/interfaces
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/mesh/bat0/interfaces
@@ -48,5 +48,6 @@ end
 return {
   wireless = nil_table(wireless),
   tunnel = nil_table(tunnel),
-  other = nil_table(other)
+  other = nil_table(other),
+  [json.null] = true
 }


### PR DESCRIPTION
Always output empty objects or nothing at all where objects are expected, but
no elements exist.

Also remove a few unneeded "requires", a few basic modules are provided by
announce.lua by default.