### PR TITLE
Do not use error() in gluon-neighbour-info

### DIFF
--- a/package/gluon-neighbour-info/src/gluon-neighbour-info.c
+++ b/package/gluon-neighbour-info/src/gluon-neighbour-info.c
@@ -176,8 +176,10 @@ int main(int argc, char **argv) {
         fprintf(stderr, "Invalid parameter %c ignored.\n", c);
     }
 
-  if (request_string == NULL)
-    error(EXIT_FAILURE, 0, "No request string supplied");
+  if (request_string == NULL) {
+    fprintf(stderr, "No request string supplied");
+    exit(EXIT_FAILURE);
+  }
 
   if (sse)
     fputs("Content-Type: text/event-stream\n\n", stdout);


### PR DESCRIPTION
error() is a glibc specific function and should not be used in
code meant to be portable.

Fixes build on musl-libc.