### PR TITLE
doc: remove "probability" from site doc (was removed in v2014.3)

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -149,7 +149,6 @@ autoupdater : package
               'http://[fdca:ffee:babe:1::fec1]/firmware/stable/sysupgrade/',
               'http://[fdca:ffee:babe:1::fec2]/firmware/stable/sysupgrade/',
             },
-            probability = 0.08,
             good_signatures = 2,
             pubkeys = {
               'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX', -- someguy


### PR DESCRIPTION
see: http://gluon.readthedocs.org/en/latest/releases/v2014.3.html

Signed-off-by: Alexander Dahl <alex@netz39.de>