### PR TITLE
gluon-mesh-batman-adv-core: Only announce valid IPv6 addresses

### DIFF
--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/addresses
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/addresses
@@ -1,10 +1,13 @@
 local ip = require 'luci.ip'
+local bit = require 'nixio'.bit
 
 local addresses = {}
 
 for line in io.lines('/proc/net/if_inet6') do
-  local matches = { line:match('^' .. string.rep('(%x%x%x%x)', 8) .. string.rep(' %x%x', 4) .. '%s+([^%s]+)$') }
-  if matches[9] == 'br-client' then
+  local matches = { line:match('^' .. string.rep('(%x%x%x%x)', 8) .. string.rep(' %x%x', 3) .. ' (%x%x)%s+([^%s]+)$') }
+  -- exclude wrong interfaces and deprecated as well as tentative addresses
+  -- (see /include/uapi/linux/if_addr.h in linux source for flags)
+  if matches[10] == 'br-client' and bit.band(tonumber(matches[9], 16), 0x60) == 0 then
     table.insert(addresses, ip.IPv6(string.format('%s:%s:%s:%s:%s:%s:%s:%s', unpack(matches))):string():lower())
   end
 end


### PR DESCRIPTION
The nodeinfo/network/addresses announcement included deprecated and
tentative addresses, which it clearly shouldn't as the host doesn't want
to be contacted on those addresses. They are now filtered out.