### PR TITLE
gluon-wan-dnsmasq: fix usage of libpacketmark

### DIFF
--- a/package/gluon-wan-dnsmasq/files/etc/init.d/gluon-wan-dnsmasq
+++ b/package/gluon-wan-dnsmasq/files/etc/init.d/gluon-wan-dnsmasq
@@ -18,7 +18,10 @@ start() {
 	mkdir -p $RESOLV_CONF_DIR
 	/lib/gluon/wan-dnsmasq/update.lua
 
-	LD_PRELOAD=libpacketmark.so LIBPACKETMARK_MARK=$PACKET_MARK service_start /usr/sbin/dnsmasq -x $SERVICE_PID_FILE -u root -i lo -p $PORT -h -r $RESOLV_CONF
+	export LD_PRELOAD=libpacketmark.so
+	export LIBPACKETMARK_MARK=$PACKET_MARK
+
+	service_start /usr/sbin/dnsmasq -x $SERVICE_PID_FILE -u root -i lo -p $PORT -h -r $RESOLV_CONF
 }
 
 stop() {


### PR DESCRIPTION
Using service_start requires exporting of environment variables.

Fixes #397