### PR TITLE
Add support for TP-Link TL-WR710N v2

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -18,9 +18,10 @@ $(eval $(call GluonModel,TLWA701,tl-wa701nd-v2,tp-link-tl-wa701n-nd-v2))
 $(eval $(call GluonProfile,TLWR703))
 $(eval $(call GluonModel,TLWR703,tl-wr703n-v1,tp-link-tl-wr703n-v1))
 
-# TL-WR710N v1
+# TL-WR710N v1, v2
 $(eval $(call GluonProfile,TLWR710))
 $(eval $(call GluonModel,TLWR710,tl-wr710n-v1,tp-link-tl-wr710n-v1))
+$(eval $(call GluonModel,TLWR710,tl-wr710n-v2,tp-link-tl-wr710n-v2))
 
 # TL-WR740N v1, v3, v4, v5
 $(eval $(call GluonProfile,TLWR740))


### PR DESCRIPTION
This PR adds support for the device TP-Link TL-WR710N v2.

Current OpenWRT Chaos Calmer has added support for this device. I have taken the current gluon master branch and built an image successfully.

The device could be flashed and configured correctly and is up and running now without any problems.
If I should provide some more information about the device like CLI output of any kind please let me know.

The image I used is available [here](http://pudding.freifunk-mwu.de/_archive/0.2-exp-wr710n-v2-20150806/factory/gluon-ffwi-0.2-exp-wr710n-v2-20150806-tp-link-tl-wr710n-v2.bin).