### PR TITLE
gluon-radio-config: basic wireless configuration

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,8 @@ Packages
 .. toctree::
    :maxdepth: 1
 
+   package/gluon-radio-config
+
 Releases
 --------
 

--- a/docs/package/gluon-radio-config.rst
+++ b/docs/package/gluon-radio-config.rst
@@ -1,0 +1,20 @@
+gluon-radio-config
+==================
+
+This package takes care of setting basic wireless settings:
+
+- regulatory domain
+- htmode
+- channel
+
+site.conf
+---------
+
+regdom
+    regulatory domain (e.g. *de*)
+
+wifi24.channel / wifi5.channel
+    wireless channel for radio
+
+wifi24.htmode / wifi5.htmode
+    desired HT mode (e.g. *HT20*)

--- a/package/gluon-mesh-batman-adv-core/Makefile
+++ b/package/gluon-mesh-batman-adv-core/Makefile
@@ -11,7 +11,7 @@ define Package/gluon-mesh-batman-adv-core
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Support for batman-adv meshing (core)
-  DEPENDS:=+gluon-core +firewall +libiwinfo-lua
+  DEPENDS:=+gluon-core +gluon-radio-config +firewall +libiwinfo-lua
 endef
 
 define Build/Prepare

--- a/package/gluon-mesh-batman-adv-core/check_site.lua
+++ b/package/gluon-mesh-batman-adv-core/check_site.lua
@@ -1,9 +1,4 @@
-need_string('regdom')
-
 for _, config in ipairs({'wifi24', 'wifi5'}) do
-   need_number(config .. '.channel')
-   need_string(config .. '.htmode')
-
    if need_table(config .. '.ap', nil, false) then
       need_string(config .. '.ap.ssid')
       need_boolean(config .. '.ap.disabled', false)

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
@@ -118,36 +118,12 @@ end
 local function configure_radio(radio, index, config)
   local suffix = radio:match('^radio(%d+)$')
 
-  uci:delete('wireless', radio, 'disabled')
-
-  uci:set('wireless', radio, 'channel', config.channel)
-  uci:set('wireless', radio, 'htmode', config.htmode)
-  uci:set('wireless', radio, 'country', site.regdom)
-
   configure_client(config.ap, radio, index, suffix)
   configure_ibss(config.ibss, radio, index, suffix)
   configure_mesh(config.mesh, radio, index, suffix)
 end
 
-
-local radios = {}
-
-uci:foreach('wireless', 'wifi-device',
-  function(s)
-    table.insert(radios, s['.name'])
-  end
-)
-
-for index, radio in ipairs(radios) do
-  local hwmode = uci:get('wireless', radio, 'hwmode')
-
-  if hwmode == '11g' or hwmode == '11ng' then
-    configure_radio(radio, index, site.wifi24)
-  elseif hwmode == '11a' or hwmode == '11na' then
-    configure_radio(radio, index, site.wifi5)
-  end
-end
-
+util.iterate_radios(configure_radio)
 
 uci:save('wireless')
 uci:save('network')

--- a/package/gluon-radio-config/Makefile
+++ b/package/gluon-radio-config/Makefile
@@ -1,0 +1,31 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-radio-config
+PKG_VERSION:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(GLUONDIR)/include/package.mk
+
+define Package/gluon-radio-config
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=Basic radio config (regdom, channel, htmode)
+  DEPENDS:=+gluon-core
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-radio-config/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gluon-radio-config))

--- a/package/gluon-radio-config/check_site.lua
+++ b/package/gluon-radio-config/check_site.lua
@@ -1,0 +1,6 @@
+need_string('regdom')
+
+for _, config in ipairs({'wifi24', 'wifi5'}) do
+   need_number(config .. '.channel')
+   need_string(config .. '.htmode')
+end

--- a/package/gluon-radio-config/files/lib/gluon/upgrade/250-gluon-radio-config
+++ b/package/gluon-radio-config/files/lib/gluon/upgrade/250-gluon-radio-config
@@ -1,0 +1,18 @@
+#!/usr/bin/lua
+
+local util = require 'gluon.util'
+local uci = require('luci.model.uci').cursor()
+local site = require 'gluon.site_config'
+
+local function configure_radio(radio, index, config)
+  uci:delete('wireless', radio, 'disabled')
+
+  uci:set('wireless', radio, 'channel', config.channel)
+  uci:set('wireless', radio, 'htmode', config.htmode)
+  uci:set('wireless', radio, 'country', site.regdom)
+end
+
+util.iterate_radios(configure_radio)
+
+uci:save('wireless')
+uci:commit('wireless')


### PR DESCRIPTION
Split basic radio configuration from gluon-mesh-batman-adv as this will
be required for virtually any wireless mesh protocol.

This package takes care of setting:

  - wireless channel,
  - htmode and
  - regulatory domain

gluon-mesh-batman-adv-core depends on this package.

Fixes #437