### PR TITLE
gluon-wifi-mesh-macfilter

### DIFF
--- a/package/gluon-wifi-mesh-macfilter/Makefile
+++ b/package/gluon-wifi-mesh-macfilter/Makefile
@@ -1,0 +1,38 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-wifi-mesh-macfilter
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include $(INCLUDE_DIR)/package.mk
+
+define Package/gluon-wifi-block-station
+  SECTION:=gluon
+  CATEGORY:=GLUON
+  TITLE:=WiFi - block/open 802.11s-mesh stations
+  DEPENDS:=+iw +uci
+endef
+
+define Package/gluon-wifi-mesh-macfilter/description
+	Setting plink_action [block|open], when 802.11s mesh-interface comes up.
+	Define filterpolicy in uci wireless.<wifi-iface>.macfilter=[disable|deny|allow], deny sets plink_action block, allow sets plink_action open.
+	List MAC adresses (divided by spaces) in uci wireless.<wifi-iface>.maclist.
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-wifi-mesh-macfilter/install
+	$(CP) ./files/* $(1)/
+endef
+
+$(eval $(call BuildPackage,gluon-wifi-mesh-macfilter))

--- a/package/gluon-wifi-mesh-macfilter/files/etc/hotplug.d/iface/80-gluon-wifi-mesh-macfilter
+++ b/package/gluon-wifi-mesh-macfilter/files/etc/hotplug.d/iface/80-gluon-wifi-mesh-macfilter
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+[[ "$ACTION" != ifup ]] && exit 0;
+[[ "$( uci show wireless.$INTERFACE.mode 2>/dev/null | cut -d '=' -f2 | sed s/\'//g )" != mesh ]] && exit 0;
+
+local POLICY=$( uci show wireless.$INTERFACE.macfilter 2>/dev/null | cut -d '=' -f2 | sed s/\'//g )
+	
+case $POLICY in
+	deny)	local IW_POLICY="block";;
+	allow)	local IW_POLICY="open";;
+	*) 		exit 0;;
+esac
+
+for MAC in $( uci show wireless.$INTERFACE.maclist 2>/dev/null | cut -d '=' -f2 | sed s/\'//g ); do
+	iw dev $DEVICE station set $MAC plink_action $IW_POLICY
+done


### PR DESCRIPTION
setting plink_action [block|open], when 802.11s mesh-interface comes up

Fixes: #421