### PR TITLE
Announce client count separated by frequency

### DIFF
--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/statistics.d/clients
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/statistics.d/clients
@@ -1,20 +1,55 @@
-local list = io.lines("/sys/kernel/debug/batman_adv/bat0/transtable_local")
+local iwinfo = require 'iwinfo'
 
-local count = 0
-local wifi = 0
+local counts = { total = 0
+               , wifi = 0
+               , wifi24 = 0
+               , wifi5 = 0
+               }
+
+local list = io.lines("/sys/kernel/debug/batman_adv/bat0/transtable_local")
+local clients = {}
 for line in list do
   local mac, _, flags, lastseen = line:match("^ %* ([0-9a-f:]+) *(.- )%[(.-)%] +(%d+%.%d+)")
   if mac then
     if not flags:match('P') then
-      count = count + 1
+      counts.total = counts.total + 1
+      clients[mac:lower()] = true
 
       if flags:match('W') then
-        wifi = wifi +1
+        counts.wifi = counts.wifi +1
       end
     end
   end
 end
 
-return { total = count
-       , wifi  = wifi
-       }
+function count_iface_stations(iface)
+  local wifitype = iwinfo.type(iface)
+  if wifitype == nil then
+    return
+  end
+
+  local freq = iwinfo[wifitype].frequency(iface)
+  local key
+  if freq >= 2400 and freq < 2500 then
+    key = "wifi24"
+  elseif freq >= 5000 and freq < 6000 then
+    key = "wifi5"
+  else
+    return
+  end
+
+  for k, v in pairs(iwinfo[wifitype].assoclist(iface)) do
+    if clients[k:lower()] then
+      counts[key] = counts[key] + 1
+    end
+  end
+end
+
+local ifaces = {}
+uci:foreach("wireless", "wifi-iface", function(s)
+  if s.network == "client" and s.mode == "ap" then
+    count_iface_stations(s.ifname)
+  end
+end)
+
+return counts


### PR DESCRIPTION
It might be nice to distinguish how many clients are connected to a node via 2.4 GHz and 5 GHz, so we could gather information about the usage of the 5 GHz band if available.

While the actual implementation is rather easy (we already used [a hackish version](https://github.com/FreifunkBremen/ffhb-packages/blob/breminale/ffhb/ffhb-breminale/files/lib/gluon/announce/statistics.d/clients) that simply parses the output of `iw dev ... station dump`), we should probably first fix the output format in the JSON. Currently, we have:

    "clients": {
      "wifi": 3,
      "total": 3
    },

I would propose the following format, which obviously isn't backwards compatible:

    "clients": {
      "wifi24": 2,
      "wifi50": 1,
      "other": 0
    },

Having a "total" field doesn't make much sense when having more than one other field, I think, because you can get the total by something like `.clients | add` (in jq), whereas it would be more cumbersome and less flexible to get the count of "other" given "wifi24", "wifi50" and "total".

(I was by the way told that @NeoRaider already approved of the general idea at CCCamp, and that he would like different types of clients to have different color tints on the map)