### PR TITLE
remove 802.11b-support, limit wifi-capabilitys to some faster speeds

### DIFF
--- a/package/gluon-radio-config/files/lib/gluon/upgrade/250-gluon-radio-config
+++ b/package/gluon-radio-config/files/lib/gluon/upgrade/250-gluon-radio-config
@@ -10,6 +10,8 @@ local function configure_radio(radio, index, config)
   uci:set('wireless', radio, 'channel', config.channel)
   uci:set('wireless', radio, 'htmode', config.htmode)
   uci:set('wireless', radio, 'country', site.regdom)
+  uci:set('wireless', radio, 'supported_rates', '6000 9000 12000 18000 24000 36000 48000 54000')
+  uci:set('wireless', radio, 'basic_rate', '6000 9000 18000 36000 54000')
 end
 
 util.iterate_radios(configure_radio)


### PR DESCRIPTION
Hallo zusammen,

hiermit wird der 802.11b-Support entfernt, und die minimale Datenrate fürs Verbinden von Endgeräten wird auf 6 MBit angehoben.

Es empfiehlt sich, die Multicast-Rate dann auch auf 6 Mbit festzulegen, dann ist garantiert, dass alle verbundenen Geräte auch die Multicast-Pakete bekommen.

Durch den Patch gehen einige schlechte Mesh-Verbindungen verloren, die im Endeffekt aber eh nicht richtig funktionieren, da die Multicast-Rate von 12 Mbit effektiv das Mesh derzeit beschränkt.

Für Endgeräte hat der Patch den Vorteil, dass sehr langsame Verbindungen von unter 1 MBit effektivem Durchsatz nicht mehr möglich sind.

LG Ruben