### PR TITLE
add iapp-interface (bat0) for faster roaming

### DIFF
--- a/package/gluon-radio-config/files/lib/gluon/upgrade/250-gluon-radio-config
+++ b/package/gluon-radio-config/files/lib/gluon/upgrade/250-gluon-radio-config
@@ -10,6 +10,7 @@ local function configure_radio(radio, index, config)
   uci:set('wireless', radio, 'channel', config.channel)
   uci:set('wireless', radio, 'htmode', config.htmode)
   uci:set('wireless', radio, 'country', site.regdom)
+  uci:set('wireless', radio, 'iapp_interface', 'bat0')
 end
 
 util.iterate_radios(configure_radio)


### PR DESCRIPTION
Hallo zusammen,

mit diesem Parameter wird bat0 als iapp-interface festgelegt. Die bewirkt, dass während des Handshakes mit einem Endgerät ein Paket vom hostapd mit der MAC-Adresse des Endgeräts über das definierte Interface geschickt wird. Hierdurch sollte Batman-adv früher anfangen Datenpakete umzuleiten. Hierdurch wird das Roaming-verhalten verbessert.


LG Ruben