### PR TITLE
add noscan = 1 option

### DIFF
--- a/package/gluon-radio-config/files/lib/gluon/upgrade/250-gluon-radio-config
+++ b/package/gluon-radio-config/files/lib/gluon/upgrade/250-gluon-radio-config
@@ -10,6 +10,7 @@ local function configure_radio(radio, index, config)
   uci:set('wireless', radio, 'channel', config.channel)
   uci:set('wireless', radio, 'htmode', config.htmode)
   uci:set('wireless', radio, 'country', site.regdom)
+  uci:set('wireless', radio, 'noscan', 1)
 end
 
 util.iterate_radios(configure_radio)


### PR DESCRIPTION
Hallo zusammen,

dieser Patch fügt die noscan-Option ein.

Derzeit wird, wie vom Standard verlangt, ein Scan vor dem Hochschalten des Hotspots von HT20 auf HT40 auf dem Kanal gemacht. Problem an der Sache ist natürlich, dass in der Umgebung meist sehr viele andere Freifunk-Router in Reichweite stehen.

Da man diese nicht vom Scan ausnehmen kann, wird meist nicht auf HT40 hoch geschaltet, was bedeutet es wird die Hälfte der möglichen Bandbreite verschenkt, dadurch das man sich selbst beim Scan findet.

Da der ath9k sowieso dynamisch den zweiten Kanal dazu schaltet, je nachdem ob dort viel oder wenig Datenverkehr ist, sollten keine Störungen der benachbarten WLANs auftreten, trotz nicht gemachtem Scan.

Eine bessere Lösung währe vermutlich, eine Blacklist an SSIDs / BSSIDs / Mesh-IDs an den Hostapd geben zu können, die er beim Scan ignoriert. Damit würde die NoScan-Option dann wie vom Standard vorgesehen weiter funktionieren.

Allerdings würde das sicher größere Umbauarbeiten am Hostapd erfordern, die vermutlich nicht mehr in ChaosCalmer einfließen werden.

Das setzen der NoScan-Option ist somit vermutlich der beste Kompromiss.


LG Ruben