### PR TITLE
Don't fork batctl from announce scripts

### DIFF
--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/neighbours.d/wifi
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/neighbours.d/wifi
@@ -1,3 +1,4 @@
+local batman_adv = require 'gluon.batman_adv'
 local iwinfo = require 'iwinfo'
 
 function neighbours(iface)
@@ -16,8 +17,7 @@ end
 
 function interfaces()
   local interfaces = {}
-  local popen = io.popen('exec batctl if')
-  for ifname in popen:read('*a'):gmatch('([^%s]+): active') do
+  for ifname in batman_adv.interfaces('bat0') do
     pcall(function()
       local address = util.readline(io.open('/sys/class/net/' .. ifname .. '/address'))
       local wifitype = iwinfo.type(ifname)
@@ -26,7 +26,6 @@ function interfaces()
       end
     end)
   end
-  popen:close()
 
   return interfaces
 end

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/mesh/bat0/interfaces
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/mesh/bat0/interfaces
@@ -1,3 +1,5 @@
+local batman_adv = require 'gluon.batman_adv'
+
 local wireless = {}
 local tunnel = {}
 local other = {}
@@ -36,8 +38,7 @@ local function nil_table(t)
   end
 end
 
-local popen = io.popen('exec batctl if')
-for ifname in popen:read('*a'):gmatch('([^%s]+): active') do
+for ifname in batman_adv.interfaces('bat0') do
   if is_wireless(ifname) then
     get_address(wireless, ifname)
   elseif is_tuntap(ifname) then
@@ -46,7 +47,6 @@ for ifname in popen:read('*a'):gmatch('([^%s]+): active') do
     get_address(other, ifname)
   end
 end
-popen:close()
 
 return {
   wireless = nil_table(wireless),

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/mesh_interfaces
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/nodeinfo.d/network/mesh_interfaces
@@ -1,13 +1,13 @@
+local batman_adv = require 'gluon.batman_adv'
+
 local interfaces = {}
 
-local popen = io.popen('exec batctl if')
-for ifname in popen:read('*a'):gmatch('([^%s]+): active') do
+for ifname in batman_adv.interfaces('bat0') do
   pcall(
     function()
       table.insert(interfaces, util.readline(io.open('/sys/class/net/' .. ifname .. '/address')))
     end
   )
 end
-popen:close()
 
 return interfaces

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/statistics.d/gateway
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/announce/statistics.d/gateway
@@ -1,13 +1,11 @@
 local gateway = ''
 
-local popen = io.popen("exec batctl -m bat0 gateways")
-for line in popen:lines() do
+for line in io.lines('/sys/kernel/debug/batman_adv/bat0/gateways') do
   if line:sub(1, 3) == '=> ' then
     gateway = line:sub(4, 20)
     break
   end
 end
-popen:close()
 
 if gateway ~= '' then
   return gateway

--- a/package/gluon-mesh-batman-adv-core/files/usr/lib/lua/gluon/batman_adv.lua
+++ b/package/gluon-mesh-batman-adv-core/files/usr/lib/lua/gluon/batman_adv.lua
@@ -1,0 +1,15 @@
+local nixio = require 'nixio'
+
+module 'gluon.batman_adv'
+
+function interfaces(bat_if)
+    local iter = nixio.fs.glob('/sys/class/net/' .. bat_if .. '/lower_*')
+    return function()
+            local path = iter()
+            if path == nil then
+                return nil
+            end
+            local ifname = path:match('/lower_([^/]+)$')
+            return ifname
+        end
+end


### PR DESCRIPTION
In particular this means to generate the list of mesh interfaces in lua (done in new module `gluon.batman_adv` by globbing `/sys/class/net/bat0/lower_*`) and to open `/sys/kernel/debug/batman_adv/bat0/gateways` instead of calling `batctl gateways`.

This PR contains the changes from #461 