### PR TITLE
Documentation added Python dependency

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -25,6 +25,7 @@ Dependencies
 To build Gluon, several packages need to be installed on the system. On a
 freshly installed Debian Wheezy system the following packages are required:
 
+* `python2` (Python 3 will not work)
 * `git` (to get Gluon and other dependencies)
 * `subversion`
 * `build-essential`

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -33,6 +33,7 @@ freshly installed Debian Wheezy system the following packages are required:
 * `unzip`
 * `libncurses-dev` (actually `libncurses5-dev`)
 * `libz-dev` (actually `zlib1g-dev`)
+* `libssl-dev`
 
 
 Building the images


### PR DESCRIPTION
If you try to build with Python 3 you run in build errors. Python 2 has to be the system default.