### PR TITLE
Update build dependency documentation

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -27,12 +27,13 @@ freshly installed Debian Wheezy system the following packages are required:
 
 * `git` (to get Gluon and other dependencies)
 * `subversion`
+* `python2` (Python 3 doesn't work)
 * `build-essential`
 * `gawk`
 * `unzip`
 * `libncurses-dev` (actually `libncurses5-dev`)
 * `libz-dev` (actually `zlib1g-dev`)
-
+* `libssl-dev`
 
 Building the images
 -------------------


### PR DESCRIPTION
Build requires Python 2 and libssl-dev