### PR TITLE
docs: Change suggested wifi24 channel to 6

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -88,7 +88,7 @@ wifi24
     ::
 
        wifi24 = {
-         channel = 11,
+         channel = 6,
          htmode = 'HT20',
          ap = {
            ssid = 'entenhausen.freifunk.net',


### PR DESCRIPTION
TP-Link has a lower txpower on channel 1 and 11