### PR TITLE
gluon-ebtables-filter-multicast: drop icmpv6 echo-requests to all-nodes & all-routers

### DIFF
--- a/package/gluon-ebtables-filter-multicast/files/lib/gluon/ebtables/110-mcast-allow-icmp
+++ b/package/gluon-ebtables-filter-multicast/files/lib/gluon/ebtables/110-mcast-allow-icmp
@@ -1,1 +1,0 @@
-rule 'MULTICAST_OUT -p IPv4 --ip-protocol icmp -j RETURN'

--- a/package/gluon-ebtables-filter-multicast/files/lib/gluon/ebtables/110-mcast-allow-icmpv6
+++ b/package/gluon-ebtables-filter-multicast/files/lib/gluon/ebtables/110-mcast-allow-icmpv6
@@ -1,2 +1,5 @@
-rule 'MULTICAST_OUT -p IPv6 --ip6-protocol 0 -j RETURN' -- hop-by-hop
+rule 'MULTICAST_OUT -p IPv6 --ip6-protocol ipv6-icmp --ip6-icmp-type echo-request -j DROP'
+rule 'MULTICAST_OUT -p IPv6 --ip6-protocol ipv6-icmp --ip6-icmp-type 139 -j DROP'
 rule 'MULTICAST_OUT -p IPv6 --ip6-protocol ipv6-icmp -j RETURN'
+
+rule 'MULTICAST_OUT -p IPv6 --ip6-protocol 0 -j RETURN' -- hop-by-hop


### PR DESCRIPTION
in a layer 2 mesh network, pings to ff02::1 (all-nodes) and ff02::2 (all-routers) cause a lot of traffic in the network, significantly increasing the 'background noise' (= Grundrauschen) and stressing nodes in the network.

![all-nodes](https://cloud.githubusercontent.com/assets/775756/9862454/440717ae-5b39-11e5-8db9-aa5cd52aff90.png)
picture shows increased background noise (peaks on the right) in the network (~850 nodes, 1500 clients at that moment) generated by pings to ff02::1.

a solution would be the switch to a layer 3 mesh, but this is not a possible short-term change.

@T-X stated, that there should be no problems by blocking this: "ja, denke, ICMPv6 echo-req. nach ff02::1 und ff02::2 sollte man blockieren. habe noch keinen RFC gefunden, der damit probleme hätte"
