### PR TITLE
contrib/sigtest.sh - testing signature

### DIFF
--- a/contrib/sigtest.sh
+++ b/contrib/sigtest.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+if [ $# -eq 0 -o "-h" = "$1" -o "-help" = "$1" -o "--help" = "$1" ]; then
+    cat <<EOHELP
+Usage: $0 <public> <signed manifest>
+
+sigtest.sh checks if a manifest is signed by the public key <public>. There is
+no output, success or failure is indicated via the return code.
+
+See also:
+ * ecdsautils in https://github.com/tcatm/ecdsautils
+ * http://gluon.readthedocs.org/en/latest/features/autoupdater.html
+
+EOHELP
+    exit 1
+fi
+
+public="$1"
+manifest="$2"
+upper="$(mktemp)"
+lower="$(mktemp)"
+ret=1
+
+awk "BEGIN    { sep=0 }
+    /^---\$/ { sep=1; next }
+              { if(sep==0) print > \"$upper\";
+                else       print > \"$lower\"}" \
+    "$manifest"
+
+while read line
+do
+    if ecdsaverify -s "$line" -p "$public" "$upper"; then
+        ret=0
+        break
+    fi
+done < "$lower"
+
+rm -f "$upper" "$lower"
+exit $ret


### PR DESCRIPTION
Because the author of #250 seems to have vanished, and I'd like to have that script merged, here is a version of the signature testing script that incorporates all issues mentioned in #250. Also, it doesn't output anything anymore (except errors from ecdsaverify), but instead indicates success via exit code.