### PR TITLE
gluon-announce: statistics.loadinfo has 3 averages

### DIFF
--- a/package/gluon-announce/files/lib/gluon/announce/statistics.d/loadavg
+++ b/package/gluon-announce/files/lib/gluon/announce/statistics.d/loadavg
@@ -1,1 +1,10 @@
-return tonumber(util.readline(io.open('/proc/loadavg')):match('^([^ ]+) '))
+local info = fs.readfile('/proc/loadavg')
+local loadavg = {}
+local a, b, c
+a, b, c = info:match('^([^ ]+) ([^ ]+) ([^ ]+)')
+
+loadavg['1'] = tonumber(a)
+loadavg['5'] = tonumber(b)
+loadavg['15'] = tonumber(c)
+
+return loadavg


### PR DESCRIPTION
It would be nice if all three values would be announced. For monitoring purposes the 5 and 15 min values are more interesting than the 1 min.