### PR TITLE
gluon-core: replace opkg configuration in site.conf by more flexible options

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -46,14 +46,31 @@ ntp_server
 
        ntp_servers = {'1.ntp.services.ffeh','2.tnp.services.ffeh'}
 
-opkg_repo : optional
-    Overwrite the default ``opkg`` repository server, e.g.:
+opkg : optional
+    ``opkg`` package manager configuration.
+
+    There are two optional fields in the ``opkg`` section:
+
+    - ``openwrt`` overrides the default OpenWrt repository URL
+    - ``extra`` specifies a table of additional repositories (with arbitrary keys)
+
     ::
 
-      opkg_repo = 'http://opkg.services.ffeh/attitude_adjustment/12.09/%S/packages'
+      opkg = {
+        openwrt = 'http://opkg.services.ffeh/openwrt/%n/%v/%S/packages',
+        extra = {
+          modules = 'http://opkg.services.ffeh/modules/gluon-%GS-%GR/%S',
+        },
+      }
 
-    The `%S` is a variable, which is replaced with the platform of an device
-    during the build process.
+    There are various patterns which can be used in the URLs:
+
+    - ``%n`` is replaced by the OpenWrt version codename (e.g. "chaos_calmer")
+    - ``%v`` is replaced by the OpenWrt version number (e.g. "15.05")
+    - ``%S`` is replaced by the target architecture (e.g. "ar71xx/generic")
+    - ``%GS`` is replaced by the Gluon site code (as specified in ``site.conf``)
+    - ``%GV`` is replaced by the Gluon version
+    - ``%GR`` is replaced by the Gluon release (as specified in ``site.mk``)
 
 regdom
     The wireless regulatory domain responsible for your area, e.g.:

--- a/include/gluon.mk
+++ b/include/gluon.mk
@@ -35,10 +35,8 @@ export GLUON_LANGS
 ifeq ($(OPENWRT_BUILD),1)
 ifeq ($(GLUON_TOOLS),1)
 
-DEFAULT_OPKG_REPO := http://downloads.openwrt.org/chaos_calmer/15.05/%S/packages
-
-CONFIG_VERSION_REPO := $(shell $(GLUONDIR)/scripts/site.sh opkg_repo || echo '$(DEFAULT_OPKG_REPO)')
-export CONFIG_VERSION_REPO
+GLUON_OPENWRT_FEEDS := base packages luci routing telephony management
+export GLUON_OPENWRT_FEEDS
 
 GLUON_SITE_CODE := $(shell $(GLUONDIR)/scripts/site.sh site_code)
 export GLUON_SITE_CODE

--- a/package/gluon-core/Makefile
+++ b/package/gluon-core/Makefile
@@ -32,6 +32,7 @@ endef
 
 define Package/gluon-core/install
 	$(CP) ./files/* $(1)/
+	$(SED) 's/__GLUON_OPENWRT_FEEDS__/{$(GLUON_OPENWRT_FEEDS:%="%",)}/' $(1)/lib/gluon/upgrade/500-opkg
 
 	$(INSTALL_DIR) $(1)/lib/gluon
 	echo "$(GLUON_VERSION)" > $(1)/lib/gluon/gluon-version

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -1,6 +1,19 @@
 need_string 'site_code'
 need_string 'site_name'
 
+if need_table('opkg', nil, false) then
+  need_string('opkg.openwrt', false)
+
+  function check_repo(k, _)
+    -- this is not actually a uci name, but using the same naming rules here is fine
+    assert_uci_name(k)
+
+    need_string(string.format('opkg.extra[%q]', k))
+  end
+
+  need_table('opkg.extra', check_repo, false)
+end
+
 need_string('hostname_prefix', false)
 need_string 'timezone'
 

--- a/package/gluon-core/files/lib/gluon/upgrade/500-opkg
+++ b/package/gluon-core/files/lib/gluon/upgrade/500-opkg
@@ -1,0 +1,49 @@
+#!/usr/bin/lua
+
+local fs = require 'nixio.fs'
+local site = require 'gluon.site_config'
+local util = require 'luci.util'
+
+
+local subst = {}
+
+subst['%%v'] = util.trim(fs.readfile('/etc/openwrt_version'))
+subst['%%n'], subst['%%S'] = util.exec('. /etc/openwrt_release; echo $DISTRIB_CODENAME; echo $DISTRIB_TARGET'):match('([^\n]*)\n([^\n]*)')
+subst['%%GS'] = site.site_code
+subst['%%GV'] = util.trim(fs.readfile('/lib/gluon/gluon-version'))
+subst['%%GR'] = util.trim(fs.readfile('/lib/gluon/release'))
+
+function replace_patterns(url)
+  for k, v in pairs(subst) do
+    url = url:gsub(k, v)
+  end
+
+  return url
+end
+
+
+if site.opkg then
+  if site.opkg.openwrt then
+    local url = replace_patterns(site.opkg.openwrt)
+    local f = io.open('/etc/opkg/distfeeds.conf', 'w')
+
+    for _, v in ipairs(__GLUON_OPENWRT_FEEDS__) do
+      f:write(replace_patterns(string.format('src/gz %%n_%s %s/%s\n', v, site.opkg.openwrt, v)))
+    end
+
+    f:close()
+  end
+
+  if site.opkg.extra and next(site.opkg.extra) then
+    local f = io.open('/etc/opkg/gluon.conf', 'w')
+
+    for k, v in pairs(site.opkg.extra) do
+      f:write(string.format('src/gz %s %s\n', k, replace_patterns(v)))
+    end
+
+    f:close()
+
+  else
+    os.remove('/etc/opkg/gluon.conf')
+  end
+end


### PR DESCRIPTION
The new options allow specifying custom repositories and are evaluated
in an upgrade script, not during build.