### PR TITLE
doc: remove double opening next_node line in site.conf example

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -85,7 +85,6 @@
     -- },
   -- },
 
-  next_node = {
   -- Refer to http://fastd.readthedocs.org/en/latest/ to better understand
   -- what these options do.
   fastd_mesh_vpn = {


### PR DESCRIPTION
I guess this is some copy and paste mistake which makes the example an
invalid site.conf. In my case merging the changes of the example into
our actual site.conf lead to an error because this line was merged to.