### PR TITLE
Timeout 30 is to less Change to 60

### DIFF
--- a/patches/packages/routing/0004-alfred-not-only-wait-for-the-interface-but-also-a-link-local-address.patch
+++ b/patches/packages/routing/0004-alfred-not-only-wait-for-the-interface-but-also-a-link-local-address.patch
@@ -27,7 +27,7 @@ index 5ce06c0..8e1f11d 100755
 +	local iface="$1"
 +	local timeout
 +
-+	timeout=30
++	timeout=60
 +	echo "${initscript}: waiting $timeout secs for $iface address..."
 +	for i in $(seq $timeout); do
 +		# We look for


### PR DESCRIPTION
in some cases ( with Tunneldigger) the Bat0 interfaces need more than 30 sec to come up. 
i think 60 Second is enough.