### PR TITLE
contrib/sign.sh: Let it fail if ecdsasign fails

### DIFF
--- a/contrib/sign.sh
+++ b/contrib/sign.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 if [ $# -eq 0 -o "-h" = "$1" -o "-help" = "$1" -o "--help" = "$1" ]; then
 	cat <<EOHELP
 Usage: $0 <secret> <manifest>


### PR DESCRIPTION
Before this change sign.sh succeeded with exit status zero, even if ecdsasign was not installed.