### PR TITLE
OpenSSL: Added source/old to PKG_SOURCE_URL

### DIFF
--- a/patches/openwrt/0043-OpenSSL-Added-source-old-to-PKG_SOURCE_URL.patch
+++ b/patches/openwrt/0043-OpenSSL-Added-source-old-to-PKG_SOURCE_URL.patch
@@ -1,0 +1,24 @@
+From: Ranlvor <ranlvor@starletp9.de>
+Date: Sun, 6 Dec 2015 16:12:55 +0100
+Subject: OpenSSL: Added source/old to PKG_SOURCE_URL
+
+OpenSSL moves old versions of the library from http://www.openssl.org/source/
+to http://www.openssl.org/source/old/1.0.2/ breaking the old links. That
+behavior breaks the OpenWRT-build every time OpenSSL releases a new version.
+
+This patch adds http://www.openssl.org/source/old/1.0.2/ to the PKG_SOURCE_URL
+of OpenSSL to avoid breaking the build whenever OpenSSL releases a new
+version.
+
+diff --git a/package/libs/openssl/Makefile b/package/libs/openssl/Makefile
+index 7f0da8b..039e1ab 100644
+--- a/package/libs/openssl/Makefile
++++ b/package/libs/openssl/Makefile
+@@ -16,6 +16,7 @@ PKG_BUILD_PARALLEL:=1
+ 
+ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+ PKG_SOURCE_URL:=http://www.openssl.org/source/ \
++	http://www.openssl.org/source/old/1.0.2/ \
+ 	ftp://ftp.funet.fi/pub/crypt/mirrors/ftp.openssl.org/source \
+ 	ftp://ftp.sunet.se/pub/security/tools/net/openssl/source/
+ PKG_MD5SUM:=38dd619b2e77cbac69b99f52a053d25a


### PR DESCRIPTION
OpenSSL moves old versions of the library from http://www.openssl.org/source/
to http://www.openssl.org/source/old/1.0.2/ breaking the old links. That
behavior breaks the OpenWRT-build every time OpenSSL releases a new version.

This patch adds http://www.openssl.org/source/old/1.0.2/ to the PKG_SOURCE_URL
of OpenSSL to avoid breaking the build whenever OpenSSL releases a new
version.