### PR TITLE
docs: fix typo

### DIFF
--- a/docs/features/wired-mesh.rst
+++ b/docs/features/wired-mesh.rst
@@ -61,5 +61,5 @@ It may be disabled by running::
   uci commit
 
 Please note that this configuration has changed in Gluon v2016.1. Using
-the old commands on v2016.1 will break the corresponding Export Mode
+the old commands on v2016.1 will break the corresponding Expert Mode
 settings.


### PR DESCRIPTION
The last occurance of the 'Export Mode' 