### PR TITLE
ar71xx-generic: add support for D-Link DIR-505

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -166,6 +166,11 @@ endif
 
 ## D-Link
 
+# D-Link DIR-505 rev. A1
+
+$(eval $(call GluonProfile,DIR505A1))
+$(eval $(call GluonModel,DIR505A1,dir-505-a1,d-link-dir-505-rev-a1))
+
 # D-Link DIR-615 rev. C1
 $(eval $(call GluonProfile,DIR615C1))
 $(eval $(call GluonModel,DIR615C1,dir-615-c1,d-link-dir-615-rev-c1))


### PR DESCRIPTION
This commit enables the support for the D-Link DIR-505 router.
All Gluon features tested successfully (MAC, WIFI, WAN ports (only 1 eth), mesh, reset button, config mode, mesh-on-wan).