### PR TITLE
gluon-neighbour-info: Open firewall on WAN for respondd replies

### DIFF
--- a/package/gluon-neighbour-info/Makefile
+++ b/package/gluon-neighbour-info/Makefile
@@ -32,6 +32,8 @@ define Build/Compile
 endef
 
 define Package/gluon-neighbour-info/install
+	$(CP) ./files/* $(1)/
+
 	$(INSTALL_DIR) $(1)/usr/bin
 	$(INSTALL_BIN) $(PKG_BUILD_DIR)/gluon-neighbour-info $(1)/usr/bin/
 endef

--- a/package/gluon-neighbour-info/files/lib/gluon/upgrade/400-neighbour-info-firewall
+++ b/package/gluon-neighbour-info/files/lib/gluon/upgrade/400-neighbour-info-firewall
@@ -1,0 +1,20 @@
+#!/usr/bin/lua
+
+local uci = require('luci.model.uci').cursor()
+
+-- Allow incoming respondd replies to queries on WAN
+-- If the query was via multicast, the response isn't matched by --state RELATED
+uci:section('firewall', 'rule', 'wan_respondd_reply',
+  {
+    name = 'wan_respondd_reply',
+    src = 'wan',
+    src_ip = 'fe80::/64',
+    src_port = '1001',
+    dest_port = '32768:61000', -- see /proc/sys/net/ipv4/ip_local_port_range
+    proto = 'udp',
+    target = 'ACCEPT',
+  }
+)
+
+uci:save('firewall')
+uci:commit('firewall')


### PR DESCRIPTION
If the query was via multicast, the response isn't matched by
--state ESTABLISHED,RELATED

This fixes #619