### PR TITLE
gluon-respondd: restrict queries from the mesh to link-local addresses

### DIFF
--- a/package/gluon-respondd/files/lib/gluon/upgrade/400-respondd-firewall
+++ b/package/gluon-respondd/files/lib/gluon/upgrade/400-respondd-firewall
@@ -16,5 +16,17 @@ uci:section('firewall', 'rule', 'wan_respondd',
   }
 )
 
+-- Restrict respondd queries to link-local addresses to prevent amplification attacks from outside
+uci:section('firewall', 'rule', 'client_respondd',
+  {
+    name = 'client_respondd',
+    src = 'client',
+    src_ip = '!fe80::/64',
+    dest_port = '1001',
+    proto = 'udp',
+    target = 'REJECT',
+  }
+)
+
 uci:save('firewall')
 uci:commit('firewall')


### PR DESCRIPTION
Restrict to link-local addresses to prevent amplification attacks from
outside the mesh, or such attacks affecting the outside world.

Fixes #637