### PR TITLE
gluon-core: add preserve wifi channel feature

### DIFF
--- a/docs/features/wlan-configuration.rst
+++ b/docs/features/wlan-configuration.rst
@@ -24,3 +24,11 @@ existing configuration will also be set for the new configuration.
 This allows upgrades to change from IBSS to 11s and vice-versa while retaining the
 "wireless meshing is enabled/disabled" property configured by the user regardless
 of the used mode.
+
+During upgrades the wifi channel of the 2.4GHz and 5GHz radio will be restored to the channel
+configured in the site.conf. If you need to preserve a user defined wifi channel during upgrades
+you can configure this via the uci section ``gluon-core.wireless``::
+
+  uci set gluon-core.@wireless[0].preserve_channels='1'
+
+Keep in mind that nodes running wifi interfaces on custom channels can't mesh with default nodes anymore!

--- a/package/gluon-core/files/etc/config/gluon-core
+++ b/package/gluon-core/files/etc/config/gluon-core
@@ -1,0 +1,1 @@
+config wireless

--- a/package/gluon-core/files/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/files/lib/gluon/upgrade/200-wireless
@@ -10,11 +10,21 @@ if not sysconfig.gluon_version then
   uci:delete_all('wireless', 'wifi-iface')
 end
 
+local function get_channel(radio, config)
+  if uci:get_first('gluon-core', 'wireless', 'preserve_channels') then
+    return uci:get('wireless', radio, 'channel') or config.channel
+  else
+    return config.channel
+  end
+end
+
 local function configure_radio(radio, index, config)
   if config then
+    local channel = get_channel(radio, config)
+
     uci:delete('wireless', radio, 'disabled')
 
-    uci:set('wireless', radio, 'channel', config.channel)
+    uci:set('wireless', radio, 'channel', channel)
     uci:set('wireless', radio, 'htmode', 'HT20')
     uci:set('wireless', radio, 'country', site.regdom)
   end


### PR DESCRIPTION
**Old description:**
This changes introduces the new uci section 'gluon-core.wireless' with a preserve_channel option per radio:
 * preserve_channel_radio0 (boolean)
 * preserve_channel_radio1 (boolean)

By setting these options to true the wifi channel of the regarding radio will be preserved during upgrades.

**New description:**
This change introduces the new uci section 'gluon-core.wireless' with a preserve_channels option:
 * preserve_channels (boolean)

By setting this option to 1 (true) wifi channels will be preserved during upgrades.