### PR TITLE
Limit number of connected peers 1

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -177,7 +177,7 @@ fastd_mesh_vpn
         groups = {
           backbone = {
             -- Limit number of connected peers from this group
-            limit = 2,
+            limit = 1,
             peers = {
               peer1 = {
                 key = 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',


### PR DESCRIPTION
It should be recommended to set the limit number of connected peers to `1` to minimize background traffic in larger networks