### PR TITLE
Backport patch for GPIO control

### DIFF
--- a/patches/openwrt/0039-base-files-implemented-basic-GPIO-control.patch
+++ b/patches/openwrt/0039-base-files-implemented-basic-GPIO-control.patch
@@ -1,0 +1,144 @@
+From 24d54f8b0c6b18e5ec1f8c202afdbae14d347737 Mon Sep 17 00:00:00 2001
+From: blogic <blogic@3c298f89-4303-0410-b956-a3cf2f4a3e73>
+Date: Wed, 8 Jul 2015 14:25:52 +0000
+Subject: [PATCH] base-files: implemented basic GPIO control
+
+Internal GPIO pins are used for PoE passthrough setups in multi-port
+routers. This patch implemnets control over this hardware feature for
+Ubiquiti Nanostations and TP-Link CPE510.
+
+Signed-off-by: Lars Kruse <lists@sumpfralle.de>
+
+git-svn-id: svn://svn.openwrt.org/openwrt/trunk@46271 3c298f89-4303-0410-b956-a3cf2f4a3e73
+---
+ package/base-files/files/etc/init.d/gpio_switch    | 42 ++++++++++++++++++++++
+ .../base-files/files/lib/functions/uci-defaults.sh | 24 +++++++++++++
+ .../base-files/etc/uci-defaults/01_gpio-switches   | 25 +++++++++++++
+ 3 files changed, 91 insertions(+)
+ create mode 100755 package/base-files/files/etc/init.d/gpio_switch
+ create mode 100644 target/linux/ar71xx/base-files/etc/uci-defaults/01_gpio-switches
+
+diff --git a/package/base-files/files/etc/init.d/gpio_switch b/package/base-files/files/etc/init.d/gpio_switch
+new file mode 100755
+index 0000000..1f1b44b
+--- /dev/null
++++ b/package/base-files/files/etc/init.d/gpio_switch
+@@ -0,0 +1,42 @@
++#!/bin/sh /etc/rc.common
++# Copyright (C) 2015 OpenWrt.org
++
++START=98
++STOP=10
++USE_PROCD=1
++
++
++load_gpio_switch()
++{
++	local name
++	local gpio_pin
++	local value
++
++	config_get gpio_pin "$1" gpio_pin
++	config_get name "$1" name
++	config_get value "$1" value 0
++
++	local gpio_path="/sys/class/gpio/gpio${gpio_pin}"
++	# export GPIO pin for access
++	[ -d "$gpio_path" ] || {
++		echo "$gpio_pin" >/sys/class/gpio/export
++		# we need to wait a bit until the GPIO appears
++		[ -d "$gpio_path" ] || sleep 1
++		echo out >"$gpio_path/direction"
++	}
++	# write 0 or 1 to the "value" field
++	{ [ "$value" = "0" ] && echo "0" || echo "1"; } >"$gpio_path/value"
++}
++
++service_triggers()
++{
++	procd_add_reload_trigger "system"
++}
++
++start_service()
++{
++	[ -e /sys/class/gpio/ ] && {
++		config_load system
++		config_foreach load_gpio_switch gpio_switch
++	}
++}
+diff --git a/package/base-files/files/lib/functions/uci-defaults.sh b/package/base-files/files/lib/functions/uci-defaults.sh
+index 5a8809d..6577ecd 100644
+--- a/package/base-files/files/lib/functions/uci-defaults.sh
++++ b/package/base-files/files/lib/functions/uci-defaults.sh
+@@ -2,6 +2,7 @@
+ # Copyright (C) 2011 OpenWrt.org
+
+ UCIDEF_LEDS_CHANGED=0
++UCIDEF_GPIO_SWITCHES_CHANGED=0
+
+ ucidef_set_led_netdev() {
+ 	local cfg="led_$1"
+@@ -180,6 +181,29 @@ ucidef_commit_leds()
+ 	[ "$UCIDEF_LEDS_CHANGED" = "1" ] && uci commit system
+ }
+
++ucidef_set_gpio_switch() {
++	local cfg="gpio_switch_$1"
++	local name="$2"
++	local gpio_pin="$3"
++	# use "0" as default value
++	local default="${4:-0}"
++
++	uci -q get "system.$cfg" && return 0
++
++	uci batch <<EOF
++set system.$cfg='gpio_switch'
++set system.$cfg.name='$name'
++set system.$cfg.gpio_pin='$gpio_pin'
++set system.$cfg.value='$default'
++EOF
++	UCIDEF_GPIO_SWITCHES_CHANGED=1
++}
++
++ucidef_commit_gpio_switches()
++{
++	[ "$UCIDEF_GPIO_SWITCHES_CHANGED" = "1" ] && uci commit system
++}
++
+ ucidef_set_interface_loopback() {
+ 	uci batch <<EOF
+ set network.loopback='interface'
+diff --git a/target/linux/ar71xx/base-files/etc/uci-defaults/01_gpio-switches b/target/linux/ar71xx/base-files/etc/uci-defaults/01_gpio-switches
+new file mode 100644
+index 0000000..81d3982
+--- /dev/null
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/01_gpio-switches
+@@ -0,0 +1,25 @@
++#!/bin/sh
++#
++# Copyright (C) 2015 OpenWrt.org
++#
++
++. /lib/functions/uci-defaults.sh
++. /lib/ar71xx.sh
++
++board=$(ar71xx_board_name)
++
++case "$board" in
++nanostation-m)
++	ucidef_set_gpio_switch "poe_passthrough" "PoE Passthrough" "2"
++	;;
++nanostation-m-xw)
++	ucidef_set_gpio_switch "poe_passthrough" "PoE Passthrough" "8"
++	;;
++cpe*)
++	ucidef_set_gpio_switch "poe_passthrough" "PoE Passthrough" "20"
++	;;
++esac
++
++ucidef_commit_gpio_switches
++
++exit 0
+--
+2.1.4
+


### PR DESCRIPTION
First prototype, still untested.
- Where is the best place to store the PoE value in the configuration?
- Is it possible to exclude this package in images for non compatible devices?