### PR TITLE
Status page compatiblity improvements (and some misc. improvements)

### DIFF
--- a/package/gluon-status-page/src/js/lib/gui/statistics.js
+++ b/package/gluon-status-page/src/js/lib/gui/statistics.js
@@ -171,7 +171,7 @@ define(["lib/helper"], function (Helper) {
   }
 
   function prettyPackets(d) {
-    var v = new Intl.NumberFormat("de-DE", {maximumFractionDigits: 0}).format(d)
+    var v = Helper.formatNumberFixed(d, 0)
     return v + " Pakete/s"
   }
 
@@ -183,7 +183,7 @@ define(["lib/helper"], function (Helper) {
       prefix++
     }
 
-    d = new Intl.NumberFormat("de-DE", {maximumSignificantDigits: 3}).format(d)
+    d = Helper.formatNumber(d, 3)
     return d + " " + prefixes[prefix]
   }
 
@@ -220,11 +220,11 @@ define(["lib/helper"], function (Helper) {
   }
 
   function prettyNVRAM(usage) {
-    return new Intl.NumberFormat("de-DE", {maximumSignificantDigits: 3}).format(usage * 100) + "% belegt"
+    return Helper.formatNumber(usage * 100, 3) + "% belegt"
   }
 
   function prettyLoad(load) {
-    return new Intl.NumberFormat("de-DE", {maximumSignificantDigits: 3}).format(load)
+    return Helper.formatNumberFixed(load, 2)
   }
 
   function prettyRAM(memory) {

--- a/package/gluon-status-page/src/js/lib/gui/statistics.js
+++ b/package/gluon-status-page/src/js/lib/gui/statistics.js
@@ -178,7 +178,7 @@ define(["lib/helper"], function (Helper) {
   function prettyPrefix(prefixes, step, d) {
     var prefix = 0
 
-    while (d > step && prefix < 4) {
+    while (d > step && prefix < prefixes.length - 1) {
       d /= step
       prefix++
     }
@@ -187,12 +187,16 @@ define(["lib/helper"], function (Helper) {
     return d + " " + prefixes[prefix]
   }
 
+  function prettySize(d) {
+    return prettyPrefix([ "", "k", "M", "G", "T" ], 1024, d)
+  }
+
   function prettyBits(d) {
-    return prettyPrefix([ "bps", "kbps", "Mbps", "Gbps" ], 1024, d * 8)
+    return prettySize(d * 8) + "bps"
   }
 
   function prettyBytes(d) {
-    return prettyPrefix([ "B", "kB", "MB", "GB", "TB" ], 1024, d)
+    return prettySize(d) + "B"
   }
 
   function prettyUptime(seconds) {

--- a/package/gluon-status-page/src/js/lib/helper.js
+++ b/package/gluon-status-page/src/js/lib/helper.js
@@ -51,6 +51,25 @@ define([ "bacon" ], function (Bacon) {
     return dictGet(dict[k], key)
   }
 
+  function localizeNumber(d) {
+    var sep = ','
+    return d.replace('.', sep)
+  }
+
+  function formatNumberFixed(d, digits) {
+    return localizeNumber(d.toFixed(digits))
+  }
+
+  function formatNumber(d, digits) {
+    digits--
+
+    for (var v = d; v >= 10 && digits > 0; v /= 10)
+      digits--
+
+    // avoid toPrecision as it might produce strings in exponential notation
+    return formatNumberFixed(d, digits)
+  }
+
   function haversine() {
     var radians = Array.prototype.map.call(arguments, function(deg) { return deg / 180.0 * Math.PI })
     var lat1 = radians[0], lon1 = radians[1], lat2 = radians[2], lon2 = radians[3]
@@ -66,6 +85,8 @@ define([ "bacon" ], function (Bacon) {
          , request: request
          , getJSON: getJSON
          , dictGet: dictGet
+         , formatNumber: formatNumber
+         , formatNumberFixed: formatNumberFixed
          , haversine: haversine
          }
 })


### PR DESCRIPTION
Avoid using Intl and Set.

Is now working nicely in Firefox & Chrome on desktop and Android, default WebView of Android 5.0 and Safari on an outdated MacOS X 10.9. I suspect it might also work on iPhones, but I haven't tested it.