### PR TITLE
ar71xx-generic: add support for TP-Link MR13U

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -117,6 +117,10 @@ $(eval $(call GluonModel,TLWA901,tl-wa901nd-v1,tp-link-tl-wa901n-nd-v1))
 $(eval $(call GluonModel,TLWA901,tl-wa901nd-v2,tp-link-tl-wa901n-nd-v2))
 $(eval $(call GluonModel,TLWA901,tl-wa901nd-v3,tp-link-tl-wa901n-nd-v3))
 
+# TL-MR13U v1
+$(eval $(call GluonProfile,TLMR13U))
+$(eval $(call GluonModel,TLMR13U,tl-mr13u-v1,tp-link-tl-mr13u-v1))
+
 # TL-MR3020 v1
 $(eval $(call GluonProfile,TLMR3020))
 $(eval $(call GluonModel,TLMR3020,tl-mr3020-v1,tp-link-tl-mr3020-v1))


### PR DESCRIPTION
Please add this patch to enable FF-images for TP-Link MR13U, a device very similar to MR3020 but with a big internal battery. I have heavily tested the device with fastd-VPN and/or as mesh-device with the munich site-config. Throughput is comparable to MR3020.

MR13U is supported by OpenWrt for a while already: https://wiki.openwrt.org/toh/tp-link/tl-mr13u