### PR TITLE
provide contact-information for reboot-page

### DIFF
--- a/package/gluon-config-mode-mesh-vpn/files/lib/gluon/config-mode/reboot/0100-mesh-vpn.lua
+++ b/package/gluon-config-mode-mesh-vpn/files/lib/gluon/config-mode/reboot/0100-mesh-vpn.lua
@@ -11,6 +11,7 @@ else
 
   local pubkey = util.trim(util.exec("/etc/init.d/fastd show_key " .. "mesh_vpn"))
   local hostname = uci:get_first("system", "system", "hostname")
+  local contact = uci:get_first("gluon-node-info", "owner", "contact")
 
   local msg = i18n.translate('gluon-config-mode:pubkey')
 
@@ -19,6 +20,7 @@ else
                                             , hostname=hostname
                                             , site=site
                                             , sysconfig=sysconfig
+                                            , contact=contact
                                             })
          end
 end


### PR DESCRIPTION
The user may enter contact-information within the config-mode. This information can for example be provided for a node-registration-link on the reboot-page.

In our community we had some confusion about asking for contact-information two times (in the config-mode and at node-registration).