### PR TITLE
gluon-autoupdater: add function replace_patterns(url)

### DIFF
--- a/package/gluon-autoupdater/files/lib/gluon/upgrade/500-autoupdater
+++ b/package/gluon-autoupdater/files/lib/gluon/upgrade/500-autoupdater
@@ -1,17 +1,38 @@
 #!/usr/bin/lua
 
+local fs = require 'nixio.fs'
 local site = require 'gluon.site_config'
 local uci = require 'luci.model.uci'
+local util = require 'luci.util'
 
 local c = uci.cursor()
 
+local subst = {}
+
+subst['%%v'] = util.trim(fs.readfile('/etc/openwrt_version'))
+subst['%%n'], subst['%%S'] = util.exec('. /etc/openwrt_release; echo $DISTRIB_CODENAME; echo $DISTRIB_TARGET'):match('([^\n]*)\n([^\n]*)')
+subst['%%GS'] = site.site_code
+subst['%%GV'] = util.trim(fs.readfile('/lib/gluon/gluon-version'))
+subst['%%GR'] = util.trim(fs.readfile('/lib/gluon/release'))
+
+function replace_patterns(url)
+  for k, v in pairs(subst) do
+    url = url:gsub(k, v)
+  end
+
+  return url
+end
 
 for name, config in pairs(site.autoupdater.branches) do
 	c:delete('autoupdater', name)
+	mirrors = {}
+	for i, v in ipairs(config.mirrors) do
+		mirrors[i]=replace_patterns(v)
+	end
 	c:section('autoupdater', 'branch', name,
 		  {
 			  name = config.name,
-			  mirror = config.mirrors,
+			  mirror = mirrors,
 			  good_signatures = config.good_signatures,
 			  pubkey = config.pubkeys,
 		  }


### PR DESCRIPTION
As already discussed on #gluon:
In some cases it could be helpful, to replace patterns in the autoupdater-path, like it is possible for the opkg-repos.

In my case replacement of %GS is sufficient, but there are maybe some other cases, so I took the entire list.

The function is copied from package/gluon-core/files/lib/gluon/upgrade/500-opkg.