### PR TITLE
Preparations for Multicast Snooping

### DIFF
--- a/package/gluon-core/files/lib/gluon/upgrade/110-network
+++ b/package/gluon-core/files/lib/gluon/upgrade/110-network
@@ -56,5 +56,31 @@ uci:save('network')
 uci:commit('network')
 
 
+uci:section('firewall', 'rule', 'wan_igmp',
+	    {
+	       name = 'Allow-IGMP',
+	       src = 'wan',
+	       proto = 'igmp',
+	       family = 'ipv4',
+	       target = 'ACCEPT',
+	    }
+)
+
+uci:section('firewall', 'rule', 'wan_mld',
+	    {
+	       name = 'Allow-MLD',
+	       src = 'wan',
+	       proto = 'icmp',
+	       src_ip = 'fe80::/10',
+	       icmp_type = { '130/0', '131/0', '132/0', '143/0', },
+	       family = 'ipv6',
+	       target = 'ACCEPT',
+	    }
+)
+
+uci:save('firewall')
+uci:commit('firewall')
+
+
 sysctl.set('net.ipv6.conf.all.accept_ra', 0)
 sysctl.set('net.ipv6.conf.default.accept_ra', 0)

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
@@ -48,6 +48,7 @@ uci:section('network', 'interface', 'bat0',
 		    ifname = 'bat0',
 		    proto = 'none',
 		    macaddr = sysconfig.primary_mac,
+		    multicast_router = 2,
 	    }
 )
 


### PR DESCRIPTION
This pull request adds two patches mandatory for bridge multicast snooping. For now, as multicast snooping is still disabled, they are basically a no-op.

Ref.:  #278 (#402), #674