### PR TITLE
add support for TP-Link TL-WA7510

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -123,6 +123,7 @@ ar71xx-generic
   - TL-MR3220 (v1, v2)
   - TL-MR3420 (v1, v2)
   - TL-WA701N/ND (v1, v2)
+  - TL-WA7510N (v1)
   - TL-WA750RE (v1)
   - TL-WA801N/ND (v1, v2)
   - TL-WA830RE (v1, v2)

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -19,6 +19,10 @@ $(eval $(call GluonProfile,TLWA701))
 $(eval $(call GluonModel,TLWA701,tl-wa701n-v1,tp-link-tl-wa701n-nd-v1))
 $(eval $(call GluonModel,TLWA701,tl-wa701nd-v2,tp-link-tl-wa701n-nd-v2))
 
+# TL-WA7510 v1
+$(eval $(call GluonProfile,TLWA7510))
+$(eval $(call GluonModel,TLWA7510,tl-wa7510n,tp-link-tl-wa7510n-v1))
+
 # TL-WR703N v1
 $(eval $(call GluonProfile,TLWR703))
 $(eval $(call GluonModel,TLWR703,tl-wr703n-v1,tp-link-tl-wr703n-v1))


### PR DESCRIPTION
We have one of these CPEs in our network and needed the support for this because it is part of a larger mesh cloud.

http://meshviewer.chemnitz.freifunk.net/#!v:m;n:00037fbef892