### PR TITLE
Preparations for Multicast Snooping Final

### DIFF
--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
@@ -39,6 +39,8 @@ end
 uci:set('network', 'client', 'proto', 'dhcpv6')
 uci:set('network', 'client', 'reqprefix', 'no')
 uci:set('network', 'client', 'igmp_snooping', 0)
+uci:set('network', 'client', 'query_interval', 2000)
+uci:set('network', 'client', 'query_response_interval', 500)
 uci:set('network', 'client', 'peerdns', 1)
 uci:set('network', 'client', 'sourcefilter', 0)
 

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
@@ -39,6 +39,7 @@ end
 uci:set('network', 'client', 'proto', 'dhcpv6')
 uci:set('network', 'client', 'reqprefix', 'no')
 uci:set('network', 'client', 'igmp_snooping', 0)
+uci:set('network', 'client', 'robustness', 3)
 uci:set('network', 'client', 'query_interval', 2000)
 uci:set('network', 'client', 'query_response_interval', 500)
 uci:set('network', 'client', 'peerdns', 1)


### PR DESCRIPTION
These are supposed to be the last two patches necessary before re-activating multicast snooping.

The first one lowers the query intervals for br-client, the second one increases the robustness against potential packetloss on the wifi.

For now, as multicast snooping is still disabled, they are basically a no-op.

Ref.: #674, #675, #278 ( #402)