### PR TITLE
Add Support for the ALFA Hornet UB and similar devices

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -77,6 +77,12 @@ Supported Devices & Architectures
 ar71xx-generic
 ^^^^^^^^^^^^^^
 
+* ALFA Network
+
+  - AP121
+  - AP121U
+  - Hornet-UB
+
 * Allnet
 
   - ALL0315N

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -278,3 +278,12 @@ $(eval $(call GluonModel,MYNETN750,mynet-n750,wd-my-net-n750))
 # Omega
 $(eval $(call GluonProfile,OMEGA))
 $(eval $(call GluonModel,OMEGA,onion-omega,onion-omega))
+
+## ALFA
+
+# Hornet-UB
+$(eval $(call GluonProfile,HORNETUB))
+$(eval $(call GluonModel,HORNETUB,hornet-ub,alfa-hornet-ub))
+$(eval $(call GluonModelAlias,HORNETUB,alfa-hornet-ub,alfa-ap121))
+$(eval $(call GluonModelAlias,HORNETUB,alfa-hornet-ub,alfa-ap121u))
+


### PR DESCRIPTION
The Hornet UB is sold at least in the varieties. Without case it is a Hornet UB, with case and without connected USB port it is called AP121. If the USB port is present this device is called AP121U.
We have a AP121U in our mesh http://meshviewer.chemnitz.freifunk.net/#!v:m;n:00c0ca6efffa