### PR TITLE
Enable multicast snooping

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/110-network
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/110-network
@@ -9,11 +9,12 @@ uci:section('network', 'interface', 'wan',
 	    {
 	      ifname = sysconfig.wan_ifname,
 	      type = 'bridge',
-	      igmp_snooping = 0,
+	      multicast_querier = 0,
 	      peerdns = 0,
 	      auto = 1,
 	    }
 )
+uci:delete('network', 'wan', 'igmp_snooping')
 
 if not uci:get('network', 'wan', 'proto') then
   uci:set('network', 'wan', 'proto', 'dhcp')

--- a/package/gluon-mesh-batman-adv-core/luasrc/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
+++ b/package/gluon-mesh-batman-adv-core/luasrc/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
@@ -37,7 +37,7 @@ end
 
 uci:set('network', 'client', 'proto', 'dhcpv6')
 uci:set('network', 'client', 'reqprefix', 'no')
-uci:set('network', 'client', 'igmp_snooping', 0)
+uci:delete('network', 'client', 'igmp_snooping')
 uci:set('network', 'client', 'robustness', 3)
 uci:set('network', 'client', 'query_interval', 2000)
 uci:set('network', 'client', 'query_response_interval', 500)


### PR DESCRIPTION
This commit enables multicast snooping on br-wan and br-client again.

Should be pulled only _after_ #674  and #679 got merged. This PR is rebased onto #679 for easier merging, the according two commits are identical to the ones in #679 .

Ref.: #278 (#402)