### PR TITLE
openwrt: add patch fixing sysupgrade on Xen DomU

### DIFF
--- a/patches/openwrt/0018-x86-fix-platform_export_bootpart-for-Xen-virtual-disks.patch
+++ b/patches/openwrt/0018-x86-fix-platform_export_bootpart-for-Xen-virtual-disks.patch
@@ -1,0 +1,25 @@
+From: Alexander Dahl <alex@netz39.de>
+Date: Thu, 17 Mar 2016 15:04:09 +0100
+Subject: x86: fix platform_export_bootpart() for Xen virtual disks
+
+Virtual disk devices in a Xen virtual machine (DomU) can be /dev/xvda,
+/dev/xvdb and so on with partitions like /dev/xdva1. Devices named like
+this where not considered before. This resulted in a non working
+sysupgrade, because the boot partition could not be found.
+
+Signed-off-by: Alexander Dahl <alex@netz39.de>
+Suggested-by: Matthias Schiffer <mschiffer@universe-factory.net>
+
+diff --git a/target/linux/x86/base-files/lib/upgrade/platform.sh b/target/linux/x86/base-files/lib/upgrade/platform.sh
+index 73ab5ef..adc119c 100644
+--- a/target/linux/x86/base-files/lib/upgrade/platform.sh
++++ b/target/linux/x86/base-files/lib/upgrade/platform.sh
+@@ -17,7 +17,7 @@ platform_export_bootpart() {
+ 			PARTUUID=[a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9][a-f0-9]-02)
+ 				uuid="${disk#PARTUUID=}"
+ 				uuid="${uuid%-02}"
+-				for disk in /dev/[hsv]d[a-z]; do
++				for disk in /dev/[hsv]d[a-z] /dev/xvd[a-z]; do
+ 					set -- $(dd if=$disk bs=1 skip=440 count=4 2>/dev/null | hexdump -v -e '4/1 "%02x "')
+ 					if [ "$4$3$2$1" = "$uuid" ]; then
+ 						export BOOTPART="${disk}1"


### PR DESCRIPTION
Patch tested on v2016.1.x branch with Freifunk Magdeburg firmware on
Debian Jessie amd64 Xen host. See the same patch in our gluon fork here:
https://github.com/FreifunkMD/gluon/blob/fix-sysupgrade-xen/patches/openwrt/0058-x86-fix-platform_export_bootpart-for-Xen-virtual-disks.patch

Sysupgrade was tested successfully by manually making the change before
upgrading in the filesystem of the running node and upgrading to the
fixed FFMD experimental build in config mode via expert settings in
webgui.

Patch also submitted to OpenWRT trunk already.

Signed-off-by: Alexander Dahl <alex@netz39.de>