### PR TITLE
Do not have the ugly "-e" printed for CheckTarget

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ include $(GLUONDIR)/targets/targets.mk
 
 
 CheckTarget := [ -n '$(GLUON_TARGET)' -a -n '$(GLUON_TARGET_$(GLUON_TARGET)_BOARD)' ] \
-	|| (echo -e 'Please set GLUON_TARGET to a valid target. Gluon supports the following targets:$(subst $(space),\n * ,$(GLUON_TARGETS))'; false)
+	|| (/bin/echo -e 'Please set GLUON_TARGET to a valid target. Gluon supports the following targets:$(subst $(space),\n * ,$(GLUON_TARGETS))'; false)
 
 
 CheckExternal := test -d $(GLUON_ORIGOPENWRTDIR) || (echo 'You don'"'"'t seem to have obtained the external repositories needed by Gluon; please call `make update` first!'; false)


### PR DESCRIPTION
The "echo -e" is executed in a newly spawned shell (the enclosing ()s). That shell by default is a bourne shell. And that has a built-in echo that fails to understand the -e option and just prints it. Same for dash. If you set a SHELL=/bin/bash then this would also solve the issue. I had felt that by explicitly executing the binary echo implementation this would be the easiest to grasp. Well. Make your pick.