### PR TITLE
Tcatm's meraki branch merged

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -94,6 +94,11 @@ ar71xx-generic
   - WZR-HP-G300NH
   - WZR-HP-G450H
 
+* Cisco Meraki
+
+  - MR12 / MR62
+  - MR16 / MR66
+
 * D-Link
 
   - DIR-505 (A1)

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -288,3 +288,16 @@ $(eval $(call GluonModel,HORNETUB,hornet-ub,alfa-hornet-ub))
 $(eval $(call GluonModelAlias,HORNETUB,alfa-hornet-ub,alfa-ap121))
 $(eval $(call GluonModelAlias,HORNETUB,alfa-hornet-ub,alfa-ap121u))
 
+## Meraki
+
+# Meraki MR12/MR62
+$(eval $(call GluonProfile,MR12,rssileds))
+$(eval $(call GluonProfileFactorySuffix,MR12))
+$(eval $(call GluonModel,MR12,mr12,meraki-mr12))
+$(eval $(call GluonModelAlias,MR12,meraki-mr12,meraki-mr62))
+
+# Meraki MR16/MR66
+$(eval $(call GluonProfile,MR16,rssileds))
+$(eval $(call GluonProfileFactorySuffix,MR16))
+$(eval $(call GluonModel,MR16,mr16,meraki-mr16))
+$(eval $(call GluonModelAlias,MR16,meraki-mr16,meraki-mr66))


### PR DESCRIPTION
This patch brings the work of @tcatm with @Garunda on support for the CISCO Meraki series for Gluon in sync with OpenWRT as distributed with 2016.1.x. That latest redistributed OpenWRT release has accepted the patch that the two had previously applied for their cause and thus this merge basically removes the patch to OpenWRT while leaving the build-invocation by Gluon intact.

OpenWRT not only supports the MR12 (similar to the MR62) but also the MR16 (similar to the MR66). The firmware was successfully tested by @Garunda for the MR62. Gluon images for the MR16 were added to the patch of @tcatm. The confirmation of the functionality of the image for the MR66 is still pending.

The devices are of interest to the community as they are perceived as "enterprise class" hardware (makes a rock-solid impression, indeed) which comes with an annually renewed fairly hefty license. The Freifunk may offer an escape route for those who had signed up and want to keep their investment into the similarly expensive hardware. Used evices sell for $60 on ebay/amazon in the US. Here in the old world it is all >300 €, still. 