### PR TITLE
Fix ralink-rt305x/vocore mac schema generation.

### DIFF
--- a/package/gluon-client-bridge/files/lib/gluon/upgrade/320-gluon-client-bridge-wireless
+++ b/package/gluon-client-bridge/files/lib/gluon/upgrade/320-gluon-client-bridge-wireless
@@ -21,13 +21,9 @@ local function configure_client(config, radio, index, suffix)
 
   uci:delete('wireless', name)
 
-  if index == 0 then
-    macaddr = util.generate_mac(0)
-  elseif index == 1 then
-    macaddr = util.generate_mac(3)
-  end
+  macaddr = util.generate_mac(3*index)
 
-  if config then
+  if config and macaddr then
     uci:section('wireless', 'wifi-iface', name,
       {
         device = radio,

--- a/package/gluon-client-bridge/files/lib/gluon/upgrade/320-gluon-client-bridge-wireless
+++ b/package/gluon-client-bridge/files/lib/gluon/upgrade/320-gluon-client-bridge-wireless
@@ -21,6 +21,12 @@ local function configure_client(config, radio, index, suffix)
 
   uci:delete('wireless', name)
 
+  if index == 0 then
+    macaddr = util.generate_mac(0)
+  elseif index == 1 then
+    macaddr = util.generate_mac(3)
+  end
+
   if config then
     uci:section('wireless', 'wifi-iface', name,
       {
@@ -28,7 +34,7 @@ local function configure_client(config, radio, index, suffix)
         network = 'client',
         mode = 'ap',
         ssid = config.ssid,
-        macaddr = util.generate_mac(2, index),
+        macaddr = macaddr,
         ifname = suffix and 'client' .. suffix,
         disabled = disabled,
       }

--- a/package/gluon-core/Makefile
+++ b/package/gluon-core/Makefile
@@ -12,7 +12,7 @@ define Package/gluon-core
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Base files of Gluon
-  DEPENDS:=+gluon-site +libgluonutil +lua-platform-info +luci-base +luci-lib-jsonc +odhcp6c +firewall
+  DEPENDS:=+gluon-site +libgluonutil +lua-platform-info +lua-hash +luci-base +luci-lib-jsonc +odhcp6c +firewall
 endef
 
 

--- a/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
@@ -10,9 +10,8 @@ end
 
 local platform = require 'gluon.platform'
 
-local sys = require 'luci.sys'
+local fs = require 'nixio.fs'
 local util = require 'luci.util'
-local nixio = require 'nixio'
 
 
 local try_files = {
@@ -33,15 +32,9 @@ end
 
 
 for _, file in ipairs(try_files) do
-  local addr = nixio.fs.readfile(file)
+  local addr = fs.readfile(file)
 
   if addr then
-    if platform.match('ramips', 'rt305x', {'vocore'}) then
-      -- Hash the mac address since we need to iterate in the last bits for
-      -- the VIF. (This chip uses a hardware mac filter)
-      addr = util.hash_mac(addr)
-    end
-
     sysconfig.primary_mac = util.trim(addr)
     break
   end

--- a/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
@@ -10,8 +10,9 @@ end
 
 local platform = require 'gluon.platform'
 
-local fs = require 'nixio.fs'
+local sys = require 'luci.sys'
 local util = require 'luci.util'
+local nixio = require 'nixio'
 
 
 local try_files = {
@@ -32,9 +33,15 @@ end
 
 
 for _, file in ipairs(try_files) do
-  local addr = fs.readfile(file)
+  local addr = nixio.fs.readfile(file)
 
   if addr then
+    if platform.match('ramips', 'rt305x', {'vocore'}) then
+      -- Hash the mac address since we need to iterate in the last bits for
+      -- the VIF. (This chip uses a hardware mac filter)
+      addr = util.hash_mac(addr)
+    end
+
     sysconfig.primary_mac = util.trim(addr)
     break
   end

--- a/package/gluon-core/files/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/files/usr/lib/lua/gluon/util.lua
@@ -84,6 +84,8 @@ end
 -- 6: mesh-on-lan
 -- 7: unused
 function generate_mac(i)
+  if i > 7 or i < 0 then return nil end -- max allowed id (0b111)
+
   local hashed = string.sub(hash.md5(sysconfig.primary_mac), 0, 12)
   local m1, m2, m3, m4, m5, m6 = string.match(hashed, '(%x%x)(%x%x)(%x%x)(%x%x)(%x%x)(%x%x)')
 
@@ -96,8 +98,6 @@ function generate_mac(i)
   -- It's necessary that the first 45 bits of the mac do
   -- not vary on a single hardware interface, since some chips are using
   -- a hardware mac filter. (e.g 'ramips-rt305x')
-
-  if i > 7 then return nil end  -- max allowed id (0b111)
 
   m6 = nixio.bit.band(m6, 0xF8) -- zero the last three bits (space needed for counting)
   m6 = m6 + i                   -- add virtual interface id

--- a/package/gluon-core/files/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/files/usr/lib/lua/gluon/util.lua
@@ -32,7 +32,6 @@ local table = table
 local nixio = require 'nixio'
 local hash = require 'hash'
 local sysconfig = require 'gluon.sysconfig'
-local platform = require 'gluon.platform'
 local site = require 'gluon.site_config'
 local uci = require('luci.model.uci').cursor()
 

--- a/package/gluon-core/files/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/files/usr/lib/lua/gluon/util.lua
@@ -31,6 +31,7 @@ local table = table
 
 local nixio = require 'nixio'
 local sysconfig = require 'gluon.sysconfig'
+local platform = require 'gluon.platform'
 local site = require 'gluon.site_config'
 local uci = require('luci.model.uci').cursor()
 
@@ -83,10 +84,34 @@ end
 function generate_mac(f, i)
   local m1, m2, m3, m4, m5, m6 = string.match(sysconfig.primary_mac, '(%x%x):(%x%x):(%x%x):(%x%x):(%x%x):(%x%x)')
   m1 = nixio.bit.bor(tonumber(m1, 16), 0x02)
-  m2 = (tonumber(m2, 16)+f) % 0x100
+  m2 = tonumber(m2, 16)
   m3 = (tonumber(m3, 16)+i) % 0x100
+  m6 = tonumber(m6, 16)
 
-  return string.format('%02x:%02x:%02x:%s:%s:%s', m1, m2, m3, m4, m5, m6)
+  if platform.match('ramips', 'rt305x', {'vocore'}) then
+    -- We need to iterate in the last byte, since the vocore does
+    -- hardware mac filtering on the wlan interface.
+    m6 = (m6+f) % 0x100
+  else
+    m2 = (m2+f) % 0x100
+  end
+
+  return string.format('%02x:%02x:%02x:%s:%s:%02x', m1, m2, m3, m4, m5, m6)
+end
+
+-- Generates a mac hashed from the original
+-- The last three bits will be zeroed, since these bits are
+-- iterated on some devices for the VIF.
+function hash_mac(original)
+  local hashed = string.sub(sys.exec('echo -n "' .. original .. '" | sha512sum'),0,12)
+  local m1, m2, m3, m4, m5, m6 = string.match(hashed, '(%x%x)(%x%x)(%x%x)(%x%x)(%x%x)(%x%x)')
+  local m1 = nixio.bit.bor(tonumber(m1, 16), 0x02)
+  local m6 = nixio.bit.band(tonumber(m6, 16), 0xF8) -- zero the last three bits
+  -- It's necessary that the upper bits of the mac do
+  -- not vary on a single interface, since they are using
+  -- a hardware mac filter. (e.g 'ramips-rt305x')
+
+  return string.format('%02x:%s:%s:%s:%s:%02x', m1, m2, m3, m4, m5, m6)
 end
 
 -- Iterate over all radios defined in UCI calling

--- a/package/gluon-core/files/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/files/usr/lib/lua/gluon/util.lua
@@ -93,11 +93,12 @@ function generate_mac(i)
   m1 = nixio.bit.bor(m1, 0x02)  -- set locally administered bit
   m1 = nixio.bit.band(m1, 0xFE) -- unset the multicast bit
 
-  -- It's necessary that the last bits of the mac do
-  -- not vary on a single interface, since some chips are using
+  -- It's necessary that the first 45 bits of the mac do
+  -- not vary on a single hardware interface, since some chips are using
   -- a hardware mac filter. (e.g 'ramips-rt305x')
 
-  i = i % 0x08                  -- max allowed value is 0x07
+  if i > 7 then return nil end  -- max allowed id (0b111)
+
   m6 = nixio.bit.band(m6, 0xF8) -- zero the last three bits (space needed for counting)
   m6 = m6 + i                   -- add virtual interface id
 

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/300-gluon-mesh-batman-adv-core-wan
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/300-gluon-mesh-batman-adv-core-wan
@@ -5,7 +5,7 @@ local uci = require('luci.model.uci').cursor()
 
 
 -- fix up duplicate mac addresses (for mesh-on-WAN)
-uci:set('network', 'wan', 'macaddr', util.generate_mac(1, 0))
+uci:set('network', 'wan', 'macaddr', util.generate_mac(3))
 uci:save('network')
 uci:commit('network')
 

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
@@ -53,6 +53,12 @@ local function configure_ibss(config, radio, index, suffix, disabled)
       )
     end
 
+    if index == 0 then
+      macaddr = util.generate_mac(2)
+    elseif index == 1 then
+      macaddr = util.generate_mac(5)
+    end
+
     uci:section('wireless', 'wifi-iface', name,
       {
         device = radio,
@@ -60,7 +66,7 @@ local function configure_ibss(config, radio, index, suffix, disabled)
         mode = 'adhoc',
         ssid = config.ssid,
         bssid = config.bssid,
-        macaddr = util.generate_mac(3, index),
+        macaddr = macaddr,
         mcast_rate = config.mcast_rate,
         ifname = suffix and 'ibss' .. suffix,
         disabled = disabled and 1 or 0,
@@ -85,6 +91,12 @@ local function configure_mesh(config, radio, index, suffix, disabled)
       }
     )
 
+    if index == 0 then
+      macaddr = util.generate_mac(1)
+    elseif index == 1 then
+      macaddr = util.generate_mac(4)
+    end
+
     uci:section('wireless', 'wifi-iface', name,
       {
         device = radio,
@@ -92,7 +104,7 @@ local function configure_mesh(config, radio, index, suffix, disabled)
         mode = 'mesh',
         mesh_id = config.id,
         mesh_fwding = 0,
-        macaddr = util.generate_mac(5, index),
+        macaddr = macaddr,
         mcast_rate = config.mcast_rate,
         ifname = suffix and 'mesh' .. suffix,
         disabled = disabled and 1 or 0,

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/320-gluon-mesh-batman-adv-core-wireless
@@ -29,7 +29,9 @@ local function configure_ibss(config, radio, index, suffix, disabled)
   uci:delete('network', name .. '_vlan')
   uci:delete('wireless', name)
 
-  if config then
+  macaddr = util.generate_mac(3*index+2)
+
+  if config and macaddr then
     if config.vlan then
       uci:section('network', 'interface', name,
         {
@@ -51,12 +53,6 @@ local function configure_ibss(config, radio, index, suffix, disabled)
           mesh = 'bat0',
         }
       )
-    end
-
-    if index == 0 then
-      macaddr = util.generate_mac(2)
-    elseif index == 1 then
-      macaddr = util.generate_mac(5)
     end
 
     uci:section('wireless', 'wifi-iface', name,
@@ -83,19 +79,15 @@ local function configure_mesh(config, radio, index, suffix, disabled)
   uci:delete('network', name)
   uci:delete('wireless', name)
 
-  if config then
+  macaddr = util.generate_mac(3*index+1)
+
+  if config and macaddr then
     uci:section('network', 'interface', name,
       {
         proto = 'batadv',
         mesh = 'bat0',
       }
     )
-
-    if index == 0 then
-      macaddr = util.generate_mac(1)
-    elseif index == 1 then
-      macaddr = util.generate_mac(4)
-    end
 
     uci:section('wireless', 'wifi-iface', name,
       {

--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/340-gluon-mesh-batman-adv-core-mesh-on-lan
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/upgrade/340-gluon-mesh-batman-adv-core-mesh-on-lan
@@ -28,7 +28,7 @@ if sysconfig.lan_ifname and not uci:get('network', 'mesh_lan') then
               , proto   = 'batadv'
               , mesh    = 'bat0'
               , mesh_no_rebroadcast = '1'
-              , macaddr = util.generate_mac(1, 1)
+              , macaddr = util.generate_mac(6)
               , auto    = enable and 1 or 0
   })
 

--- a/package/gluon-mesh-vpn-fastd/files/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/files/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -128,7 +128,7 @@ uci:section('network', 'interface', 'mesh_vpn',
 		  proto = 'batadv',
 		  mesh = 'bat0',
 		  mesh_no_rebroadcast = 1,
-		  macaddr = util.generate_mac(4, 0),
+		  macaddr = util.generate_mac(0),
 	  }
 )
 


### PR DESCRIPTION
The VIF mac addresses in the ralink-rt305x chip must be sequential in
the last bits, since they are using a hardware mac filter.

1. Hash the original primary mac, since the addresses of devices bought
   together could be sequential in the last byte.

2. Increment the last byte for the VIF on the vocore (```generate_mac``` routine)

Implements #648