### PR TITLE
gluon-next-node: mark local-node ip6 as deprecated

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,6 +53,7 @@ Packages
    package/gluon-client-bridge
    package/gluon-ebtables-filter-multicast
    package/gluon-ebtables-filter-ra-dhcp
+   package/gluon-next-node
 
 Releases
 --------

--- a/docs/package/gluon-next-node.rst
+++ b/docs/package/gluon-next-node.rst
@@ -5,7 +5,7 @@ This package provides a virtual interface (tied to *br-client*) called *local-no
 using the same MAC, IP4 and IP6 across all nodes in a mesh. Thus, the node that
 the client is currently connected to, can always be reached under a known address.
 
-The IP6 is marked es deprecated to prevent it from being used as a source
+The IP6 is marked as deprecated to prevent it from being used as a source
 address for packages originating from a node.
 
 site.conf

--- a/docs/package/gluon-next-node.rst
+++ b/docs/package/gluon-next-node.rst
@@ -1,21 +1,22 @@
 gluon-next-node
 ===============
 
-This package provides a virtual interface (tied to *br-client*) called *local-node*
-using the same MAC, IP4 and IP6 across all nodes in a mesh. Thus, the node that
-the client is currently connected to, can always be reached under a known address.
+This package provides a virtual interface (tied to *br-client*) called
+*local-node* using the same MAC, IPv4 and IPv6 addresses across all nodes in
+a mesh. Thus, the node that the client is currently connected to, can always
+be reached under a known address.
 
-The IP6 is marked as deprecated to prevent it from being used as a source
-address for packages originating from a node.
+The IPv6 address is marked as deprecated to prevent it from being used as a
+source address for packages originating from a node.
 
 site.conf
 ---------
 
 next_node.mac
-    MAC to be set on the interface.
+    MAC address to be set on the interface.
 
 next_node.ip4
-    IP4 to be set on the interface.
+    IPv4 address to be set on the interface.
 
 next_node.ip6
-    IP6 to be set on the interface.
+    IPv6 address to be set on the interface.

--- a/docs/package/gluon-next-node.rst
+++ b/docs/package/gluon-next-node.rst
@@ -1,0 +1,21 @@
+gluon-next-node
+===============
+
+This package provides a virtual interface (tied to *br-client*) called *local-node*
+using the same MAC, IP4 and IP6 across all nodes in a mesh. Thus, the node that
+the client is currently connected to, can always be reached under a known address.
+
+The IP6 is marked es deprecated to prevent it from being used as a source
+address for packages originating from a node.
+
+site.conf
+---------
+
+next_node.mac
+    MAC to be set on the interface.
+
+next_node.ip4
+    IP4 to be set on the interface.
+
+next_node.ip6
+    IP6 to be set on the interface.

--- a/package/gluon-next-node/files/lib/gluon/upgrade/400-next-node
+++ b/package/gluon-next-node/files/lib/gluon/upgrade/400-next-node
@@ -19,14 +19,23 @@ c:section('network', 'device', 'local_node_dev',
 
 local prefix4 = ip.IPv4(site.prefix4)
 c:delete('network', 'local_node')
-c:section('network', 'interface', 'local_node',
-	  {
-		  ifname = 'local-node',
-		  proto = 'static',
-		  ipaddr = site.next_node.ip4,
-		  netmask = prefix4:mask():string(),
-		  ip6addr = site.next_node.ip6 .. '/128',
-	  }
+c:delete('network', 'local_node4')
+c:delete('network', 'local_node6')
+
+c:section('network', 'interface', 'local_node4',
+         {
+           ifname = 'local-node',
+           proto = 'static',
+           ipaddr = site.next_node.ip4 .. '/32',
+         }
+)
+
+c:section('network', 'interface', 'local_node6',
+         {
+           ifname = 'local-node',
+           proto = 'static_deprecated',
+           ip6addr = site.next_node.ip6,
+         }
 )
 
 c:delete('network', 'local_node_route6')

--- a/package/gluon-next-node/files/lib/netifd/proto/static_deprecated.sh
+++ b/package/gluon-next-node/files/lib/netifd/proto/static_deprecated.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+. /lib/functions.sh
+. ../netifd-proto.sh
+init_proto "$@"
+
+proto_static_deprecated_init_config() {
+	renew_handler=1
+
+	proto_config_add_string 'ip6addr:ip6addr'
+}
+
+proto_static_deprecated_setup() {
+	local config="$1"
+	local iface="$2"
+
+	local ip6addr
+	json_get_vars ip6addr
+
+	proto_init_update "*" 1
+	proto_add_ipv6_address "$ip6addr" "" "0"
+	proto_send_update "$config"
+}
+
+proto_static_deprecated_teardown() {
+	local config="$1"
+}
+
+add_protocol static_deprecated
+


### PR DESCRIPTION
Prevent the local-node ip6 from being eligible for source address
selection. This is highly undesireable in a layer 3 mesh.

(Also adds documentation for gluon-next-node)
