### PR TITLE
Add support for carambola 2 board

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -78,6 +78,10 @@ Supported Devices & Architectures
 ar71xx-generic
 ^^^^^^^^^^^^^^
 
+* 8devices
+
+  - Carambola 2
+
 * ALFA Network
 
   - AP121

--- a/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
@@ -24,7 +24,7 @@ end
 
 if platform.match('ar71xx', 'generic', {'tl-wdr3600', 'tl-wdr4300'}) then
   table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')
-elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus'}) then
+elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c7'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -302,3 +302,10 @@ $(eval $(call GluonProfile,MR16,rssileds))
 $(eval $(call GluonProfileFactorySuffix,MR16))
 $(eval $(call GluonModel,MR16,mr16,meraki-mr16))
 $(eval $(call GluonModelAlias,MR16,meraki-mr16,meraki-mr66))
+
+## 8devices
+
+# Carambola 2
+$(eval $(call GluonProfile,CARAMBOLA2))
+$(eval $(call GluonModel,CARAMBOLA2,carambola2,8devices-carambola2-board))
+$(eval $(call GluonProfileFactorySuffix,CARAMBOLA2))


### PR DESCRIPTION
Device information can be found at:
http://www.8devices.com/products/carambola-2
https://wiki.openwrt.org/toh/8devices/carambola2

I only did some minimal testing of gluon on the carambola 2 development
board:

 - Config mode works
 - Connects to Wifi Mesh
 - Allows clients to connect

Notably, autoupgrade has not yet been tested.

Change to 010-primary-mac is necessary as the mac address printed
on the sticker is the one of eth0, not the wifi mac.