### PR TITLE
gluon-node-info: add a script to fix whitespaces within the coordinates

### DIFF
--- a/package/gluon-node-info/files/lib/gluon/upgrade/520-node-info-whitespace-fix
+++ b/package/gluon-node-info/files/lib/gluon/upgrade/520-node-info-whitespace-fix
@@ -1,0 +1,20 @@
+#!/usr/bin/lua
+
+local uci = require('luci.model.uci').cursor()
+
+local sname = uci:get_first('gluon-node-info', 'location')
+if sname then
+  local latitude = uci:get('gluon-node-info', sname, 'latitude')
+  if latitude then
+    uci:set('gluon-node-info', sname, 'latitude', latitude:trim())
+  end
+  local longitude = uci:get('gluon-node-info', sname, 'longitude')
+  if longitude then
+    uci:set('gluon-node-info', sname, 'longitude', longitude:trim())
+  end
+  local altitude = uci:get('gluon-node-info', sname, 'altitude')
+  if altitude then
+    uci:set('gluon-node-info', sname, 'altitude', altitude:trim())
+  end
+  uci:save('gluon-node-info')
+end

--- a/package/gluon-node-info/files/lib/gluon/upgrade/520-node-info-whitespace-fix
+++ b/package/gluon-node-info/files/lib/gluon/upgrade/520-node-info-whitespace-fix
@@ -1,20 +1,14 @@
 #!/usr/bin/lua
-
 local uci = require('luci.model.uci').cursor()
 
 local sname = uci:get_first('gluon-node-info', 'location')
 if sname then
-  local latitude = uci:get('gluon-node-info', sname, 'latitude')
-  if latitude then
-    uci:set('gluon-node-info', sname, 'latitude', latitude:trim())
-  end
-  local longitude = uci:get('gluon-node-info', sname, 'longitude')
-  if longitude then
-    uci:set('gluon-node-info', sname, 'longitude', longitude:trim())
-  end
-  local altitude = uci:get('gluon-node-info', sname, 'altitude')
-  if altitude then
-    uci:set('gluon-node-info', sname, 'altitude', altitude:trim())
+  local options = {'longitude', 'latitude', 'altitude'}
+  for _, option in ipairs(options) do
+    local value = uci:get('gluon-node-info', sname, option)
+    if value then
+      uci:set('gluon-node-info', sname, option, value:trim())
+    end
   end
   uci:save('gluon-node-info')
 end


### PR DESCRIPTION
This fixes #703 
First version, this may be improved by iterating through the listed items within _gluon-node-info_ - _location_, instead of hard coded stuff.