### PR TITLE
Add D-Link DIR-505 rev. A2 as alias of D-Link DIR-505 rev. A1

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,7 +107,7 @@ ar71xx-generic
 
 * D-Link
 
-  - DIR-505 (A1)
+  - DIR-505 (A1, A2)
   - DIR-615 (C1)
   - DIR-825 (B1)
 

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -193,10 +193,12 @@ endif
 
 ## D-Link
 
-# D-Link DIR-505 rev. A1
+# D-Link DIR-505 rev. A1/A2
 
 $(eval $(call GluonProfile,DIR505A1))
-$(eval $(call GluonModel,DIR505A1,dir-505-a1,d-link-dir-505-rev-a1))
+$(eval $(call GluonModel,DIR505A1,dir-505-a1-a2,d-link-dir-505-rev-a1))
+
+$(eval $(call GluonModelAlias,DIR505A1,d-link-dir-505-rev-a1,d-link-dir-505-rev-a2))
 
 # D-Link DIR-615 rev. C1
 $(eval $(call GluonProfile,DIR615C1))


### PR DESCRIPTION
Due to https://wiki.openwrt.org/toh/d-link/dir-505 rev. A1 and A2 are the same, but differ on outer hardware. I myself have flashed two DIR-505 rev. A2 with DIR-505 rev. A1 firmware (2016.1.4) without any problems, yet.