### PR TITLE
ar71xx-generic: corrected the naming of alfa products

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -289,9 +289,9 @@ $(eval $(call GluonModel,OMEGA,onion-omega,onion-omega))
 
 # Hornet-UB
 $(eval $(call GluonProfile,HORNETUB))
-$(eval $(call GluonModel,HORNETUB,hornet-ub,alfa-hornet-ub))
-$(eval $(call GluonModelAlias,HORNETUB,alfa-hornet-ub,alfa-ap121))
-$(eval $(call GluonModelAlias,HORNETUB,alfa-hornet-ub,alfa-ap121u))
+$(eval $(call GluonModel,HORNETUB,alfa-hornet-ub,alfa-network-hornet-ub))
+$(eval $(call GluonModelAlias,HORNETUB,alfa-ap121,alfa-network-ap121))
+$(eval $(call GluonModelAlias,HORNETUB,alfa-ap121u,alfa-network-ap121u))
 
 ## Meraki
 


### PR DESCRIPTION
the current profile definition does is not correct according to the definition in the docs. the new naming will enable a working autoupdate.