### PR TITLE
openwrt: enabled iw connect module

### DIFF
--- a/patches/openwrt/0033-reenabled-iw-connect.patch
+++ b/patches/openwrt/0033-reenabled-iw-connect.patch
@@ -1,0 +1,21 @@
+From: Georg von Zengen <vonzengen@ibr.cs.tu-bs.de>
+Date: Sun, 8 May 2016 18:55:28 +0200
+Subject: reenabled iw connect
+
+diff --git a/package/network/utils/iw/patches/304-reinsert_connect.patch b/package/network/utils/iw/patches/304-reinsert_connect.patch
+new file mode 100644
+index 0000000..4641775
+--- /dev/null
++++ b/package/network/utils/iw/patches/304-reinsert_connect.patch
+@@ -0,0 +1,11 @@
++--- a/Makefile
+++++ b/Makefile
++@@ -16,7 +16,7 @@ OBJS = iw.o genl.o event.o info.o phy.o
++ 	interface.o ibss.o station.o survey.o util.o ocb.o \
++ 	mesh.o mpath.o mpp.o scan.o reg.o version.o \
++ 	reason.o status.o link.o offch.o ps.o cqm.o \
++-	bitrate.o vendor.o
+++	bitrate.o vendor.o connect.o
++ OBJS += sections.o
++ 
++ OBJS-$(HWSIM) += hwsim.o


### PR DESCRIPTION
This re-enables the connect module of iw.
The connect module was disabled beside others to save some space in upstream openwrt, recently.

It is needed for the fallback [autoupdater](https://git.c3pb.de/freifunk-pb/ffho-packages/blob/master/ffho/ffho-autoupdater-wifi-fallback/) by Freifunk Hochstift or Paderborn.
The uncompressed binary size increases by 513bytes without fs-compression, a workaround for the connect module by [fuzzle](https://forum.freifunk.net/t/fork-von-ffho-autoupdater-wifi-fallback-gesucht/11423/16) is approx. 581bytes in shell script.
Both will be much smaller on the device, so to have the feature to join a wifi approx. the same space is needed. I would prefer to use the "official" rather than using a workaround.

Let me know if something in this commit needs to be changed or if there are serious doubts about it. 