### PR TITLE
Add support for OpenMesh hardware available in OpenWrt CC

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -130,6 +130,16 @@ ar71xx-generic
 
   - Omega
 
+* OpenMesh
+
+ - MR600 (v1, v2)
+ - MR900 (v1, v2)
+ - OM2P (v1, v2)
+ - OM2P-HS (v1, v2)
+ - OM2P-LC
+ - OM5P
+ - OM5P-AN
+
 * TP-Link
 
   - CPE210 (v1.0, v1.1)

--- a/package/gluon-luci-admin/files/usr/lib/lua/luci/controller/admin/upgrade.lua
+++ b/package/gluon-luci-admin/files/usr/lib/lua/luci/controller/admin/upgrade.lua
@@ -101,9 +101,7 @@ end
 function image_supported(tmpfile)
 	-- XXX: yay...
 	return ( 0 == os.execute(
-		". /lib/functions.sh; " ..
-		"include /lib/upgrade; " ..
-		"platform_check_image %q >/dev/null"
+		"/sbin/sysupgrade -T %q >/dev/null"
 			% tmpfile
 	) )
 end

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -295,6 +295,35 @@ $(eval $(call GluonModel,MYNETN750,mynet-n750,wd-my-net-n750))
 $(eval $(call GluonProfile,OMEGA))
 $(eval $(call GluonModel,OMEGA,onion-omega,onion-omega))
 
+## OpenMesh
+
+# MR600
+$(eval $(call GluonProfile,MR600,om-watchdog uboot-envtools))
+$(eval $(call GluonProfileSysupgradeSuffix,MR600,-squashfs-factory,.bin))
+$(eval $(call GluonModel,MR600,mr600,openmesh-mr600))
+$(eval $(call GluonModelAlias,MR600,openmesh-mr600,openmesh-mr600-v2))
+
+# MR900
+$(eval $(call GluonProfile,MR900,om-watchdog uboot-envtools))
+$(eval $(call GluonProfileSysupgradeSuffix,MR900,-squashfs-factory,.bin))
+$(eval $(call GluonModel,MR900,mr900,openmesh-mr900))
+$(eval $(call GluonModelAlias,MR900,openmesh-mr900,openmesh-mr900-v2))
+
+# OM2P
+$(eval $(call GluonProfile,OM2P,om-watchdog uboot-envtools))
+$(eval $(call GluonProfileSysupgradeSuffix,OM2P,-squashfs-factory,.bin))
+$(eval $(call GluonModel,OM2P,om2p,openmesh-om2p))
+$(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-v2))
+$(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-hs))
+$(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-hs-v2))
+$(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-lc))
+
+# OM5P
+$(eval $(call GluonProfile,OM5P,om-watchdog uboot-envtools))
+$(eval $(call GluonProfileSysupgradeSuffix,OM5P,-squashfs-factory,.bin))
+$(eval $(call GluonModel,OM5P,om5p,openmesh-om5p))
+$(eval $(call GluonModelAlias,OM5P,openmesh-om5p,openmesh-om5p-an))
+
 ## ALFA
 
 # Hornet-UB


### PR DESCRIPTION
Following hardware was tested with gluon-2016.1.4

 - MR600
 - MR600v2
 - MR900
 - MR900v2
 - OM2P
 - OM2P-HS
 - OM2P-HSv2
 - OM2P-LC
 - OM2Pv2
 - OM5P
 - OM5P-AN

OpenMesh hardware is for example used at https://meshviewer.chemnitz.freifunk.net/#!v:m;n:ac867400ec02

----

The gluon-luci-admin change itself is a fix but there will be also a patch for OpenWrt/LEDE to modify the behavior of `platform_check_image_openmesh`