### PR TITLE
Add support for OpenMesh hardware available in OpenWrt trunk

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -132,12 +132,14 @@ ar71xx-generic
 
 * OpenMesh
 
+ - MR1750
  - MR600 (v1, v2)
  - MR900 (v1, v2)
  - OM2P (v1, v2)
  - OM2P-HS (v1, v2)
  - OM2P-LC
  - OM5P
+ - OM5P-AC (v1, v2)
  - OM5P-AN
 
 * TP-Link

--- a/patches/openwrt/0046-ar71xx-Generate-sysupgrade-images-for-OpenMesh-devic.patch
+++ b/patches/openwrt/0046-ar71xx-Generate-sysupgrade-images-for-OpenMesh-devic.patch
@@ -1,0 +1,30 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Tue, 17 May 2016 16:38:29 +0200
+Subject: ar71xx: Generate sysupgrade images for OpenMesh devices
+
+Some OpenWrt based firmwares like Gluon expect that a sysupgrade image
+exists when a device firmware can be updated via sysupgrade. This image
+wasn't created until now because OpenMesh devices use the same image for
+factory and sysupgrade flash. Copying the image from *factory.bin to
+*sysupgrade.bin is therefore enough to make the sysupgrade functionality
+visible.
+
+Reported-by: Matthias Schiffer <mschiffer@universe-factory.net>
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/624172/
+
+diff --git a/target/linux/ar71xx/image/Makefile b/target/linux/ar71xx/image/Makefile
+index 916d4e2..f91e20e 100644
+--- a/target/linux/ar71xx/image/Makefile
++++ b/target/linux/ar71xx/image/Makefile
+@@ -1877,6 +1877,9 @@ define Image/Build/OpenMesh
+ 		"$(BUILD_DIR)/fwupgrade.cfg-$(4)" "fwupgrade.cfg" \
+ 		"$(KDIR_TMP)/vmlinux-$(2).uImage" "kernel" \
+ 		"$(KDIR)/root.$(1)" "rootfs"
++	if [ -e "$(call factoryname,$(1),$(2))" ]; then \
++		cp "$(call factoryname,$(1),$(2))" "$(call sysupname,$(1),$(2))"; \
++	fi
+ endef
+ 
+ 

--- a/patches/openwrt/0047-ar71xx-add-kernel-support-for-the-OpenMesh-MR1750-bo.patch
+++ b/patches/openwrt/0047-ar71xx-add-kernel-support-for-the-OpenMesh-MR1750-bo.patch
@@ -1,0 +1,202 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Mon, 14 Sep 2015 20:10:43 +0000
+Subject: ar71xx: add kernel support for the OpenMesh MR1750 board
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46926
+
+Forwarded: https://patchwork.ozlabs.org/patch/624173/
+
+diff --git a/target/linux/ar71xx/config-3.18 b/target/linux/ar71xx/config-3.18
+index 9a81911..c5a3c9a 100644
+--- a/target/linux/ar71xx/config-3.18
++++ b/target/linux/ar71xx/config-3.18
+@@ -79,6 +79,7 @@ CONFIG_ATH79_MACH_JWAP003=y
+ CONFIG_ATH79_MACH_MC_MAC1200R=y
+ CONFIG_ATH79_MACH_MR16=y
+ CONFIG_ATH79_MACH_MR12=y
++CONFIG_ATH79_MACH_MR1750=y
+ CONFIG_ATH79_MACH_MR600=y
+ CONFIG_ATH79_MACH_MR900=y
+ CONFIG_ATH79_MACH_MYNET_N600=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
+new file mode 100644
+index 0000000..8ace02f
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
+@@ -0,0 +1,129 @@
++/*
++ * MR1750 board support
++ *
++ * Copyright (c) 2012 Qualcomm Atheros
++ * Copyright (c) 2012-2013 Marek Lindner <marek@open-mesh.com>
++ *
++ * Permission to use, copy, modify, and/or distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ *
++ */
++
++#include <linux/platform_device.h>
++#include <linux/ar8216_platform.h>
++
++#include <asm/mach-ath79/ar71xx_regs.h>
++
++#include "common.h"
++#include "dev-ap9x-pci.h"
++#include "dev-gpio-buttons.h"
++#include "dev-eth.h"
++#include "dev-leds-gpio.h"
++#include "dev-m25p80.h"
++#include "dev-wmac.h"
++#include "machtypes.h"
++#include "pci.h"
++
++#define MR1750_GPIO_LED_LAN		12
++#define MR1750_GPIO_LED_WLAN_2G		13
++#define MR1750_GPIO_LED_STATUS_GREEN	19
++#define MR1750_GPIO_LED_STATUS_RED	21
++#define MR1750_GPIO_LED_POWER		22
++#define MR1750_GPIO_LED_WLAN_5G		23
++
++#define MR1750_GPIO_BTN_RESET		17
++
++#define MR1750_KEYS_POLL_INTERVAL	20	/* msecs */
++#define MR1750_KEYS_DEBOUNCE_INTERVAL	(3 * MR1750_KEYS_POLL_INTERVAL)
++
++#define MR1750_MAC0_OFFSET		0
++#define MR1750_WMAC_CALDATA_OFFSET	0x1000
++
++static struct gpio_led mr1750_leds_gpio[] __initdata = {
++	{
++		.name		= "mr1750:blue:power",
++		.gpio		= MR1750_GPIO_LED_POWER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "mr1750:blue:wan",
++		.gpio		= MR1750_GPIO_LED_LAN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "mr1750:blue:wlan24",
++		.gpio		= MR1750_GPIO_LED_WLAN_2G,
++		.active_low	= 1,
++	},
++	{
++		.name		= "mr1750:blue:wlan58",
++		.gpio		= MR1750_GPIO_LED_WLAN_5G,
++		.active_low	= 1,
++	},
++	{
++		.name		= "mr1750:green:status",
++		.gpio		= MR1750_GPIO_LED_STATUS_GREEN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "mr1750:red:status",
++		.gpio		= MR1750_GPIO_LED_STATUS_RED,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button mr1750_gpio_keys[] __initdata = {
++	{
++		.desc		= "Reset button",
++		.type		= EV_KEY,
++		.code		= KEY_RESTART,
++		.debounce_interval = MR1750_KEYS_DEBOUNCE_INTERVAL,
++		.gpio		= MR1750_GPIO_BTN_RESET,
++		.active_low	= 1,
++	},
++};
++
++static void __init mr1750_setup(void)
++{
++	u8 *art = (u8 *)KSEG1ADDR(0x1fff0000);
++	u8 mac[6];
++
++	ath79_eth0_pll_data.pll_1000 = 0xbe000101;
++	ath79_eth0_pll_data.pll_100 = 0x80000101;
++	ath79_eth0_pll_data.pll_10 = 0x80001313;
++
++	ath79_register_m25p80(NULL);
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(mr1750_leds_gpio),
++				 mr1750_leds_gpio);
++	ath79_register_gpio_keys_polled(-1, MR1750_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(mr1750_gpio_keys),
++					mr1750_gpio_keys);
++
++	ath79_init_mac(mac, art + MR1750_MAC0_OFFSET, 1);
++	ath79_register_wmac(art + MR1750_WMAC_CALDATA_OFFSET, mac);
++	ath79_register_pci();
++
++	ath79_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN);
++	ath79_register_mdio(0, 0x0);
++
++	ath79_init_mac(ath79_eth0_data.mac_addr, art + MR1750_MAC0_OFFSET, 0);
++
++	/* GMAC0 is connected to the RMGII interface */
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;
++	ath79_eth0_data.phy_mask = BIT(5);
++	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
++
++	ath79_register_eth(0);
++}
++
++MIPS_MACHINE(ATH79_MACH_MR1750, "MR1750", "OpenMesh MR1750", mr1750_setup);
+diff --git a/target/linux/ar71xx/patches-3.18/815-MIPS-ath79-add-mr1750-support.patch b/target/linux/ar71xx/patches-3.18/815-MIPS-ath79-add-mr1750-support.patch
+new file mode 100644
+index 0000000..d802a12
+--- /dev/null
++++ b/target/linux/ar71xx/patches-3.18/815-MIPS-ath79-add-mr1750-support.patch
+@@ -0,0 +1,39 @@
++--- a/arch/mips/ath79/Kconfig
+++++ b/arch/mips/ath79/Kconfig
++@@ -763,6 +763,16 @@ config ATH79_MACH_CAP4200AG
++ 	select ATH79_DEV_M25P80
++ 	select ATH79_DEV_WMAC
++ 
+++config ATH79_MACH_MR1750
+++	bool "OpenMesh MR1750 board support"
+++	select SOC_QCA955X
+++	select ATH79_DEV_AP9X_PCI if PCI
+++	select ATH79_DEV_ETH
+++	select ATH79_DEV_GPIO_BUTTONS
+++	select ATH79_DEV_LEDS_GPIO
+++	select ATH79_DEV_M25P80
+++	select ATH79_DEV_WMAC
+++
++ config ATH79_MACH_MR900
++ 	bool "OpenMesh MR900 board support"
++ 	select SOC_QCA955X
++--- a/arch/mips/ath79/Makefile
+++++ b/arch/mips/ath79/Makefile
++@@ -80,6 +80,7 @@ obj-$(CONFIG_ATH79_MACH_HORNET_UB)	+= ma
++ obj-$(CONFIG_ATH79_MACH_MC_MAC1200R)     += mach-mc-mac1200r.o
++ obj-$(CONFIG_ATH79_MACH_MR12)		+= mach-mr12.o
++ obj-$(CONFIG_ATH79_MACH_MR16)		+= mach-mr16.o
+++obj-$(CONFIG_ATH79_MACH_MR1750)		+= mach-mr1750.o
++ obj-$(CONFIG_ATH79_MACH_MR600)		+= mach-mr600.o
++ obj-$(CONFIG_ATH79_MACH_MR900)		+= mach-mr900.o
++ obj-$(CONFIG_ATH79_MACH_MYNET_N600)	+= mach-mynet-n600.o
++--- a/arch/mips/ath79/machtypes.h
+++++ b/arch/mips/ath79/machtypes.h
++@@ -69,6 +69,7 @@ enum ath79_mach_type {
++ 	ATH79_MACH_HORNET_UB,		/* ALFA Networks Hornet-UB */
++ 	ATH79_MACH_MR12,		/* Cisco Meraki MR12 */
++ 	ATH79_MACH_MR16,		/* Cisco Meraki MR16 */
+++	ATH79_MACH_MR1750,		/* OpenMesh MR1750 */
++ 	ATH79_MACH_MR600V2,		/* OpenMesh MR600v2 */
++ 	ATH79_MACH_MR600,		/* OpenMesh MR600 */
++ 	ATH79_MACH_MR900,		/* OpenMesh MR900 */

--- a/patches/openwrt/0048-ar71xx-add-user-space-support-for-the-OpenMesh-MR175.patch
+++ b/patches/openwrt/0048-ar71xx-add-user-space-support-for-the-OpenMesh-MR175.patch
@@ -1,0 +1,67 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Mon, 14 Sep 2015 20:11:01 +0000
+Subject: ar71xx: add user-space support for the OpenMesh MR1750 board
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46927
+
+Forwarded: https://patchwork.ozlabs.org/patch/624174/
+
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 775aac6..44d2ddf 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -143,6 +143,9 @@ get_status_led() {
+ 	mr600v2)
+ 		status_led="mr600:blue:power"
+ 		;;
++	mr1750)
++		status_led="mr1750:blue:power"
++		;;
+ 	mr900 | \
+ 	mr900v2)
+ 		status_led="mr900:blue:power"
+diff --git a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+index a4b355a..c451124 100644
+--- a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+@@ -239,6 +239,12 @@ mr600)
+ 	ucidef_set_led_wlan "wlan58" "WLAN58" "mr600:green:wlan58" "phy0tpt"
+ 	;;
+ 
++mr1750)
++	ucidef_set_led_netdev "lan" "LAN" "mr1750:blue:wan" "eth0"
++	ucidef_set_led_wlan "wlan58" "WLAN58" "mr1750:blue:wlan58" "phy0tpt"
++	ucidef_set_led_wlan "wlan24" "WLAN24" "mr1750:blue:wlan24" "phy1tpt"
++	;;
++
+ mr900 | \
+ mr900v2)
+ 	ucidef_set_led_netdev "lan" "LAN" "mr900:blue:wan" "eth0"
+diff --git a/target/linux/ar71xx/base-files/etc/uci-defaults/02_network b/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
+index 0a23756..4066506 100755
+--- a/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
+@@ -334,6 +334,7 @@ eap300v2 |\
+ eap7660d |\
+ el-mini |\
+ loco-m-xw |\
++mr1750 |\
+ mr600 |\
+ mr600v2 |\
+ mr900 |\
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 7fc951a..587d029 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -562,6 +562,9 @@ ar71xx_board_detect() {
+ 	*MR600v2)
+ 		name="mr600v2"
+ 		;;
++	*MR1750)
++		name="mr1750"
++		;;
+ 	*MR600)
+ 		name="mr600"
+ 		;;

--- a/patches/openwrt/0049-scripts-om-fwupgradecfg-gen.sh-add-support-for-the-M.patch
+++ b/patches/openwrt/0049-scripts-om-fwupgradecfg-gen.sh-add-support-for-the-M.patch
@@ -1,0 +1,32 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Mon, 14 Sep 2015 20:11:18 +0000
+Subject: scripts/om-fwupgradecfg-gen.sh: add support for the MR1750
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46928
+
+Forwarded: https://patchwork.ozlabs.org/patch/624175/
+
+diff --git a/scripts/om-fwupgradecfg-gen.sh b/scripts/om-fwupgradecfg-gen.sh
+index e132954..c790214 100644
+--- a/scripts/om-fwupgradecfg-gen.sh
++++ b/scripts/om-fwupgradecfg-gen.sh
+@@ -7,7 +7,7 @@
+ #
+ 
+ usage() {
+-	echo "Usage: $0 <OM2P|OM5P|MR600|MR900> <out file path> <kernel path> <rootfs path>"
++	echo "Usage: $0 <OM2P|OM5P|MR600|MR900|MR1750> <out file path> <kernel path> <rootfs path>"
+ 	rm -f $CFG_OUT
+ 	exit 1
+ }
+@@ -26,7 +26,7 @@ case $CE_TYPE in
+ 		FLASH_BS=262144
+ 		MD5_SKIP_BLOCKS=1
+ 		;;
+-	OM5P|MR600|MR900)
++	OM5P|MR600|MR900|MR1750)
+ 		MAX_PART_SIZE=7808
+ 		KERNEL_FLASH_ADDR=0xb0000
+ 		FLASH_BS=65536

--- a/patches/openwrt/0050-ar71xx-enable-sysupgrade-for-the-OpenMesh-MR1750.patch
+++ b/patches/openwrt/0050-ar71xx-enable-sysupgrade-for-the-OpenMesh-MR1750.patch
@@ -1,0 +1,55 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Mon, 14 Sep 2015 20:11:24 +0000
+Subject: ar71xx: enable sysupgrade for the OpenMesh MR1750
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46929
+
+Forwarded: https://patchwork.ozlabs.org/patch/624176/
+
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+index 547116e..9ca0f5b 100644
+--- a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+@@ -72,6 +72,11 @@ platform_check_image_openmesh()
+ 			echo "Invalid image board target ($img_board_target) for this platform: $board. Use the correct image for this platform"
+ 			return 1
+ 			;;
++		MR1750)
++			[ "$board" = "mr1750" ] && break
++			echo "Invalid image board target ($img_board_target) for this platform: $board. Use the correct image for this platform"
++			return 1
++			;;
+ 		MR600)
+ 			[ "$board" = "mr600" ] && break
+ 			[ "$board" = "mr600v2" ] && break
+@@ -157,7 +162,7 @@ platform_do_upgrade_openmesh()
+ 			kernel_start_addr1=0x9f1c0000
+ 			kernel_start_addr2=0x9f8c0000
+ 			;;
+-		OM5P|MR600|MR900)
++		OM5P|MR600|MR900|MR1750)
+ 			block_size=$((64 * 1024))
+ 			total_size=7995392
+ 			kernel_start_addr1=0x9f0b0000
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index 0e9833d..ac060ea 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -296,6 +296,7 @@ platform_check_image() {
+ 
+ 		return 0;
+ 		;;
++	mr1750 | \
+ 	mr600 | \
+ 	mr600v2 | \
+ 	mr900 | \
+@@ -528,6 +529,7 @@ platform_do_upgrade() {
+ 	tew-673gru)
+ 		platform_do_upgrade_dir825b "$ARGV"
+ 		;;
++	mr1750 | \
+ 	mr600 | \
+ 	mr600v2 | \
+ 	mr900 | \

--- a/patches/openwrt/0051-package-om-watchdog-add-OpenMesh-MR1750-support.patch
+++ b/patches/openwrt/0051-package-om-watchdog-add-OpenMesh-MR1750-support.patch
@@ -1,0 +1,23 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Mon, 14 Sep 2015 20:11:35 +0000
+Subject: package/om-watchdog: add OpenMesh MR1750 support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46930
+
+Forwarded: https://patchwork.ozlabs.org/patch/624177/
+
+diff --git a/package/kernel/om-watchdog/files/om-watchdog.init b/package/kernel/om-watchdog/files/om-watchdog.init
+index 135fef7..c792968 100644
+--- a/package/kernel/om-watchdog/files/om-watchdog.init
++++ b/package/kernel/om-watchdog/files/om-watchdog.init
+@@ -25,7 +25,7 @@ boot() {
+ 			"mr600v2")
+ 				service_start /sbin/om-watchdog 15
+ 				;;
+-			"mr900"|"mr900v2")
++			"mr900"|"mr900v2"|"mr1750")
+ 				service_start /sbin/om-watchdog 16
+ 				;;
+ 		esac

--- a/patches/openwrt/0052-package-uboot-envtools-add-OpenMesh-MR1750-support.patch
+++ b/patches/openwrt/0052-package-uboot-envtools-add-OpenMesh-MR1750-support.patch
@@ -1,0 +1,22 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Mon, 14 Sep 2015 20:11:43 +0000
+Subject: package/uboot-envtools: add OpenMesh MR1750 support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46931
+
+Forwarded: https://patchwork.ozlabs.org/patch/624178/
+
+diff --git a/package/boot/uboot-envtools/files/ar71xx b/package/boot/uboot-envtools/files/ar71xx
+index ec8541c..ef00f17 100644
+--- a/package/boot/uboot-envtools/files/ar71xx
++++ b/package/boot/uboot-envtools/files/ar71xx
+@@ -21,6 +21,7 @@ carambola2 | \
+ eap300v2 | \
+ hornet-ub | \
+ hornet-ub-x2 | \
++mr1750 | \
+ mr600 | \
+ mr600v2 | \
+ mr900 | \

--- a/patches/openwrt/0053-ar71xx-create-profile-and-build-image-for-the-OpenMe.patch
+++ b/patches/openwrt/0053-ar71xx-create-profile-and-build-image-for-the-OpenMe.patch
@@ -1,0 +1,57 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Mon, 14 Sep 2015 20:11:51 +0000
+Subject: ar71xx: create profile and build image for the OpenMesh MR1750 board
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46932
+
+Forwarded: https://patchwork.ozlabs.org/patch/624179/
+
+diff --git a/target/linux/ar71xx/generic/profiles/openmesh.mk b/target/linux/ar71xx/generic/profiles/openmesh.mk
+index 41b462e..06cf135 100644
+--- a/target/linux/ar71xx/generic/profiles/openmesh.mk
++++ b/target/linux/ar71xx/generic/profiles/openmesh.mk
+@@ -49,9 +49,20 @@ endef
+ 
+ $(eval $(call Profile,MR900))
+ 
++define Profile/MR1750
++        NAME:=OpenMesh MR1750
++        PACKAGES:=kmod-ath9k kmod-ath10k ath10k-firmware-qca988x
++endef
++
++define Profile/MR1750/Description
++        Package set optimized for the OpenMesh MR1750.
++endef
++
++$(eval $(call Profile,MR1750))
++
+ define Profile/OPENMESH
+ 	NAME:=OpenMesh products
+-	PACKAGES:=kmod-ath9k om-watchdog
++	PACKAGES:=kmod-ath9k kmod-ath10k om-watchdog
+ endef
+ 
+ define Profile/OPENMESH/Description
+diff --git a/target/linux/ar71xx/image/Makefile b/target/linux/ar71xx/image/Makefile
+index f91e20e..b74aa45 100644
+--- a/target/linux/ar71xx/image/Makefile
++++ b/target/linux/ar71xx/image/Makefile
+@@ -2045,6 +2045,7 @@ $(eval $(call SingleProfile,OpenMesh,squashfs-only,OM2P,om2p,,,,OM2P))
+ $(eval $(call SingleProfile,OpenMesh,squashfs-only,OM5P,om5p,,,,OM5P))
+ $(eval $(call SingleProfile,OpenMesh,squashfs-only,MR600,mr600,,,,MR600))
+ $(eval $(call SingleProfile,OpenMesh,squashfs-only,MR900,mr900,,,,MR900))
++$(eval $(call SingleProfile,OpenMesh,squashfs-only,MR1750,mr1750,,,,MR1750))
+ 
+ $(eval $(call SingleProfile,PB4X,128k,ALL0305,all0305,ALL0305,ttyS0,115200))
+ $(eval $(call SingleProfile,PB4X,128k,EAP7660D,eap7660d,EAP7660D,ttyS0,115200))
+@@ -2138,7 +2139,7 @@ $(eval $(call MultiProfile,AP121,AP121_2M AP121_4M))
+ $(eval $(call MultiProfile,DIR615IX,DIR615I1 DIR615I3))
+ $(eval $(call MultiProfile,AP136,AP136_010 AP136_020))
+ $(eval $(call MultiProfile,EWDORIN, EWDORINAP EWDORINRT EWDORIN16M))
+-$(eval $(call MultiProfile,OPENMESH,OM2P OM5P MR600 MR900))
++$(eval $(call MultiProfile,OPENMESH,OM2P OM5P MR600 MR900 MR1750))
+ $(eval $(call MultiProfile,TEW652BRP,TEW652BRP_FW TEW652BRP_RECOVERY))
+ $(eval $(call MultiProfile,TLMR3220,TLMR3220V1))
+ $(eval $(call MultiProfile,TLMR3420,TLMR3420V1))

--- a/patches/openwrt/0054-ar71xx-Extend-the-list-of-bits-in-QCA955X_GMAC_REG_E.patch
+++ b/patches/openwrt/0054-ar71xx-Extend-the-list-of-bits-in-QCA955X_GMAC_REG_E.patch
@@ -1,0 +1,47 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Wed, 16 Mar 2016 09:27:01 +0000
+Subject: ar71xx: Extend the list of bits in QCA955X_GMAC_REG_ETH_CFG
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49027
+
+Forwarded: https://patchwork.ozlabs.org/patch/624180/
+
+diff --git a/target/linux/ar71xx/patches-3.18/601-MIPS-ath79-add-more-register-defines.patch b/target/linux/ar71xx/patches-3.18/601-MIPS-ath79-add-more-register-defines.patch
+index 8bf7658..797977f 100644
+--- a/target/linux/ar71xx/patches-3.18/601-MIPS-ath79-add-more-register-defines.patch
++++ b/target/linux/ar71xx/patches-3.18/601-MIPS-ath79-add-more-register-defines.patch
+@@ -207,7 +207,7 @@
+  #define AR934X_GPIO_REG_FUNC		0x6c
+  
+  #define AR71XX_GPIO_COUNT		16
+-@@ -560,4 +663,153 @@
++@@ -560,4 +663,170 @@
+  #define AR934X_SRIF_DPLL2_OUTDIV_SHIFT	13
+  #define AR934X_SRIF_DPLL2_OUTDIV_MASK	0x7
+  
+@@ -358,6 +358,23 @@
+ +#define QCA955X_GMAC_REG_ETH_CFG	0x00
+ +
+ +#define QCA955X_ETH_CFG_RGMII_EN	BIT(0)
+++#define QCA955X_ETH_CFG_MII_GE0		BIT(1)
+++#define QCA955X_ETH_CFG_GMII_GE0	BIT(2)
+++#define QCA955X_ETH_CFG_MII_GE0_MASTER	BIT(3)
+++#define QCA955X_ETH_CFG_MII_GE0_SLAVE	BIT(4)
+++#define QCA955X_ETH_CFG_GE0_ERR_EN	BIT(5)
+ +#define QCA955X_ETH_CFG_GE0_SGMII	BIT(6)
+++#define QCA955X_ETH_CFG_RMII_GE0	BIT(10)
+++#define QCA955X_ETH_CFG_MII_CNTL_SPEED	BIT(11)
+++#define QCA955X_ETH_CFG_RMII_GE0_MASTER	BIT(12)
+++#define QCA955X_ETH_CFG_RXD_DELAY_MASK	0x3
+++#define QCA955X_ETH_CFG_RXD_DELAY_SHIFT	14
+++#define QCA955X_ETH_CFG_RDV_DELAY	BIT(16)
+++#define QCA955X_ETH_CFG_RDV_DELAY_MASK	0x3
+++#define QCA955X_ETH_CFG_RDV_DELAY_SHIFT	16
+++#define QCA955X_ETH_CFG_TXD_DELAY_MASK	0x3
+++#define QCA955X_ETH_CFG_TXD_DELAY_SHIFT	18
+++#define QCA955X_ETH_CFG_TXE_DELAY_MASK	0x3
+++#define QCA955X_ETH_CFG_TXE_DELAY_SHIFT	20
+ +
+  #endif /* __ASM_MACH_AR71XX_REGS_H */

--- a/patches/openwrt/0055-ar71xx-Use-_eth_cfg-helper-for-Open-Mesh-MR900-board.patch
+++ b/patches/openwrt/0055-ar71xx-Use-_eth_cfg-helper-for-Open-Mesh-MR900-board.patch
@@ -1,0 +1,49 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Tue, 7 Jul 2015 13:47:39 +0000
+Subject: ar71xx: Use *_eth_cfg helper for Open Mesh MR900 boards
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46241
+
+Forwarded: https://patchwork.ozlabs.org/patch/624181/
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c
+index fe3e1fa..9c3164d 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c
+@@ -94,24 +94,6 @@ static struct gpio_keys_button mr900_gpio_keys[] __initdata = {
+ 	},
+ };
+ 
+-
+-static void __init mr900_gmac_setup(void)
+-{
+-	void __iomem *base;
+-	u32 t;
+-
+-	base = ioremap(QCA955X_GMAC_BASE, QCA955X_GMAC_SIZE);
+-
+-	t = __raw_readl(base + QCA955X_GMAC_REG_ETH_CFG);
+-
+-	t &= ~(QCA955X_ETH_CFG_RGMII_EN | QCA955X_ETH_CFG_GE0_SGMII);
+-	t |= QCA955X_ETH_CFG_RGMII_EN;
+-
+-	__raw_writel(t, base + QCA955X_GMAC_REG_ETH_CFG);
+-
+-	iounmap(base);
+-}
+-
+ static void __init mr900_setup(void)
+ {
+ 	u8 *art = (u8 *)KSEG1ADDR(0x1fff0000);
+@@ -141,8 +123,7 @@ static void __init mr900_setup(void)
+ 	}
+ 	pdata->use_eeprom = true;
+ 
+-	mr900_gmac_setup();
+-
++	ath79_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN);
+ 	ath79_register_mdio(0, 0x0);
+ 
+ 	ath79_init_mac(ath79_eth0_data.mac_addr, art + MR900_MAC0_OFFSET, 0);

--- a/patches/openwrt/0056-ar71xx-Allow-to-use-ath79_gpio_output_select-on-QCA9.patch
+++ b/patches/openwrt/0056-ar71xx-Allow-to-use-ath79_gpio_output_select-on-QCA9.patch
@@ -1,0 +1,79 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 24 Jul 2015 09:10:00 +0000
+Subject: ar71xx: Allow to use ath79_gpio_output_select on QCA955x
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46459
+
+Forwarded: https://patchwork.ozlabs.org/patch/624182/
+
+diff --git a/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch b/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
+new file mode 100644
+index 0000000..e71b6e2
+--- /dev/null
++++ b/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
+@@ -0,0 +1,63 @@
++--- a/arch/mips/ath79/gpio.c
+++++ b/arch/mips/ath79/gpio.c
++@@ -187,15 +187,30 @@ void __init ath79_gpio_output_select(uns
++ {
++ 	void __iomem *base = ath79_gpio_base;
++ 	unsigned long flags;
++-	unsigned int reg;
+++	unsigned int reg, reg_base;
+++	unsigned long gpio_count;
++ 	u32 t, s;
++ 
++-	BUG_ON(!soc_is_ar934x() && !soc_is_qca953x() && !soc_is_qca956x());
+++	if (soc_is_ar934x()) {
+++		gpio_count = AR934X_GPIO_COUNT;
+++		reg_base = AR934X_GPIO_REG_OUT_FUNC0;
+++	} else if (soc_is_qca953x()) {
+++		gpio_count = QCA953X_GPIO_COUNT;
+++		reg_base = QCA953X_GPIO_REG_OUT_FUNC0;
+++	} else if (soc_is_qca955x()) {
+++		gpio_count = QCA955X_GPIO_COUNT;
+++		reg_base = QCA955X_GPIO_REG_OUT_FUNC0;
+++	} else if (soc_is_qca956x()) {
+++		gpio_count = QCA956X_GPIO_COUNT;
+++		reg_base = QCA956X_GPIO_REG_OUT_FUNC0;
+++	} else {
+++		BUG();
+++	}
++ 
++-	if (gpio >= AR934X_GPIO_COUNT)
+++	if (gpio >= gpio_count)
++ 		return;
++ 
++-	reg = AR934X_GPIO_REG_OUT_FUNC0 + 4 * (gpio / 4);
+++	reg = reg_base + 4 * (gpio / 4);
++ 	s = 8 * (gpio % 4);
++ 
++ 	spin_lock_irqsave(&ath79_gpio_lock, flags);
++--- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+++++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
++@@ -875,6 +875,14 @@
++ #define QCA953X_GPIO_OUT_MUX_LED_LINK4		44
++ #define QCA953X_GPIO_OUT_MUX_LED_LINK5		45
++ 
+++#define QCA955X_GPIO_REG_OUT_FUNC0	0x2c
+++#define QCA955X_GPIO_REG_OUT_FUNC1	0x30
+++#define QCA955X_GPIO_REG_OUT_FUNC2	0x34
+++#define QCA955X_GPIO_REG_OUT_FUNC3	0x38
+++#define QCA955X_GPIO_REG_OUT_FUNC4	0x3c
+++#define QCA955X_GPIO_REG_OUT_FUNC5	0x40
+++#define QCA955X_GPIO_REG_FUNC		0x6c
+++
++ #define QCA956X_GPIO_REG_OUT_FUNC0	0x2c
++ #define QCA956X_GPIO_REG_OUT_FUNC1	0x30
++ #define QCA956X_GPIO_REG_OUT_FUNC2	0x34
++@@ -1014,6 +1022,8 @@
++ #define AR934X_GPIO_OUT_EXT_LNA0	46
++ #define AR934X_GPIO_OUT_EXT_LNA1	47
++ 
+++#define QCA955X_GPIO_OUT_GPIO		0
+++
++ /*
++  * MII_CTRL block
++  */

--- a/patches/openwrt/0057-ar71xx-Add-support-for-ath79_gpio_function_-on-QCA95.patch
+++ b/patches/openwrt/0057-ar71xx-Add-support-for-ath79_gpio_function_-on-QCA95.patch
@@ -1,0 +1,32 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Wed, 23 Mar 2016 12:52:27 +0000
+Subject: ar71xx: Add support for ath79_gpio_function_* on QCA955X
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49074
+
+Forwarded: https://patchwork.ozlabs.org/patch/624183/
+
+diff --git a/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch b/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
+index e71b6e2..0e87357 100644
+--- a/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
++++ b/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
+@@ -1,6 +1,16 @@
+ --- a/arch/mips/ath79/gpio.c
+ +++ b/arch/mips/ath79/gpio.c
+-@@ -187,15 +187,30 @@ void __init ath79_gpio_output_select(uns
++@@ -146,7 +146,8 @@ static void __iomem *ath79_gpio_get_func
++ 	if (soc_is_ar71xx() ||
++ 	    soc_is_ar724x() ||
++ 	    soc_is_ar913x() ||
++-	    soc_is_ar933x())
+++	    soc_is_ar933x() ||
+++	    soc_is_qca955x())
++ 		reg = AR71XX_GPIO_REG_FUNC;
++ 	else if (soc_is_ar934x() ||
++ 		 soc_is_qca953x() ||
++@@ -187,15 +188,30 @@ void __init ath79_gpio_output_select(uns
+  {
+  	void __iomem *base = ath79_gpio_base;
+  	unsigned long flags;

--- a/patches/openwrt/0058-ar71xx-Add-QCA955X-GPIO-mux-and-function-definitions.patch
+++ b/patches/openwrt/0058-ar71xx-Add-QCA955X-GPIO-mux-and-function-definitions.patch
@@ -1,0 +1,159 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Wed, 23 Mar 2016 12:52:31 +0000
+Subject: ar71xx: Add QCA955X GPIO mux and function definitions
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49075
+
+Forwarded: https://patchwork.ozlabs.org/patch/624184/
+
+diff --git a/target/linux/ar71xx/patches-3.18/601-MIPS-ath79-add-more-register-defines.patch b/target/linux/ar71xx/patches-3.18/601-MIPS-ath79-add-more-register-defines.patch
+index 797977f..0126f6a 100644
+--- a/target/linux/ar71xx/patches-3.18/601-MIPS-ath79-add-more-register-defines.patch
++++ b/target/linux/ar71xx/patches-3.18/601-MIPS-ath79-add-more-register-defines.patch
+@@ -194,7 +194,7 @@
+  #define AR933X_BOOTSTRAP_REF_CLK_40	BIT(0)
+  
+  #define AR934X_BOOTSTRAP_SW_OPTION8	BIT(23)
+-@@ -529,6 +626,12 @@
++@@ -529,8 +626,22 @@
+  #define AR71XX_GPIO_REG_INT_ENABLE	0x24
+  #define AR71XX_GPIO_REG_FUNC		0x28
+  
+@@ -206,8 +206,18 @@
+ +#define AR934X_GPIO_REG_OUT_FUNC5	0x40
+  #define AR934X_GPIO_REG_FUNC		0x6c
+  
+++#define QCA955X_GPIO_REG_OUT_FUNC0	0x2c
+++#define QCA955X_GPIO_REG_OUT_FUNC1	0x30
+++#define QCA955X_GPIO_REG_OUT_FUNC2	0x34
+++#define QCA955X_GPIO_REG_OUT_FUNC3	0x38
+++#define QCA955X_GPIO_REG_OUT_FUNC4	0x3c
+++#define QCA955X_GPIO_REG_OUT_FUNC5	0x40
+++#define QCA955X_GPIO_REG_FUNC		0x6c
+++
+  #define AR71XX_GPIO_COUNT		16
+-@@ -560,4 +663,170 @@
++ #define AR7240_GPIO_COUNT		18
++ #define AR7241_GPIO_COUNT		20
++@@ -560,4 +671,235 @@
+  #define AR934X_SRIF_DPLL2_OUTDIV_SHIFT	13
+  #define AR934X_SRIF_DPLL2_OUTDIV_MASK	0x7
+  
+@@ -288,6 +298,71 @@
+ +#define AR934X_GPIO_OUT_EXT_LNA0	46
+ +#define AR934X_GPIO_OUT_EXT_LNA1	47
+ +
+++#define QCA955X_GPIO_FUNC_CLK_OBS7_EN		BIT(9)
+++#define QCA955X_GPIO_FUNC_CLK_OBS6_EN		BIT(8)
+++#define QCA955X_GPIO_FUNC_CLK_OBS5_EN		BIT(7)
+++#define QCA955X_GPIO_FUNC_CLK_OBS4_EN		BIT(6)
+++#define QCA955X_GPIO_FUNC_CLK_OBS3_EN		BIT(5)
+++#define QCA955X_GPIO_FUNC_CLK_OBS2_EN		BIT(4)
+++#define QCA955X_GPIO_FUNC_CLK_OBS1_EN		BIT(3)
+++#define QCA955X_GPIO_FUNC_JTAG_DISABLE		BIT(1)
+++
+++#define QCA955X_GPIO_OUT_GPIO		0
+++#define QCA955X_MII_EXT_MDI		1
+++#define QCA955X_SLIC_DATA_OUT		3
+++#define QCA955X_SLIC_PCM_FS		4
+++#define QCA955X_SLIC_PCM_CLK		5
+++#define QCA955X_SPI_CLK			8
+++#define QCA955X_SPI_CS_0		9
+++#define QCA955X_SPI_CS_1		10
+++#define QCA955X_SPI_CS_2		11
+++#define QCA955X_SPI_MISO		12
+++#define QCA955X_I2S_CLK			13
+++#define QCA955X_I2S_WS			14
+++#define QCA955X_I2S_SD			15
+++#define QCA955X_I2S_MCK			16
+++#define QCA955X_SPDIF_OUT		17
+++#define QCA955X_UART1_TD		18
+++#define QCA955X_UART1_RTS		19
+++#define QCA955X_UART1_RD		20
+++#define QCA955X_UART1_CTS		21
+++#define QCA955X_UART0_SOUT		22
+++#define QCA955X_SPDIF2_OUT		23
+++#define QCA955X_LED_SGMII_SPEED0	24
+++#define QCA955X_LED_SGMII_SPEED1	25
+++#define QCA955X_LED_SGMII_DUPLEX	26
+++#define QCA955X_LED_SGMII_LINK_UP	27
+++#define QCA955X_SGMII_SPEED0_INVERT	28
+++#define QCA955X_SGMII_SPEED1_INVERT	29
+++#define QCA955X_SGMII_DUPLEX_INVERT	30
+++#define QCA955X_SGMII_LINK_UP_INVERT	31
+++#define QCA955X_GE1_MII_MDO		32
+++#define QCA955X_GE1_MII_MDC		33
+++#define QCA955X_SWCOM2			38
+++#define QCA955X_SWCOM3			39
+++#define QCA955X_MAC2_GPIO		40
+++#define QCA955X_MAC3_GPIO		41
+++#define QCA955X_ATT_LED			42
+++#define QCA955X_PWR_LED			43
+++#define QCA955X_TX_FRAME		44
+++#define QCA955X_RX_CLEAR_EXTERNAL	45
+++#define QCA955X_LED_NETWORK_EN		46
+++#define QCA955X_LED_POWER_EN		47
+++#define QCA955X_WMAC_GLUE_WOW		68
+++#define QCA955X_RX_CLEAR_EXTENSION	70
+++#define QCA955X_CP_NAND_CS1		73
+++#define QCA955X_USB_SUSPEND		74
+++#define QCA955X_ETH_TX_ERR		75
+++#define QCA955X_DDR_DQ_OE		76
+++#define QCA955X_CLKREQ_N_EP		77
+++#define QCA955X_CLKREQ_N_RC		78
+++#define QCA955X_CLK_OBS0		79
+++#define QCA955X_CLK_OBS1		80
+++#define QCA955X_CLK_OBS2		81
+++#define QCA955X_CLK_OBS3		82
+++#define QCA955X_CLK_OBS4		83
+++#define QCA955X_CLK_OBS5		84
+++
+ +/*
+ + * MII_CTRL block
+ + */
+diff --git a/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch b/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
+index 0e87357..8a54859 100644
+--- a/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
++++ b/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
+@@ -37,37 +37,12 @@
+ +	}
+  
+ -	if (gpio >= AR934X_GPIO_COUNT)
++-		return;
+ +	if (gpio >= gpio_count)
+- 		return;
+++ 		return;
+  
+ -	reg = AR934X_GPIO_REG_OUT_FUNC0 + 4 * (gpio / 4);
+ +	reg = reg_base + 4 * (gpio / 4);
+  	s = 8 * (gpio % 4);
+  
+  	spin_lock_irqsave(&ath79_gpio_lock, flags);
+---- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+-+++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+-@@ -875,6 +875,14 @@
+- #define QCA953X_GPIO_OUT_MUX_LED_LINK4		44
+- #define QCA953X_GPIO_OUT_MUX_LED_LINK5		45
+- 
+-+#define QCA955X_GPIO_REG_OUT_FUNC0	0x2c
+-+#define QCA955X_GPIO_REG_OUT_FUNC1	0x30
+-+#define QCA955X_GPIO_REG_OUT_FUNC2	0x34
+-+#define QCA955X_GPIO_REG_OUT_FUNC3	0x38
+-+#define QCA955X_GPIO_REG_OUT_FUNC4	0x3c
+-+#define QCA955X_GPIO_REG_OUT_FUNC5	0x40
+-+#define QCA955X_GPIO_REG_FUNC		0x6c
+-+
+- #define QCA956X_GPIO_REG_OUT_FUNC0	0x2c
+- #define QCA956X_GPIO_REG_OUT_FUNC1	0x30
+- #define QCA956X_GPIO_REG_OUT_FUNC2	0x34
+-@@ -1014,6 +1022,8 @@
+- #define AR934X_GPIO_OUT_EXT_LNA0	46
+- #define AR934X_GPIO_OUT_EXT_LNA1	47
+- 
+-+#define QCA955X_GPIO_OUT_GPIO		0
+-+
+- /*
+-  * MII_CTRL block
+-  */

--- a/patches/openwrt/0059-ar71xx-Use-PHY-fixups-for-Open-Mesh-MR900.patch
+++ b/patches/openwrt/0059-ar71xx-Use-PHY-fixups-for-Open-Mesh-MR900.patch
@@ -1,0 +1,78 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Wed, 16 Mar 2016 09:27:11 +0000
+Subject: ar71xx: Use PHY fixups for Open Mesh MR900
+
+The delays of PHY/MAC on the MR900 are done by u-boot and OpenWrt in
+different ways. u-boot only modifies the ETH_CFG of the QCA955x based on
+the link speed. But OpenWrt can only modify the PHY delays based on the
+link speed.
+
+This can lead to communication problems when u-boot initializes the ETH_CFG
+for a specific link speed (e.g. 10BASE-T) but then OpenWrt the sets the PHY
+delays to an incompatible value.
+
+Instead reset the ETH_CFG delay bits of the QCA955x to a specific value and
+only rely on the AT803x PHY settings.
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49030
+
+Forwarded: https://patchwork.ozlabs.org/patch/624185/
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c
+index 9c3164d..3634bf0 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c
+@@ -23,6 +23,7 @@
+ #include <linux/ath9k_platform.h>
+ 
+ #include <asm/mach-ath79/ar71xx_regs.h>
++#include <linux/platform_data/phy-at803x.h>
+ 
+ #include "common.h"
+ #include "dev-ap9x-pci.h"
+@@ -94,15 +95,30 @@ static struct gpio_keys_button mr900_gpio_keys[] __initdata = {
+ 	},
+ };
+ 
++static struct at803x_platform_data mr900_at803x_data = {
++	.disable_smarteee = 1,
++	.enable_rgmii_rx_delay = 1,
++	.enable_rgmii_tx_delay = 0,
++	.fixup_rgmii_tx_delay = 1,
++};
++
++static struct mdio_board_info mr900_mdio0_info[] = {
++	{
++		.bus_id = "ag71xx-mdio.0",
++		.phy_addr = 5,
++		.platform_data = &mr900_at803x_data,
++	},
++};
++
+ static void __init mr900_setup(void)
+ {
+ 	u8 *art = (u8 *)KSEG1ADDR(0x1fff0000);
+ 	u8 mac[6], pcie_mac[6];
+ 	struct ath9k_platform_data *pdata;
+ 
+-	ath79_eth0_pll_data.pll_1000 = 0xbe000101;
+-	ath79_eth0_pll_data.pll_100 = 0x80000101;
+-	ath79_eth0_pll_data.pll_10 = 0x80001313;
++	ath79_eth0_pll_data.pll_1000 = 0xae000000;
++	ath79_eth0_pll_data.pll_100 = 0xa0000101;
++	ath79_eth0_pll_data.pll_10 = 0xa0001313;
+ 
+ 	ath79_register_m25p80(NULL);
+ 
+@@ -126,6 +142,9 @@ static void __init mr900_setup(void)
+ 	ath79_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN);
+ 	ath79_register_mdio(0, 0x0);
+ 
++	mdiobus_register_board_info(mr900_mdio0_info,
++				    ARRAY_SIZE(mr900_mdio0_info));
++
+ 	ath79_init_mac(ath79_eth0_data.mac_addr, art + MR900_MAC0_OFFSET, 0);
+ 
+ 	/* GMAC0 is connected to the RMGII interface */

--- a/patches/openwrt/0060-ar71xx-Use-PHY-fixups-for-Open-Mesh-MR1750.patch
+++ b/patches/openwrt/0060-ar71xx-Use-PHY-fixups-for-Open-Mesh-MR1750.patch
@@ -1,0 +1,77 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Wed, 16 Mar 2016 09:27:14 +0000
+Subject: ar71xx: Use PHY fixups for Open Mesh MR1750
+
+The delays of PHY/MAC on the MR1750 are done by u-boot and OpenWrt in
+different ways. u-boot only modifies the ETH_CFG of the QCA955x based on
+the link speed. But OpenWrt can only modify the PHY delays based on the
+link speed.
+
+This can lead to communication problems when u-boot initializes the ETH_CFG
+for a specific link speed (e.g. 10BASE-T) but then OpenWrt the sets the PHY
+delays to an incompatible value.
+
+Instead reset the ETH_CFG delay bits of the QCA955x to a specific value and
+only rely on the AT803x PHY settings.
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49031
+
+Forwarded: https://patchwork.ozlabs.org/patch/624186/
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
+index 8ace02f..f9e45bd 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
+@@ -22,6 +22,7 @@
+ #include <linux/ar8216_platform.h>
+ 
+ #include <asm/mach-ath79/ar71xx_regs.h>
++#include <linux/platform_data/phy-at803x.h>
+ 
+ #include "common.h"
+ #include "dev-ap9x-pci.h"
+@@ -92,14 +93,29 @@ static struct gpio_keys_button mr1750_gpio_keys[] __initdata = {
+ 	},
+ };
+ 
++static struct at803x_platform_data mr1750_at803x_data = {
++	.disable_smarteee = 1,
++	.enable_rgmii_rx_delay = 1,
++	.enable_rgmii_tx_delay = 0,
++	.fixup_rgmii_tx_delay = 1,
++};
++
++static struct mdio_board_info mr1750_mdio0_info[] = {
++	{
++		.bus_id = "ag71xx-mdio.0",
++		.phy_addr = 5,
++		.platform_data = &mr1750_at803x_data,
++	},
++};
++
+ static void __init mr1750_setup(void)
+ {
+ 	u8 *art = (u8 *)KSEG1ADDR(0x1fff0000);
+ 	u8 mac[6];
+ 
+-	ath79_eth0_pll_data.pll_1000 = 0xbe000101;
+-	ath79_eth0_pll_data.pll_100 = 0x80000101;
+-	ath79_eth0_pll_data.pll_10 = 0x80001313;
++	ath79_eth0_pll_data.pll_1000 = 0xae000000;
++	ath79_eth0_pll_data.pll_100 = 0xa0000101;
++	ath79_eth0_pll_data.pll_10 = 0xa0001313;
+ 
+ 	ath79_register_m25p80(NULL);
+ 
+@@ -116,6 +132,9 @@ static void __init mr1750_setup(void)
+ 	ath79_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN);
+ 	ath79_register_mdio(0, 0x0);
+ 
++	mdiobus_register_board_info(mr1750_mdio0_info,
++				    ARRAY_SIZE(mr1750_mdio0_info));
++
+ 	ath79_init_mac(ath79_eth0_data.mac_addr, art + MR1750_MAC0_OFFSET, 0);
+ 
+ 	/* GMAC0 is connected to the RMGII interface */

--- a/patches/openwrt/0061-ar71xx-Use-private-version-of-ath79_setup_qca955x_et.patch
+++ b/patches/openwrt/0061-ar71xx-Use-private-version-of-ath79_setup_qca955x_et.patch
@@ -1,0 +1,58 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Wed, 23 Mar 2016 12:52:09 +0000
+Subject: ar71xx: Use private version of ath79_setup_qca955x_eth_cfg for MR900
+
+The MR900 must unset some bits in ETH_CFG which were set by u-boot to work
+correctly under OpenWrt. But the global function
+ath79_setup_qca955x_eth_cfg will not unset all of them to increase the
+backward compatiblity with older mach-* files. A private (simplified)
+version for MR900 can be used instead.
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49069
+
+Forwarded: https://patchwork.ozlabs.org/patch/624187/
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c
+index 3634bf0..b439f58 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr900.c
+@@ -110,6 +110,28 @@ static struct mdio_board_info mr900_mdio0_info[] = {
+ 	},
+ };
+ 
++static void __init mr900_setup_qca955x_eth_cfg(u32 mask,
++					       unsigned int rxd,
++					       unsigned int rxdv,
++					       unsigned int txd,
++					       unsigned int txe)
++{
++	void __iomem *base;
++	u32 t;
++
++	base = ioremap(QCA955X_GMAC_BASE, QCA955X_GMAC_SIZE);
++
++	t = mask;
++	t |= rxd << QCA955X_ETH_CFG_RXD_DELAY_SHIFT;
++	t |= rxdv << QCA955X_ETH_CFG_RDV_DELAY_SHIFT;
++	t |= txd << QCA955X_ETH_CFG_TXD_DELAY_SHIFT;
++	t |= txe << QCA955X_ETH_CFG_TXE_DELAY_SHIFT;
++
++	__raw_writel(t, base + QCA955X_GMAC_REG_ETH_CFG);
++
++	iounmap(base);
++}
++
+ static void __init mr900_setup(void)
+ {
+ 	u8 *art = (u8 *)KSEG1ADDR(0x1fff0000);
+@@ -139,7 +161,7 @@ static void __init mr900_setup(void)
+ 	}
+ 	pdata->use_eeprom = true;
+ 
+-	ath79_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN);
++	mr900_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN, 3, 3, 0, 0);
+ 	ath79_register_mdio(0, 0x0);
+ 
+ 	mdiobus_register_board_info(mr900_mdio0_info,

--- a/patches/openwrt/0062-ar71xx-Use-private-version-of-ath79_setup_qca955x_et.patch
+++ b/patches/openwrt/0062-ar71xx-Use-private-version-of-ath79_setup_qca955x_et.patch
@@ -1,0 +1,58 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Wed, 23 Mar 2016 12:52:12 +0000
+Subject: ar71xx: Use private version of ath79_setup_qca955x_eth_cfg for MR1750
+
+The MR1750 must unset some bits in ETH_CFG which were set by u-boot to work
+correctly under OpenWrt. But the global function
+ath79_setup_qca955x_eth_cfg will not unset all of them to increase the
+backward compatiblity with older mach-* files. A private (simplified)
+version for MR1750 can be used instead.
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49070
+
+Forwarded: https://patchwork.ozlabs.org/patch/624188/
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
+index f9e45bd..e3c04e7 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
+@@ -108,6 +108,28 @@ static struct mdio_board_info mr1750_mdio0_info[] = {
+ 	},
+ };
+ 
++static void __init mr1750_setup_qca955x_eth_cfg(u32 mask,
++						unsigned int rxd,
++						unsigned int rxdv,
++						unsigned int txd,
++						unsigned int txe)
++{
++	void __iomem *base;
++	u32 t;
++
++	base = ioremap(QCA955X_GMAC_BASE, QCA955X_GMAC_SIZE);
++
++	t = mask;
++	t |= rxd << QCA955X_ETH_CFG_RXD_DELAY_SHIFT;
++	t |= rxdv << QCA955X_ETH_CFG_RDV_DELAY_SHIFT;
++	t |= txd << QCA955X_ETH_CFG_TXD_DELAY_SHIFT;
++	t |= txe << QCA955X_ETH_CFG_TXE_DELAY_SHIFT;
++
++	__raw_writel(t, base + QCA955X_GMAC_REG_ETH_CFG);
++
++	iounmap(base);
++}
++
+ static void __init mr1750_setup(void)
+ {
+ 	u8 *art = (u8 *)KSEG1ADDR(0x1fff0000);
+@@ -129,7 +151,7 @@ static void __init mr1750_setup(void)
+ 	ath79_register_wmac(art + MR1750_WMAC_CALDATA_OFFSET, mac);
+ 	ath79_register_pci();
+ 
+-	ath79_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN);
++	mr1750_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN, 3, 3, 0, 0);
+ 	ath79_register_mdio(0, 0x0);
+ 
+ 	mdiobus_register_board_info(mr1750_mdio0_info,

--- a/patches/openwrt/0063-scripts-om-fwupgradecfg-gen.sh-Fix-u-boot-image-md5s.patch
+++ b/patches/openwrt/0063-scripts-om-fwupgradecfg-gen.sh-Fix-u-boot-image-md5s.patch
@@ -1,0 +1,43 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Mon, 14 Sep 2015 20:10:10 +0000
+Subject: scripts/om-fwupgradecfg-gen.sh: Fix u-boot image md5sum check
+
+The u-boot on Open Mesh devices checks the whole transfered image against a
+md5sum. This is stored inside the option filemd5sum inside the
+fwupgrade.cfg. The bootloader will not check it when this setting is
+missing and could therefore write invalid images to the flash.
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r46925
+
+Forwarded: https://patchwork.ozlabs.org/patch/624189/
+
+diff --git a/scripts/om-fwupgradecfg-gen.sh b/scripts/om-fwupgradecfg-gen.sh
+index c790214..fab1582 100644
+--- a/scripts/om-fwupgradecfg-gen.sh
++++ b/scripts/om-fwupgradecfg-gen.sh
+@@ -48,6 +48,7 @@ ROOTFS_FLASH_ADDR=$(addr=$(($KERNEL_FLASH_ADDR + ($KERNEL_PART_SIZE * 1024))); p
+ ROOTFS_SIZE=$(stat -c%s "$ROOTFS_PATH")
+ ROOTFS_CHECK_BLOCKS=$((($ROOTFS_SIZE / $CHECK_BS) - $MD5_SKIP_BLOCKS))
+ ROOTFS_MD5=$(md5=$(dd if=$ROOTFS_PATH bs=$CHECK_BS count=$ROOTFS_CHECK_BLOCKS 2>&- | md5sum); echo ${md5%% *})
++ROOTFS_MD5_FULL=$(md5=$(md5sum $ROOTFS_PATH); echo ${md5%% *})
+ ROOTFS_CHECK_SIZE=$(printf '0x%x' $(($ROOTFS_CHECK_BLOCKS * $CHECK_BS)))
+ ROOTFS_PART_SIZE=$(($MAX_PART_SIZE - $KERNEL_PART_SIZE))
+ 
+@@ -55,6 +56,7 @@ cat << EOF > $CFG_OUT
+ [vmlinux]
+ filename=kernel
+ md5sum=$KERNEL_MD5
++filemd5sum=$KERNEL_MD5
+ flashaddr=$KERNEL_FLASH_ADDR
+ checksize=0x0
+ cmd_success=setenv bootseq 1,2; setenv kernel_size_1 $KERNEL_PART_SIZE; saveenv
+@@ -63,6 +65,7 @@ cmd_fail=reset
+ [rootfs]
+ filename=rootfs
+ md5sum=$ROOTFS_MD5
++filemd5sum=$ROOTFS_MD5_FULL
+ flashaddr=$ROOTFS_FLASH_ADDR
+ checksize=$ROOTFS_CHECK_SIZE
+ cmd_success=setenv bootseq 1,2; setenv kernel_size_1 $KERNEL_PART_SIZE; setenv rootfs_size_1 $ROOTFS_PART_SIZE; saveenv

--- a/patches/openwrt/0064-scripts-om-fwupgradecfg-gen.sh-Generate-sha256sum-fo.patch
+++ b/patches/openwrt/0064-scripts-om-fwupgradecfg-gen.sh-Generate-sha256sum-fo.patch
@@ -1,0 +1,50 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:25:42 +0000
+Subject: scripts/om-fwupgradecfg-gen.sh: Generate sha256sum for uboot verification
+
+Future Open Mesh u-boot versions are changing the check of the image files
+(vmlinux, rootfs) from md5 to sha256. Having both in them should be enough
+to ensure backward and forward compatibility.
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49140
+
+Forwarded: https://patchwork.ozlabs.org/patch/624190/
+
+diff --git a/scripts/om-fwupgradecfg-gen.sh b/scripts/om-fwupgradecfg-gen.sh
+index fab1582..e208e6d 100644
+--- a/scripts/om-fwupgradecfg-gen.sh
++++ b/scripts/om-fwupgradecfg-gen.sh
+@@ -42,6 +42,7 @@ CHECK_BS=65536
+ 
+ KERNEL_SIZE=$(stat -c%s "$KERNEL_PATH")
+ KERNEL_MD5=$(md5=$(md5sum $KERNEL_PATH); echo ${md5%% *})
++KERNEL_SHA256=$(openssl dgst -sha256 $KERNEL_PATH | awk '{print $2}')
+ KERNEL_PART_SIZE=$(size=$(($KERNEL_SIZE / $FLASH_BS)); [ $(($size * $FLASH_BS)) -lt $KERNEL_SIZE ] && size=$(($size + 1)); echo $(($size * $FLASH_BS / 1024)))
+ 
+ ROOTFS_FLASH_ADDR=$(addr=$(($KERNEL_FLASH_ADDR + ($KERNEL_PART_SIZE * 1024))); printf "0x%x" $addr)
+@@ -49,6 +50,7 @@ ROOTFS_SIZE=$(stat -c%s "$ROOTFS_PATH")
+ ROOTFS_CHECK_BLOCKS=$((($ROOTFS_SIZE / $CHECK_BS) - $MD5_SKIP_BLOCKS))
+ ROOTFS_MD5=$(md5=$(dd if=$ROOTFS_PATH bs=$CHECK_BS count=$ROOTFS_CHECK_BLOCKS 2>&- | md5sum); echo ${md5%% *})
+ ROOTFS_MD5_FULL=$(md5=$(md5sum $ROOTFS_PATH); echo ${md5%% *})
++ROOTFS_SHA256_FULL=$(openssl dgst -sha256 $ROOTFS_PATH | awk '{print $2}')
+ ROOTFS_CHECK_SIZE=$(printf '0x%x' $(($ROOTFS_CHECK_BLOCKS * $CHECK_BS)))
+ ROOTFS_PART_SIZE=$(($MAX_PART_SIZE - $KERNEL_PART_SIZE))
+ 
+@@ -57,6 +59,7 @@ cat << EOF > $CFG_OUT
+ filename=kernel
+ md5sum=$KERNEL_MD5
+ filemd5sum=$KERNEL_MD5
++filesha256sum=$KERNEL_SHA256
+ flashaddr=$KERNEL_FLASH_ADDR
+ checksize=0x0
+ cmd_success=setenv bootseq 1,2; setenv kernel_size_1 $KERNEL_PART_SIZE; saveenv
+@@ -66,6 +69,7 @@ cmd_fail=reset
+ filename=rootfs
+ md5sum=$ROOTFS_MD5
+ filemd5sum=$ROOTFS_MD5_FULL
++filesha256sum=$ROOTFS_SHA256_FULL
+ flashaddr=$ROOTFS_FLASH_ADDR
+ checksize=$ROOTFS_CHECK_SIZE
+ cmd_success=setenv bootseq 1,2; setenv kernel_size_1 $KERNEL_PART_SIZE; setenv rootfs_size_1 $ROOTFS_PART_SIZE; saveenv

--- a/patches/openwrt/0065-ar71xx-add-kernel-support-for-the-OpenMesh-OM5P-AC-b.patch
+++ b/patches/openwrt/0065-ar71xx-add-kernel-support-for-the-OpenMesh-OM5P-AC-b.patch
@@ -1,0 +1,265 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:25:47 +0000
+Subject: ar71xx: add kernel support for the OpenMesh OM5P-AC board
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49141
+
+Forwarded: https://patchwork.ozlabs.org/patch/624191/
+
+diff --git a/target/linux/ar71xx/config-3.18 b/target/linux/ar71xx/config-3.18
+index c5a3c9a..dd89357 100644
+--- a/target/linux/ar71xx/config-3.18
++++ b/target/linux/ar71xx/config-3.18
+@@ -91,6 +91,7 @@ CONFIG_ATH79_MACH_NBG460N=y
+ CONFIG_ATH79_MACH_NBG6716=y
+ CONFIG_ATH79_MACH_OM2P=y
+ CONFIG_ATH79_MACH_OM5P=y
++CONFIG_ATH79_MACH_OM5P_AC=y
+ CONFIG_ATH79_MACH_ONION_OMEGA=y
+ CONFIG_ATH79_MACH_PB42=y
+ CONFIG_ATH79_MACH_PB44=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-om5pac.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-om5pac.c
+new file mode 100644
+index 0000000..f6974af
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-om5pac.c
+@@ -0,0 +1,193 @@
++/*
++ *  OpenMesh OM5P-AC support
++ *
++ *  Copyright (C) 2013 Marek Lindner <marek@open-mesh.com>
++ *  Copyright (C) 2014 Sven Eckelmann <sven@open-mesh.com>
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under the terms of the GNU General Public License version 2 as published
++ *  by the Free Software Foundation.
++ */
++
++#include <linux/gpio.h>
++#include <linux/mtd/mtd.h>
++#include <linux/mtd/partitions.h>
++#include <linux/platform_device.h>
++#include <linux/i2c.h>
++#include <linux/i2c-algo-bit.h>
++#include <linux/i2c-gpio.h>
++#include <linux/platform_data/phy-at803x.h>
++
++#include <asm/mach-ath79/ar71xx_regs.h>
++#include <asm/mach-ath79/ath79.h>
++
++#include "common.h"
++#include "dev-ap9x-pci.h"
++#include "dev-eth.h"
++#include "dev-leds-gpio.h"
++#include "dev-m25p80.h"
++#include "dev-wmac.h"
++#include "machtypes.h"
++#include "pci.h"
++
++#define OM5PAC_GPIO_LED_POWER	18
++#define OM5PAC_GPIO_LED_GREEN	21
++#define OM5PAC_GPIO_LED_RED	23
++#define OM5PAC_GPIO_LED_YELLOW	22
++#define OM5PAC_GPIO_LED_LAN	20
++#define OM5PAC_GPIO_LED_WAN	19
++#define OM5PAC_GPIO_I2C_SCL	12
++#define OM5PAC_GPIO_I2C_SDA	11
++
++#define OM5PAC_KEYS_POLL_INTERVAL	20	/* msecs */
++#define OM5PAC_KEYS_DEBOUNCE_INTERVAL	(3 * OM5PAC_KEYS_POLL_INTERVAL)
++
++#define OM5PAC_WMAC_CALDATA_OFFSET	0x1000
++
++static struct gpio_led om5pac_leds_gpio[] __initdata = {
++	{
++		.name		= "om5pac:blue:power",
++		.gpio		= OM5PAC_GPIO_LED_POWER,
++		.active_low	= 1,
++	}, {
++		.name		= "om5pac:red:wifi",
++		.gpio		= OM5PAC_GPIO_LED_RED,
++		.active_low	= 1,
++	}, {
++		.name		= "om5pac:yellow:wifi",
++		.gpio		= OM5PAC_GPIO_LED_YELLOW,
++		.active_low	= 1,
++	}, {
++		.name		= "om5pac:green:wifi",
++		.gpio		= OM5PAC_GPIO_LED_GREEN,
++		.active_low	= 1,
++	}, {
++		.name		= "om5pac:blue:lan",
++		.gpio		= OM5PAC_GPIO_LED_LAN,
++		.active_low	= 1,
++	}, {
++		.name		= "om5pac:blue:wan",
++		.gpio		= OM5PAC_GPIO_LED_WAN,
++		.active_low	= 1,
++	}
++};
++
++static struct flash_platform_data om5pac_flash_data = {
++	.type = "mx25l12805d",
++};
++
++static struct i2c_gpio_platform_data om5pac_i2c_device_platdata = {
++	.sda_pin		= OM5PAC_GPIO_I2C_SDA,
++	.scl_pin		= OM5PAC_GPIO_I2C_SCL,
++	.udelay			= 10,
++	.sda_is_open_drain	= 1,
++	.scl_is_open_drain	= 1,
++};
++
++static struct platform_device om5pac_i2c_device = {
++	.name		= "i2c-gpio",
++	.id		= 0,
++	.dev		= {
++		.platform_data	= &om5pac_i2c_device_platdata,
++	},
++};
++
++static struct i2c_board_info om5pac_i2c_devs[] __initdata = {
++	{
++		I2C_BOARD_INFO("tmp423", 0x4c),
++	},
++};
++
++static struct at803x_platform_data om5pac_at803x_data = {
++	.disable_smarteee = 1,
++	.enable_rgmii_rx_delay = 1,
++	.enable_rgmii_tx_delay = 1,
++};
++
++static struct mdio_board_info om5pac_mdio0_info[] = {
++	{
++		.bus_id = "ag71xx-mdio.0",
++		.phy_addr = 1,
++		.platform_data = &om5pac_at803x_data,
++	},
++	{
++		.bus_id = "ag71xx-mdio.0",
++		.phy_addr = 2,
++		.platform_data = &om5pac_at803x_data,
++	},
++};
++
++static void __init om5p_ac_setup_qca955x_eth_cfg(u32 mask,
++						 unsigned int rxd,
++						 unsigned int rxdv,
++						 unsigned int txd,
++						 unsigned int txe)
++{
++	void __iomem *base;
++	u32 t;
++
++	base = ioremap(QCA955X_GMAC_BASE, QCA955X_GMAC_SIZE);
++
++	t = mask;
++	t |= rxd << QCA955X_ETH_CFG_RXD_DELAY_SHIFT;
++	t |= rxdv << QCA955X_ETH_CFG_RDV_DELAY_SHIFT;
++	t |= txd << QCA955X_ETH_CFG_TXD_DELAY_SHIFT;
++	t |= txe << QCA955X_ETH_CFG_TXE_DELAY_SHIFT;
++
++	__raw_writel(t, base + QCA955X_GMAC_REG_ETH_CFG);
++
++	iounmap(base);
++}
++
++static void __init om5p_ac_setup(void)
++{
++	u8 *art = (u8 *)KSEG1ADDR(0x1fff0000);
++	u8 mac[6];
++
++	/* temperature sensor */
++	platform_device_register(&om5pac_i2c_device);
++	i2c_register_board_info(0, om5pac_i2c_devs,
++				ARRAY_SIZE(om5pac_i2c_devs));
++
++	ath79_gpio_output_select(OM5PAC_GPIO_LED_WAN, QCA955X_GPIO_OUT_GPIO);
++
++	ath79_register_m25p80(&om5pac_flash_data);
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(om5pac_leds_gpio),
++				 om5pac_leds_gpio);
++
++	ath79_init_mac(mac, art, 0x02);
++	ath79_register_wmac(art + OM5PAC_WMAC_CALDATA_OFFSET, mac);
++
++	om5p_ac_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN, 3, 3, 0, 0);
++	ath79_register_mdio(0, 0x0);
++
++	mdiobus_register_board_info(om5pac_mdio0_info,
++				    ARRAY_SIZE(om5pac_mdio0_info));
++
++	ath79_init_mac(ath79_eth0_data.mac_addr, art, 0x00);
++	ath79_init_mac(ath79_eth1_data.mac_addr, art, 0x01);
++
++	/* GMAC0 is connected to the PHY1 */
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;
++	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
++	ath79_eth0_data.phy_mask = BIT(1);
++	ath79_eth0_pll_data.pll_1000 = 0x82000101;
++	ath79_eth0_pll_data.pll_100 = 0x80000101;
++	ath79_eth0_pll_data.pll_10 = 0x80001313;
++	ath79_register_eth(0);
++
++	/* GMAC1 is connected to MDIO1 in SGMII mode */
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_SGMII;
++	ath79_eth1_data.mii_bus_dev = &ath79_mdio0_device.dev;
++	ath79_eth1_data.phy_mask = BIT(2);
++	ath79_eth1_pll_data.pll_1000 = 0x03000101;
++	ath79_eth1_pll_data.pll_100 = 0x80000101;
++	ath79_eth1_pll_data.pll_10 = 0x80001313;
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_register_eth(1);
++
++	ath79_register_pci();
++}
++
++MIPS_MACHINE(ATH79_MACH_OM5P_AC, "OM5P-AC", "OpenMesh OM5P AC", om5p_ac_setup);
+diff --git a/target/linux/ar71xx/patches-3.18/815-MIPS-ath79-add-om5pac-support.patch b/target/linux/ar71xx/patches-3.18/815-MIPS-ath79-add-om5pac-support.patch
+new file mode 100644
+index 0000000..4accd03
+--- /dev/null
++++ b/target/linux/ar71xx/patches-3.18/815-MIPS-ath79-add-om5pac-support.patch
+@@ -0,0 +1,38 @@
++--- a/arch/mips/ath79/Kconfig
+++++ b/arch/mips/ath79/Kconfig
++@@ -799,6 +799,15 @@ config ATH79_MACH_OM5P
++ 	select ATH79_DEV_M25P80
++ 	select ATH79_DEV_WMAC
++ 
+++config ATH79_MACH_OM5P_AC
+++	bool "OpenMesh OM5P-AC board support"
+++	select SOC_QCA955X
+++	select ATH79_DEV_AP9X_PCI if PCI
+++	select ATH79_DEV_ETH
+++	select ATH79_DEV_LEDS_GPIO
+++	select ATH79_DEV_M25P80
+++	select ATH79_DEV_WMAC
+++
++ config ATH79_MACH_ONION_OMEGA
++ 	bool "ONION OMEGA support"
++ 	select SOC_AR933X
++--- a/arch/mips/ath79/Makefile
+++++ b/arch/mips/ath79/Makefile
++@@ -100,6 +100,7 @@ obj-$(CONFIG_ATH79_MACH_MZK_W300NH)	+= m
++ obj-$(CONFIG_ATH79_MACH_NBG460N)	+= mach-nbg460n.o
++ obj-$(CONFIG_ATH79_MACH_OM2P)		+= mach-om2p.o
++ obj-$(CONFIG_ATH79_MACH_OM5P)		+= mach-om5p.o
+++obj-$(CONFIG_ATH79_MACH_OM5P_AC)	+= mach-om5pac.o
++ obj-$(CONFIG_ATH79_MACH_ONION_OMEGA)	+= mach-onion-omega.o
++ obj-$(CONFIG_ATH79_MACH_PB42)		+= mach-pb42.o
++ obj-$(CONFIG_ATH79_MACH_PB44)		+= mach-pb44.o
++--- a/arch/mips/ath79/machtypes.h
+++++ b/arch/mips/ath79/machtypes.h
++@@ -95,6 +95,7 @@ enum ath79_mach_type {
++ 	ATH79_MACH_OM2P_LC,		/* OpenMesh OM2P-LC */
++ 	ATH79_MACH_OM2Pv2,		/* OpenMesh OM2Pv2 */
++ 	ATH79_MACH_OM2P,		/* OpenMesh OM2P */
+++	ATH79_MACH_OM5P_AC,		/* OpenMesh OM5P-AC */
++ 	ATH79_MACH_OM5P_AN,		/* OpenMesh OM5P-AN */
++ 	ATH79_MACH_OM5P,		/* OpenMesh OM5P */
++ 	ATH79_MACH_ONION_OMEGA,		/* ONION OMEGA */

--- a/patches/openwrt/0066-ar71xx-add-user-space-support-for-the-OpenMesh-OM5P-.patch
+++ b/patches/openwrt/0066-ar71xx-add-user-space-support-for-the-OpenMesh-OM5P-.patch
@@ -1,0 +1,54 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:25:51 +0000
+Subject: ar71xx: add user-space support for the OpenMesh OM5P-AC
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49142
+
+Forwarded: https://patchwork.ozlabs.org/patch/624192/
+
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 44d2ddf..a4051f2 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -178,6 +178,9 @@ get_status_led() {
+ 	om5p-an)
+ 		status_led="om5p:blue:power"
+ 		;;
++	om5p-ac)
++		status_led="om5pac:blue:power"
++		;;
+ 	onion-omega)
+ 		status_led="onion:amber:system"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+index c451124..9a768cd 100644
+--- a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+@@ -304,6 +304,11 @@ om5p-an)
+ 	ucidef_set_led_netdev "port2" "port2" "om5p:blue:lan" "eth1"
+ 	;;
+ 
++om5p-ac)
++	ucidef_set_led_netdev "port1" "port1" "om5pac:blue:lan" "eth0"
++	ucidef_set_led_netdev "port2" "port2" "om5pac:blue:wan" "eth1"
++	;;
++
+ qihoo-c301)
+ 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "qihoo:red:status" "phy1tpt"
+ 	;;
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 587d029..10b8048 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -616,6 +616,9 @@ ar71xx_board_detect() {
+ 	*"OM5P AN")
+ 		name="om5p-an"
+ 		;;
++	*"OM5P AC")
++		name="om5p-ac"
++		;;
+ 	*"Onion Omega")
+ 		name="onion-omega"
+ 		;;

--- a/patches/openwrt/0067-scripts-om-fwupgradecfg-gen.sh-add-support-for-the-O.patch
+++ b/patches/openwrt/0067-scripts-om-fwupgradecfg-gen.sh-add-support-for-the-O.patch
@@ -1,0 +1,32 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:25:54 +0000
+Subject: scripts/om-fwupgradecfg-gen.sh: add support for the OM5P-AC
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49143
+
+Forwarded: https://patchwork.ozlabs.org/patch/624193/
+
+diff --git a/scripts/om-fwupgradecfg-gen.sh b/scripts/om-fwupgradecfg-gen.sh
+index e208e6d..6c3b74c 100644
+--- a/scripts/om-fwupgradecfg-gen.sh
++++ b/scripts/om-fwupgradecfg-gen.sh
+@@ -7,7 +7,7 @@
+ #
+ 
+ usage() {
+-	echo "Usage: $0 <OM2P|OM5P|MR600|MR900|MR1750> <out file path> <kernel path> <rootfs path>"
++	echo "Usage: $0 <OM2P|OM5P|OM5PAC|MR600|MR900|MR1750> <out file path> <kernel path> <rootfs path>"
+ 	rm -f $CFG_OUT
+ 	exit 1
+ }
+@@ -26,7 +26,7 @@ case $CE_TYPE in
+ 		FLASH_BS=262144
+ 		MD5_SKIP_BLOCKS=1
+ 		;;
+-	OM5P|MR600|MR900|MR1750)
++	OM5P|OM5PAC|MR600|MR900|MR1750)
+ 		MAX_PART_SIZE=7808
+ 		KERNEL_FLASH_ADDR=0xb0000
+ 		FLASH_BS=65536

--- a/patches/openwrt/0068-ar71xx-enable-sysupgrade-for-the-OpenMesh-OM5P-AC.patch
+++ b/patches/openwrt/0068-ar71xx-enable-sysupgrade-for-the-OpenMesh-OM5P-AC.patch
@@ -1,0 +1,59 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:25:57 +0000
+Subject: ar71xx: enable sysupgrade for the OpenMesh OM5P-AC
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49144
+
+Forwarded: https://patchwork.ozlabs.org/patch/624194/
+
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+index 9ca0f5b..1cfead9 100644
+--- a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+@@ -72,6 +72,11 @@ platform_check_image_openmesh()
+ 			echo "Invalid image board target ($img_board_target) for this platform: $board. Use the correct image for this platform"
+ 			return 1
+ 			;;
++		OM5PAC)
++			[ "$board" = "om5p-ac" ] && break
++			echo "Invalid image board target ($img_board_target) for this platform: $board. Use the correct image for this platform"
++			return 1
++			;;
+ 		MR1750)
+ 			[ "$board" = "mr1750" ] && break
+ 			echo "Invalid image board target ($img_board_target) for this platform: $board. Use the correct image for this platform"
+@@ -162,7 +167,7 @@ platform_do_upgrade_openmesh()
+ 			kernel_start_addr1=0x9f1c0000
+ 			kernel_start_addr2=0x9f8c0000
+ 			;;
+-		OM5P|MR600|MR900|MR1750)
++		OM5P|OM5PAC|MR600|MR900|MR1750)
+ 			block_size=$((64 * 1024))
+ 			total_size=7995392
+ 			kernel_start_addr1=0x9f0b0000
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index ac060ea..67c0661 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -307,7 +307,8 @@ platform_check_image() {
+ 	om2p-hsv2 | \
+ 	om2p-lc | \
+ 	om5p | \
+-	om5p-an)
++	om5p-an | \
++	om5p-ac)
+ 		platform_check_image_openmesh "$magic_long" "$1" && return 0
+ 		return 1
+ 		;;
+@@ -540,7 +541,8 @@ platform_do_upgrade() {
+ 	om2p-hsv2 | \
+ 	om2p-lc | \
+ 	om5p | \
+-	om5p-an)
++	om5p-an | \
++	om5p-ac)
+ 		platform_do_upgrade_openmesh "$ARGV"
+ 		;;
+ 	unifi-outdoor-plus | \

--- a/patches/openwrt/0069-om-watchdog-add-OpenMesh-OM5P-AC-support.patch
+++ b/patches/openwrt/0069-om-watchdog-add-OpenMesh-OM5P-AC-support.patch
@@ -1,0 +1,24 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:01 +0000
+Subject: om-watchdog: add OpenMesh OM5P-AC support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49145
+
+Forwarded: https://patchwork.ozlabs.org/patch/624195/
+
+diff --git a/package/kernel/om-watchdog/files/om-watchdog.init b/package/kernel/om-watchdog/files/om-watchdog.init
+index c792968..8cec13b 100644
+--- a/package/kernel/om-watchdog/files/om-watchdog.init
++++ b/package/kernel/om-watchdog/files/om-watchdog.init
+@@ -22,6 +22,9 @@ boot() {
+ 			"om5p"|"om5p-an")
+ 				service_start /sbin/om-watchdog 11
+ 				;;
++			"om5p-ac")
++				service_start /sbin/om-watchdog 17
++				;;
+ 			"mr600v2")
+ 				service_start /sbin/om-watchdog 15
+ 				;;

--- a/patches/openwrt/0070-uboot-envtools-add-OpenMesh-OM5P-AC-support.patch
+++ b/patches/openwrt/0070-uboot-envtools-add-OpenMesh-OM5P-AC-support.patch
@@ -1,0 +1,22 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:04 +0000
+Subject: uboot-envtools: add OpenMesh OM5P-AC support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49146
+
+Forwarded: https://patchwork.ozlabs.org/patch/624196/
+
+diff --git a/package/boot/uboot-envtools/files/ar71xx b/package/boot/uboot-envtools/files/ar71xx
+index ef00f17..657b25f 100644
+--- a/package/boot/uboot-envtools/files/ar71xx
++++ b/package/boot/uboot-envtools/files/ar71xx
+@@ -28,6 +28,7 @@ mr900 | \
+ mr900v2 | \
+ nbg6716 | \
+ om5p-an | \
++om5p-ac | \
+ om5p | \
+ tube2h | \
+ wndr3700)

--- a/patches/openwrt/0071-ar71xx-extract-ath10k-wifi-board.bin-for-the-OpenMes.patch
+++ b/patches/openwrt/0071-ar71xx-extract-ath10k-wifi-board.bin-for-the-OpenMes.patch
@@ -1,0 +1,25 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:08 +0000
+Subject: ar71xx: extract ath10k wifi board.bin for the OpenMesh OM5P-AC board
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49147
+
+Forwarded: https://patchwork.ozlabs.org/patch/624197/
+
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index cde7aaf..c1f4b85 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -96,6 +96,10 @@ case "$FIRMWARE" in
+ 	rb-911g-5hpacd)
+ 		ath10kcal_from_file "/sys/firmware/routerboot/ext_wlan_data" 20480 2116
+ 		;;
++	om5p-ac)
++		ath10kcal_extract "ART" 20480 2116
++		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
++		;;
+ 	esac
+ 	;;
+ *)

--- a/patches/openwrt/0072-ar71xx-create-profile-and-build-image-for-the-OpenMe.patch
+++ b/patches/openwrt/0072-ar71xx-create-profile-and-build-image-for-the-OpenMe.patch
@@ -1,0 +1,53 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:11 +0000
+Subject: ar71xx: create profile and build image for the OpenMesh OM5P-AC board
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49148
+
+Forwarded: https://patchwork.ozlabs.org/patch/624198/
+
+diff --git a/target/linux/ar71xx/generic/profiles/openmesh.mk b/target/linux/ar71xx/generic/profiles/openmesh.mk
+index 06cf135..64aaa24 100644
+--- a/target/linux/ar71xx/generic/profiles/openmesh.mk
++++ b/target/linux/ar71xx/generic/profiles/openmesh.mk
+@@ -27,6 +27,17 @@ endef
+ 
+ $(eval $(call Profile,OM5P))
+ 
++define Profile/OM5PAC
++	NAME:=OpenMesh OM5P-AC
++	PACKAGES:=kmod-ath9k kmod-ath10k om-watchdog ath10k-firmware-qca988x
++endef
++
++define Profile/OM5PAC/Description
++	Package set optimized for the OpenMesh OM5P-AC.
++endef
++
++$(eval $(call Profile,OM5PAC))
++
+ define Profile/MR600
+         NAME:=OpenMesh MR600
+         PACKAGES:=kmod-ath9k om-watchdog
+diff --git a/target/linux/ar71xx/image/Makefile b/target/linux/ar71xx/image/Makefile
+index b74aa45..06dbb77 100644
+--- a/target/linux/ar71xx/image/Makefile
++++ b/target/linux/ar71xx/image/Makefile
+@@ -2043,6 +2043,7 @@ $(eval $(call SingleProfile,Netgear,64kraw,WPN824N,wpn824n,WPN824N,ttyS0,115200,
+ 
+ $(eval $(call SingleProfile,OpenMesh,squashfs-only,OM2P,om2p,,,,OM2P))
+ $(eval $(call SingleProfile,OpenMesh,squashfs-only,OM5P,om5p,,,,OM5P))
++$(eval $(call SingleProfile,OpenMesh,squashfs-only,OM5PAC,om5pac,,,,OM5PAC))
+ $(eval $(call SingleProfile,OpenMesh,squashfs-only,MR600,mr600,,,,MR600))
+ $(eval $(call SingleProfile,OpenMesh,squashfs-only,MR900,mr900,,,,MR900))
+ $(eval $(call SingleProfile,OpenMesh,squashfs-only,MR1750,mr1750,,,,MR1750))
+@@ -2139,7 +2140,7 @@ $(eval $(call MultiProfile,AP121,AP121_2M AP121_4M))
+ $(eval $(call MultiProfile,DIR615IX,DIR615I1 DIR615I3))
+ $(eval $(call MultiProfile,AP136,AP136_010 AP136_020))
+ $(eval $(call MultiProfile,EWDORIN, EWDORINAP EWDORINRT EWDORIN16M))
+-$(eval $(call MultiProfile,OPENMESH,OM2P OM5P MR600 MR900 MR1750))
++$(eval $(call MultiProfile,OPENMESH,OM2P OM5P OM5PAC MR600 MR900 MR1750))
+ $(eval $(call MultiProfile,TEW652BRP,TEW652BRP_FW TEW652BRP_RECOVERY))
+ $(eval $(call MultiProfile,TLMR3220,TLMR3220V1))
+ $(eval $(call MultiProfile,TLMR3420,TLMR3420V1))

--- a/patches/openwrt/0073-ar71xx-add-kernel-support-for-the-OpenMesh-OM5P-ACv2.patch
+++ b/patches/openwrt/0073-ar71xx-add-kernel-support-for-the-OpenMesh-OM5P-ACv2.patch
@@ -1,0 +1,289 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:15 +0000
+Subject: ar71xx: add kernel support for the OpenMesh OM5P-ACv2 board
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49149
+
+Forwarded: https://patchwork.ozlabs.org/patch/624199/
+
+diff --git a/target/linux/ar71xx/config-3.18 b/target/linux/ar71xx/config-3.18
+index dd89357..514f7d5 100644
+--- a/target/linux/ar71xx/config-3.18
++++ b/target/linux/ar71xx/config-3.18
+@@ -92,6 +92,7 @@ CONFIG_ATH79_MACH_NBG6716=y
+ CONFIG_ATH79_MACH_OM2P=y
+ CONFIG_ATH79_MACH_OM5P=y
+ CONFIG_ATH79_MACH_OM5P_AC=y
++CONFIG_ATH79_MACH_OM5P_ACv2=y
+ CONFIG_ATH79_MACH_ONION_OMEGA=y
+ CONFIG_ATH79_MACH_PB42=y
+ CONFIG_ATH79_MACH_PB44=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-om5pacv2.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-om5pacv2.c
+new file mode 100644
+index 0000000..587ca32
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-om5pacv2.c
+@@ -0,0 +1,216 @@
++/*
++ *  OpenMesh OM5P-ACv2 support
++ *
++ *  Copyright (C) 2013 Marek Lindner <marek@open-mesh.com>
++ *  Copyright (C) 2014-2016 Sven Eckelmann <sven@open-mesh.com>
++ *  Copyright (C) 2015 Open-Mesh - Jim Collar <jim.collar@eqware.net>
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under the terms of the GNU General Public License version 2 as published
++ *  by the Free Software Foundation.
++ */
++
++#include <linux/gpio.h>
++#include <linux/mdio-gpio.h>
++#include <linux/mtd/mtd.h>
++#include <linux/mtd/partitions.h>
++#include <linux/platform_device.h>
++#include <linux/i2c.h>
++#include <linux/i2c-algo-bit.h>
++#include <linux/i2c-gpio.h>
++#include <linux/platform_data/phy-at803x.h>
++
++#include <asm/mach-ath79/ar71xx_regs.h>
++#include <asm/mach-ath79/ath79.h>
++
++#include "common.h"
++#include "dev-ap9x-pci.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-m25p80.h"
++#include "dev-wmac.h"
++#include "machtypes.h"
++#include "pci.h"
++
++#define OM5PACV2_GPIO_LED_POWER	14
++#define OM5PACV2_GPIO_LED_GREEN	13
++#define OM5PACV2_GPIO_LED_RED	23
++#define OM5PACV2_GPIO_LED_YELLOW	15
++#define OM5PACV2_GPIO_BTN_RESET	1
++#define OM5PACV2_GPIO_I2C_SCL	18
++#define OM5PACV2_GPIO_I2C_SDA	19
++#define OM5PACV2_GPIO_PA_DCDC	2
++#define OM5PACV2_GPIO_PA_HIGH	16
++
++#define OM5PACV2_KEYS_POLL_INTERVAL	20	/* msecs */
++#define OM5PACV2_KEYS_DEBOUNCE_INTERVAL	(3 * OM5PACV2_KEYS_POLL_INTERVAL)
++
++#define OM5PACV2_WMAC_CALDATA_OFFSET	0x1000
++
++static struct gpio_led om5pacv2_leds_gpio[] __initdata = {
++	{
++		.name		= "om5pac:blue:power",
++		.gpio		= OM5PACV2_GPIO_LED_POWER,
++		.active_low	= 1,
++	}, {
++		.name		= "om5pac:red:wifi",
++		.gpio		= OM5PACV2_GPIO_LED_RED,
++		.active_low	= 1,
++	}, {
++		.name		= "om5pac:yellow:wifi",
++		.gpio		= OM5PACV2_GPIO_LED_YELLOW,
++		.active_low	= 1,
++	}, {
++		.name		= "om5pac:green:wifi",
++		.gpio		= OM5PACV2_GPIO_LED_GREEN,
++		.active_low	= 1,
++	}
++};
++
++static struct gpio_keys_button om5pacv2_gpio_keys[] __initdata = {
++	{
++		.desc		= "reset",
++		.type		= EV_KEY,
++		.code		= KEY_RESTART,
++		.debounce_interval = OM5PACV2_KEYS_DEBOUNCE_INTERVAL,
++		.gpio		= OM5PACV2_GPIO_BTN_RESET,
++		.active_low	= 1,
++	}
++};
++
++static struct i2c_gpio_platform_data om5pacv2_i2c_device_platdata = {
++	.sda_pin		= OM5PACV2_GPIO_I2C_SDA,
++	.scl_pin		= OM5PACV2_GPIO_I2C_SCL,
++	.udelay			= 10,
++	.sda_is_open_drain	= 1,
++	.scl_is_open_drain	= 1,
++};
++
++static struct platform_device om5pacv2_i2c_device = {
++	.name		= "i2c-gpio",
++	.id		= 0,
++	.dev		= {
++		.platform_data	= &om5pacv2_i2c_device_platdata,
++	},
++};
++
++static struct i2c_board_info om5pacv2_i2c_devs[] __initdata = {
++	{
++		I2C_BOARD_INFO("tmp423", 0x4e),
++	},
++};
++
++static struct flash_platform_data om5pacv2_flash_data = {
++	.type = "mx25l12805d",
++};
++
++static struct at803x_platform_data om5pacv2_an_at803x_data = {
++	.disable_smarteee = 1,
++	.enable_rgmii_rx_delay = 1,
++	.enable_rgmii_tx_delay = 1,
++};
++
++static struct at803x_platform_data om5pacv2_an_at8031_data = {
++	.disable_smarteee = 1,
++	.enable_rgmii_rx_delay = 1,
++	.enable_rgmii_tx_delay = 1,
++};
++
++static struct mdio_board_info om5pacv2_an_mdio0_info[] = {
++	{
++		.bus_id = "ag71xx-mdio.0",
++		.phy_addr = 4,
++		.platform_data = &om5pacv2_an_at803x_data,
++	},
++	{
++		.bus_id = "ag71xx-mdio.1",
++		.phy_addr = 1,
++		.platform_data = &om5pacv2_an_at8031_data,
++	},
++};
++
++static void __init om5p_acv2_setup_qca955x_eth_cfg(u32 mask,
++						   unsigned int rxd,
++						   unsigned int rxdv,
++						   unsigned int txd,
++						   unsigned int txe)
++{
++	void __iomem *base;
++	u32 t;
++
++	base = ioremap(QCA955X_GMAC_BASE, QCA955X_GMAC_SIZE);
++
++	t = mask;
++	t |= rxd << QCA955X_ETH_CFG_RXD_DELAY_SHIFT;
++	t |= rxdv << QCA955X_ETH_CFG_RDV_DELAY_SHIFT;
++	t |= txd << QCA955X_ETH_CFG_TXD_DELAY_SHIFT;
++	t |= txe << QCA955X_ETH_CFG_TXE_DELAY_SHIFT;
++
++	__raw_writel(t, base + QCA955X_GMAC_REG_ETH_CFG);
++
++	iounmap(base);
++}
++
++static void __init om5p_acv2_setup(void)
++{
++	u8 *art = (u8 *)KSEG1ADDR(0x1fff0000);
++	u8 mac[6];
++
++	/* power amplifier high power, 4.2V at RFFM4203/4503 instead of 3.3 */
++	ath79_gpio_function_enable(QCA955X_GPIO_FUNC_JTAG_DISABLE);
++	ath79_gpio_output_select(OM5PACV2_GPIO_PA_DCDC, QCA955X_GPIO_OUT_GPIO);
++	ath79_gpio_output_select(OM5PACV2_GPIO_PA_HIGH, QCA955X_GPIO_OUT_GPIO);
++	gpio_request_one(OM5PACV2_GPIO_PA_DCDC, GPIOF_OUT_INIT_HIGH,
++			 "PA DC/DC");
++	gpio_request_one(OM5PACV2_GPIO_PA_HIGH, GPIOF_OUT_INIT_HIGH, "PA HIGH");
++
++	/* temperature sensor */
++	platform_device_register(&om5pacv2_i2c_device);
++	i2c_register_board_info(0, om5pacv2_i2c_devs,
++				ARRAY_SIZE(om5pacv2_i2c_devs));
++
++	ath79_register_m25p80(&om5pacv2_flash_data);
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(om5pacv2_leds_gpio),
++				 om5pacv2_leds_gpio);
++	ath79_register_gpio_keys_polled(-1, OM5PACV2_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(om5pacv2_gpio_keys),
++					om5pacv2_gpio_keys);
++
++	ath79_init_mac(mac, art, 0x02);
++	ath79_register_wmac(art + OM5PACV2_WMAC_CALDATA_OFFSET, mac);
++
++	om5p_acv2_setup_qca955x_eth_cfg(QCA955X_ETH_CFG_RGMII_EN, 2, 2, 0, 0);
++	ath79_register_mdio(0, 0x0);
++	ath79_register_mdio(1, 0x0);
++
++	mdiobus_register_board_info(om5pacv2_an_mdio0_info,
++				    ARRAY_SIZE(om5pacv2_an_mdio0_info));
++
++	ath79_init_mac(ath79_eth0_data.mac_addr, art, 0x00);
++	ath79_init_mac(ath79_eth1_data.mac_addr, art, 0x01);
++
++	/* GMAC0 is connected to the PHY4 */
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;
++	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
++	ath79_eth0_data.phy_mask = BIT(4);
++	ath79_eth0_pll_data.pll_1000 = 0x82000101;
++	ath79_eth0_pll_data.pll_100 = 0x80000101;
++	ath79_eth0_pll_data.pll_10 = 0x80001313;
++	ath79_register_eth(0);
++
++	/* GMAC1 is connected to MDIO1 in SGMII mode */
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_SGMII;
++	ath79_eth1_data.mii_bus_dev = &ath79_mdio1_device.dev;
++	ath79_eth1_data.phy_mask = BIT(1);
++	ath79_eth1_pll_data.pll_1000 = 0x03000101;
++	ath79_eth1_pll_data.pll_100 = 0x80000101;
++	ath79_eth1_pll_data.pll_10 = 0x80001313;
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_register_eth(1);
++
++	ath79_register_pci();
++}
++
++MIPS_MACHINE(ATH79_MACH_OM5P_ACv2, "OM5P-ACv2", "OpenMesh OM5P ACv2", om5p_acv2_setup);
+diff --git a/target/linux/ar71xx/patches-3.18/816-MIPS-ath79-add-om5pacv-support.patch b/target/linux/ar71xx/patches-3.18/816-MIPS-ath79-add-om5pacv-support.patch
+new file mode 100644
+index 0000000..fbbf171
+--- /dev/null
++++ b/target/linux/ar71xx/patches-3.18/816-MIPS-ath79-add-om5pacv-support.patch
+@@ -0,0 +1,39 @@
++--- a/arch/mips/ath79/Kconfig
+++++ b/arch/mips/ath79/Kconfig
++@@ -808,6 +808,16 @@ config ATH79_MACH_OM5P_AC
++ 	select ATH79_DEV_M25P80
++ 	select ATH79_DEV_WMAC
++ 
+++config ATH79_MACH_OM5P_ACv2
+++	bool "OpenMesh OM5P-ACv2 board support"
+++	select SOC_QCA955X
+++	select ATH79_DEV_AP9X_PCI if PCI
+++	select ATH79_DEV_ETH
+++	select ATH79_DEV_GPIO_BUTTONS
+++	select ATH79_DEV_LEDS_GPIO
+++	select ATH79_DEV_M25P80
+++	select ATH79_DEV_WMAC
+++
++ config ATH79_MACH_ONION_OMEGA
++ 	bool "ONION OMEGA support"
++ 	select SOC_AR933X
++--- a/arch/mips/ath79/Makefile
+++++ b/arch/mips/ath79/Makefile
++@@ -101,6 +101,7 @@ obj-$(CONFIG_ATH79_MACH_NBG460N)	+= mach
++ obj-$(CONFIG_ATH79_MACH_OM2P)		+= mach-om2p.o
++ obj-$(CONFIG_ATH79_MACH_OM5P)		+= mach-om5p.o
++ obj-$(CONFIG_ATH79_MACH_OM5P_AC)	+= mach-om5pac.o
+++obj-$(CONFIG_ATH79_MACH_OM5P_ACv2)	+= mach-om5pacv2.o
++ obj-$(CONFIG_ATH79_MACH_ONION_OMEGA)	+= mach-onion-omega.o
++ obj-$(CONFIG_ATH79_MACH_PB42)		+= mach-pb42.o
++ obj-$(CONFIG_ATH79_MACH_PB44)		+= mach-pb44.o
++--- a/arch/mips/ath79/machtypes.h
+++++ b/arch/mips/ath79/machtypes.h
++@@ -96,6 +96,7 @@ enum ath79_mach_type {
++ 	ATH79_MACH_OM2Pv2,		/* OpenMesh OM2Pv2 */
++ 	ATH79_MACH_OM2P,		/* OpenMesh OM2P */
++ 	ATH79_MACH_OM5P_AC,		/* OpenMesh OM5P-AC */
+++	ATH79_MACH_OM5P_ACv2,		/* OpenMesh OM5P-ACv2 */
++ 	ATH79_MACH_OM5P_AN,		/* OpenMesh OM5P-AN */
++ 	ATH79_MACH_OM5P,		/* OpenMesh OM5P */
++ 	ATH79_MACH_ONION_OMEGA,		/* ONION OMEGA */

--- a/patches/openwrt/0074-ar71xx-add-user-space-support-for-the-OpenMesh-OM5P-.patch
+++ b/patches/openwrt/0074-ar71xx-add-user-space-support-for-the-OpenMesh-OM5P-.patch
@@ -1,0 +1,38 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:18 +0000
+Subject: ar71xx: add user-space support for the OpenMesh OM5P-ACv2
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49150
+
+Forwarded: https://patchwork.ozlabs.org/patch/624200/
+
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index a4051f2..d4d8b4e 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -178,7 +178,8 @@ get_status_led() {
+ 	om5p-an)
+ 		status_led="om5p:blue:power"
+ 		;;
+-	om5p-ac)
++	om5p-ac | \
++	om5p-acv2)
+ 		status_led="om5pac:blue:power"
+ 		;;
+ 	onion-omega)
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 10b8048..fbf76c8 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -619,6 +619,9 @@ ar71xx_board_detect() {
+ 	*"OM5P AC")
+ 		name="om5p-ac"
+ 		;;
++	*"OM5P ACv2")
++		name="om5p-acv2"
++		;;
+ 	*"Onion Omega")
+ 		name="onion-omega"
+ 		;;

--- a/patches/openwrt/0075-ar71xx-enable-sysupgrade-for-the-OpenMesh-OM5P-ACv2.patch
+++ b/patches/openwrt/0075-ar71xx-enable-sysupgrade-for-the-OpenMesh-OM5P-ACv2.patch
@@ -1,0 +1,46 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:22 +0000
+Subject: ar71xx: enable sysupgrade for the OpenMesh OM5P-ACv2
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49151
+
+Forwarded: https://patchwork.ozlabs.org/patch/624201/
+
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+index 1cfead9..209cdaa 100644
+--- a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+@@ -74,6 +74,7 @@ platform_check_image_openmesh()
+ 			;;
+ 		OM5PAC)
+ 			[ "$board" = "om5p-ac" ] && break
++			[ "$board" = "om5p-acv2" ] && break
+ 			echo "Invalid image board target ($img_board_target) for this platform: $board. Use the correct image for this platform"
+ 			return 1
+ 			;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index 67c0661..4a4c476 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -308,7 +308,8 @@ platform_check_image() {
+ 	om2p-lc | \
+ 	om5p | \
+ 	om5p-an | \
+-	om5p-ac)
++	om5p-ac | \
++	om5p-acv2)
+ 		platform_check_image_openmesh "$magic_long" "$1" && return 0
+ 		return 1
+ 		;;
+@@ -542,7 +543,8 @@ platform_do_upgrade() {
+ 	om2p-lc | \
+ 	om5p | \
+ 	om5p-an | \
+-	om5p-ac)
++	om5p-ac | \
++	om5p-acv2)
+ 		platform_do_upgrade_openmesh "$ARGV"
+ 		;;
+ 	unifi-outdoor-plus | \

--- a/patches/openwrt/0076-om-watchdog-add-OpenMesh-OM5P-ACv2-support.patch
+++ b/patches/openwrt/0076-om-watchdog-add-OpenMesh-OM5P-ACv2-support.patch
@@ -1,0 +1,23 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:25 +0000
+Subject: om-watchdog: add OpenMesh OM5P-ACv2 support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49152
+
+Forwarded: https://patchwork.ozlabs.org/patch/624202/
+
+diff --git a/package/kernel/om-watchdog/files/om-watchdog.init b/package/kernel/om-watchdog/files/om-watchdog.init
+index 8cec13b..6b96966 100644
+--- a/package/kernel/om-watchdog/files/om-watchdog.init
++++ b/package/kernel/om-watchdog/files/om-watchdog.init
+@@ -13,7 +13,7 @@ boot() {
+ 		local board=$(ar71xx_board_name)
+ 
+ 		case "$board" in
+-			"om2p"|"om2p-hs"|"om2p-hsv2")
++			"om2p"|"om2p-hs"|"om2p-hsv2"|"om5p-acv2")
+ 				service_start /sbin/om-watchdog 12
+ 				;;
+ 			"om2pv2"|"om2p-lc")

--- a/patches/openwrt/0077-uboot-envtools-add-OpenMesh-OM5P-ACv2-support.patch
+++ b/patches/openwrt/0077-uboot-envtools-add-OpenMesh-OM5P-ACv2-support.patch
@@ -1,0 +1,22 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:28 +0000
+Subject: uboot-envtools: add OpenMesh OM5P-ACv2 support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49153
+
+Forwarded: https://patchwork.ozlabs.org/patch/624203/
+
+diff --git a/package/boot/uboot-envtools/files/ar71xx b/package/boot/uboot-envtools/files/ar71xx
+index 657b25f..9071c11 100644
+--- a/package/boot/uboot-envtools/files/ar71xx
++++ b/package/boot/uboot-envtools/files/ar71xx
+@@ -29,6 +29,7 @@ mr900v2 | \
+ nbg6716 | \
+ om5p-an | \
+ om5p-ac | \
++om5p-acv2 | \
+ om5p | \
+ tube2h | \
+ wndr3700)

--- a/patches/openwrt/0078-ar71xx-extract-ath10k-wifi-board.bin-for-the-OpenMes.patch
+++ b/patches/openwrt/0078-ar71xx-extract-ath10k-wifi-board.bin-for-the-OpenMes.patch
@@ -1,0 +1,24 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:31 +0000
+Subject: ar71xx: extract ath10k wifi board.bin for the OpenMesh OM5P-ACv2 board
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49154
+
+Forwarded: https://patchwork.ozlabs.org/patch/624204/
+
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index c1f4b85..d925a85 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -71,7 +71,8 @@ case "$FIRMWARE" in
+ 		ath10kcal_extract "caldata" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
+ 		;;
+-	mr1750)
++	mr1750 | \
++	om5p-acv2)
+ 		ath10kcal_extract "ART" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
+ 		;;

--- a/patches/openwrt/0079-ar71xx-add-OM5P-ACv2-to-the-OM5P-AC-profile.patch
+++ b/patches/openwrt/0079-ar71xx-add-OM5P-ACv2-to-the-OM5P-AC-profile.patch
@@ -1,0 +1,29 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Sat, 9 Apr 2016 10:26:34 +0000
+Subject: ar71xx: add OM5P-ACv2 to the OM5P-AC profile
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Backport of r49155
+
+Forwarded: https://patchwork.ozlabs.org/patch/624205/
+
+diff --git a/target/linux/ar71xx/generic/profiles/openmesh.mk b/target/linux/ar71xx/generic/profiles/openmesh.mk
+index 64aaa24..c0919ed 100644
+--- a/target/linux/ar71xx/generic/profiles/openmesh.mk
++++ b/target/linux/ar71xx/generic/profiles/openmesh.mk
+@@ -28,12 +28,12 @@ endef
+ $(eval $(call Profile,OM5P))
+ 
+ define Profile/OM5PAC
+-	NAME:=OpenMesh OM5P-AC
++	NAME:=OpenMesh OM5P-AC/OM5P-ACv2
+ 	PACKAGES:=kmod-ath9k kmod-ath10k om-watchdog ath10k-firmware-qca988x
+ endef
+ 
+ define Profile/OM5PAC/Description
+-	Package set optimized for the OpenMesh OM5P-AC.
++	Package set optimized for the OpenMesh OM5P-AC/OM5P-ACv2.
+ endef
+ 
+ $(eval $(call Profile,OM5PAC))

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -297,6 +297,10 @@ $(eval $(call GluonModel,OMEGA,onion-omega,onion-omega))
 
 ## OpenMesh
 
+# MR1750
+$(eval $(call GluonProfile,MR1750,om-watchdog uboot-envtools kmod-ath10k ath10k-firmware-qca988x-ct))
+$(eval $(call GluonModel,MR1750,mr1750,openmesh-mr1750))
+
 # MR600
 $(eval $(call GluonProfile,MR600,om-watchdog uboot-envtools))
 $(eval $(call GluonModel,MR600,mr600,openmesh-mr600))
@@ -319,6 +323,11 @@ $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-lc))
 $(eval $(call GluonProfile,OM5P,om-watchdog uboot-envtools))
 $(eval $(call GluonModel,OM5P,om5p,openmesh-om5p))
 $(eval $(call GluonModelAlias,OM5P,openmesh-om5p,openmesh-om5p-an))
+
+# OM5P-AC
+$(eval $(call GluonProfile,OM5PAC,om-watchdog uboot-envtools kmod-ath10k ath10k-firmware-qca988x-ct))
+$(eval $(call GluonModel,OM5PAC,om5pac,openmesh-om5p-ac))
+$(eval $(call GluonModelAlias,OM5PAC,openmesh-om5p-ac,openmesh-om5p-acv2))
 
 ## ALFA
 

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -299,19 +299,16 @@ $(eval $(call GluonModel,OMEGA,onion-omega,onion-omega))
 
 # MR600
 $(eval $(call GluonProfile,MR600,om-watchdog uboot-envtools))
-$(eval $(call GluonProfileSysupgradeSuffix,MR600,-squashfs-factory,.bin))
 $(eval $(call GluonModel,MR600,mr600,openmesh-mr600))
 $(eval $(call GluonModelAlias,MR600,openmesh-mr600,openmesh-mr600-v2))
 
 # MR900
 $(eval $(call GluonProfile,MR900,om-watchdog uboot-envtools))
-$(eval $(call GluonProfileSysupgradeSuffix,MR900,-squashfs-factory,.bin))
 $(eval $(call GluonModel,MR900,mr900,openmesh-mr900))
 $(eval $(call GluonModelAlias,MR900,openmesh-mr900,openmesh-mr900-v2))
 
 # OM2P
 $(eval $(call GluonProfile,OM2P,om-watchdog uboot-envtools))
-$(eval $(call GluonProfileSysupgradeSuffix,OM2P,-squashfs-factory,.bin))
 $(eval $(call GluonModel,OM2P,om2p,openmesh-om2p))
 $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-v2))
 $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-hs))
@@ -320,7 +317,6 @@ $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-lc))
 
 # OM5P
 $(eval $(call GluonProfile,OM5P,om-watchdog uboot-envtools))
-$(eval $(call GluonProfileSysupgradeSuffix,OM5P,-squashfs-factory,.bin))
 $(eval $(call GluonModel,OM5P,om5p,openmesh-om5p))
 $(eval $(call GluonModelAlias,OM5P,openmesh-om5p,openmesh-om5p-an))
 


### PR DESCRIPTION
Following hardware was added (mostly tested with gluon 2016.1.x)

* MR1750
* OM5P-AC
* OM5P-ACv2

The patches were forwarded to OpenWrt CC before they were integrated in gluon. Each patch also contains a link to the entry in patchwork.

The GluonProfileSysupgradeSuffix workaround was also replaced with proper build sysupgrade images.