### PR TITLE
gluon-mesh-batman-adv-core: disable bridge port learning on bat0

### DIFF
--- a/package/gluon-mesh-batman-adv-core/luasrc/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
+++ b/package/gluon-mesh-batman-adv-core/luasrc/lib/gluon/upgrade/310-gluon-mesh-batman-adv-core-mesh
@@ -51,8 +51,19 @@ uci:section('network', 'interface', 'bat0',
 		    proto = 'none',
 		    macaddr = sysconfig.primary_mac,
 		    multicast_router = 2,
+		    learning = 0,
 	    }
 )
+
+uci:delete('network', 'client_lan')
+if sysconfig.lan_ifname then
+	uci:section('network', 'interface', 'client_lan',
+		    {
+			    unicast_flood = 0,
+		    }
+	)
+	uci:set('network', 'client_lan', 'ifname', sysconfig.lan_ifname)
+end
 
 uci:save('network')
 


### PR DESCRIPTION
The mesh side has become fairly huge in many communities. Up to
a few thousand entries can currently be found in the forwarding
database (fdb) of a bridge for its bridge port bat0.

The bridge fdb is kind of redundant to the batman-adv global translation
table here. Therefore this patch tries to reduce memory footprint by
following an approach similar to the IGMP/MLD split patchset approach:

Make the bridge oblivious not only regarding multicast listeners towards
the mesh but with this patch unicast hosts on the mesh, too.

If the destination of an ethernet frame is known by the bridge to be a
local one, then the frame is forwarded to the according port. If it is
unknown, then the frame is forwarded to the wifi AP interface and bat0.

mac80211 and batman-adv then know whether to drop or forward a frame
further through their own book-keeping.

Note that unicast-flood is not disabled for the wifi AP bridge port, nor
is learning disabled on the wifi AP. This is mainly to keep the
configuration in UCI and according setup scripts simple ;). However, not
disalbling unicast-flood on the wifi AP interface might also give a
minor latency improvement for newly joining wifi clients.

Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>