### PR TITLE
ag71xx-generic: Remove extra dash between v2 and OpenMesh device name

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -301,21 +301,21 @@ $(eval $(call GluonModel,OMEGA,onion-omega,onion-omega))
 $(eval $(call GluonProfile,MR600,om-watchdog uboot-envtools))
 $(eval $(call GluonProfileSysupgradeSuffix,MR600,-squashfs-factory,.bin))
 $(eval $(call GluonModel,MR600,mr600,openmesh-mr600))
-$(eval $(call GluonModelAlias,MR600,openmesh-mr600,openmesh-mr600-v2))
+$(eval $(call GluonModelAlias,MR600,openmesh-mr600,openmesh-mr600v2))
 
 # MR900
 $(eval $(call GluonProfile,MR900,om-watchdog uboot-envtools))
 $(eval $(call GluonProfileSysupgradeSuffix,MR900,-squashfs-factory,.bin))
 $(eval $(call GluonModel,MR900,mr900,openmesh-mr900))
-$(eval $(call GluonModelAlias,MR900,openmesh-mr900,openmesh-mr900-v2))
+$(eval $(call GluonModelAlias,MR900,openmesh-mr900,openmesh-mr900v2))
 
 # OM2P
 $(eval $(call GluonProfile,OM2P,om-watchdog uboot-envtools))
 $(eval $(call GluonProfileSysupgradeSuffix,OM2P,-squashfs-factory,.bin))
 $(eval $(call GluonModel,OM2P,om2p,openmesh-om2p))
-$(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-v2))
+$(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2pv2))
 $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-hs))
-$(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-hs-v2))
+$(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-hsv2))
 $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-lc))
 
 # OM5P


### PR DESCRIPTION
The returned name for OpenMesh devices with a an extra vX when calling

    lua -e 'print(require("platform_info").get_image_name())'

doesn't contain a dash between the vX and the device name. Thus the image
should also not contain a dash.