### PR TITLE
ar71xx-generic: Use eth0 as OpenMesh primary mac address

### DIFF
--- a/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
@@ -24,7 +24,15 @@ end
 
 if platform.match('ar71xx', 'generic', {'tl-wdr3600', 'tl-wdr4300'}) then
   table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')
-elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2'}) then
+elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2',
+                                            'mr600', 'mr600v2',
+                                            'mr900', 'mr900v2',
+                                            'mr1750',
+                                            'om2p', 'om2pv2',
+                                            'om2p-hs', 'om2p-hsv2',
+                                            'om2p-lc',
+                                            'om5p', 'om5p-an',
+                                            'om5p-ac', 'om5p-acv2'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c7'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')


### PR DESCRIPTION
The OpenMesh devices have a sticker with the eth0 mac address on the bottom. Also all other mac addresses are calculated based on this address. Therefore, it is better to use this as primary mac address instead of the WiFi mac address.