### PR TITLE
docs: how to show the list of supported targets

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -88,7 +88,7 @@ When calling make, the OpenWrt build environment is prepared/updated.
 In case of errors read the messages carefully and try to fix the stated issues (e.g. install tools not available yet).
 
 ``ar71xx-generic`` is the most common target and will generate images for most of the supported hardware.
-To see a complete list of supported targets, call ``make`` without setting ``GLUON_TARGET``.
+To see a complete list of supported targets, call ``make`` with setting an empty string for ``GLUON_TARGET``.
 
 You should reserve about 10GB of disk space for each `GLUON_TARGET`.
 


### PR DESCRIPTION
The complete list of supported targets is only shown, when you call `make` with setting an empty string for `GLUON_TARGET`
