### PR TITLE
ar71xx: add GL-AR150 support

### DIFF
--- a/patches/openwrt/0095-ar71xx-add-GL-AR150-support.patch
+++ b/patches/openwrt/0095-ar71xx-add-GL-AR150-support.patch
@@ -1,0 +1,326 @@
+From: Jan Niehusmann <jan@gondor.com>
+Date: Wed, 15 Jun 2016 14:57:47 +0200
+Subject: ar71xx: add GL-AR150 support
+
+patch from https://github.com/domino-team/OpenWrt-patches
+
+https://raw.githubusercontent.com/domino-team/OpenWrt-patches/master/AR150%2C%20AR300%2C%20Domino%20-%20CC1505/000-gl-ar150-cc.patch
+
+(and fixed indentation in target/linux/ar71xx/base-files/lib/ar71xx.sh)
+
+diff --git a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+index 129f6b7..e29c1b5 100644
+--- a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+@@ -182,6 +182,10 @@ dlan-pro-1200-ac)
+ 	ucidef_set_led_trigger_gpio "plcr" "dLAN" "devolo:error:dlan" "16" "0"
+ 	;;
+ 
++gl-ar150)
++	ucidef_set_led_wlan "wlan" "WLAN" "gl_ar150:wlan" "phy0tpt"
++	;;
++
+ gl-inet)
+ 	ucidef_set_led_netdev "lan" "LAN" "gl-connect:green:lan" "eth1"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "gl-connect:red:wlan" "phy0tpt"
+diff --git a/target/linux/ar71xx/base-files/etc/uci-defaults/02_network b/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
+index 1d0142f..3895394 100755
+--- a/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
+@@ -382,6 +382,7 @@ dir-505-a1)
+ alfa-ap96 |\
+ alfa-nx |\
+ ap83 |\
++gl-ar150 |\
+ gl-inet |\
+ jwap003 |\
+ pb42 |\
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 4000b5b..2cb884b 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -504,6 +504,9 @@ ar71xx_board_detect() {
+ 		name="gl-inet"
+ 		gl_inet_board_detect
+ 		;;
++	*"GL AR150")
++		name="gl-ar150"
++		;;
+ 	*"EnGenius EPG5000")
+ 		name="epg5000"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index eded91e..5bd4c2b 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -215,6 +215,7 @@ platform_check_image() {
+ 	dlan-pro-500-wp | \
+ 	dlan-pro-1200-ac | \
+ 	dragino2 | \
++	gl-ar150 | \
+ 	epg5000 | \
+ 	esr1750 | \
+ 	esr900 | \
+diff --git a/target/linux/ar71xx/config-3.18 b/target/linux/ar71xx/config-3.18
+index 514f7d5..0903ee9 100644
+--- a/target/linux/ar71xx/config-3.18
++++ b/target/linux/ar71xx/config-3.18
+@@ -69,6 +69,7 @@ CONFIG_ATH79_MACH_ESR1750=y
+ CONFIG_ATH79_MACH_ESR900=y
+ CONFIG_ATH79_MACH_EW_DORIN=y
+ CONFIG_ATH79_MACH_F9K1115V2=y
++CONFIG_ATH79_MACH_GL_AR150=y
+ CONFIG_ATH79_MACH_GL_INET=y
+ CONFIG_ATH79_MACH_GS_MINIBOX_V1=y
+ CONFIG_ATH79_MACH_GS_OOLITE=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar150.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar150.c
+new file mode 100644
+index 0000000..310182c
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar150.c
+@@ -0,0 +1,125 @@
++/*
++ *  GL_ar150 board support
++ *
++ *  Copyright (C) 2011 dongyuqi <729650915@qq.com>
++ *  Copyright (C) 2011-2012 Gabor Juhos <juhosg@openwrt.org>
++ *  Copyright (C) 2013 alzhao <alzhao@gmail.com>
++ *  Copyright (C) 2014 Michel Stempin <michel.stempin@wanadoo.fr>
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under the terms of the GNU General Public License version 2 as published
++ *  by the Free Software Foundation.
++*/
++
++#include <linux/gpio.h>
++
++#include <asm/mach-ath79/ath79.h>
++
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-m25p80.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++#include "machtypes.h"
++
++#define GL_AR150_GPIO_LED_WLAN		   0
++#define GL_AR150_GPIO_LED_LAN		   13
++#define GL_AR150_GPIO_LED_WAN		   15 
++
++#define GL_AR150_GPIO_BIN_USB         6
++#define GL_AR150_GPIO_BTN_MANUAL      7
++#define GL_AR150_GPIO_BTN_AUTO	   	   8
++#define GL_AR150_GPIO_BTN_RESET	   11
++
++#define GL_AR150_KEYS_POLL_INTERVAL   20	/* msecs */
++#define GL_AR150_KEYS_DEBOUNCE_INTERVAL	(3 * GL_AR150_KEYS_POLL_INTERVAL)
++
++#define GL_AR150_MAC0_OFFSET	0x0000
++#define GL_AR150_MAC1_OFFSET	0x0000
++#define GL_AR150_CALDATA_OFFSET	0x1000
++#define GL_AR150_WMAC_MAC_OFFSET	0x0000
++
++static struct gpio_led gl_ar150_leds_gpio[] __initdata = {
++	{
++		.name = "gl_ar150:wlan",
++		.gpio = GL_AR150_GPIO_LED_WLAN,
++		.active_low = 0,
++	},
++	{
++		.name = "gl_ar150:lan",
++		.gpio = GL_AR150_GPIO_LED_LAN,
++		.active_low = 0,
++	},
++	{
++		.name = "gl_ar150:wan",
++		.gpio = GL_AR150_GPIO_LED_WAN,
++		.active_low = 0,
++ 		.default_state = 1,
++	},
++};
++
++static struct gpio_keys_button gl_ar150_gpio_keys[] __initdata = {
++	{
++		.desc = "BTN_7",
++		.type = EV_KEY,
++		.code = BTN_7,
++		.debounce_interval = GL_AR150_KEYS_DEBOUNCE_INTERVAL,
++		.gpio = GL_AR150_GPIO_BTN_MANUAL,
++		.active_low = 0,
++	},
++	{
++		.desc = "BTN_8",
++		.type = EV_KEY,
++		.code = BTN_8,
++		.debounce_interval = GL_AR150_KEYS_DEBOUNCE_INTERVAL,
++		.gpio = GL_AR150_GPIO_BTN_AUTO,
++		.active_low = 0,
++	},
++	{
++		.desc = "reset",
++		.type = EV_KEY,
++		.code = KEY_RESTART,
++		.debounce_interval = GL_AR150_KEYS_DEBOUNCE_INTERVAL,
++		.gpio = GL_AR150_GPIO_BTN_RESET,
++		.active_low = 0,
++	},
++};
++
++static void __init gl_ar150_setup(void)
++{
++
++	/* ART base address */
++	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
++
++	/* disable PHY_SWAP and PHY_ADDR_SWAP bits */
++	ath79_setup_ar933x_phy4_switch(false, false);
++
++	/* register flash. */
++	ath79_register_m25p80(NULL);
++
++	/* register gpio LEDs and keys */
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(gl_ar150_leds_gpio),
++				 gl_ar150_leds_gpio);
++	ath79_register_gpio_keys_polled(-1, GL_AR150_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(gl_ar150_gpio_keys),
++					gl_ar150_gpio_keys);
++
++	/* enable usb */
++	gpio_request_one(GL_AR150_GPIO_BIN_USB,
++				 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++	 			 "USB power");
++	ath79_register_usb();
++	
++	/* register eth0 as WAN, eth1 as LAN */
++	ath79_init_mac(ath79_eth0_data.mac_addr, art+GL_AR150_MAC0_OFFSET, 0);
++	ath79_init_mac(ath79_eth1_data.mac_addr, art+GL_AR150_MAC1_OFFSET, 0);
++	ath79_register_mdio(0, 0x0);
++	ath79_register_eth(0);
++	ath79_register_eth(1);
++
++	/* register wireless mac with cal data */
++	ath79_register_wmac(art + GL_AR150_CALDATA_OFFSET, art + GL_AR150_WMAC_MAC_OFFSET);
++}
++
++MIPS_MACHINE(ATH79_MACH_GL_AR150, "GL-AR150", "GL AR150",gl_ar150_setup);
+diff --git a/target/linux/ar71xx/generic/profiles/gl-connect.mk b/target/linux/ar71xx/generic/profiles/gl-connect.mk
+deleted file mode 100644
+index e9377db..0000000
+--- a/target/linux/ar71xx/generic/profiles/gl-connect.mk
++++ /dev/null
+@@ -1,17 +0,0 @@
+-#
+-# Copyright (C) 2014 OpenWrt.org
+-#
+-# This is free software, licensed under the GNU General Public License v2.
+-# See /LICENSE for more information.
+-#
+-
+-define Profile/GLINET
+-	NAME:=GL.iNet
+-	PACKAGES:=kmod-usb-core kmod-usb2
+-endef
+-
+-define Profile/GLINET/Description
+-	Package set optimized for the GL-Connect GL.iNet v1.
+-endef
+-
+-$(eval $(call Profile,GLINET))
+diff --git a/target/linux/ar71xx/generic/profiles/gli.mk b/target/linux/ar71xx/generic/profiles/gli.mk
+new file mode 100644
+index 0000000..a6ad661
+--- /dev/null
++++ b/target/linux/ar71xx/generic/profiles/gli.mk
+@@ -0,0 +1,27 @@
++#
++# Copyright (C) 2013 OpenWrt.org
++#
++# This is free software, licensed under the GNU General Public License v2.
++# See /LICENSE for more information.
++#
++define Profile/GLINET
++	NAME:=GL.iNet 6416
++	PACKAGES:=kmod-usb-core kmod-usb2
++endef
++
++define Profile/GLINET/Description
++	Package set optimized for the GL-Connect GL.iNet v1.
++endef
++
++$(eval $(call Profile,GLINET))
++
++define Profile/GL-AR150
++	NAME:=GL AR150
++	PACKAGES:=kmod-usb-core kmod-usb2
++endef
++
++define Profile/GL-AR150/Description
++	Configuration of GL AR150.
++endef
++
++$(eval $(call Profile,GL-AR150))
+diff --git a/target/linux/ar71xx/image/Makefile b/target/linux/ar71xx/image/Makefile
+index 57f38a5..3ce1809 100644
+--- a/target/linux/ar71xx/image/Makefile
++++ b/target/linux/ar71xx/image/Makefile
+@@ -144,6 +144,14 @@ define Device/weio
+ endef
+ TARGET_DEVICES += weio
+ 
++define Device/gl-ar150
++  BOARDNAME = GL-AR150
++  IMAGE_SIZE = 16000k
++  CONSOLE = ttyATH0,115200
++  MTDPARTS = spi0.0:256k(u-boot)ro,64k(u-boot-env)ro,16000k(firmware),64k(art)ro
++endef
++TARGET_DEVICES += gl-ar150
++
+ define Device/wndr3700
+   BOARDNAME = WNDR3700
+   NETGEAR_KERNEL_MAGIC = 0x33373030
+diff --git a/target/linux/ar71xx/patches-3.18/911-MIPS-ath79-add-gl_ar150.patch b/target/linux/ar71xx/patches-3.18/911-MIPS-ath79-add-gl_ar150.patch
+new file mode 100644
+index 0000000..31db581
+--- /dev/null
++++ b/target/linux/ar71xx/patches-3.18/911-MIPS-ath79-add-gl_ar150.patch
+@@ -0,0 +1,39 @@
++--- a/arch/mips/ath79/Kconfig
+++++ b/arch/mips/ath79/Kconfig
++@@ -533,6 +533,16 @@ config ATH79_MACH_GL_INET
++ 	select ATH79_DEV_USB
++ 	select ATH79_DEV_WMAC
++ 
+++config ATH79_MACH_GL_AR150
+++   bool "GL AR150 support"
+++   select SOC_AR933X
+++   select ATH79_DEV_ETH
+++   select ATH79_DEV_GPIO_BUTTONS
+++   select ATH79_DEV_LEDS_GPIO
+++   select ATH79_DEV_M25P80
+++   select ATH79_DEV_USB
+++   select ATH79_DEV_WMAC
+++
++ config ATH79_MACH_EAP300V2
++ 	bool "EnGenius EAP300 v2 support"
++ 	select SOC_AR934X
++--- a/arch/mips/ath79/Makefile
+++++ b/arch/mips/ath79/Makefile
++@@ -78,6 +78,7 @@ obj-$(CONFIG_ATH79_MACH_EL_MINI)	+= mach
++ obj-$(CONFIG_ATH79_MACH_EPG5000)	+= mach-epg5000.o
++ obj-$(CONFIG_ATH79_MACH_ESR1750)	+= mach-esr1750.o
++ obj-$(CONFIG_ATH79_MACH_F9K1115V2)	+= mach-f9k1115v2.o
+++obj-$(CONFIG_ATH79_MACH_GL_AR150)	+= mach-gl-ar150.o
++ obj-$(CONFIG_ATH79_MACH_GL_INET)	+= mach-gl-inet.o
++ obj-$(CONFIG_ATH79_MACH_GS_MINIBOX_V1)	+= mach-gs-minibox-v1.o
++ obj-$(CONFIG_ATH79_MACH_GS_OOLITE)	+= mach-gs-oolite.o
++--- a/arch/mips/ath79/machtypes.h
+++++ b/arch/mips/ath79/machtypes.h
++@@ -67,6 +67,7 @@ enum ath79_mach_type {
++ 	ATH79_MACH_ESR1750,		/* EnGenius ESR1750 */
++ 	ATH79_MACH_EPG5000,		/* EnGenius EPG5000 */
++ 	ATH79_MACH_F9K1115V2,		/* Belkin AC1750DB */
+++	ATH79_MACH_GL_AR150,	/* GL-AR150 support */
++ 	ATH79_MACH_GL_INET,		/* GL-CONNECT GL-INET */
++ 	ATH79_MACH_GS_MINIBOX_V1,	/* Gainstrong MiniBox V1.0 */
++ 	ATH79_MACH_GS_OOLITE,           /* GS OOLITE V1.0 */

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -289,6 +289,10 @@ $(eval $(call GluonProfile,GLINET))
 $(eval $(call GluonModel,GLINET,gl-inet-6408A-v1,gl-inet-6408a-v1))
 $(eval $(call GluonModel,GLINET,gl-inet-6416A-v1,gl-inet-6416a-v1))
 
+$(eval $(call GluonProfile,GL-AR150))
+$(eval $(call GluonModel,GL-AR150,gl-ar150,gl-ar150))
+$(eval $(call GluonProfileFactorySuffix,GL-AR150))
+
 ## Western Digital
 
 # WD MyNet N600


### PR DESCRIPTION
I added support for GL-AR150 because a friend bought such a device and wanted to use it with Freifunk.

The device worked with branch v2016.1.x, and the same patch also applies to master. Unfortunately, he broke the router (via static discharge, not software-related), so I'm unable to test it with a current gluon version. Therefore, for now, I marked the device as 'BROKEN'.