### PR TITLE
ar71xx-generic: Add support for OpenMesh OM2P-HSv3/MR1750v2

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -133,7 +133,7 @@ ar71xx-generic
 
 * OpenMesh
 
-  - MR1750
+  - MR1750 (v1, v2)
   - MR600 (v1, v2)
   - MR900 (v1, v2)
   - OM2P (v1, v2)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -133,15 +133,15 @@ ar71xx-generic
 
 * OpenMesh
 
- - MR1750
- - MR600 (v1, v2)
- - MR900 (v1, v2)
- - OM2P (v1, v2)
- - OM2P-HS (v1, v2)
- - OM2P-LC
- - OM5P
- - OM5P-AC (v1, v2)
- - OM5P-AN
+  - MR1750
+  - MR600 (v1, v2)
+  - MR900 (v1, v2)
+  - OM2P (v1, v2)
+  - OM2P-HS (v1, v2)
+  - OM2P-LC
+  - OM5P
+  - OM5P-AC (v1, v2)
+  - OM5P-AN
 
 * TP-Link
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -137,7 +137,7 @@ ar71xx-generic
   - MR600 (v1, v2)
   - MR900 (v1, v2)
   - OM2P (v1, v2)
-  - OM2P-HS (v1, v2)
+  - OM2P-HS (v1, v2, v3)
   - OM2P-LC
   - OM5P
   - OM5P-AC (v1, v2)

--- a/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
@@ -27,7 +27,7 @@ if platform.match('ar71xx', 'generic', {'tl-wdr3600', 'tl-wdr4300'}) then
 elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2',
                                             'mr600', 'mr600v2',
                                             'mr900', 'mr900v2',
-                                            'mr1750',
+                                            'mr1750', 'mr1750v2',
                                             'om2p', 'om2pv2',
                                             'om2p-hs', 'om2p-hsv2', 'om2p-hsv3',
                                             'om2p-lc',

--- a/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/files/lib/gluon/upgrade/010-primary-mac
@@ -29,7 +29,7 @@ elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2',
                                             'mr900', 'mr900v2',
                                             'mr1750',
                                             'om2p', 'om2pv2',
-                                            'om2p-hs', 'om2p-hsv2',
+                                            'om2p-hs', 'om2p-hsv2', 'om2p-hsv3',
                                             'om2p-lc',
                                             'om5p', 'om5p-an',
                                             'om5p-ac', 'om5p-acv2'}) then

--- a/patches/openwrt/0097-ar71xx-add-kernel-support-for-the-OpenMesh-OM2P-HSv3.patch
+++ b/patches/openwrt/0097-ar71xx-add-kernel-support-for-the-OpenMesh-OM2P-HSv3.patch
@@ -1,0 +1,33 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:48 +0200
+Subject: ar71xx: add kernel support for the OpenMesh OM2P-HSv3
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637052/
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-om2p.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-om2p.c
+index 6b0bdc3..3b282a3 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-om2p.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-om2p.c
+@@ -223,3 +223,4 @@ static void __init om2p_hs_setup(void)
+ 
+ MIPS_MACHINE(ATH79_MACH_OM2P_HS, "OM2P-HS", "OpenMesh OM2P HS", om2p_hs_setup);
+ MIPS_MACHINE(ATH79_MACH_OM2P_HSv2, "OM2P-HSv2", "OpenMesh OM2P HSv2", om2p_hs_setup);
++MIPS_MACHINE(ATH79_MACH_OM2P_HSv3, "OM2P-HSv3", "OpenMesh OM2P HSv3", om2p_hs_setup);
+diff --git a/target/linux/ar71xx/patches-3.18/817-MIPS-ath79-add-om2phsv3-support.patch b/target/linux/ar71xx/patches-3.18/817-MIPS-ath79-add-om2phsv3-support.patch
+new file mode 100644
+index 0000000..7305b2e
+--- /dev/null
++++ b/target/linux/ar71xx/patches-3.18/817-MIPS-ath79-add-om2phsv3-support.patch
+@@ -0,0 +1,10 @@
++--- a/arch/mips/ath79/machtypes.h
+++++ b/arch/mips/ath79/machtypes.h
++@@ -88,6 +88,7 @@ enum ath79_mach_type {
++ 	ATH79_MACH_NBG460N,		/* Zyxel NBG460N/550N/550NH */
++ 	ATH79_MACH_NBG6716,		/* Zyxel NBG6716 */
++ 	ATH79_MACH_OM2P_HSv2,		/* OpenMesh OM2P-HSv2 */
+++	ATH79_MACH_OM2P_HSv3,		/* OpenMesh OM2P-HSv3 */
++ 	ATH79_MACH_OM2P_HS,		/* OpenMesh OM2P-HS */
++ 	ATH79_MACH_OM2P_LC,		/* OpenMesh OM2P-LC */
++ 	ATH79_MACH_OM2Pv2,		/* OpenMesh OM2Pv2 */

--- a/patches/openwrt/0098-ar71xx-add-user-space-support-for-the-OpenMesh-OM2P-HSv3.patch
+++ b/patches/openwrt/0098-ar71xx-add-user-space-support-for-the-OpenMesh-OM2P-HSv3.patch
@@ -1,0 +1,46 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:49 +0200
+Subject: ar71xx: add user-space support for the OpenMesh OM2P-HSv3
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637053/
+
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index d4d8b4e..aa02212 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -171,6 +171,7 @@ get_status_led() {
+ 	om2pv2 | \
+ 	om2p-hs | \
+ 	om2p-hsv2 | \
++	om2p-hsv3 | \
+ 	om2p-lc)
+ 		status_led="om2p:blue:power"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+index dc8b8d6..5767f48 100644
+--- a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+@@ -297,6 +297,7 @@ om2p | \
+ om2pv2 | \
+ om2p-hs | \
+ om2p-hsv2 | \
++om2p-hsv3 | \
+ om2p-lc)
+ 	ucidef_set_led_netdev "port1" "port1" "om2p:blue:wan" "eth0"
+ 	ucidef_set_led_netdev "port2" "port2" "om2p:blue:lan" "eth1"
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index db908f9..dc51b03 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -610,6 +610,9 @@ ar71xx_board_detect() {
+ 	*"OM2P HSv2")
+ 		name="om2p-hsv2"
+ 		;;
++	*"OM2P HSv3")
++		name="om2p-hsv3"
++		;;
+ 	*"OM2P LC")
+ 		name="om2p-lc"
+ 		;;

--- a/patches/openwrt/0099-ar71xx-enable-sysupgrade-for-the-OpenMesh-OM2P-HSv3.patch
+++ b/patches/openwrt/0099-ar71xx-enable-sysupgrade-for-the-OpenMesh-OM2P-HSv3.patch
@@ -1,0 +1,40 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:50 +0200
+Subject: ar71xx: enable sysupgrade for the OpenMesh OM2P-HSv3
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637054/
+
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+index 209cdaa..0e8ea27 100644
+--- a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+@@ -63,6 +63,7 @@ platform_check_image_openmesh()
+ 			[ "$board" = "om2p-lc" ] && break
+ 			[ "$board" = "om2p-hs" ] && break
+ 			[ "$board" = "om2p-hsv2" ] && break
++			[ "$board" = "om2p-hsv3" ] && break
+ 			echo "Invalid image board target ($img_board_target) for this platform: $board. Use the correct image for this platform"
+ 			return 1
+ 			;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index aeb4577..9b26e73 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -306,6 +306,7 @@ platform_check_image() {
+ 	om2pv2 | \
+ 	om2p-hs | \
+ 	om2p-hsv2 | \
++	om2p-hsv3 | \
+ 	om2p-lc | \
+ 	om5p | \
+ 	om5p-an | \
+@@ -541,6 +542,7 @@ platform_do_upgrade() {
+ 	om2pv2 | \
+ 	om2p-hs | \
+ 	om2p-hsv2 | \
++	om2p-hsv3 | \
+ 	om2p-lc | \
+ 	om5p | \
+ 	om5p-an | \

--- a/patches/openwrt/0100-package-om-watchdog-add-OpenMesh-OM2P-HSv3-support.patch
+++ b/patches/openwrt/0100-package-om-watchdog-add-OpenMesh-OM2P-HSv3-support.patch
@@ -1,0 +1,21 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:51 +0200
+Subject: package/om-watchdog: add OpenMesh OM2P-HSv3 support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637055/
+
+diff --git a/package/kernel/om-watchdog/files/om-watchdog.init b/package/kernel/om-watchdog/files/om-watchdog.init
+index 6b96966..bf8a124 100644
+--- a/package/kernel/om-watchdog/files/om-watchdog.init
++++ b/package/kernel/om-watchdog/files/om-watchdog.init
+@@ -13,7 +13,7 @@ boot() {
+ 		local board=$(ar71xx_board_name)
+ 
+ 		case "$board" in
+-			"om2p"|"om2p-hs"|"om2p-hsv2"|"om5p-acv2")
++			"om2p"|"om2p-hs"|"om2p-hsv2"|"om2p-hsv3"|"om5p-acv2")
+ 				service_start /sbin/om-watchdog 12
+ 				;;
+ 			"om2pv2"|"om2p-lc")

--- a/patches/openwrt/0101-package-uboot-envtools-add-OpenMesh-OM2P-HSv3-support.patch
+++ b/patches/openwrt/0101-package-uboot-envtools-add-OpenMesh-OM2P-HSv3-support.patch
@@ -1,0 +1,20 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:52 +0200
+Subject: package/uboot-envtools: add OpenMesh OM2P-HSv3 support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637056/
+
+diff --git a/package/boot/uboot-envtools/files/ar71xx b/package/boot/uboot-envtools/files/ar71xx
+index 9071c11..81c6481 100644
+--- a/package/boot/uboot-envtools/files/ar71xx
++++ b/package/boot/uboot-envtools/files/ar71xx
+@@ -41,6 +41,7 @@ om2p | \
+ om2pv2 | \
+ om2p-hs | \
+ om2p-hsv2 | \
++om2p-hsv3 | \
+ om2p-lc)
+ 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x40000"
+ 	;;

--- a/patches/openwrt/0102-ar71xx-add-OM2P-HSv3-to-the-OM2P-profile.patch
+++ b/patches/openwrt/0102-ar71xx-add-OM2P-HSv3-to-the-OM2P-profile.patch
@@ -1,0 +1,27 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:53 +0200
+Subject: ar71xx: add OM2P-HSv3 to the OM2P profile
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637057/
+
+diff --git a/target/linux/ar71xx/generic/profiles/openmesh.mk b/target/linux/ar71xx/generic/profiles/openmesh.mk
+index c0919ed..ddd3f8d 100644
+--- a/target/linux/ar71xx/generic/profiles/openmesh.mk
++++ b/target/linux/ar71xx/generic/profiles/openmesh.mk
+@@ -6,12 +6,12 @@
+ #
+ 
+ define Profile/OM2P
+-	NAME:=OpenMesh OM2P/OM2Pv2/OM2P-HS/OM2P-HSv2/OM2P-LC
++	NAME:=OpenMesh OM2P/OM2Pv2/OM2P-HS/OM2P-HSv2/OM2P-HSv3/OM2P-LC
+ 	PACKAGES:=kmod-ath9k om-watchdog
+ endef
+ 
+ define Profile/OM2P/Description
+-	Package set optimized for the OpenMesh OM2P/OM2Pv2/OM2P-HS/OM2P-HSv2/OM2P-LC.
++	Package set optimized for the OpenMesh OM2P/OM2Pv2/OM2P-HS/OM2P-HSv2/OM2P-HSv3/OM2P-LC.
+ endef
+ 
+ $(eval $(call Profile,OM2P))

--- a/patches/openwrt/0103-ar71xx-add-kernel-support-for-the-OpenMesh-MR1750v2.patch
+++ b/patches/openwrt/0103-ar71xx-add-kernel-support-for-the-OpenMesh-MR1750v2.patch
@@ -1,0 +1,33 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:54 +0200
+Subject: ar71xx: add kernel support for the OpenMesh MR1750v2
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637058/
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
+index e3c04e7..18101ce 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-mr1750.c
+@@ -168,3 +168,4 @@ static void __init mr1750_setup(void)
+ }
+ 
+ MIPS_MACHINE(ATH79_MACH_MR1750, "MR1750", "OpenMesh MR1750", mr1750_setup);
++MIPS_MACHINE(ATH79_MACH_MR1750V2, "MR1750v2", "OpenMesh MR1750v2", mr1750_setup);
+diff --git a/target/linux/ar71xx/patches-3.18/818-MIPS-ath79-add-mr1750v2-support.patch b/target/linux/ar71xx/patches-3.18/818-MIPS-ath79-add-mr1750v2-support.patch
+new file mode 100644
+index 0000000..de732ec
+--- /dev/null
++++ b/target/linux/ar71xx/patches-3.18/818-MIPS-ath79-add-mr1750v2-support.patch
+@@ -0,0 +1,10 @@
++--- a/arch/mips/ath79/machtypes.h
+++++ b/arch/mips/ath79/machtypes.h
++@@ -76,6 +76,7 @@ enum ath79_mach_type {
++ 	ATH79_MACH_MR12,		/* Cisco Meraki MR12 */
++ 	ATH79_MACH_MR16,		/* Cisco Meraki MR16 */
++ 	ATH79_MACH_MR1750,		/* OpenMesh MR1750 */
+++	ATH79_MACH_MR1750V2,		/* OpenMesh MR1750v2 */
++ 	ATH79_MACH_MR600V2,		/* OpenMesh MR600v2 */
++ 	ATH79_MACH_MR600,		/* OpenMesh MR600 */
++ 	ATH79_MACH_MR900,		/* OpenMesh MR900 */

--- a/patches/openwrt/0104-ar71xx-add-user-space-support-for-the-OpenMesh-MR1750v2.patch
+++ b/patches/openwrt/0104-ar71xx-add-user-space-support-for-the-OpenMesh-MR1750v2.patch
@@ -1,0 +1,62 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:55 +0200
+Subject: ar71xx: add user-space support for the OpenMesh MR1750v2
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637059/
+
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index aa02212..f182d60 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -143,7 +143,8 @@ get_status_led() {
+ 	mr600v2)
+ 		status_led="mr600:blue:power"
+ 		;;
+-	mr1750)
++	mr1750 | \
++	mr1750v2)
+ 		status_led="mr1750:blue:power"
+ 		;;
+ 	mr900 | \
+diff --git a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+index 5767f48..032acc9 100644
+--- a/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/01_leds
+@@ -243,7 +243,8 @@ mr600)
+ 	ucidef_set_led_wlan "wlan58" "WLAN58" "mr600:green:wlan58" "phy0tpt"
+ 	;;
+ 
+-mr1750)
++mr1750 | \
++mr1750v2)
+ 	ucidef_set_led_netdev "lan" "LAN" "mr1750:blue:wan" "eth0"
+ 	ucidef_set_led_wlan "wlan58" "WLAN58" "mr1750:blue:wlan58" "phy0tpt"
+ 	ucidef_set_led_wlan "wlan24" "WLAN24" "mr1750:blue:wlan24" "phy1tpt"
+diff --git a/target/linux/ar71xx/base-files/etc/uci-defaults/02_network b/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
+index 89a2184..b8ae576 100755
+--- a/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
++++ b/target/linux/ar71xx/base-files/etc/uci-defaults/02_network
+@@ -335,6 +335,7 @@ eap7660d |\
+ el-mini |\
+ loco-m-xw |\
+ mr1750 |\
++mr1750v2 |\
+ mr600 |\
+ mr600v2 |\
+ mr900 |\
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index dc51b03..5119b36 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -568,6 +568,9 @@ ar71xx_board_detect() {
+ 	*MR1750)
+ 		name="mr1750"
+ 		;;
++	*MR1750v2)
++		name="mr1750v2"
++		;;
+ 	*MR600)
+ 		name="mr600"
+ 		;;

--- a/patches/openwrt/0105-ar71xx-enable-sysupgrade-for-the-OpenMesh-MR1750v2.patch
+++ b/patches/openwrt/0105-ar71xx-enable-sysupgrade-for-the-OpenMesh-MR1750v2.patch
@@ -1,0 +1,40 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:56 +0200
+Subject: ar71xx: enable sysupgrade for the OpenMesh MR1750v2
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637060/
+
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+index 0e8ea27..95d39bf 100644
+--- a/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/openmesh.sh
+@@ -81,6 +81,7 @@ platform_check_image_openmesh()
+ 			;;
+ 		MR1750)
+ 			[ "$board" = "mr1750" ] && break
++			[ "$board" = "mr1750v2" ] && break
+ 			echo "Invalid image board target ($img_board_target) for this platform: $board. Use the correct image for this platform"
+ 			return 1
+ 			;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index 9b26e73..f33419f 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -298,6 +298,7 @@ platform_check_image() {
+ 		return 0;
+ 		;;
+ 	mr1750 | \
++	mr1750v2 | \
+ 	mr600 | \
+ 	mr600v2 | \
+ 	mr900 | \
+@@ -534,6 +535,7 @@ platform_do_upgrade() {
+ 		platform_do_upgrade_dir825b "$ARGV"
+ 		;;
+ 	mr1750 | \
++	mr1750v2 | \
+ 	mr600 | \
+ 	mr600v2 | \
+ 	mr900 | \

--- a/patches/openwrt/0106-package-om-watchdog-add-OpenMesh-MR1750v2-support.patch
+++ b/patches/openwrt/0106-package-om-watchdog-add-OpenMesh-MR1750v2-support.patch
@@ -1,0 +1,21 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:57 +0200
+Subject: package/om-watchdog: add OpenMesh MR1750v2 support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637062/
+
+diff --git a/package/kernel/om-watchdog/files/om-watchdog.init b/package/kernel/om-watchdog/files/om-watchdog.init
+index bf8a124..8a1b66e 100644
+--- a/package/kernel/om-watchdog/files/om-watchdog.init
++++ b/package/kernel/om-watchdog/files/om-watchdog.init
+@@ -28,7 +28,7 @@ boot() {
+ 			"mr600v2")
+ 				service_start /sbin/om-watchdog 15
+ 				;;
+-			"mr900"|"mr900v2"|"mr1750")
++			"mr900"|"mr900v2"|"mr1750"|"mr1750v2")
+ 				service_start /sbin/om-watchdog 16
+ 				;;
+ 		esac

--- a/patches/openwrt/0107-package-uboot-envtools-add-OpenMesh-MR1750v2-support.patch
+++ b/patches/openwrt/0107-package-uboot-envtools-add-OpenMesh-MR1750v2-support.patch
@@ -1,0 +1,20 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:58 +0200
+Subject: package/uboot-envtools: add OpenMesh MR1750v2 support
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637064/
+
+diff --git a/package/boot/uboot-envtools/files/ar71xx b/package/boot/uboot-envtools/files/ar71xx
+index 81c6481..459e73d 100644
+--- a/package/boot/uboot-envtools/files/ar71xx
++++ b/package/boot/uboot-envtools/files/ar71xx
+@@ -22,6 +22,7 @@ eap300v2 | \
+ hornet-ub | \
+ hornet-ub-x2 | \
+ mr1750 | \
++mr1750v2 | \
+ mr600 | \
+ mr600v2 | \
+ mr900 | \

--- a/patches/openwrt/0108-ar71xx-extract-ath10k-wifi-board.bin-for-the-OpenMesh-MR1750v2-board.patch
+++ b/patches/openwrt/0108-ar71xx-extract-ath10k-wifi-board.bin-for-the-OpenMesh-MR1750v2-board.patch
@@ -1,0 +1,20 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:03:59 +0200
+Subject: ar71xx: extract ath10k wifi board.bin for the OpenMesh MR1750v2 board
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637063/
+
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index d925a85..0e93feb 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -72,6 +72,7 @@ case "$FIRMWARE" in
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
+ 		;;
+ 	mr1750 | \
++	mr1750v2 | \
+ 	om5p-acv2)
+ 		ath10kcal_extract "ART" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)

--- a/patches/openwrt/0109-ar71xx-add-MR1750v2-to-the-MR1750-profile.patch
+++ b/patches/openwrt/0109-ar71xx-add-MR1750v2-to-the-MR1750-profile.patch
@@ -1,0 +1,27 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 20 May 2016 18:04:00 +0200
+Subject: ar71xx: add MR1750v2 to the MR1750 profile
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://patchwork.ozlabs.org/patch/637065/
+
+diff --git a/target/linux/ar71xx/generic/profiles/openmesh.mk b/target/linux/ar71xx/generic/profiles/openmesh.mk
+index ddd3f8d..e245e6c 100644
+--- a/target/linux/ar71xx/generic/profiles/openmesh.mk
++++ b/target/linux/ar71xx/generic/profiles/openmesh.mk
+@@ -61,12 +61,12 @@ endef
+ $(eval $(call Profile,MR900))
+ 
+ define Profile/MR1750
+-        NAME:=OpenMesh MR1750
++        NAME:=OpenMesh MR1750/MR1750v2
+         PACKAGES:=kmod-ath9k kmod-ath10k ath10k-firmware-qca988x
+ endef
+ 
+ define Profile/MR1750/Description
+-        Package set optimized for the OpenMesh MR1750.
++        Package set optimized for the OpenMesh MR1750/MR1750v2.
+ endef
+ 
+ $(eval $(call Profile,MR1750))

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -330,6 +330,7 @@ $(eval $(call GluonModel,OM2P,om2p,openmesh-om2p))
 $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2pv2))
 $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-hs))
 $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-hsv2))
+$(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-hsv3))
 $(eval $(call GluonModelAlias,OM2P,openmesh-om2p,openmesh-om2p-lc))
 
 # OM5P

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -313,6 +313,7 @@ $(eval $(call GluonModel,OMEGA,onion-omega,onion-omega))
 # MR1750
 $(eval $(call GluonProfile,MR1750,om-watchdog uboot-envtools kmod-ath10k ath10k-firmware-qca988x-ct))
 $(eval $(call GluonModel,MR1750,mr1750,openmesh-mr1750))
+$(eval $(call GluonModelAlias,MR1750,openmesh-mr1750,openmesh-mr1750v2))
 
 # MR600
 $(eval $(call GluonProfile,MR600,om-watchdog uboot-envtools))


### PR DESCRIPTION
The new OM2P-HSv3/MR1750v2 device support is only available in LEDE master. The relevant patches had to be backported to add support for them in Gluon.

All patches were also forwarded to OpenWrt for inclusion in CC and trunk.