### PR TITLE
batman-adv: Fix speedy join in gateway client mode

### DIFF
--- a/patches/packages/routing/0004-batman-adv-Fix-speedy-join-in-gateway-client-mode.patch
+++ b/patches/packages/routing/0004-batman-adv-Fix-speedy-join-in-gateway-client-mode.patch
@@ -1,0 +1,57 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Fri, 17 Jun 2016 15:54:03 +0200
+Subject: batman-adv: Fix speedy join in gateway client mode
+
+Speedy join only works when the received packet is either broadcast or an
+4addr unicast packet. Thus packets converted from broadcast to unicast via
+the gateway handling code have to be converted to 4addr packets to allow
+the receiving gateway server to add the sender address as temporary entry
+to the translation table.
+
+Not doing it will make the batman-adv gateway server drop the DHCP response
+in many situations because it doesn't yet have the TT entry for the
+destination of the DHCP response.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+diff --git a/batman-adv/patches/0001-batman-adv-Fix-speedy-join-in-gateway-client-mode.patch b/batman-adv/patches/0001-batman-adv-Fix-speedy-join-in-gateway-client-mode.patch
+new file mode 100644
+index 0000000..e63b782
+--- /dev/null
++++ b/batman-adv/patches/0001-batman-adv-Fix-speedy-join-in-gateway-client-mode.patch
+@@ -0,0 +1,35 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Sun, 12 Jun 2016 10:43:19 +0200
++Subject: [PATCH] batman-adv: Fix speedy join in gateway client mode
++
++Speedy join only works when the received packet is either broadcast or an
++4addr unicast packet. Thus packets converted from broadcast to unicast via
++the gateway handling code have to be converted to 4addr packets to allow
++the receiving gateway server to add the sender address as temporary entry
++to the translation table.
++
++Not doing it will make the batman-adv gateway server drop the DHCP response
++in many situations because it doesn't yet have the TT entry for the
++destination of the DHCP response.
++
++Fixes: 9cbc67d9da47 ("batman-adv: change interface_rx to get orig node")
++Signed-off-by: Sven Eckelmann <sven@narfation.org>
++---
++ net/batman-adv/send.c | 4 ++--
++ 1 file changed, 2 insertions(+), 2 deletions(-)
++
++diff --git a/net/batman-adv/send.c b/net/batman-adv/send.c
++index f2f1256..0103976 100644
++--- a/net/batman-adv/send.c
+++++ b/net/batman-adv/send.c
++@@ -424,8 +424,8 @@ int batadv_send_skb_via_gw(struct batadv_priv *bat_priv, struct sk_buff *skb,
++ 	struct batadv_orig_node *orig_node;
++ 
++ 	orig_node = batadv_gw_get_selected_orig(bat_priv);
++-	return batadv_send_skb_unicast(bat_priv, skb, BATADV_UNICAST, 0,
++-				       orig_node, vid);
+++	return batadv_send_skb_unicast(bat_priv, skb, BATADV_UNICAST_4ADDR,
+++				       BATADV_P_DATA, orig_node, vid);
++ }
++ 
++ void batadv_schedule_bat_ogm(struct batadv_hard_iface *hard_iface)


### PR DESCRIPTION
Speedy join only works when the received packet is either broadcast or an 4addr unicast packet. Thus packets converted from broadcast to unicast via the gateway handling code have to be converted to 4addr packets to allow the receiving gateway server to add the sender address as temporary entry
to the translation table.

Not doing it will make the batman-adv gateway server drop the DHCP response in many situations because it doesn't yet have the TT entry for the destination of the DHCP response.