### PR TITLE
add option to change/limit wifi rates

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -35,6 +35,12 @@
     -- Wireless channel.
     channel = 1,
 
+    -- Supported wifi rates, example removes 802.11b compatibility for better performance (optional, implies basic_rate)
+    -- supported_rates = '6000 9000 12000 18000 24000 36000 48000 54000',
+
+    -- Basic wifi rates, example removes 802.11b compatibility for better performance (optional)
+    -- basic_rate = '6000 9000 18000 36000 54000',
+
     -- ESSID used for client network.
     ap = {
       ssid = 'entenhausen.freifunk.net',

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -98,6 +98,12 @@ wifi24 \: optional
     This will only affect new installations.
     Upgrades will not changed the disabled state.
 
+    Additionally it is possible to configure the ``supported_rates`` and ``basic_rate``
+    of each radio. Both are optional, by default hostapd/driver dictate the rates.
+    ``supported_rates`` implies ``basic_rate``, because ``basic_rate`` has to be a subset
+    of ``supported_rates``.
+    The example below disables 802.11b rates.
+
     ``ap`` requires a single parameter, a string, named ``ssid`` which sets the
     interface's ESSID.
 
@@ -112,6 +118,8 @@ wifi24 \: optional
 
        wifi24 = {
          channel = 11,
+         supported_rates = '6000 9000 12000 18000 24000 36000 48000 54000',
+         basic_rate = '6000 9000 18000 36000 54000',
          ap = {
            ssid = 'entenhausen.freifunk.net',
          },

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -28,5 +28,10 @@ for _, config in ipairs({'wifi24', 'wifi5'}) do
     need_string('regdom') -- regdom is only required when wifi24 or wifi5 is configured
 
     need_number(config .. '.channel')
+    if need_string(config .. '.supported_rates', false) then
+      need_string(config .. '.basic_rate')
+    else
+      need_string(config .. '.basic_rate', false)
+    end
   end
 end

--- a/package/gluon-core/files/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/files/lib/gluon/upgrade/200-wireless
@@ -27,6 +27,14 @@ local function configure_radio(radio, index, config)
     uci:set('wireless', radio, 'channel', channel)
     uci:set('wireless', radio, 'htmode', 'HT20')
     uci:set('wireless', radio, 'country', site.regdom)
+
+    if config.supported_rates then
+      uci:set('wireless', radio, 'supported_rates', config.supported_rates)
+    end
+
+    if config.basic_rate then
+      uci:set('wireless', radio, 'basic_rate', config.basic_rate)
+    end
   end
 end
 


### PR DESCRIPTION
as first suggested by @RubenKelevra in #467 it might make sense to disable slow wifi rates to improve overall performance for clients.
credits also go to @Brother-Lal and @kb-light on whose work this PR is based.
it adds optional settings to the site.conf and suggests to set them to the values discussed in #467 .

build and flash tested on a WDR3500, rates are only set on 2,4GHz radio0 as it is expected.
