### PR TITLE
gluon-core: make wifi rates configurable

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -35,6 +35,14 @@
     -- Wireless channel.
     channel = 1,
 
+    -- List of supported wifi rates (optional)
+    -- Example removes 802.11b compatibility for better performance
+    supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000},
+
+    -- List of basic wifi rates (optional, required if supported_rates is set)
+    -- Example removes 802.11b compatibility for better performance
+    basic_rate = {6000, 9000, 18000, 36000, 54000},
+
     -- ESSID used for client network.
     ap = {
       ssid = 'entenhausen.freifunk.net',

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -98,6 +98,12 @@ wifi24 \: optional
     This will only affect new installations.
     Upgrades will not changed the disabled state.
 
+    Additionally it is possible to configure the ``supported_rates`` and ``basic_rate``
+    of each radio. Both are optional, by default hostapd/driver dictate the rates.
+    If ``supported_rates`` is set, ``basic_rate`` is required, because ``basic_rate``
+    has to be a subset of ``supported_rates``.
+    The example below disables 802.11b rates.
+
     ``ap`` requires a single parameter, a string, named ``ssid`` which sets the
     interface's ESSID.
 
@@ -112,6 +118,8 @@ wifi24 \: optional
 
        wifi24 = {
          channel = 11,
+         supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000},
+         basic_rate = {6000, 9000, 18000, 36000, 54000},
          ap = {
            ssid = 'entenhausen.freifunk.net',
          },

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -28,6 +28,14 @@ for _, config in ipairs({'wifi24', 'wifi5'}) do
     need_string('regdom') -- regdom is only required when wifi24 or wifi5 is configured
 
     need_number(config .. '.channel')
+
+    local rates = {1000, 2000, 5500, 6000, 9000, 11000, 12000, 18000, 24000, 36000, 48000, 54000}
+    local supported_rates = need_array_of(config .. '.supported_rates', rates, false)
+    if supported_rates then
+      need_array_of(config .. '.basic_rate', supported_rates, true)
+    else
+      need_array_of(config .. '.basic_rate', rates, false)
+    end
   end
 end
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -27,6 +27,18 @@ local function configure_radio(radio, index, config)
     uci:set('wireless', radio, 'channel', channel)
     uci:set('wireless', radio, 'htmode', 'HT20')
     uci:set('wireless', radio, 'country', site.regdom)
+
+    if config.supported_rates then
+      uci:set_list('wireless', radio, 'supported_rates', config.supported_rates)
+    else
+      uci:delete('wireless', radio, 'supported_rates')
+    end
+
+    if config.basic_rate then
+      uci:set_list('wireless', radio, 'basic_rate', config.basic_rate)
+    else
+      uci:delete('wireless', radio, 'basic_rate')
+    end
   end
 end
 

--- a/package/gluon-mesh-batman-adv-core/check_site.lua
+++ b/package/gluon-mesh-batman-adv-core/check_site.lua
@@ -1,15 +1,18 @@
 for _, config in ipairs({'wifi24', 'wifi5'}) do
+   local rates = {1000, 2000, 5500, 6000, 9000, 11000, 12000, 18000, 24000, 36000, 48000, 54000}
+   rates = need_array_of(config .. '.supported_rates', rates, false) or rates
+
    if need_table(config .. '.ibss', nil, false) then
       need_string(config .. '.ibss.ssid')
       need_string_match(config .. '.ibss.bssid', '^%x[02468aAcCeE]:%x%x:%x%x:%x%x:%x%x:%x%x$')
-      need_number(config .. '.ibss.mcast_rate', false)
+      need_one_of(config .. '.ibss.mcast_rate', rates, false)
       need_number(config .. '.ibss.vlan', false)
       need_boolean(config .. '.ibss.disabled', false)
    end
 
    if need_table(config .. '.mesh', nil, false) then
       need_string(config .. '.mesh.id')
-      need_number(config .. '.mesh.mcast_rate', false)
+      need_one_of(config .. '.mesh.mcast_rate', rates, false)
       need_boolean(config .. '.mesh.disabled', false)
    end
 end

--- a/scripts/check_site_lib.lua
+++ b/scripts/check_site_lib.lua
@@ -7,6 +7,27 @@ local function loadvar(varname)
    end
 end
 
+local function array_to_string(array)
+   local string = ''
+   for _, v in ipairs(array) do
+      if #string >= 1 then
+         string = string .. ', '
+      end
+      string = string .. v
+   end
+   return '[' .. string .. ']'
+end
+
+local function assert_one_of(var, array, msg)
+   for _, v in ipairs(array) do
+      if v == var then
+         return true
+      end
+   end
+
+   error(msg)
+end
+
 local function assert_type(var, t, msg)
    assert(type(var) == t, msg)
 end
@@ -99,7 +120,25 @@ function need_table(varname, subcheck, required)
    return var
 end
 
+function need_one_of(varname, array, required)
+   local var = loadvar(varname)
+
+   if required == false and var == nil then
+      return nil
+   end
+
+   assert_one_of(var, array, "site.conf error: expected `" .. varname .. "' to be one of given array: " .. array_to_string(array))
+
+   return var
+end
+
 function need_string_array(varname, required)
    return assert(pcall(need_array, varname, function(e) assert_type(e, 'string') end, required),
 		 "site.conf error: expected `" .. varname .. "' to be a string array")
+end
+
+function need_array_of(varname, array, required)
+   local ok, var = pcall(need_array, varname, function(e) assert_one_of(e, array) end,required)
+   assert(ok, "site.conf error: expected `" .. varname .. "' to be a subset of given array: " .. array_to_string(array))
+   return var
 end

--- a/scripts/check_site_lib.lua
+++ b/scripts/check_site_lib.lua
@@ -133,8 +133,9 @@ function need_one_of(varname, array, required)
 end
 
 function need_string_array(varname, required)
-   return assert(pcall(need_array, varname, function(e) assert_type(e, 'string') end, required),
-		 "site.conf error: expected `" .. varname .. "' to be a string array")
+   local ok, var = pcall(need_array, varname, function(e) assert_type(e, 'string') end, required)
+   assert(ok, "site.conf error: expected `" .. varname .. "' to be a string array")
+   return var
 end
 
 function need_array_of(varname, array, required)


### PR DESCRIPTION
First commit adds a new function to check_site_lib.lua, to check whether a value is included in a given array. This is needed, to check that the list of wifi rates only contains unprohibited values.

Second commit adds the functionality to specify a list of allowed wifi rates within site.conf, which was already discussed in #467. Additionally this should fix all issues mentioned by @NeoRaider in #808.

Thanks to:
@RubenKelevra
@Brother-Lal
@rotanid