### PR TITLE
Added support for ALFA Networks Tube2H

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -355,6 +355,13 @@ $(eval $(call GluonModel,HORNETUB,hornet-ub,alfa-hornet-ub))
 $(eval $(call GluonModelAlias,HORNETUB,alfa-hornet-ub,alfa-ap121))
 $(eval $(call GluonModelAlias,HORNETUB,alfa-hornet-ub,alfa-ap121u))
 
+ifneq ($(BROKEN),)
+# Tube2H
+$(eval $(call GluonProfile,TUBE2H))
+$(eval $(call GluonModel,TUBE2H8M,tube2h-8m,alfa-tube2h-8m)) # BROKEN: working, only generic bgn
+$(eval $(call GluonModel,TUBE2H16M,tube2h-16m,alfa-tube2h-16m)) # BROKEN: untested
+endif
+
 ## Meraki
 
 # Meraki MR12/MR62


### PR DESCRIPTION
The Tube2H is a cheap Bullet-Clone.
It is supported barely undocumented by openwrt.
So it's a good point to add Gluon support to it.

I am testing it on the small 8M version and runs quiet well and stable.
The only ToDo is enhance the implementation of the rf chip. It's actually not possible to set txpower.
MultiSSID is working and default txpower seems to be normal compared to the possible range.