### PR TITLE
ar71xx-generic: add support for WBS210/510 v1.20

### DIFF
--- a/patches/openwrt/0115-ar71xx-add-support-for-WBS210-510-v1.20.patch
+++ b/patches/openwrt/0115-ar71xx-add-support-for-WBS210-510-v1.20.patch
@@ -1,0 +1,58 @@
+From: kb-light <freifunk@kb-light.de>
+Date: Wed, 3 Aug 2016 20:05:29 +0200
+Subject: ar71xx: add support for WBS210/510 v1.20
+
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 480cf93..90ff05b 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -344,6 +344,12 @@ tplink_pharos_board_detect() {
+ 	'CPE520(TP-LINK|UN|N300-5)')
+ 		model='TP-Link CPE520'
+ 		;;
++	'WBS210(TP-LINK|UN|N300-2)')
++		model='TP-Link WBS210'
++		;;
++	'WBS510(TP-LINK|UN|N300-5)')
++		model='TP-Link WBS510'
++		;;
+ 	esac
+ 
+ 	[ -n "$model" ] && AR71XX_MODEL="$model v$2"
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c
+index 8bf5c0f..f120ff9 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c
+@@ -28,7 +28,7 @@
+ #define CPE510_GPIO_LED_L1	13
+ #define CPE510_GPIO_LED_L2	14
+ #define CPE510_GPIO_LED_L3	15
+-#define CPE510_GPIO_LED_L4	16
++#define CPE510_GPIO_LED_L4	2
+ 
+ #define CPE510_GPIO_BTN_RESET	4
+ 
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index 77a894b..4c1b763 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -128,7 +128,7 @@ static const struct flash_partition_entry cpe510_partitions[] = {
+ };
+ 
+ /**
+-   The support list for CPE210/220/510/520
++   The support list for CPE210/220/510/520 and WBS210/510
+ */
+ static const char cpe510_support_list[] =
+ 	"SupportList:\r\n"
+@@ -139,7 +139,9 @@ static const char cpe510_support_list[] =
+ 	"CPE210(TP-LINK|UN|N300-2):1.0\r\n"
+ 	"CPE210(TP-LINK|UN|N300-2):1.1\r\n"
+ 	"CPE220(TP-LINK|UN|N300-2):1.0\r\n"
+-	"CPE220(TP-LINK|UN|N300-2):1.1\r\n";
++	"CPE220(TP-LINK|UN|N300-2):1.1\r\n"
++	"WBS510(TP-LINK|UN|N300-5):1.20\r\n"
++	"WBS210(TP-LINK|UN|N300-2):1.20\r\n";
+ 
+ #define error(_ret, _errno, _str, ...)				\
+ 	do {							\

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -14,6 +14,12 @@ $(eval $(call GluonModelAlias,CPE510,tp-link-cpe510-v1.0,tp-link-cpe220-v1.1))
 $(eval $(call GluonModelAlias,CPE510,tp-link-cpe510-v1.0,tp-link-cpe510-v1.1))
 $(eval $(call GluonModelAlias,CPE510,tp-link-cpe510-v1.0,tp-link-cpe520-v1.1))
 
+# WBS210/510
+ifeq ($(BROKEN),)
+$(eval $(call GluonModelAlias,CPE510,tp-link-cpe510-v1.0,tp-link-wbs510-v1.20))
+$(eval $(call GluonModelAlias,CPE510,tp-link-cpe510-v1.0,tp-link-wbs210-v1.20)) # BROKEN: untested
+endif
+
 # TL-WA701N/ND v1, v2
 $(eval $(call GluonProfile,TLWA701))
 $(eval $(call GluonModel,TLWA701,tl-wa701n-v1,tp-link-tl-wa701n-nd-v1))


### PR DESCRIPTION
Corresponding to #729, this adds support for TP-Link WBS210/510 v1.20

This should currently not be merged, because it breaks link4-led on CPE. Since they moved the led to gpio2, I actually just changed the gpio within `target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c` to test the led.
- Tested with WBS210 v1.20 based on Gluon v2016.1.5
- Device is detected as `TP-Link WBS210 v1.20`
- The maximum transmit power limits seems to be strange, corresponding to 27dBm specified by TP-Link:

```
* 2412 MHz [1] (13.0 dBm)
* 2417 MHz [2] (18.0 dBm)
* 2422 MHz [3] (18.0 dBm)
* 2427 MHz [4] (18.0 dBm)
* 2432 MHz [5] (18.0 dBm)
* 2437 MHz [6] (18.0 dBm)
* 2442 MHz [7] (18.0 dBm)
* 2447 MHz [8] (18.0 dBm)
* 2452 MHz [9] (18.0 dBm)
* 2457 MHz [10] (18.0 dBm)
* 2462 MHz [11] (13.0 dBm)
* 2467 MHz [12] (20.0 dBm)
* 2472 MHz [13] (20.0 dBm)
* 2484 MHz [14] (disabled)
```

Some maybe useful information:

```
# dd if=/dev/mtd2ro bs=1 skip=4360 | head -n 1 | tr -d '\r'
WBS210(TP-LINK|UN|N300-2):1.20
```

```
# lua -e 'print(require("platform_info").get_image_name())'
tp-link-wbs210-v1.20
```
