### PR TITLE
gluon-luci-private-wifi: limit ssid to 32 characters

### DIFF
--- a/package/gluon-luci-private-wifi/luasrc/usr/lib/lua/luci/model/cbi/admin/privatewifi.lua
+++ b/package/gluon-luci-private-wifi/luasrc/usr/lib/lua/luci/model/cbi/admin/privatewifi.lua
@@ -24,6 +24,7 @@ o.rmempty = false
 
 o = s:option(Value, "ssid", translate("Name (SSID)"))
 o:depends("enabled", '1')
+o.datatype = "maxlength(32)"
 o.default = ssid
 
 o = s:option(Value, "key", translate("Key"), translate("8-63 characters"))


### PR DESCRIPTION
fixes #845