### PR TITLE
gluon-config-mode-hostname: clarify the use of the nodename

### DIFF
--- a/package/gluon-config-mode-hostname/i18n/de.po
+++ b/package/gluon-config-mode-hostname/i18n/de.po
@@ -12,3 +12,11 @@ msgstr ""
 
 msgid "Node name"
 msgstr "Name dieses Knotens"
+
+msgid ""
+"The node name is used solely for identification of your node, e.g. on a "
+"nodemap. It has no influence on the name (SSID) of the broadcasted WLAN."
+msgstr ""
+"Der Knotenname dient ausschließlich zur Identifikation deines Knotens, z.B. "
+"auf einer Knotenkarte. Er hat keinen Einfluss auf den Namen (SSID) des "
+"ausgestrahlten WLANs."

--- a/package/gluon-config-mode-hostname/i18n/fr.po
+++ b/package/gluon-config-mode-hostname/i18n/fr.po
@@ -12,3 +12,11 @@ msgstr ""
 
 msgid "Node name"
 msgstr "Nom du nœud"
+
+msgid ""
+"The node name is used solely for identification of your node, e.g. on a "
+"nodemap. It has no influence on the name (SSID) of the broadcasted WLAN."
+msgstr ""
+"Le nom du nœud est utilisé uniquement pour l'identification de votre nœud, "
+"par ex. sur un carte des nœuds. Il n'a aucune influence sur le nom du WLAN "
+"(SSID) rayonné."

--- a/package/gluon-config-mode-hostname/i18n/gluon-config-mode-hostname.pot
+++ b/package/gluon-config-mode-hostname/i18n/gluon-config-mode-hostname.pot
@@ -3,3 +3,8 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 
 msgid "Node name"
 msgstr ""
+
+msgid ""
+"The node name is used solely for identification of your node, e.g. on a "
+"nodemap. It has no influence on the name (SSID) of the broadcasted WLAN."
+msgstr ""

--- a/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
+++ b/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
@@ -3,6 +3,11 @@ return function(form, uci)
 
 	local pretty_hostname = require "pretty_hostname"
 
+	form:section(Section, nil, pkg_i18n.translate(
+		"The node name is used solely for identification of your node, e.g. on a "
+		.. "nodemap. It has no influence on the name (SSID) of the broadcasted WLAN."
+	))
+	
 	local s = form:section(Section)
 	local o = s:option(Value, "hostname", pkg_i18n.translate("Node name"))
 	o.default = pretty_hostname.get(uci)


### PR DESCRIPTION
Maybe I can also get the name of the community in a variable? And is there a way to get the ssid here? So I could write this also in the hint.

This is just a first stub, I will enhance this later. also in the english version then.
