### PR TITLE
ar71xx-generic: remove broken mark for wr842n-v3

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -71,9 +71,7 @@ $(eval $(call GluonModel,TLWR841,tl-wr841n-v11,tp-link-tl-wr841n-nd-v11))
 $(eval $(call GluonProfile,TLWR842))
 $(eval $(call GluonModel,TLWR842,tl-wr842n-v1,tp-link-tl-wr842n-nd-v1))
 $(eval $(call GluonModel,TLWR842,tl-wr842n-v2,tp-link-tl-wr842n-nd-v2))
-ifneq ($(BROKEN),)
-$(eval $(call GluonModel,TLWR842,tl-wr842n-v3,tp-link-tl-wr842n-nd-v3)) # BROKEN: untested
-endif
+$(eval $(call GluonModel,TLWR842,tl-wr842n-v3,tp-link-tl-wr842n-nd-v3))
 
 # TL-WR843N/ND v1
 $(eval $(call GluonProfile,TLWR843))


### PR DESCRIPTION
I've bought a couple of those devices from Senetic GmbH.

https://www.senetic.de/product/TL-WR842N

They have 16 MB of Flash and 64 MB of RAM. Platform support works fine,
I've also tested a little with Ethernet (since I saw some regressions on
OpenWRT/LEDE with 841v11), no problems.

Therefore, lets remove the broken mark.

Signed-off-by: Simon Wunderlich <sw@simonwunderlich.de>