### PR TITLE
 ar71xx-generic: add support for ALFA N2 and N5

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -90,6 +90,9 @@ ar71xx-generic
   - AP121
   - AP121U
   - Hornet-UB
+  - Tube2H
+  - N2
+  - N5
 
 * Allnet
 

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -369,6 +369,10 @@ $(eval $(call GluonModelAlias,HORNETUB,alfa-network-hornet-ub,alfa-network-ap121
 $(eval $(call GluonProfile,TUBE2H))
 $(eval $(call GluonModel,TUBE2H,tube2h-8M,alfa-network-tube2h))
 
+# N2/N5
+$(eval $(call GluonProfile,ALFANX))
+$(eval $(call GluonModel,ALFANX,alfa-nx,alfa-network-n2-n5))
+
 ## Meraki
 
 # Meraki MR12/MR62


### PR DESCRIPTION
+ added profile for these devices
+ added entry in the docs for these devices plus the missing alfa tube