### PR TITLE
ar71xx-generic: Mark MR1750 and OM5P-AC devices as BROKEN

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -138,14 +138,12 @@ ar71xx-generic
 
 * OpenMesh
 
-  - MR1750 (v1, v2)
   - MR600 (v1, v2)
   - MR900 (v1, v2)
   - OM2P (v1, v2)
   - OM2P-HS (v1, v2, v3)
   - OM2P-LC
   - OM5P
-  - OM5P-AC (v1, v2)
   - OM5P-AN
 
 * TP-Link

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -323,10 +323,12 @@ $(eval $(call GluonModel,OMEGA,onion-omega,onion-omega))
 
 ## OpenMesh
 
+ifneq ($(BROKEN),)
 # MR1750
 $(eval $(call GluonProfile,MR1750,om-watchdog uboot-envtools kmod-ath10k-ct ath10k-firmware-qca988x-ct))
-$(eval $(call GluonModel,MR1750,mr1750,openmesh-mr1750))
-$(eval $(call GluonModelAlias,MR1750,openmesh-mr1750,openmesh-mr1750v2))
+$(eval $(call GluonModel,MR1750,mr1750,openmesh-mr1750)) # BROKEN: ath10k
+$(eval $(call GluonModelAlias,MR1750,openmesh-mr1750,openmesh-mr1750v2)) # BROKEN: ath10k
+endif
 
 # MR600
 $(eval $(call GluonProfile,MR600,om-watchdog uboot-envtools))
@@ -352,10 +354,12 @@ $(eval $(call GluonProfile,OM5P,om-watchdog uboot-envtools))
 $(eval $(call GluonModel,OM5P,om5p,openmesh-om5p))
 $(eval $(call GluonModelAlias,OM5P,openmesh-om5p,openmesh-om5p-an))
 
+ifneq ($(BROKEN),)
 # OM5P-AC
 $(eval $(call GluonProfile,OM5PAC,om-watchdog uboot-envtools kmod-ath10k-ct ath10k-firmware-qca988x-ct))
-$(eval $(call GluonModel,OM5PAC,om5pac,openmesh-om5p-ac))
-$(eval $(call GluonModelAlias,OM5PAC,openmesh-om5p-ac,openmesh-om5p-acv2))
+$(eval $(call GluonModel,OM5PAC,om5pac,openmesh-om5p-ac)) # BROKEN: ath10k
+$(eval $(call GluonModelAlias,OM5PAC,openmesh-om5p-ac,openmesh-om5p-acv2)) # BROKEN: ath10k
+endif
 
 ## ALFA NETWORK
 


### PR DESCRIPTION
The MR1750 and OM5P-AC devices are based on ath9k SoCs and an external ath10k chip. All devices which are using ath10k should be marked as broken due to deficits in their IBSS support.