### PR TITLE
Firmware upgrade: reload after 3 Minutes

### DIFF
--- a/package/gluon-luci-admin/files/usr/lib/lua/luci/view/admin/upgrade_reboot.htm
+++ b/package/gluon-luci-admin/files/usr/lib/lua/luci/view/admin/upgrade_reboot.htm
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <title><%:Upgrading firmware%></title>
     <link rel="stylesheet" type="text/css" media="screen" href="<%=media%>/cascade.css" />
+    <meta http-equiv="refresh" content="180; URL=http://192.168.1.1/">
   </head>
   <body>
     <div id="maincontainer">


### PR DESCRIPTION
This will redirect to http://192.168.1.1/ from the Firmware Upgrade screen after a safe timeout
