### PR TITLE
Add support for TP-Link TL-WA901ND-v4

### DIFF
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -136,9 +136,7 @@ $(eval $(call GluonProfile,TLWA901))
 $(eval $(call GluonModel,TLWA901,tl-wa901nd-v1,tp-link-tl-wa901n-nd-v1))
 $(eval $(call GluonModel,TLWA901,tl-wa901nd-v2,tp-link-tl-wa901n-nd-v2))
 $(eval $(call GluonModel,TLWA901,tl-wa901nd-v3,tp-link-tl-wa901n-nd-v3))
-ifneq ($(BROKEN),)
-$(eval $(call GluonModel,TLWA901,tl-wa901nd-v4,tp-link-tl-wa901n-nd-v4)) # BROKEN: untested
-endif
+$(eval $(call GluonModel,TLWA901,tl-wa901nd-v4,tp-link-tl-wa901n-nd-v4))
 
 # TL-MR13U v1
 $(eval $(call GluonProfile,TLMR13U))


### PR DESCRIPTION
I veriefied the functionality of this device, IBSS and 802.11s meshing, Ethernet, LEDs and Buttons, WiFi works perfectly with this device. The primary MAC is the same as printed on the devices sticker.

The firmware cannot be flashed via the stock firmwares web ui (OpenWrt and LEDE can't be flashed either). The firmware has to be flashed onto the device via the TFTP method mentioned in [this post](https://forum.openwrt.org/viewtopic.php?pid=320942#p320942).

In short: Download the firmware and rename it to wa901ndv4_tp_recovery.bin, setup a tftp server and configure a static IP address (192.168.0.66), press (and hold for a few seconds) the reset button while turning the device on. The device is now downloading the firmware and you should be able to configure your new Gluon node after the device has rebooted.