### PR TITLE
gluon-status-page: add info if javascript is disabled to enable it

### DIFF
--- a/package/gluon-status-page/src/index.html.m4
+++ b/package/gluon-status-page/src/index.html.m4
@@ -13,6 +13,6 @@
     </script>
   </head>
   <body>
-	  <noscript>Bitte Javascript aktivieren.</noscript>
+    <noscript>Bitte Javascript aktivieren.</noscript>
   </body>
 </html>

--- a/package/gluon-status-page/src/index.html.m4
+++ b/package/gluon-status-page/src/index.html.m4
@@ -13,5 +13,6 @@
     </script>
   </head>
   <body>
+	  <h1 id="jswarn">Bitte Javascript aktivieren.</h1>
   </body>
 </html>

--- a/package/gluon-status-page/src/index.html.m4
+++ b/package/gluon-status-page/src/index.html.m4
@@ -13,6 +13,6 @@
     </script>
   </head>
   <body>
-	  <h1 id="jswarn">Bitte Javascript aktivieren.</h1>
+	  <noscript>Bitte Javascript aktivieren.</noscript>
   </body>
 </html>

--- a/package/gluon-status-page/src/js/main.js
+++ b/package/gluon-status-page/src/js/main.js
@@ -5,8 +5,6 @@ require([ "bacon"
         , "lib/gui"
         ], function(Bacon, Helper, Streams, GUI) {
 
-  document.getElementById("jswarn").remove();
-
   var mgmtBus = new Bacon.Bus()
 
   mgmtBus.pushEvent = function (key, a) {

--- a/package/gluon-status-page/src/js/main.js
+++ b/package/gluon-status-page/src/js/main.js
@@ -5,6 +5,8 @@ require([ "bacon"
         , "lib/gui"
         ], function(Bacon, Helper, Streams, GUI) {
 
+  document.getElementById("jswarn").remove();
+
   var mgmtBus = new Bacon.Bus()
 
   mgmtBus.pushEvent = function (key, a) {


### PR DESCRIPTION
The current statuspage is completely empty if JS is disabled.
This at least displays a message to please enable JS in the case its disabled.