### PR TITLE
Make fastd syslog level configurable

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -102,6 +102,7 @@
     methods = {'salsa2012+umac'},
     -- enabled = true,
     -- configurable = true,
+    -- syslog_level = 'warn',
 
     mtu = 1280,
     groups = {

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -183,7 +183,7 @@ fastd_mesh_vpn
     if it is supported at all. You should only set `configurable` to `true` if the
     configured peers support both the ``null`` method and methods with encryption.
     
-    You can set syslog_level from verbose(default) to warn to reduce syslog output.
+    You can set syslog_level from verbose (default) to warn to reduce syslog output.
     ::
 
       fastd_mesh_vpn = {

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -182,12 +182,15 @@ fastd_mesh_vpn
     In any case, the ``null`` method should always be the first method in the list
     if it is supported at all. You should only set `configurable` to `true` if the
     configured peers support both the ``null`` method and methods with encryption.
+    
+    You can set syslog_level from verbose(default) to warn to reduce syslog output.
     ::
 
       fastd_mesh_vpn = {
         methods = {'salsa2012+umac'},
       	-- enabled = true,
       	-- configurable = true,
+	-- syslog_level = 'warn',
         mtu = 1280,
         groups = {
           backbone = {

--- a/package/gluon-mesh-vpn-fastd/check_site.lua
+++ b/package/gluon-mesh-vpn-fastd/check_site.lua
@@ -3,6 +3,7 @@ need_number('fastd_mesh_vpn.mtu')
 need_boolean('fastd_mesh_vpn.enabled', false)
 need_boolean('fastd_mesh_vpn.configurable', false)
 
+need_one_of('fastd_mesh_vpn.syslog_level', {'error', 'warn', 'info', 'verbose', 'debug', 'debug2'}, false)
 
 local function check_peer(prefix)
   return function(k, _)

--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -21,6 +21,12 @@ if not enabled then
 end
 
 
+local syslog_level = uci:get('fastd', 'mesh_vpn', 'syslog_level')
+if not syslog_level then
+  syslog_level = 'verbose'
+end
+
+
 local methods
 
 if site.fastd_mesh_vpn.configurable then
@@ -52,7 +58,7 @@ uci:section('fastd', 'fastd', 'mesh_vpn',
 	  {
 		  enabled = enabled,
 		  group = 'gluon-fastd',
-		  syslog_level = 'warn',
+		  syslog_level = syslog_level,
 		  interface = 'mesh-vpn',
 		  mode = 'tap',
 		  mtu = site.fastd_mesh_vpn.mtu,

--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -52,7 +52,7 @@ uci:section('fastd', 'fastd', 'mesh_vpn',
 	  {
 		  enabled = enabled,
 		  group = 'gluon-fastd',
-		  syslog_level = 'verbose',
+		  syslog_level = 'warn',
 		  interface = 'mesh-vpn',
 		  mode = 'tap',
 		  mtu = site.fastd_mesh_vpn.mtu,

--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -15,17 +15,9 @@ users.remove_user('gluon-fastd')
 users.add_group('gluon-fastd', 800)
 
 
-local enabled = uci:get('fastd', 'mesh_vpn', 'enabled')
-if not enabled then
-  enabled = site.fastd_mesh_vpn.enabled and 1 or 0
-end
+local enabled = uci:get('fastd', 'mesh_vpn', 'enabled') and 1 or 0
 
-
-local syslog_level = uci:get('fastd', 'mesh_vpn', 'syslog_level')
-if not syslog_level then
-  syslog_level = 'verbose'
-end
-
+local syslog_level = uci:get('fastd', 'mesh_vpn', 'syslog_level') or 'verbose'
 
 local methods
 
@@ -36,7 +28,6 @@ if site.fastd_mesh_vpn.configurable then
   if old_methods then
     has_null = lutil.contains(old_methods, 'null')
   end
-
 
   methods = {}
   if has_null then

--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -15,7 +15,10 @@ users.remove_user('gluon-fastd')
 users.add_group('gluon-fastd', 800)
 
 
-local enabled = uci:get('fastd', 'mesh_vpn', 'enabled') and 1 or 0
+local enabled = uci:get('fastd', 'mesh_vpn', 'enabled')
+if not enabled then
+  enabled = site.fastd_mesh_vpn.enabled and 1 or 0
+end
 
 local syslog_level = uci:get('fastd', 'mesh_vpn', 'syslog_level') or 'verbose'
 


### PR DESCRIPTION
it is easy to set this to a higher value again if needed. This will prevent fastd from flooding the log ringbuffer, even when it is not needed/no uplink via fastd. 
This log - flooding raise with every peer known from site.conf.

Fixes #896
