### PR TITLE
X86 network drivers

### DIFF
--- a/targets/x86-64/profiles.mk
+++ b/targets/x86-64/profiles.mk
@@ -1,4 +1,4 @@
-X86_64_NETWORK_MODULES := kmod-3c59x kmod-e100 kmod-e1000 kmod-e1000e kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-8139too kmod-r8169 kmod-sis900 kmod-tg3 kmod-via-rhine kmod-via-velocity kmod-forcedeth
+X86_64_NETWORK_MODULES := kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-e1000e kmod-forcedeth kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-tg3 kmod-via-rhine kmod-via-velocity
 
 
 $(eval $(call GluonProfile,GENERIC,$(X86_64_NETWORK_MODULES)))

--- a/targets/x86-64/profiles.mk
+++ b/targets/x86-64/profiles.mk
@@ -1,4 +1,4 @@
-X86_64_NETWORK_MODULES := kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-e1000e kmod-forcedeth kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-tg3 kmod-via-rhine kmod-via-velocity
+X86_64_NETWORK_MODULES := kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-e1000e kmod-forcedeth kmod-igb kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-sky2 kmod-tg3 kmod-tulip kmod-via-rhine kmod-via-velocity
 
 
 $(eval $(call GluonProfile,GENERIC,$(X86_64_NETWORK_MODULES)))

--- a/targets/x86-generic/profiles.mk
+++ b/targets/x86-generic/profiles.mk
@@ -1,4 +1,4 @@
-X86_GENERIC_NETWORK_MODULES := kmod-3c59x kmod-e100 kmod-e1000 kmod-e1000e kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-8139too kmod-r8169 kmod-sis900 kmod-tg3 kmod-via-rhine kmod-via-velocity kmod-forcedeth
+X86_GENERIC_NETWORK_MODULES := kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-e1000e kmod-forcedeth kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-tg3 kmod-via-rhine kmod-via-velocity
 
 
 $(eval $(call GluonProfile,GENERIC,$(X86_GENERIC_NETWORK_MODULES)))

--- a/targets/x86-generic/profiles.mk
+++ b/targets/x86-generic/profiles.mk
@@ -1,4 +1,4 @@
-X86_GENERIC_NETWORK_MODULES := kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-e1000e kmod-forcedeth kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-tg3 kmod-via-rhine kmod-via-velocity
+X86_GENERIC_NETWORK_MODULES := kmod-3c59x kmod-8139too kmod-e100 kmod-e1000 kmod-e1000e kmod-forcedeth kmod-igb kmod-natsemi kmod-ne2k-pci kmod-pcnet32 kmod-r8169 kmod-sis900 kmod-sky2 kmod-tg3 kmod-tulip kmod-via-rhine kmod-via-velocity
 
 
 $(eval $(call GluonProfile,GENERIC,$(X86_GENERIC_NETWORK_MODULES)))


### PR DESCRIPTION
this PR sorts the list of network modules integrated in x86 images and adds the 3 new modules kmod-igb, kmod-sky2, kmod-tulip