### PR TITLE
Add site commit-ID and dirty-flag to gluon and site commit descriptions

### DIFF
--- a/include/gluon.mk
+++ b/include/gluon.mk
@@ -35,8 +35,11 @@ $(GLUON_SITEDIR)/site.mk:
 -include $(GLUON_SITEDIR)/site.mk
 
 
-GLUON_VERSION := $(shell cd $(GLUONDIR) && git describe --always 2>/dev/null || echo unknown)
+GLUON_VERSION := $(shell cd $(GLUONDIR) && git --git-dir=.git describe --always --dirty=+ 2>/dev/null || echo unknown)
 export GLUON_VERSION
+
+GLUON_SITE_VERSION := $(shell cd $(GLUON_SITEDIR) && git --git-dir=.git describe --always --dirty=+ 2>/dev/null || echo unknown)
+export GLUON_SITE_VERSION
 
 GLUON_LANGS ?= en
 export GLUON_LANGS

--- a/package/gluon-core/Makefile
+++ b/package/gluon-core/Makefile
@@ -38,6 +38,7 @@ define Package/gluon-core/install
 
 	$(INSTALL_DIR) $(1)/lib/gluon
 	echo "$(GLUON_VERSION)" > $(1)/lib/gluon/gluon-version
+	echo "$(GLUON_SITE_VERSION)" > $(1)/lib/gluon/site-version
 endef
 
 define Package/gluon-core/postinst


### PR DESCRIPTION
First test:

```
cat build/ar71xx-generic/profiles/TLWR841/root/lib/gluon/site-remote 
https://github.com/rubo77/site-ffki/

cat build/ar71xx-generic/profiles/TLWR841/root/lib/gluon/site-version 
v0.4-140-g6de441e
```
which looks fine. you can construct this URL out of it: [https://github.com/rubo77/site-ffki/tree/**6de441e**](https://github.com/rubo77/site-ffki/tree/6de441e)

for the gluon repo:
```
cat build/ar71xx-generic/profiles/TLWR841/root/lib/gluon/gluon-remote 
https://github.com/freifunk-gluon/gluon.git
```
this could be improved, cause I really used my own repo: https://github.com/rubo77/gluon.git

the url shows my origin, but not the branch, I actually built upon. but the commit Id is correct anyway:

```
cat build/ar71xx-generic/profiles/TLWR841/root/lib/gluon/gluon-version 
v2016.2.1-4-g7a7b1a7
```
the result shows the right commit, but not the right organization:

https://github.com/freifunk-gluon/gluon/tree/7a7b1a7 (here  you had to cutoff the `.git` at the end)

