### PR TITLE
make respondd initialisation mesh protocol agnostic

### DIFF
--- a/package/gluon-mesh-batman-adv-core/files/lib/gluon/respondd/client.dev
+++ b/package/gluon-mesh-batman-adv-core/files/lib/gluon/respondd/client.dev
@@ -1,0 +1,1 @@
+br-client

--- a/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
+++ b/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
@@ -1,34 +1,10 @@
 #!/bin/sh
 
-. /usr/share/libubox/jshn.sh
 . /lib/functions/service.sh
 
-DEVLIST=/var/run/gluon-respondd.devs
-
-ifname_to_dev () {
-	json_load "$(ubus call network.interface.$1 status)"
-	json_get_var dev device
-
-	echo "$dev"
-}
-
 case "$ACTION" in
-	ifdown)
-		sed "/ $INTERFACE$/d" $DEVLIST > $DEVLIST.new
-		mv $DEVLIST.new $DEVLIST
-		;;
+	ifdown) ;;
 	ifup)
-		DEVICE="$(ifname_to_dev "$INTERFACE")"
-		MESH="$(cat "/sys/class/net/$DEVICE/batman_adv/mesh_iface" 2>/dev/null)"
-
-		[ "$MESH" = "bat0" -o "$INTERFACE" = "client" ] || exit 0
-
-		DEVS=$(cat $DEVLIST 2>/dev/null; echo $DEVICE $INTERFACE)
-
-		echo "$DEVS" | sort -u > $DEVLIST.new
-		mv $DEVLIST.new $DEVLIST
-
 		/etc/init.d/gluon-respondd restart_if_running &
-
 		;;
 esac

--- a/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
+++ b/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
@@ -2,17 +2,15 @@
 
 . /lib/functions/service.sh
 
-DEVLIST=/var/run/gluon-respondd.devs
-
 ifname_to_dev () {
-  ifstatus client "$1"|jsonfilter -e "@.device"
+	ifstatus client "$1"|jsonfilter -e "@.device"
 }
 
 case "$ACTION" in
-  ifup)   
-    DEVICE="$(ifname_to_dev "$INTERFACE")"
+	ifup)   
+		DEVICE="$(ifname_to_dev "$INTERFACE")"
 
-    [ "$DEVICE" != "$(cat /lib/gluon/respondd/client.dev)" ] || 
-      /etc/init.d/gluon-respondd restart_if_running &
-    ;;
+		[ "$DEVICE" != "$(cat /lib/gluon/respondd/client.dev 2>/dev/null)" ] || 
+			/etc/init.d/gluon-respondd restart_if_running &
+		;;
 esac

--- a/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
+++ b/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+. /usr/share/libubox/jshn.sh
+. /lib/functions/service.sh
+
+DEVLIST=/var/run/gluon-respondd.devs
+
+ifname_to_dev () {
+  json_load "$(ubus call network.interface.$1 status)"
+  json_get_var dev device
+
+  echo "$dev"
+}
+
+case "$ACTION" in
+  ifup)   
+    DEVICE="$(ifname_to_dev "$INTERFACE")"
+
+    [ "$DEVICE" == $(cat /lib/gluon/respondd/client.dev) ] && 
+      /etc/init.d/gluon-respondd restart_if_running &
+    ;;
+esac

--- a/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
+++ b/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
@@ -1,22 +1,18 @@
 #!/bin/sh
 
-. /usr/share/libubox/jshn.sh
 . /lib/functions/service.sh
 
 DEVLIST=/var/run/gluon-respondd.devs
 
 ifname_to_dev () {
-  json_load "$(ubus call network.interface.$1 status)"
-  json_get_var dev device
-
-  echo "$dev"
+  ifstatus client "$1"|jsonfilter -e "@.device"
 }
 
 case "$ACTION" in
   ifup)   
     DEVICE="$(ifname_to_dev "$INTERFACE")"
 
-    [ "$DEVICE" == $(cat /lib/gluon/respondd/client.dev) ] && 
+    [ "$DEVICE" != "$(cat /lib/gluon/respondd/client.dev)" ] || 
       /etc/init.d/gluon-respondd restart_if_running &
     ;;
 esac

--- a/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
+++ b/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
@@ -1,9 +1,0 @@
-#!/bin/sh
-
-. /lib/functions/service.sh
-
-case "$ACTION" in
-	ifup)
-		/etc/init.d/gluon-respondd restart_if_running &
-		;;
-esac

--- a/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
+++ b/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
@@ -3,7 +3,6 @@
 . /lib/functions/service.sh
 
 case "$ACTION" in
-	ifdown) ;;
 	ifup)
 		/etc/init.d/gluon-respondd restart_if_running &
 		;;

--- a/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
+++ b/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
@@ -7,10 +7,10 @@ ifname_to_dev () {
 }
 
 case "$ACTION" in
-	ifup)   
+	ifup)
 		DEVICE="$(ifname_to_dev "$INTERFACE")"
 
-		[ "$DEVICE" != "$(cat /lib/gluon/respondd/client.dev 2>/dev/null)" ] || 
+		[ "$DEVICE" != "$(cat /lib/gluon/respondd/client.dev 2>/dev/null)" ] ||
 			/etc/init.d/gluon-respondd restart_if_running &
 		;;
 esac

--- a/package/gluon-respondd/files/etc/init.d/gluon-respondd
+++ b/package/gluon-respondd/files/etc/init.d/gluon-respondd
@@ -7,13 +7,16 @@ START=50
 SERVICE_WRITE_PID=1
 SERVICE_DAEMONIZE=1
 
-DEVLIST=/var/run/gluon-respondd.devs
 DAEMON=/usr/bin/respondd
 LOCK=/var/run/gluon-respondd.lock
 
 
 do_start() {
-	DEVS=$(cat $DEVLIST 2>/dev/null | while read dev iface; do echo -n " -i $dev"; done)
+	DEVS=""
+	for dev in "$( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") br-wan br-client"
+	do
+	  DEVS="$DEVS -i $dev"
+	done
 	service_start $DAEMON -g ff02::2:1001 -p 1001 -d /lib/gluon/respondd $DEVS
 }
 

--- a/package/gluon-respondd/files/etc/init.d/gluon-respondd
+++ b/package/gluon-respondd/files/etc/init.d/gluon-respondd
@@ -15,7 +15,7 @@ do_start() {
 	DEVS=""
 	for dev in $( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") $(cat /lib/gluon/respondd/client.dev)
 	do
-	  DEVS="$DEVS -i $dev"
+		DEVS="$DEVS -i $dev"
 	done
 	service_start $DAEMON -g ff02::2:1001 -p 1001 -d /lib/gluon/respondd $DEVS
 }

--- a/package/gluon-respondd/files/etc/init.d/gluon-respondd
+++ b/package/gluon-respondd/files/etc/init.d/gluon-respondd
@@ -13,7 +13,7 @@ LOCK=/var/run/gluon-respondd.lock
 
 do_start() {
 	DEVS=""
-	for dev in "$( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") br-wan br-client"
+	for dev in $( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") br-wan br-client
 	do
 	  DEVS="$DEVS -i $dev"
 	done

--- a/package/gluon-respondd/files/etc/init.d/gluon-respondd
+++ b/package/gluon-respondd/files/etc/init.d/gluon-respondd
@@ -13,7 +13,7 @@ LOCK=/var/run/gluon-respondd.lock
 
 do_start() {
 	DEVS=""
-	for dev in $( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") br-wan br-client
+	for dev in $( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") br-client
 	do
 	  DEVS="$DEVS -i $dev"
 	done

--- a/package/gluon-respondd/files/etc/init.d/gluon-respondd
+++ b/package/gluon-respondd/files/etc/init.d/gluon-respondd
@@ -13,7 +13,7 @@ LOCK=/var/run/gluon-respondd.lock
 
 do_start() {
 	DEVS=""
-	for dev in $( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") br-client
+	for dev in $( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") $(cat /lib/gluon/respondd/client.dev)
 	do
 	  DEVS="$DEVS -i $dev"
 	done

--- a/package/gluon-respondd/files/etc/init.d/gluon-respondd
+++ b/package/gluon-respondd/files/etc/init.d/gluon-respondd
@@ -13,7 +13,7 @@ LOCK=/var/run/gluon-respondd.lock
 
 do_start() {
 	DEVS=""
-	for dev in $( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") $(cat /lib/gluon/respondd/client.dev)
+	for dev in $( ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device") $(cat /lib/gluon/respondd/client.dev 2>/dev/null)
 	do
 		DEVS="$DEVS -i $dev"
 	done

--- a/package/gluon-respondd/files/lib/gluon/core/mesh/setup.d/10-gluon-respondd
+++ b/package/gluon-respondd/files/lib/gluon/core/mesh/setup.d/10-gluon-respondd
@@ -1,0 +1,2 @@
+#!/bin/sh
+/etc/init.d/gluon-respondd restart_if_running &


### PR DESCRIPTION
this PR will make babel firmware able to run respondd while not breaking compatibility with batman.
This is done by making device detection independent of batman-specific calls. 

This has been tested in a batman network