### PR TITLE
Add support for ZBT-WG3526-32M

### DIFF
--- a/patches/openwrt/0081-ramips-Add-support-for-ZBT-WG3526.patch
+++ b/patches/openwrt/0081-ramips-Add-support-for-ZBT-WG3526.patch
@@ -1,0 +1,264 @@
+From: John Crispin <blogic@openwrt.org>
+Date: Thu, 21 Apr 2016 19:47:08 +0000
+Subject: ramips: Add support for ZBT WG3526
+
+The WG3526 is the follow-up to the 2626 and is mostly the same, with the
+excaption that the mt7602 has been replaced with the mt7603. The internal wifi
+setup has also changed slightly. Based on my tests, everything that worked on
+the 2626 works on the 3526 and with roughly the same performance.
+
+v1->v2:
+* Remove some references to 2626 that I had missed in the dts.
+
+v2->v3:
+* Update patch to match new file structure.
+* Removed SD driver to be consistent with other MT7621 targets.
+
+Signed-off-by: Kristian Evensen <kristian.evensen@gmail.com>
+
+git-svn-id: svn://svn.openwrt.org/openwrt/trunk@49213 3c298f89-4303-0410-b956-a3cf2f4a3e73
+
+diff --git a/target/linux/ramips/base-files/etc/board.d/02_network b/target/linux/ramips/base-files/etc/board.d/02_network
+index 4e6e507..d287002 100755
+--- a/target/linux/ramips/base-files/etc/board.d/02_network
++++ b/target/linux/ramips/base-files/etc/board.d/02_network
+@@ -147,7 +147,8 @@ ramips_setup_interfaces()
+ 	wt1520 | \
+ 	xiaomi-miwifi-mini |\
+ 	y1|\
+-	zbt-wg2626)
++	zbt-wg2626|\
++	zbt-wg3526)
+ 		ucidef_set_interfaces_lan_wan "eth0.1" "eth0.2"
+ 		ucidef_add_switch "switch0" "1" "1"
+ 		ucidef_add_switch_vlan "switch0" "1" "0 1 2 3 6t"
+diff --git a/target/linux/ramips/base-files/etc/diag.sh b/target/linux/ramips/base-files/etc/diag.sh
+index 37360a4..90e6561 100644
+--- a/target/linux/ramips/base-files/etc/diag.sh
++++ b/target/linux/ramips/base-files/etc/diag.sh
+@@ -15,6 +15,10 @@ get_status_led() {
+ 	ai-br100)
+ 		status_led="aigale:blue:wlan"
+ 		;;
++	zbt-wg2626|\
++	zbt-wg3526)
++		status_led="zbt:green:status"
++		;;
+ 	ar670w)
+ 		status_led="ar670w:green:power"
+ 		;;
+diff --git a/target/linux/ramips/base-files/lib/ramips.sh b/target/linux/ramips/base-files/lib/ramips.sh
+index 8dc05b0..8535785 100755
+--- a/target/linux/ramips/base-files/lib/ramips.sh
++++ b/target/linux/ramips/base-files/lib/ramips.sh
+@@ -427,6 +427,9 @@ ramips_board_detect() {
+ 	*"Mediatek MT7628AN evaluation board")
+ 		name="mt7628"
+ 		;;
++	*"ZBT-WG3526")
++		name="zbt-wg3526"
++		;;
+ 	*"MediaTek LinkIt Smart 7688")
+ 		linkit="$(dd bs=1 skip=1024 count=12 if=/dev/mtd2 2> /dev/null)"
+ 		if [ "${linkit}" = "LINKITS7688D" ]; then
+diff --git a/target/linux/ramips/base-files/lib/upgrade/platform.sh b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+index a3d0175..084e72a 100755
+--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+@@ -14,6 +14,7 @@ platform_check_image() {
+ 	[ "$#" -gt 1 ] && return 1
+ 
+ 	case "$board" in
++<<<<<<< HEAD
+ 	3g-6200n | \
+ 	3g-6200nl | \
+ 	3g150b | \
+@@ -129,6 +130,8 @@ platform_check_image() {
+ 	y1s |\
+ 	zbt-wa05 |\
+ 	zbt-wg2626 |\
++	zbt-wg3526 |\
++	zbt-wr8305rt |\
+ 	zte-q7)
+ 		[ "$magic" != "27051956" ] && {
+ 			echo "Invalid image type."
+diff --git a/target/linux/ramips/dts/ZBT-WG3526.dts b/target/linux/ramips/dts/ZBT-WG3526.dts
+new file mode 100644
+index 0000000..b62471b
+--- /dev/null
++++ b/target/linux/ramips/dts/ZBT-WG3526.dts
+@@ -0,0 +1,127 @@
++/dts-v1/;
++
++/include/ "mt7621.dtsi"
++
++/ {
++	compatible = "mediatek,mt7621-eval-board", "mediatek,mt7621-soc";
++	model = "ZBT-WG3526";
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x1c000000>, <0x20000000 0x4000000>;
++	};
++
++	chosen {
++		bootargs = "console=ttyS0,115200";
++	};
++
++	sdhci@10130000 {
++		status = "okay";
++	};
++
++	palmbus@1E000000 {
++		spi@b00 {
++			status = "okay";
++
++			m25p80@0 {
++				#address-cells = <1>;
++				#size-cells = <1>;
++				compatible = "jedec,spi-nor";
++				reg = <0 0>;
++				linux,modalias = "m25p80";
++				spi-max-frequency = <10000000>;
++
++				partition@0 {
++					label = "u-boot";
++					reg = <0x0 0x30000>;
++					read-only;
++				};
++
++				partition@30000 {
++					label = "u-boot-env";
++					reg = <0x30000 0x10000>;
++					read-only;
++				};
++
++				factory: partition@40000 {
++					label = "factory";
++					reg = <0x40000 0x10000>;
++					read-only;
++				};
++
++				partition@50000 {
++					label = "firmware";
++					reg = <0x50000 0xfb0000>;
++				};
++
++			};
++		};
++
++		i2c@900 {
++			compatible = "ralink,i2c-mt7621";
++			reg = <0x900 0x100>;
++			#address-cells = <1>;
++			#size-cells = <0>;
++			pinctrl-names = "default";
++			pinctrl-0 = <&i2c_pins>;
++			status = "okay";
++		};
++	};
++
++	pcie@1e140000 {
++		status = "okay";
++
++		pcie0 {
++			mt76@0,0 {
++				reg = <0x0000 0 0 0 0>;
++				device_type = "pci";
++				mediatek,mtd-eeprom = <&factory 0x0000>;
++				mediatek,5ghz = <0>;
++			};
++		};
++
++		pcie1 {
++			mt76@1,0 {
++				reg = <0x0000 0 0 0 0>;
++				device_type = "pci";
++				mediatek,mtd-eeprom = <&factory 0x8000>;
++				mediatek,2ghz = <0>;
++			};
++		};
++	};
++
++	ethernet@1e100000 {
++		mtd-mac-address = <&factory 0xe000>;
++	};
++
++	gpio-keys-polled {
++		compatible = "gpio-keys-polled";
++		#address-cells = <1>;
++		#size-cells = <0>;
++		poll-interval = <20>;
++
++		reset {
++			label = "reset";
++			gpios = <&gpio0 18 1>;
++			linux,code = <0x198>;
++		};
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++
++		status {
++			label = "zbt-wg3526:green:status";
++			gpios = <&gpio0 24 1>;
++		};
++	};
++
++	pinctrl {
++		state_default: pinctrl0 {
++			gpio {
++				ralink,group = "wdt", "rgmii2", "wdt rst", "jtag", "mdio";
++				ralink,function = "gpio";
++			};
++		};
++	};
++};
+diff --git a/target/linux/ramips/image/Makefile b/target/linux/ramips/image/Makefile
+index c4f4028..80c2d8e 100644
+--- a/target/linux/ramips/image/Makefile
++++ b/target/linux/ramips/image/Makefile
+@@ -956,7 +956,7 @@ endif
+ #
+ 
+ ifeq ($(SUBTARGET),mt7621)
+-  TARGET_DEVICES += mt7621 wsr-600 wsr-1166 dir-860l-b1 firewrt pbr-m1 re6500 zbt-wg2626
++  TARGET_DEVICES += mt7621 wsr-600 wsr-1166 dir-860l-b1 firewrt pbr-m1 re6500 zbt-wg2626 zbt-wg3526
+ endif
+ 
+ define Device/mt7621
+@@ -1007,6 +1007,12 @@ define Device/zbt-wg2626
+   IMAGE_SIZE := $(ralink_default_fw_size_16M)
+ endef
+ 
++define Device/zbt-wg3526
++  DTS := ZBT-WG3526
++  IMAGE_SIZE := $(ralink_default_fw_size_16M)
++endef
++TARGET_DEVICES += zbt-wg3526
++
+ #
+ # MT7628 Profiles
+ #
+diff --git a/target/linux/ramips/mt7621/profiles/zbt.mk b/target/linux/ramips/mt7621/profiles/zbt.mk
+index cf9beff..0a8fe0c 100644
+--- a/target/linux/ramips/mt7621/profiles/zbt.mk
++++ b/target/linux/ramips/mt7621/profiles/zbt.mk
+@@ -17,3 +17,16 @@ define Profile/ZBT-WG2626/Description
+ 	Package set for ZBT-WG2626 device
+ endef
+ $(eval $(call Profile,ZBT-WG2626))
++
++
++define Profile/ZBT-WG3526
++	NAME:=ZBT-WG3526 Device
++	PACKAGES:=\
++		kmod-usb-core kmod-usb3 \
++		kmod-ledtrig-usbdev kmod-ata-core kmod-ata-ahci
++endef
++
++define Profile/ZBT-WG3526/Description
++	Package set for ZBT-WG3526 device
++endef
++$(eval $(call Profile,ZBT-WG3526))

--- a/patches/openwrt/0082-Add-support-for-Digineo-AC1200-Pro.patch
+++ b/patches/openwrt/0082-Add-support-for-Digineo-AC1200-Pro.patch
@@ -1,92 +1,72 @@
-From: John Crispin <blogic@openwrt.org>
-Date: Thu, 21 Apr 2016 19:47:08 +0000
-Subject: ramips: Add support for ZBT WG3526
-
-The WG3526 is the follow-up to the 2626 and is mostly the same, with the
-excaption that the mt7602 has been replaced with the mt7603. The internal wifi
-setup has also changed slightly. Based on my tests, everything that worked on
-the 2626 works on the 3526 and with roughly the same performance.
-
-v1->v2:
-* Remove some references to 2626 that I had missed in the dts.
-
-v2->v3:
-* Update patch to match new file structure.
-* Removed SD driver to be consistent with other MT7621 targets.
-
-Signed-off-by: Kristian Evensen <kristian.evensen@gmail.com>
-
-git-svn-id: svn://svn.openwrt.org/openwrt/trunk@49213 3c298f89-4303-0410-b956-a3cf2f4a3e73
+From: Julian Kornberger <jk+github@digineo.de>
+Date: Sat, 17 Dec 2016 19:47:00 +0100
+Subject: Add support for Digineo AC1200 Pro
 
 diff --git a/target/linux/ramips/base-files/etc/board.d/02_network b/target/linux/ramips/base-files/etc/board.d/02_network
-index 4e6e507..d287002 100755
+index 4e6e507..453af2c 100755
 --- a/target/linux/ramips/base-files/etc/board.d/02_network
 +++ b/target/linux/ramips/base-files/etc/board.d/02_network
-@@ -147,7 +147,8 @@ ramips_setup_interfaces()
- 	wt1520 | \
- 	xiaomi-miwifi-mini |\
- 	y1|\
--	zbt-wg2626)
-+	zbt-wg2626|\
-+	zbt-wg3526)
- 		ucidef_set_interfaces_lan_wan "eth0.1" "eth0.2"
- 		ucidef_add_switch "switch0" "1" "1"
- 		ucidef_add_switch_vlan "switch0" "1" "0 1 2 3 6t"
+@@ -128,6 +128,7 @@ ramips_setup_interfaces()
+ 		;;
+ 
+ 	3g-6200n | \
++	ac1200pro | \
+ 	ai-br100 | \
+ 	dir-610-a1 | \
+ 	dir-300-b7 | \
+@@ -365,6 +366,7 @@ ramips_setup_macs()
+ 		wan_mac=$(mtd_get_mac_binary factory 32772)
+ 		;;
+ 
++	ac1200pro | \
+ 	all0239-3g | \
+ 	carambola | \
+ 	freestation5 | \
 diff --git a/target/linux/ramips/base-files/etc/diag.sh b/target/linux/ramips/base-files/etc/diag.sh
-index 37360a4..90e6561 100644
+index 37360a4..7f93d3f 100644
 --- a/target/linux/ramips/base-files/etc/diag.sh
 +++ b/target/linux/ramips/base-files/etc/diag.sh
-@@ -15,6 +15,10 @@ get_status_led() {
+@@ -12,6 +12,9 @@ get_status_led() {
+ 	3g150b | 3g300m | w150m)
+ 		status_led="tenda:blue:ap"
+ 		;;
++	ac1200pro)
++		status_led="ac1200pro:green:status"
++		;;
  	ai-br100)
  		status_led="aigale:blue:wlan"
  		;;
-+	zbt-wg2626|\
-+	zbt-wg3526)
-+		status_led="zbt:green:status"
-+		;;
- 	ar670w)
- 		status_led="ar670w:green:power"
- 		;;
 diff --git a/target/linux/ramips/base-files/lib/ramips.sh b/target/linux/ramips/base-files/lib/ramips.sh
-index 8dc05b0..8535785 100755
+index 8dc05b0..090831e 100755
 --- a/target/linux/ramips/base-files/lib/ramips.sh
 +++ b/target/linux/ramips/base-files/lib/ramips.sh
-@@ -427,6 +427,9 @@ ramips_board_detect() {
- 	*"Mediatek MT7628AN evaluation board")
- 		name="mt7628"
+@@ -109,6 +109,9 @@ ramips_board_detect() {
+ 	*"DCS-930L B1")
+ 		name="dcs-930l-b1"
  		;;
-+	*"ZBT-WG3526")
-+		name="zbt-wg3526"
++	*"Digineo AC1200 Pro")
++		name="ac1200pro"
 +		;;
- 	*"MediaTek LinkIt Smart 7688")
- 		linkit="$(dd bs=1 skip=1024 count=12 if=/dev/mtd2 2> /dev/null)"
- 		if [ "${linkit}" = "LINKITS7688D" ]; then
+ 	*"DIR-300 B1")
+ 		name="dir-300-b1"
+ 		;;
 diff --git a/target/linux/ramips/base-files/lib/upgrade/platform.sh b/target/linux/ramips/base-files/lib/upgrade/platform.sh
-index a3d0175..084e72a 100755
+index a3d0175..8af8506 100755
 --- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
 +++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
-@@ -14,6 +14,7 @@ platform_check_image() {
- 	[ "$#" -gt 1 ] && return 1
- 
- 	case "$board" in
-+<<<<<<< HEAD
- 	3g-6200n | \
- 	3g-6200nl | \
+@@ -19,6 +19,7 @@ platform_check_image() {
  	3g150b | \
-@@ -129,6 +130,8 @@ platform_check_image() {
- 	y1s |\
- 	zbt-wa05 |\
- 	zbt-wg2626 |\
-+	zbt-wg3526 |\
-+	zbt-wr8305rt |\
- 	zte-q7)
- 		[ "$magic" != "27051956" ] && {
- 			echo "Invalid image type."
-diff --git a/target/linux/ramips/dts/ZBT-WG3526.dts b/target/linux/ramips/dts/ZBT-WG3526.dts
+ 	3g300m | \
+ 	a5-v11 | \
++	ac1200pro | \
+ 	air3gii | \
+ 	ai-br100 |\
+ 	all0239-3g | \
+diff --git a/target/linux/ramips/dts/AC1200pro.dts b/target/linux/ramips/dts/AC1200pro.dts
 new file mode 100644
-index 0000000..b62471b
+index 0000000..18b60c6
 --- /dev/null
-+++ b/target/linux/ramips/dts/ZBT-WG3526.dts
++++ b/target/linux/ramips/dts/AC1200pro.dts
 @@ -0,0 +1,127 @@
 +/dts-v1/;
 +
@@ -141,7 +121,7 @@ index 0000000..b62471b
 +
 +				partition@50000 {
 +					label = "firmware";
-+					reg = <0x50000 0xfb0000>;
++					reg = <0x50000 0x1fb0000>;
 +				};
 +
 +			};
@@ -201,7 +181,7 @@ index 0000000..b62471b
 +		compatible = "gpio-leds";
 +
 +		status {
-+			label = "zbt-wg3526:green:status";
++			label = "ac1200pro:green:status";
 +			gpios = <&gpio0 24 1>;
 +		};
 +	};
@@ -216,15 +196,24 @@ index 0000000..b62471b
 +	};
 +};
 diff --git a/target/linux/ramips/image/Makefile b/target/linux/ramips/image/Makefile
-index c4f4028..80c2d8e 100644
+index c4f4028..e28dcf3 100644
 --- a/target/linux/ramips/image/Makefile
 +++ b/target/linux/ramips/image/Makefile
+@@ -616,7 +616,7 @@ Image/Build/Profile/WCR150GN=$(call BuildFirmware/Default4M/$(1),$(1),wcr150gn,W
+ buffalo_whrg300n_mtd_size=3801088
+ define BuildFirmware/WHRG300N/squashfs
+ 	$(call BuildFirmware/Default4M/$(1),$(1),whr-g300n,WHR-G300N)
+-	# the following line has a bad argument 3 ... the old Makefile was already broken	
++	# the following line has a bad argument 3 ... the old Makefile was already broken
+ 	$(call BuildFirmware/Buffalo,$(1),whr-g300n,whr-g300n)
+ 	if [ -e "$(call sysupname,$(1),$(2))" ]; then \
+ 		( \
 @@ -956,7 +956,7 @@ endif
  #
  
  ifeq ($(SUBTARGET),mt7621)
 -  TARGET_DEVICES += mt7621 wsr-600 wsr-1166 dir-860l-b1 firewrt pbr-m1 re6500 zbt-wg2626
-+  TARGET_DEVICES += mt7621 wsr-600 wsr-1166 dir-860l-b1 firewrt pbr-m1 re6500 zbt-wg2626 zbt-wg3526
++  TARGET_DEVICES += mt7621 wsr-600 wsr-1166 dir-860l-b1 firewrt pbr-m1 re6500 zbt-wg2626 ac1200pro
  endif
  
  define Device/mt7621
@@ -232,17 +221,17 @@ index c4f4028..80c2d8e 100644
    IMAGE_SIZE := $(ralink_default_fw_size_16M)
  endef
  
-+define Device/zbt-wg3526
-+  DTS := ZBT-WG3526
-+  IMAGE_SIZE := $(ralink_default_fw_size_16M)
++define Device/ac1200pro
++  DTS := AC1200pro
++  IMAGE_SIZE := $(ralink_default_fw_size_32M)
 +endef
-+TARGET_DEVICES += zbt-wg3526
++TARGET_DEVICES += ac1200pro
 +
  #
  # MT7628 Profiles
  #
 diff --git a/target/linux/ramips/mt7621/profiles/zbt.mk b/target/linux/ramips/mt7621/profiles/zbt.mk
-index cf9beff..0a8fe0c 100644
+index cf9beff..53b100c 100644
 --- a/target/linux/ramips/mt7621/profiles/zbt.mk
 +++ b/target/linux/ramips/mt7621/profiles/zbt.mk
 @@ -17,3 +17,16 @@ define Profile/ZBT-WG2626/Description
@@ -251,14 +240,14 @@ index cf9beff..0a8fe0c 100644
  $(eval $(call Profile,ZBT-WG2626))
 +
 +
-+define Profile/ZBT-WG3526
-+	NAME:=ZBT-WG3526 Device
++define Profile/ac1200pro
++	NAME:=Digineo AC1200 Pro
 +	PACKAGES:=\
 +		kmod-usb-core kmod-usb3 \
 +		kmod-ledtrig-usbdev kmod-ata-core kmod-ata-ahci
 +endef
 +
-+define Profile/ZBT-WG3526/Description
-+	Package set for ZBT-WG3526 device
++define Profile/ac1200pro/Description
++	Package set for ac1200pro device
 +endef
-+$(eval $(call Profile,ZBT-WG3526))
++$(eval $(call Profile,ac1200pro))

--- a/patches/openwrt/0084-ramips-Add-patches-to-support-devices-with-128Mib-flash.patch
+++ b/patches/openwrt/0084-ramips-Add-patches-to-support-devices-with-128Mib-flash.patch
@@ -1,0 +1,301 @@
+From: Julian Kornberger <jk+github@digineo.de>
+Date: Sat, 17 Dec 2016 15:56:53 +0100
+Subject: ramips: Add patches to support devices with > 128Mib flash
+
+Patch extracted from:
+- http://lists.infradead.org/pipermail/linux-mtd/2016-December/070890.html
+- http://lists.infradead.org/pipermail/linux-mtd/2016-December/070891.html
+
+diff --git a/target/linux/generic/patches-3.18/407-mtd-spi-nor-rename-SPINOR-macros.patch b/target/linux/generic/patches-3.18/407-mtd-spi-nor-rename-SPINOR-macros.patch
+new file mode 100644
+index 0000000..ce7911e
+--- /dev/null
++++ b/target/linux/generic/patches-3.18/407-mtd-spi-nor-rename-SPINOR-macros.patch
+@@ -0,0 +1,160 @@
++This patch renames the SPINOR_OP_* macros of the 4-byte address
++instruction set so the new names all share a common pattern: the 4-byte
++address name is built from the 3-byte address name appending the "_4B"
++suffix.
++
++The patch also introduces new op codes to support other SPI protocols such
++as SPI 1-4-4 and SPI 1-2-2.
++
++This is a transitional patch and will help a later patch of spi-nor.c
++to automate the translation from the 3-byte address op codes into their
++4-byte address version.
++
++Signed-off-by: Cyrille Pitchen <cyrille.pitchen at atmel.com>
++Acked-by: Mark Brown <broonie at kernel.org>
++Acked-by: Marek Vasut <marek.vasut at gmail.com>
++---
++ drivers/mtd/devices/serial_flash_cmds.h |  7 -------
++ drivers/mtd/devices/st_spi_fsm.c        | 28 ++++++++++++++--------------
++ drivers/mtd/spi-nor/spi-nor.c           |  8 ++++----
++ drivers/spi/spi-bcm-qspi.c              |  6 +++---
++ include/linux/mtd/spi-nor.h             | 22 ++++++++++++++++------
++ 5 files changed, 37 insertions(+), 34 deletions(-)
++
++diff --git a/drivers/mtd/devices/serial_flash_cmds.h b/drivers/mtd/devices/serial_flash_cmds.h
++index f59a125295d0..8b81e15105dd 100644
++--- a/drivers/mtd/devices/serial_flash_cmds.h
+++++ b/drivers/mtd/devices/serial_flash_cmds.h
++@@ -18,19 +18,12 @@
++ #define SPINOR_OP_RDVCR		0x85
++
++ /* JEDEC Standard - Serial Flash Discoverable Parmeters (SFDP) Commands */
++-#define SPINOR_OP_READ_1_2_2	0xbb	/* DUAL I/O READ */
++-#define SPINOR_OP_READ_1_4_4	0xeb	/* QUAD I/O READ */
++-
++ #define SPINOR_OP_WRITE		0x02	/* PAGE PROGRAM */
++ #define SPINOR_OP_WRITE_1_1_2	0xa2	/* DUAL INPUT PROGRAM */
++ #define SPINOR_OP_WRITE_1_2_2	0xd2	/* DUAL INPUT EXT PROGRAM */
++ #define SPINOR_OP_WRITE_1_1_4	0x32	/* QUAD INPUT PROGRAM */
++ #define SPINOR_OP_WRITE_1_4_4	0x12	/* QUAD INPUT EXT PROGRAM */
++
++-/* READ commands with 32-bit addressing */
++-#define SPINOR_OP_READ4_1_2_2	0xbc
++-#define SPINOR_OP_READ4_1_4_4	0xec
++-
++ /* Configuration flags */
++ #define FLASH_FLAG_SINGLE	0x000000ff
++ #define FLASH_FLAG_READ_WRITE	0x00000001
++diff --git a/drivers/mtd/devices/st_spi_fsm.c b/drivers/mtd/devices/st_spi_fsm.c
++index 5454b4113589..804313a33f2b 100644
++--- a/drivers/mtd/devices/st_spi_fsm.c
+++++ b/drivers/mtd/devices/st_spi_fsm.c
++@@ -507,13 +507,13 @@ static struct seq_rw_config n25q_read3_configs[] = {
++  *	- 'FAST' variants configured for 8 dummy cycles (see note above.)
++  */
++ static struct seq_rw_config n25q_read4_configs[] = {
++-	{FLASH_FLAG_READ_1_4_4, SPINOR_OP_READ4_1_4_4,	0, 4, 4, 0x00, 0, 8},
++-	{FLASH_FLAG_READ_1_1_4, SPINOR_OP_READ4_1_1_4,	0, 1, 4, 0x00, 0, 8},
++-	{FLASH_FLAG_READ_1_2_2, SPINOR_OP_READ4_1_2_2,	0, 2, 2, 0x00, 0, 8},
++-	{FLASH_FLAG_READ_1_1_2, SPINOR_OP_READ4_1_1_2,	0, 1, 2, 0x00, 0, 8},
++-	{FLASH_FLAG_READ_FAST,	SPINOR_OP_READ4_FAST,	0, 1, 1, 0x00, 0, 8},
++-	{FLASH_FLAG_READ_WRITE, SPINOR_OP_READ4,	0, 1, 1, 0x00, 0, 0},
++-	{0x00,			0,			0, 0, 0, 0x00, 0, 0},
+++	{FLASH_FLAG_READ_1_4_4, SPINOR_OP_READ_1_4_4_4B, 0, 4, 4, 0x00, 0, 8},
+++	{FLASH_FLAG_READ_1_1_4, SPINOR_OP_READ_1_1_4_4B, 0, 1, 4, 0x00, 0, 8},
+++	{FLASH_FLAG_READ_1_2_2, SPINOR_OP_READ_1_2_2_4B, 0, 2, 2, 0x00, 0, 8},
+++	{FLASH_FLAG_READ_1_1_2, SPINOR_OP_READ_1_1_2_4B, 0, 1, 2, 0x00, 0, 8},
+++	{FLASH_FLAG_READ_FAST,	SPINOR_OP_READ_FAST_4B,  0, 1, 1, 0x00, 0, 8},
+++	{FLASH_FLAG_READ_WRITE, SPINOR_OP_READ_4B,       0, 1, 1, 0x00, 0, 0},
+++	{0x00,			0,                       0, 0, 0, 0x00, 0, 0},
++ };
++
++ /*
++@@ -553,13 +553,13 @@ static int stfsm_mx25_en_32bit_addr_seq(struct stfsm_seq *seq)
++  * entering a state that is incompatible with the SPIBoot Controller.
++  */
++ static struct seq_rw_config stfsm_s25fl_read4_configs[] = {
++-	{FLASH_FLAG_READ_1_4_4,  SPINOR_OP_READ4_1_4_4,  0, 4, 4, 0x00, 2, 4},
++-	{FLASH_FLAG_READ_1_1_4,  SPINOR_OP_READ4_1_1_4,  0, 1, 4, 0x00, 0, 8},
++-	{FLASH_FLAG_READ_1_2_2,  SPINOR_OP_READ4_1_2_2,  0, 2, 2, 0x00, 4, 0},
++-	{FLASH_FLAG_READ_1_1_2,  SPINOR_OP_READ4_1_1_2,  0, 1, 2, 0x00, 0, 8},
++-	{FLASH_FLAG_READ_FAST,   SPINOR_OP_READ4_FAST,   0, 1, 1, 0x00, 0, 8},
++-	{FLASH_FLAG_READ_WRITE,  SPINOR_OP_READ4,        0, 1, 1, 0x00, 0, 0},
++-	{0x00,                   0,                      0, 0, 0, 0x00, 0, 0},
+++	{FLASH_FLAG_READ_1_4_4,  SPINOR_OP_READ_1_4_4_4B,  0, 4, 4, 0x00, 2, 4},
+++	{FLASH_FLAG_READ_1_1_4,  SPINOR_OP_READ_1_1_4_4B,  0, 1, 4, 0x00, 0, 8},
+++	{FLASH_FLAG_READ_1_2_2,  SPINOR_OP_READ_1_2_2_4B,  0, 2, 2, 0x00, 4, 0},
+++	{FLASH_FLAG_READ_1_1_2,  SPINOR_OP_READ_1_1_2_4B,  0, 1, 2, 0x00, 0, 8},
+++	{FLASH_FLAG_READ_FAST,   SPINOR_OP_READ_FAST_4B,   0, 1, 1, 0x00, 0, 8},
+++	{FLASH_FLAG_READ_WRITE,  SPINOR_OP_READ_4B,        0, 1, 1, 0x00, 0, 0},
+++	{0x00,                   0,                        0, 0, 0, 0x00, 0, 0},
++ };
++
++ static struct seq_rw_config stfsm_s25fl_write4_configs[] = {
++diff --git a/drivers/mtd/spi-nor/spi-nor.c b/drivers/mtd/spi-nor/spi-nor.c
++index 1fd32b991eb7..8abe134e174a 100644
++--- a/drivers/mtd/spi-nor/spi-nor.c
+++++ b/drivers/mtd/spi-nor/spi-nor.c
++@@ -1490,16 +1490,16 @@ int spi_nor_scan(struct spi_nor *nor, const char *name, enum read_mode mode)
++ 			/* Dedicated 4-byte command set */
++ 			switch (nor->flash_read) {
++ 			case SPI_NOR_QUAD:
++-				nor->read_opcode = SPINOR_OP_READ4_1_1_4;
+++				nor->read_opcode = SPINOR_OP_READ_1_1_4_4B;
++ 				break;
++ 			case SPI_NOR_DUAL:
++-				nor->read_opcode = SPINOR_OP_READ4_1_1_2;
+++				nor->read_opcode = SPINOR_OP_READ_1_1_2_4B;
++ 				break;
++ 			case SPI_NOR_FAST:
++-				nor->read_opcode = SPINOR_OP_READ4_FAST;
+++				nor->read_opcode = SPINOR_OP_READ_FAST_4B;
++ 				break;
++ 			case SPI_NOR_NORMAL:
++-				nor->read_opcode = SPINOR_OP_READ4;
+++				nor->read_opcode = SPINOR_OP_READ_4B;
++ 				break;
++ 			}
++ 			nor->program_opcode = SPINOR_OP_PP_4B;
++diff --git a/include/linux/mtd/spi-nor.h b/include/linux/mtd/spi-nor.h
++index c425c7b4c2a0..8b02fd7864d0 100644
++--- a/include/linux/mtd/spi-nor.h
+++++ b/include/linux/mtd/spi-nor.h
++@@ -43,9 +43,13 @@
++ #define SPINOR_OP_WRSR		0x01	/* Write status register 1 byte */
++ #define SPINOR_OP_READ		0x03	/* Read data bytes (low frequency) */
++ #define SPINOR_OP_READ_FAST	0x0b	/* Read data bytes (high frequency) */
++-#define SPINOR_OP_READ_1_1_2	0x3b	/* Read data bytes (Dual SPI) */
++-#define SPINOR_OP_READ_1_1_4	0x6b	/* Read data bytes (Quad SPI) */
+++#define SPINOR_OP_READ_1_1_2	0x3b	/* Read data bytes (Dual Output SPI) */
+++#define SPINOR_OP_READ_1_2_2	0xbb	/* Read data bytes (Dual I/O SPI) */
+++#define SPINOR_OP_READ_1_1_4	0x6b	/* Read data bytes (Quad Output SPI) */
+++#define SPINOR_OP_READ_1_4_4	0xeb	/* Read data bytes (Quad I/O SPI) */
++ #define SPINOR_OP_PP		0x02	/* Page program (up to 256 bytes) */
+++#define SPINOR_OP_PP_1_1_4	0x32	/* Quad page program */
+++#define SPINOR_OP_PP_1_4_4	0x38	/* Quad page program */
++ #define SPINOR_OP_BE_4K		0x20	/* Erase 4KiB block */
++ #define SPINOR_OP_BE_4K_PMC	0xd7	/* Erase 4KiB block on PMC chips */
++ #define SPINOR_OP_BE_32K	0x52	/* Erase 32KiB block */
++@@ -56,11 +60,17 @@
++ #define SPINOR_OP_RDFSR		0x70	/* Read flag status register */
++
++ /* 4-byte address opcodes - used on Spansion and some Macronix flashes. */
++-#define SPINOR_OP_READ4		0x13	/* Read data bytes (low frequency) */
++-#define SPINOR_OP_READ4_FAST	0x0c	/* Read data bytes (high frequency) */
++-#define SPINOR_OP_READ4_1_1_2	0x3c	/* Read data bytes (Dual SPI) */
++-#define SPINOR_OP_READ4_1_1_4	0x6c	/* Read data bytes (Quad SPI) */
+++#define SPINOR_OP_READ_4B	0x13	/* Read data bytes (low frequency) */
+++#define SPINOR_OP_READ_FAST_4B	0x0c	/* Read data bytes (high frequency) */
+++#define SPINOR_OP_READ_1_1_2_4B	0x3c	/* Read data bytes (Dual Output SPI) */
+++#define SPINOR_OP_READ_1_2_2_4B	0xbc	/* Read data bytes (Dual I/O SPI) */
+++#define SPINOR_OP_READ_1_1_4_4B	0x6c	/* Read data bytes (Quad Output SPI) */
+++#define SPINOR_OP_READ_1_4_4_4B	0xec	/* Read data bytes (Quad I/O SPI) */
++ #define SPINOR_OP_PP_4B		0x12	/* Page program (up to 256 bytes) */
+++#define SPINOR_OP_PP_1_1_4_4B	0x34	/* Quad page program */
+++#define SPINOR_OP_PP_1_4_4_4B	0x3e	/* Quad page program */
+++#define SPINOR_OP_BE_4K_4B	0x21	/* Erase 4KiB block */
+++#define SPINOR_OP_BE_32K_4B	0x5c	/* Erase 32KiB block */
++ #define SPINOR_OP_SE_4B		0xdc	/* Sector erase (usually 64KiB) */
++
++ /* Used for SST flashes only. */
+diff --git a/target/linux/generic/patches-3.18/408-mtd-spi-nor-add-a-stateless-method-to-support-memory-size-above-128Mib.patch b/target/linux/generic/patches-3.18/408-mtd-spi-nor-add-a-stateless-method-to-support-memory-size-above-128Mib.patch
+new file mode 100644
+index 0000000..6086c21
+--- /dev/null
++++ b/target/linux/generic/patches-3.18/408-mtd-spi-nor-add-a-stateless-method-to-support-memory-size-above-128Mib.patch
+@@ -0,0 +1,121 @@
++This patch provides an alternative mean to support memory above 16MiB
++(128Mib) by replacing 3byte address op codes by their associated 4byte
++address versions.
++
++Using the dedicated 4byte address op codes doesn't change the internal
++state of the SPI NOR memory as opposed to using other means such as
++updating a Base Address Register (BAR) and sending command to enter/leave
++the 4byte mode.
++
++Hence when a CPU reset occurs, early bootloaders don't need to be aware
++of BAR value or 4byte mode being enabled: they can still access the first
++16MiB of the SPI NOR memory using the regular 3byte address op codes.
++
++Signed-off-by: Cyrille Pitchen <cyrille.pitchen at atmel.com>
++Tested-by: Vignesh R <vigneshr at ti.com>
++---
++ drivers/mtd/spi-nor/spi-nor.c | 78 +++++++++++++++++++++++++++++++------------
++ 1 file changed, 57 insertions(+), 21 deletions(-)
++
++diff --git a/drivers/mtd/spi-nor/spi-nor.c b/drivers/mtd/spi-nor/spi-nor.c
++index 8abe134e174a..40b78ebb9900 100644
++--- a/drivers/mtd/spi-nor/spi-nor.c
+++++ b/drivers/mtd/spi-nor/spi-nor.c
++@@ -68,6 +68,10 @@
++ #define	SPI_NOR_DUAL_READ	0x20    /* Flash supports Dual Read */
++ #define	SPI_NOR_QUAD_READ	0x40    /* Flash supports Quad Read */
++ #define	USE_FSR			0x80	/* use flag status register */
+++#define	SPI_NOR_4B_OPCODES	BIT(10)	/*
+++				 * Use dedicated 4byte address op codes
+++				 * to support memory size above 128Mib.
+++				 */
++ };
++
++ #define JEDEC_MFR(info)	((info)->id[0])
++@@ -181,6 +185,54 @@
++ 	return mtd->priv;
++ }
++
+++static u8 spi_nor_3to4_opcode(u8 opcode)
+++{
+++#define ENTRY_3TO4(_opcode)	{ _opcode, _opcode##_4B }
+++	static const u8 spi_nor_3to4_table[][2] = {
+++		ENTRY_3TO4(SPINOR_OP_READ),
+++		ENTRY_3TO4(SPINOR_OP_READ_FAST),
+++		ENTRY_3TO4(SPINOR_OP_READ_1_1_2),
+++		ENTRY_3TO4(SPINOR_OP_READ_1_2_2),
+++		ENTRY_3TO4(SPINOR_OP_READ_1_1_4),
+++		ENTRY_3TO4(SPINOR_OP_READ_1_4_4),
+++		ENTRY_3TO4(SPINOR_OP_PP),
+++		ENTRY_3TO4(SPINOR_OP_PP_1_1_4),
+++		ENTRY_3TO4(SPINOR_OP_PP_1_4_4),
+++		ENTRY_3TO4(SPINOR_OP_BE_4K),
+++		ENTRY_3TO4(SPINOR_OP_BE_32K),
+++		ENTRY_3TO4(SPINOR_OP_SE),
+++	};
+++#undef ENTRY_3TO4
+++	size_t i;
+++
+++	for (i = 0; i < ARRAY_SIZE(spi_nor_3to4_table); ++i)
+++		if (spi_nor_3to4_table[i][0] == opcode)
+++			return spi_nor_3to4_table[i][1];
+++
+++	/* No conversion found, keep input op code. */
+++	return opcode;
+++}
+++
+++static void spi_nor_set_4byte_opcodes(struct spi_nor *nor,
+++				      const struct flash_info *info)
+++{
+++	/* Do some manufacturer fixups first */
+++	switch (JEDEC_MFR(info)) {
+++	case SNOR_MFR_SPANSION:
+++		/* No small sector erase for 4-byte command set */
+++		nor->erase_opcode = SPINOR_OP_SE;
+++		nor->mtd.erasesize = info->sector_size;
+++		break;
+++
+++	default:
+++		break;
+++	}
+++
+++	nor->read_opcode	= spi_nor_3to4_opcode(nor->read_opcode);
+++	nor->program_opcode	= spi_nor_3to4_opcode(nor->program_opcode);
+++	nor->erase_opcode	= spi_nor_3to4_opcode(nor->erase_opcode);
+++}
+++
++ /* Enable/disable 4-byte addressing mode. */
++ static inline int set_4byte(struct spi_nor *nor, const struct flash_info *info,
++ 			    int enable)
++@@ -1351,27 +1403,10 @@
++ 	else if (mtd->size > 0x1000000) {
++ 		/* enable 4-byte addressing if the device exceeds 16MiB */
++ 		nor->addr_width = 4;
++-		if (JEDEC_MFR(info) == SNOR_MFR_SPANSION) {
++-			/* Dedicated 4-byte command set */
++-			switch (nor->flash_read) {
++-			case SPI_NOR_QUAD:
++-				nor->read_opcode = SPINOR_OP_READ_1_1_4_4B;
++-				break;
++-			case SPI_NOR_DUAL:
++-				nor->read_opcode = SPINOR_OP_READ_1_1_2_4B;
++-				break;
++-			case SPI_NOR_FAST:
++-				nor->read_opcode = SPINOR_OP_READ_FAST_4B;
++-				break;
++-			case SPI_NOR_NORMAL:
++-				nor->read_opcode = SPINOR_OP_READ_4B;
++-				break;
++-			}
++-			nor->program_opcode = SPINOR_OP_PP_4B;
++-			/* No small sector erase for 4-byte command set */
++-			nor->erase_opcode = SPINOR_OP_SE_4B;
++-			mtd->erasesize = info->sector_size;
++-		} else
+++		if (JEDEC_MFR(info) == SNOR_MFR_SPANSION ||
+++		    info->flags & SPI_NOR_4B_OPCODES)
+++			spi_nor_set_4byte_opcodes(nor, info);
+++		else
++ 			set_4byte(nor, info, 1);
++ 	} else {
++ 		nor->addr_width = 3;

--- a/targets/ramips-mt7621/profiles.mk
+++ b/targets/ramips-mt7621/profiles.mk
@@ -2,3 +2,9 @@
 
 $(eval $(call GluonProfile,Default))
 $(eval $(call GluonModel,Default,dir-860l-b1,d-link-dir-860l-b1))
+
+ifneq ($(BROKEN),)
+$(eval $(call GluonProfile,ZBT-WG3526)) # BROKEN: hangs during reboot (http://lists.infradead.org/pipermail/linux-mtd/2016-November/070368.html)
+$(eval $(call GluonProfileFactorySuffix,ZBT-WG3526))
+$(eval $(call GluonModel,ZBT-WG3526,zbt-wg3526,zbt-wg3526))
+endif

--- a/targets/ramips-mt7621/profiles.mk
+++ b/targets/ramips-mt7621/profiles.mk
@@ -3,8 +3,6 @@
 $(eval $(call GluonProfile,Default))
 $(eval $(call GluonModel,Default,dir-860l-b1,d-link-dir-860l-b1))
 
-ifneq ($(BROKEN),)
-$(eval $(call GluonProfile,ZBT-WG3526)) # BROKEN: hangs during reboot (http://lists.infradead.org/pipermail/linux-mtd/2016-November/070368.html)
-$(eval $(call GluonProfileFactorySuffix,ZBT-WG3526))
-$(eval $(call GluonModel,ZBT-WG3526,zbt-wg3526,zbt-wg3526))
-endif
+$(eval $(call GluonProfile,AC1200pro))
+$(eval $(call GluonProfileFactorySuffix,AC1200pro))
+$(eval $(call GluonModel,AC1200pro,ac1200pro,digineo-ac1200pro))


### PR DESCRIPTION
These are (almost) the devices that @corny has shipped in from China.

While those have 32 MB Flash, the image only works with 16 MB currently. They have 512 MB RAM and support 802.11ac.

The image currently has a [problem with rebooting because of the flash chip](http://lists.infradead.org/pipermail/linux-mtd/2016-November/070368.html), thus it would even be broken if the target wouldn't be as a whole. Nonetheless, I would like to challenge the note by @NeoRaider left in `targets/targets.mk`:
```
$(eval $(call GluonTarget,ramips,mt7621)) # BROKEN: No AP+IBSS support, 11s has high packet loss
```
I do currently operate the device in AP+IBSS mode. Thus, this either seems to be fixed or a restriction of the only other device in that subtarget (d-link-dir-860l-b1). However, throughput through IBSS is quite low (11 MBit/s net).

Another caveat is that seemingly random, there are stack traces like these in the log:
```
[ 2739.120000] ------------[ cut here ]------------
[ 2739.120000] WARNING: CPU: 0 PID: 0 at /home/jplitza/Code/freifunk/site/gluon/build/ramips-mt7621/openwrt/build_dir/target-mipsel_1004kc+dsp_uClibc-0.9.33.2_gluon-ramips-mt7621/linux-ramips_mt7621/mt76-2016-08-25/mt7603_mac.c:403 mt7603_mac_fill_rx+0x2c4/0x3cc [mt7603e]()
[ 2739.140000] Modules linked in: iptable_nat nf_nat_ipv4 nf_conntrack_ipv6 nf_conntrack_ipv4 ipt_REJECT ipt_MASQUERADE ebtable_nat ebtable_filter ebtable_broute xt_time xt_tcpudp xt_state xt_quota xt_pkttype xt_physdev xt_owner xt_nat xt_multiport xt_mark xt_mac xt_limit xt_id xt_conntrack xt_comment xt_addrtype xt_TCPMSS xt_REDIRECT xt_LOG xt_CT nf_reject_ipv4 nf_nat_masquerade_ipv4 nf_nat nf_log_ipv4 nf_defrag_ipv6 nf_defrag_ipv4 nf_conntrack_rtcache nf_conntrack macvlan iptable_raw iptable_mangle iptable_filter ip_tables ebtables ebt_vlan ebt_stp ebt_snat ebt_redirect ebt_pkttype ebt_mark_m ebt_mark ebt_limit ebt_ip6 ebt_ip ebt_dnat ebt_arpreply ebt_arp ebt_among ebt_802_3 sch_fq em_nbyte sch_prio sch_pie act_ipt em_meta sch_gred sch_dsmark sch_teql sch_codel em_cmp em_text sch_htb sch_sfq sch_red act_skbedit act_mirred em_u32 cls_u32 cls_tcindex cls_flow cls_route cls_fw sch_hfsc mt7603e mt76x2e mt76 mac80211 cfg80211 compat batman_adv libcrc32c ip6t_REJECT nf_reject_ipv6 nf_log_ipv6 nf_log_common ip6table_raw ip6table_mangle ip6table_filter ip6_tables x_tables dummy tun leds_gpio act_police cls_basic sch_tbf sch_ingress gpio_button_hotplug crc16 crc32c_generic crypto_hash
[ 2739.250000] CPU: 0 PID: 0 Comm: swapper/0 Tainted: G        W      3.18.44 #7
[ 2739.250000] Stack : 00000000 00000004 00000006 00000001 00000000 00000000 00000000 00000000
[ 2739.250000] 	  803e56e2 00000041 00000000 00000000 00000000 8039f5e0 8033510c 8039f243
[ 2739.250000] 	  00000000 00000000 803e4468 8039f5e0 8f2dd9c0 0000007c 80410000 8005ab6c
[ 2739.250000] 	  00000001 8002982c 803a3760 803a3764 80338dc4 8038dbf4 8038dbf4 8033510c
[ 2739.250000] 	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[ 2739.250000] 	  ...
[ 2739.250000] Call Trace:
[ 2739.250000] [<800167ac>] show_stack+0x50/0x84
[ 2739.250000] [<801638e4>] dump_stack+0x88/0xc0
[ 2739.250000] [<800299a8>] warn_slowpath_common+0x84/0xb4
[ 2739.250000] [<80029a60>] warn_slowpath_null+0x18/0x24
[ 2739.250000] [<8ec5bd54>] mt7603_mac_fill_rx+0x2c4/0x3cc [mt7603e]
[ 2739.250000] [<8ec5ab10>] mt7603_queue_rx_skb+0xb8/0x100 [mt7603e]
[ 2739.250000] [<8f21cd18>] mt76_dma_attach+0x890/0x9cc [mt76]
[ 2739.250000] 
[ 2739.330000] ---[ end trace ad9914c04a5b78a4 ]---
[ 2739.340000] ------------[ cut here ]------------
[ 2739.340000] WARNING: CPU: 0 PID: 0 at /home/jplitza/Code/freifunk/site/gluon/openwrt/build_dir/target-mipsel_1004kc+dsp_uClibc-0.9.33.2_gluon-ramips-mt7621/linux-ramips_mt7621/compat-wireless-2016-06-20/net/mac80211/rx.c:4124 ieee80211_rx_napi+0xb4/0x8cc [mac80211]()
[ 2739.360000] Modules linked in: iptable_nat nf_nat_ipv4 nf_conntrack_ipv6 nf_conntrack_ipv4 ipt_REJECT ipt_MASQUERADE ebtable_nat ebtable_filter ebtable_broute xt_time xt_tcpudp xt_state xt_quota xt_pkttype xt_physdev xt_owner xt_nat xt_multiport xt_mark xt_mac xt_limit xt_id xt_conntrack xt_comment xt_addrtype xt_TCPMSS xt_REDIRECT xt_LOG xt_CT nf_reject_ipv4 nf_nat_masquerade_ipv4 nf_nat nf_log_ipv4 nf_defrag_ipv6 nf_defrag_ipv4 nf_conntrack_rtcache nf_conntrack macvlan iptable_raw iptable_mangle iptable_filter ip_tables ebtables ebt_vlan ebt_stp ebt_snat ebt_redirect ebt_pkttype ebt_mark_m ebt_mark ebt_limit ebt_ip6 ebt_ip ebt_dnat ebt_arpreply ebt_arp ebt_among ebt_802_3 sch_fq em_nbyte sch_prio sch_pie act_ipt em_meta sch_gred sch_dsmark sch_teql sch_codel em_cmp em_text sch_htb sch_sfq sch_red act_skbedit act_mirred em_u32 cls_u32 cls_tcindex cls_flow cls_route cls_fw sch_hfsc mt7603e mt76x2e mt76 mac80211 cfg80211 compat batman_adv libcrc32c ip6t_REJECT nf_reject_ipv6 nf_log_ipv6 nf_log_common ip6table_raw ip6table_mangle ip6table_filter ip6_tables x_tables dummy tun leds_gpio act_police cls_basic sch_tbf sch_ingress gpio_button_hotplug crc16 crc32c_generic crypto_hash
[ 2739.470000] CPU: 0 PID: 0 Comm: swapper/0 Tainted: G        W      3.18.44 #7
[ 2739.470000] Stack : 00000000 00000004 00000006 00000001 00000000 00000000 00000000 00000000
	  803e56e2 00000041 00000000 00000000 00000000 8039f5e0 8033510c 8039f243
	  00000000 00000000 803e4468 8039f5e0 8f2dd9c0 0000000c 80410000 8005ab6c
	  00000001 8002982c 803a3760 803a3764 80338dc4 8038dbb4 8038dbb4 8033510c
	  00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
	  ...
[ 2739.470000] Call Trace:
[ 2739.470000] [<800167ac>] show_stack+0x50/0x84
[ 2739.470000] [<801638e4>] dump_stack+0x88/0xc0
[ 2739.470000] [<800299a8>] warn_slowpath_common+0x84/0xb4
[ 2739.470000] [<80029a60>] warn_slowpath_null+0x18/0x24
[ 2739.470000] [<8eca3cdc>] ieee80211_rx_napi+0xb4/0x8cc [mac80211]
[ 2739.470000] [<8f21d538>] mt76_rx_complete+0x78/0x104 [mt76]
[ 2739.470000] [<8f21cd2c>] mt76_dma_attach+0x8a4/0x9cc [mt76]
[ 2739.470000] 
[ 2739.550000] ---[ end trace ad9914c04a5b78a5 ]---
```

However, they do not seem to impact operation.

**Edit**: Hm, maybe they do for 2.4 GHz. I've only tested 5 GHz, but in 2.4 GHz, the graphs on the status page have holes (on both sides of the connection):
![canvas](https://cloud.githubusercontent.com/assets/3628012/20867173/8de7ba3a-ba3e-11e6-86f1-2488d2af893c.png)