### PR TITLE
openwrt: Remove extra soc check in ath79_gpio_output_select

### DIFF
--- a/patches/openwrt/0034-ar71xx-update-QCA956x-support.patch
+++ b/patches/openwrt/0034-ar71xx-update-QCA956x-support.patch
@@ -380,7 +380,7 @@ index 2bb4286..61b8976 100644
  +
   extern void __iomem *ath79_ddr_base;
 diff --git a/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch b/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
-index a36b8c3..fa4eba2 100644
+index a36b8c3..44c9c62 100644
 --- a/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
 +++ b/target/linux/ar71xx/patches-3.18/739-MIPS-ath79-add-gpio-func-register-for-QCA955x-SoC.patch
 @@ -9,8 +9,8 @@
@@ -390,7 +390,7 @@ index a36b8c3..fa4eba2 100644
 - 		 soc_is_qca953x() || soc_is_qca956x())
 -@@ -185,15 +186,27 @@ void __init ath79_gpio_output_select(uns
 + 		 soc_is_qca953x() ||
-+@@ -187,15 +188,31 @@ void __init ath79_gpio_output_select(uns
++@@ -187,15 +188,30 @@ void __init ath79_gpio_output_select(uns
   {
   	void __iomem *base = ath79_gpio_base;
   	unsigned long flags;
@@ -399,7 +399,7 @@ index a36b8c3..fa4eba2 100644
   	u32 t, s;
   
 --	BUG_ON(!soc_is_ar934x() && !soc_is_qca953x());
-+ 	BUG_ON(!soc_is_ar934x() && !soc_is_qca953x() && !soc_is_qca956x());
++-	BUG_ON(!soc_is_ar934x() && !soc_is_qca953x() && !soc_is_qca956x());
  +	if (soc_is_ar934x()) {
  +		gpio_count = AR934X_GPIO_COUNT;
  +		reg_base = AR934X_GPIO_REG_OUT_FUNC0;


### PR DESCRIPTION
The  assignment of the gpio_count and reg_base in ath79_gpio_output_select
takes care that only supported platforms can use ath79_gpio_output_select.
But the rebase of the patches after the last OpenWrt base update
accidentally added an extra check for the SoC which was missing support
soc_is_qca955x().

Boots on QCA955X devices which were using ath79_gpio_output_select ended
with an

    Kernel bug detected[#1]:
    [...]
    Call Trace:
    [<803e6174>] ath79_gpio_output_select+0x30/0xe8
    [<803ed590>] om5p_acv2_setup+0x24/0x200
    [<803e4dc0>] ath79_setup+0x28/0x38
    [<80069ac8>] do_one_initcall+0x148/0x1ec
    [<803e2cc4>] kernel_init_freeable+0x150/0x208
    [<80065218>] kernel_init+0x10/0x114
    [<80060878>] ret_from_kernel_thread+0x14/0x1c

Fixes: a22c1d5670c1 ("Update OpenWrt base")
Signed-off-by: Sven Eckelmann <sven@narfation.org>