### PR TITLE
ar71xx-generic: Added Ubiquiti Rocket M2 Titanium to profiles.

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -212,6 +212,10 @@ device ubiquiti-rocket-m-xw ubnt-rocket-m-xw
 alias ubiquiti-rocket-m2-xw
 alias ubiquiti-rocket-m5-xw
 
+device ubiquiti-rocket-m-ti ubnt-rocket-m-ti
+alias ubiquiti-rocket-m2-ti
+alias ubiquiti-rocket-m5-ti
+
 device ubiquiti-unifi ubnt-unifi
 alias ubiquiti-unifi-ap
 alias ubiquiti-unifi-ap-lr


### PR DESCRIPTION
The current LEDE build is working fine on a Ubiquiti Rocket M2 Titanium.

But the rocket-m-ti images are missing from a recent gluon build.

Is this commit sufficient to build working images?

This PR is related to #943