### PR TITLE
mvebu: add missing package & correct wrong comment

### DIFF
--- a/targets/mvebu/profiles.mk
+++ b/targets/mvebu/profiles.mk
@@ -4,7 +4,7 @@
 $(eval $(call GluonProfile,Caiman,kmod-usb2 kmod-usb3 kmod-usb-storage kmod-i2c-core \
 	kmod-i2c-mv64xxx kmod-ata-core kmod-ata-mvebu-ahci kmod-rtc-armada38x \
 	kmod-thermal-armada kmod-gpio-button-hotplug kmod-hwmon-tmp421 kmod-leds-pca963x \
-	kmod-ledtrig-usbdev kmod-mwlwifi swconfig))
+	kmod-ledtrig-usbdev kmod-mwlwifi swconfig uboot-envtools))
 $(eval $(call GluonProfileFactorySuffix,Caiman,-squashfs-factory,.img))
 $(eval $(call GluonProfileSysupgradeSuffix,Caiman,-squashfs-sysupgrade,.tar))
 $(eval $(call GluonModel,Caiman,armada-385-linksys-caiman,linksys-wrt1200ac))

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -10,7 +10,7 @@ $(eval $(call GluonTarget,x86,xen_domu))
 
 ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,ar71xx,mikrotik)) # BROKEN: no sysupgrade support
-$(eval $(call GluonTarget,mvebu)) # BROKEN: No AP+IBSS support
+$(eval $(call GluonTarget,mvebu)) # BROKEN: No IBSS+11s support
 $(eval $(call GluonTarget,ramips,mt7621)) # BROKEN: No AP+IBSS support, 11s has high packet loss
 $(eval $(call GluonTarget,ramips,rt305x)) # BROKEN: No AP+IBSS support
 $(eval $(call GluonTarget,sunxi)) # BROKEN: Untested, no sysupgrade support


### PR DESCRIPTION
This PR adds the missing package uboot-envtools which is needed for a successful sysupgrade.
It also corrects a wrong comment in targets.mk.