### PR TITLE
bump openwrt/packages [lede branch]

### DIFF
--- a/modules
+++ b/modules
@@ -4,7 +4,7 @@ LEDE_REPO=git://git.lede-project.org/source.git
 LEDE_COMMIT=7c47f43fe650309e6a2383c99273dc1bde367bc1
 
 PACKAGES_OPENWRT_REPO=git://github.com/openwrt/packages.git
-PACKAGES_OPENWRT_COMMIT=18ce1a8f18a7c5ab2b654b8d30d85a381d36abcb
+PACKAGES_OPENWRT_COMMIT=3560c818bb403d4892f93ef3e4cf94a8bd34d95b
 
 PACKAGES_GLUON_REPO=git://github.com/freifunk-gluon/packages.git
 PACKAGES_GLUON_COMMIT=5280cd19070ccccc36a39dc48c7f51fe76bc4268


### PR DESCRIPTION
mainly : 
Wireguard bump to latest
bring in ecdsa 
Signed-off-by: jens viisauksena github_patch@viisauksena.de