### PR TITLE
Adding support for the Fonera Fon2303a Router

### DIFF
--- a/targets/ramips-rt305x/profiles.mk
+++ b/targets/ramips-rt305x/profiles.mk
@@ -4,3 +4,8 @@
 $(eval $(call GluonProfile,VOCORE))
 $(eval $(call GluonProfileFactorySuffix,VOCORE))
 $(eval $(call GluonModel,VOCORE,vocore,vocore))
+
+# FON2303A
+$(eval $(call GluonProfile,FONERA20N))
+$(eval $(call GluonProfileFactorySuffix,FONERA20N))
+$(eval $(call GluonModel,FONERA20N,fonera20n,fon2303a))

--- a/targets/ramips-rt305x/profiles.mk
+++ b/targets/ramips-rt305x/profiles.mk
@@ -8,4 +8,4 @@ $(eval $(call GluonModel,VOCORE,vocore,vocore))
 # FON2303A
 $(eval $(call GluonProfile,FONERA20N))
 $(eval $(call GluonProfileFactorySuffix,FONERA20N))
-$(eval $(call GluonModel,FONERA20N,fonera20n,fon2303a))
+$(eval $(call GluonModel,FONERA20N,fonera20n,fonera-fon2303a))


### PR DESCRIPTION
Adding support for the Fonera Fon2303a Router to Gluon.

A large quantity has turned up for distribution in Freifunk groups and apart from not being able to IBSS mesh, they work perfectly on 802.11s mesh.