### PR TITLE
add gluon-dns-config: a package that enables the next node to be used as dns cache

### DIFF
--- a/docs/features/dns-cache.rst
+++ b/docs/features/dns-cache.rst
@@ -1,0 +1,30 @@
+DNS-Caching
+===========
+User experience may be greatly improved when dns is accelerated. Also it
+seems like a good idea to keep the number if packages being exchanged
+between node and gateway as small as possible. In order to do this, a
+dns-cache may be used on a node. The dnsmasq instance listening on port
+53 in the node will be re-configured to answer requests, use a list of
+upstream servers and a specific cache size if the below options are
+added to site.conf All settings are optional, though if no dns server is
+set, the configuration will not be altered by gluon-core.
+
+Besides caching dns requests from clients, the next_node-addresses are set to
+resolve to a configurable name that may optionally be placed in next_node.name.
+
+::
+
+  dns = {
+    cacheentries = 5000,
+    servers = { '2001:db8::1', },
+  },
+  
+  next_node = {
+    name = 'nextnode',
+    ip6 = '2001:db8:8::1',
+    ip4 = '198.51.100.1',
+  }
+
+
+The cache will be initialized during startup. Each cache entry will use roughly
+90 Bytes of main memory.

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -2,16 +2,16 @@ need_string 'site_code'
 need_string 'site_name'
 
 if need_table('opkg', nil, false) then
-  need_string('opkg.lede', false)
+	need_string('opkg.lede', false)
 
-  function check_repo(k, _)
-    -- this is not actually a uci name, but using the same naming rules here is fine
-    assert_uci_name(k)
+	function check_repo(k, _)
+		-- this is not actually a uci name, but using the same naming rules here is fine
+		assert_uci_name(k)
 
-    need_string(string.format('opkg.extra[%q]', k))
-  end
+		need_string(string.format('opkg.extra[%q]', k))
+	end
 
-  need_table('opkg.extra', check_repo, false)
+	need_table('opkg.extra', check_repo, false)
 end
 
 need_string('hostname_prefix', false)
@@ -23,19 +23,19 @@ need_string_match('prefix6', '^[%x:]+/%d+$')
 
 
 for _, config in ipairs({'wifi24', 'wifi5'}) do
-  if need_table(config, nil, false) then
-    need_string('regdom') -- regdom is only required when wifi24 or wifi5 is configured
+	if need_table(config, nil, false) then
+		need_string('regdom') -- regdom is only required when wifi24 or wifi5 is configured
 
-    need_number(config .. '.channel')
+		need_number(config .. '.channel')
 
-    local rates = {1000, 2000, 5500, 6000, 9000, 11000, 12000, 18000, 24000, 36000, 48000, 54000}
-    local supported_rates = need_array_of(config .. '.supported_rates', rates, false)
-    if supported_rates then
-      need_array_of(config .. '.basic_rate', supported_rates, true)
-    else
-      need_array_of(config .. '.basic_rate', rates, false)
-    end
-  end
+		local rates = {1000, 2000, 5500, 6000, 9000, 11000, 12000, 18000, 24000, 36000, 48000, 54000}
+		local supported_rates = need_array_of(config .. '.supported_rates', rates, false)
+		if supported_rates then
+			need_array_of(config .. '.basic_rate', supported_rates, true)
+		else
+			need_array_of(config .. '.basic_rate', rates, false)
+		end
+	end
 end
 
 need_boolean('poe_passthrough', false)

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -39,3 +39,12 @@ for _, config in ipairs({'wifi24', 'wifi5'}) do
 end
 
 need_boolean('poe_passthrough', false)
+if need_table('dns', nil, false) then
+	need_number('dns.cacheentries', false)
+	need_string_array('dns.servers', false)
+end
+
+if need_table('next_node', nil, false) then
+	need_string_match('next_node.ip6', '^[%x:]+$', false)
+	need_string_match('next_node.ip4', '^%d+.%d+.%d+.%d+$', false)
+end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
@@ -1,0 +1,40 @@
+#!/usr/bin/lua
+local site = require 'gluon.site_config'
+local uci = require('luci.model.uci').cursor()
+
+dnsmasq=uci:get_first("dhcp", "dnsmasq")
+
+uci:set('dhcp', dnsmasq, 'localise_queries', '1')
+uci:set('dhcp', dnsmasq, 'localservice', '0')
+
+if site.dns and site.dns.servers then
+	uci:set('dhcp', dnsmasq, 'server', site.dns.servers)
+else
+	uci:delete('dhcp', dnsmasq, 'server')
+end
+
+if site.dns and site.dns.cacheentries then
+	uci:set('dhcp', dnsmasq, 'cachesize', site.dns.cacheentries)
+else
+	uci:delete('dhcp', dnsmasq, 'cachesize')
+end
+
+if site.next_node and site.next_node.name and site.next_node.ip4 then
+	uci:section('dhcp','domain','nextnode4',{
+		name=site.next_node.name,
+		ip=site.next_node.ip4,
+	})
+else
+	uci:delete('dhcp', 'domain', 'nextnode4')
+end
+
+if site.next_node and site.next_node.name and site.next_node.ip6 then
+	uci:section('dhcp','domain','nextnode6',{
+		name=site.next_node.name,
+		ip=site.next_node.ip6,
+	})
+else
+	uci:delete('dhcp', 'domain', 'nextnode6')
+end
+uci:save('dhcp')
+

--- a/package/gluon-mesh-batman-adv-core/luasrc/lib/gluon/upgrade/330-gluon-mesh-batman-adv-core-local-node
+++ b/package/gluon-mesh-batman-adv-core/luasrc/lib/gluon/upgrade/330-gluon-mesh-batman-adv-core-local-node
@@ -29,6 +29,10 @@ uci:section('network', 'interface', 'local_node',
 	}
 )
 
+if site.dns and site.dns.servers then
+	uci:set('network', 'local-node', 'peerdns','0')
+end
+
 uci:delete('network', 'local_node_route6')
 uci:section('network', 'route6', 'local_node_route6',
 	{


### PR DESCRIPTION
as dns server any server in the network can be used. for example an anycast-ip-address where dns is served ie on all gateways.