### PR TITLE
mac80211: Allow switching of the ath10k regulatory domain

### DIFF
--- a/patches/openwrt/0094-mac80211-Allow-switching-of-the-ath-regulatory-domain.patch
+++ b/patches/openwrt/0094-mac80211-Allow-switching-of-the-ath-regulatory-domain.patch
@@ -1,0 +1,70 @@
+From: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+Date: Fri, 6 Jan 2017 13:29:56 +0100
+Subject: mac80211: Allow switching of the ath regulatory domain
+
+ath10k has to switch the regulatory domain when switching the default
+country when ATH_USER_REGD is enabled. This is for example important when
+switching from country US (FCC) to DE (ETSI). The ath implementation will
+use ath_reg_dyn_country_user_allow to check if this is allowed.
+
+Unfortunately, this function always seems to return false to
+ath_reg_notifier_apply even when ATH_USER_REGD is enabled. But it must
+actually always accept the requests from the user (when ATH_USER_REGD is
+enabled) to correctly set the conformance test limits in the ath10k binary
+blob.
+
+Not doing it will sometimes allow too high transmit powers on edge channels
+for correctly calibrated devices outside their default regulatory domain.
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@open-mesh.com>
+
+Forwarded: https://github.com/openwrt/openwrt/pull/306
+
+diff --git a/package/kernel/mac80211/patches/402-ath_regd_optional.patch b/package/kernel/mac80211/patches/402-ath_regd_optional.patch
+index 463428371b4c96ee63b6eba1477023ff739c6129..a3572a297718f883f6126fc33aff5e14a046b9a0 100644
+--- a/package/kernel/mac80211/patches/402-ath_regd_optional.patch
++++ b/package/kernel/mac80211/patches/402-ath_regd_optional.patch
+@@ -1,6 +1,15 @@
+ --- a/drivers/net/wireless/ath/regd.c
+ +++ b/drivers/net/wireless/ath/regd.c
+-@@ -341,6 +341,10 @@ ath_reg_apply_beaconing_flags(struct wip
++@@ -188,6 +188,8 @@ static bool dynamic_country_user_possibl
++ 
++ static bool ath_reg_dyn_country_user_allow(struct ath_regulatory *reg)
++ {
+++	if (config_enabled(CPTCFG_ATH_USER_REGD))
+++		return true;
++ 	if (!config_enabled(CPTCFG_ATH_REG_DYNAMIC_USER_REG_HINTS))
++ 		return false;
++ 	if (!dynamic_country_user_possible(reg))
++@@ -341,6 +343,10 @@ ath_reg_apply_beaconing_flags(struct wip
+  	struct ieee80211_channel *ch;
+  	unsigned int i;
+  
+@@ -11,7 +20,7 @@
+  	for (band = 0; band < NUM_NL80211_BANDS; band++) {
+  		if (!wiphy->bands[band])
+  			continue;
+-@@ -374,6 +378,10 @@ ath_reg_apply_ir_flags(struct wiphy *wip
++@@ -374,6 +380,10 @@ ath_reg_apply_ir_flags(struct wiphy *wip
+  {
+  	struct ieee80211_supported_band *sband;
+  
+@@ -22,7 +31,7 @@
+  	sband = wiphy->bands[NL80211_BAND_2GHZ];
+  	if (!sband)
+  		return;
+-@@ -402,6 +410,10 @@ static void ath_reg_apply_radar_flags(st
++@@ -402,6 +412,10 @@ static void ath_reg_apply_radar_flags(st
+  	struct ieee80211_channel *ch;
+  	unsigned int i;
+  
+@@ -33,7 +42,7 @@
+  	if (!wiphy->bands[NL80211_BAND_5GHZ])
+  		return;
+  
+-@@ -633,6 +645,11 @@ ath_regd_init_wiphy(struct ath_regulator
++@@ -633,6 +647,11 @@ ath_regd_init_wiphy(struct ath_regulator
+  	const struct ieee80211_regdomain *regd;
+  
+  	wiphy->reg_notifier = reg_notifier;


### PR DESCRIPTION
ath10k has to switch the regulatory domain when switching the default country when ATH_USER_REGD is enabled. This is for example important when switching from country US (FCC) to DE (ETSI). The ath implementation will use ath_reg_dyn_country_user_allow to check if this is allowed.

Unfortunately, this function always seems to return false to ath_reg_notifier_apply even when ATH_USER_REGD is enabled [1]. But it must actually always accept the requests from the user (when ATH_USER_REGD is enabled) to correctly set the conformance test limits in the ath10k binary
blob.

Not doing it will sometimes allow too high transmit powers on edge channels for correctly calibrated devices outside their default regulatory domain.

[1] Assuming that ATH_REG_DYNAMIC_USER_REG_HINTS is disabled (as it is in gluon/OpenWrt)

----

ATH_USER_REGD seems to be active since 5a17b69547e4cb600a97cfa118f6e2f739f20452 but was never active. The patch was already forwarded to OpenWrt in https://github.com/openwrt/openwrt/pull/306