### PR TITLE
[RFC] add package gluon-ebtables-source-filter

### DIFF
--- a/docs/package/gluon-ebtables-source-filter.rst
+++ b/docs/package/gluon-ebtables-source-filter.rst
@@ -1,0 +1,30 @@
+gluon-ebtables-source-filter
+============================
+
+The *gluon-ebtables-source-filter* package adds an additional layer-2 filter
+ruleset to prevent unreasonable traffic entering the network via the nodes.
+Unreasonable means traffic entering the mesh via a node which source IP does
+not belong to the configured IP space.
+
+One may first check if there is a certain proportion of unreasonable traffic,
+before adding this package to the firmware image. Additional one should not
+use this package if some kind of gateway or upstream network is provided by
+a device connected to the client port.
+
+site.conf
+---------
+
+prefix4 : optional
+    - IPv4 subnet
+
+prefix6 :
+    - IPv6 subnet
+
+extra_prefixes6 : optional
+    - list of additional IPv6 subnets
+
+Example::
+
+  prefix4 = '198.51.100.0/21',
+  prefix6 = '2001:db8:8::/64',
+  extra_prefixes6 = { '2001:db8:9::/64', '2001:db8:100::/60' },

--- a/package/gluon-ebtables-source-filter/Makefile
+++ b/package/gluon-ebtables-source-filter/Makefile
@@ -1,0 +1,43 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-ebtables-source-filter
+PKG_VERSION:=1
+PKG_RELEASE:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include ../gluon.mk
+
+
+define Package/gluon-ebtables-source-filter
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=Ebtables rules to filter unreasonable L2 traffic.
+  DEPENDS:=+gluon-core +gluon-ebtables
+endef
+
+define Package/gluon-ebtables-source-filter/description
+	This package adds an additional layer-2 filter-ruleset to prevent unreasonable
+	traffic entering the network via the nodes.
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+endef
+
+define Package/gluon-ebtables-source-filter/install
+	$(CP) ./files/* $(1)/
+endef
+
+define Package/gluon-ebtables-source-filter/postinst
+#!/bin/sh
+$(call GluonCheckSite,check_site.lua)
+endef
+
+$(eval $(call BuildPackage,gluon-ebtables-source-filter))

--- a/package/gluon-ebtables-source-filter/check_site.lua
+++ b/package/gluon-ebtables-source-filter/check_site.lua
@@ -1,0 +1,2 @@
+need_string_match('prefix4', '^%d+.%d+.%d+.%d+/%d+$', false)
+need_string_array_match('extra_prefixes6', '^[%x:]+/%d+$', false)

--- a/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/100-local-forward-chain
+++ b/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/100-local-forward-chain
@@ -1,0 +1,1 @@
+chain('LOCAL_FORWARD', 'DROP')

--- a/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/110-local-forward-allow-arp
+++ b/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/110-local-forward-allow-arp
@@ -1,0 +1,6 @@
+prefix4 = require('gluon.site_config').prefix4
+
+if prefix4 then
+	rule('LOCAL_FORWARD -p ARP --arp-ip-src ' .. prefix4 .. ' --arp-ip-dst ' .. prefix4 .. ' -j RETURN')
+	rule('LOCAL_FORWARD -p ARP --arp-ip-src 0.0.0.0 --arp-ip-dst ' .. prefix4 .. ' -j RETURN')
+end

--- a/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/110-local-forward-allow-ipv4
+++ b/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/110-local-forward-allow-ipv4
@@ -1,0 +1,6 @@
+prefix4 = require('gluon.site_config').prefix4
+
+if prefix4 then
+	rule('LOCAL_FORWARD -p IPv4 --ip-protocol udp --ip-destination-port 67 -j RETURN')
+	rule('LOCAL_FORWARD -p IPv4 --ip-src ' .. prefix4 .. ' -j RETURN')
+end

--- a/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/110-local-forward-allow-ipv6
+++ b/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/110-local-forward-allow-ipv6
@@ -1,0 +1,9 @@
+site = require('gluon.site_config')
+
+rule('LOCAL_FORWARD -p IPv6 --ip6-src fe80::/64 -j RETURN')
+rule('LOCAL_FORWARD -p IPv6 --ip6-src ::/128 --ip6-proto ipv6-icmp -j RETURN')
+rule('LOCAL_FORWARD -p IPv6 --ip6-src ' .. site.prefix6 .. ' -j RETURN')
+
+for _, prefix in ipairs(site.extra_prefixes6 or {}) do
+	rule('LOCAL_FORWARD -p IPv6 --ip6-src ' .. prefix .. ' -j RETURN')
+end

--- a/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/300-local-forward-rules
+++ b/package/gluon-ebtables-source-filter/files/lib/gluon/ebtables/300-local-forward-rules
@@ -1,0 +1,1 @@
+rule('FORWARD --logical-in br-client -i ! bat0 -j LOCAL_FORWARD')


### PR DESCRIPTION
First draft to port ffho-ebtables-net-rules to Gluon

depends on #1016
fixes #541

decision needed:

- [x] the packagename is verry generic, so it should be changed to something that fits better, e.g. gluon-ebtables-strict-filter/-strict-net/-strict-source/-source-guard/-source-filter/...
  **=> gluon-ebtables-source-filter it is**
- [x] if no prefix4 is given within `site.conf` this package blocks all IPv4 traffic. Is that a reasonable default? **=> yes**
- [x] should we allow link-local-IPv4/APIPA/`169.254.0.0/16`? **=> no**
- [x] for documentation and statistics it may be intresting to use:
  `rule 'SOURCE -p IPv6 --ip6-src ::/128 --ip6-protocol ipv6-icmp --ip6-icmp-type 131 -j RETURN'`
  `rule 'SOURCE -p IPv6 --ip6-src ::/128 --ip6-protocol ipv6-icmp --ip6-icmp-type 135 -j RETURN'`
  `rule 'SOURCE -p IPv6 --ip6-src ::/128 --ip6-protocol ipv6-icmp --ip6-icmp-type 143 -j RETURN'`
  instead of: `rule 'SOURCE -p IPv6 --ip6-src ::/128 -j RETURN'` **=> keep it as it is**

One can find the original package under the following links:
https://git.c3pb.de/freifunk-pb/ffho-packages/tree/master/ffho/ffho-ebtables-net-rules
https://github.com/FreifunkHochstift/ffho-packages/tree/master/ffho/ffho-ebtables-net-rules