### PR TITLE
ramips-mt7628: add new platform and vocore2

### DIFF
--- a/targets/ramips-mt7628
+++ b/targets/ramips-mt7628
@@ -1,0 +1,4 @@
+# VoCore 2
+
+device vocore2 vocore2
+factory

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -13,6 +13,7 @@ ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,ar71xx,mikrotik)) # BROKEN: no sysupgrade support
 $(eval $(call GluonTarget,mvebu)) # BROKEN: No AP+IBSS or 11s support
 $(eval $(call GluonTarget,ramips,mt7621)) # BROKEN: No AP+IBSS support, 11s has high packet loss
+$(eval $(call GluonTarget,ramips,mt7628)) # BROKEN: No AP+IBSS support
 $(eval $(call GluonTarget,ramips,rt305x)) # BROKEN: No AP+IBSS support
 $(eval $(call GluonTarget,sunxi)) # BROKEN: Untested
 endif


### PR DESCRIPTION
This change adds the VoCore2 to the devices which are gluon ready. The VoCore2 was also able to handle ibss, 802.11s and the client net at the same time. Unfortunately the stability is not so good. 
Test device: https://meshviewer.chemnitz.freifunk.net/#!v:m;n:b8d81267052b