### PR TITLE
add support for TP-Link TL-WA7210N

### DIFF
--- a/targets/ar71xx-tiny
+++ b/targets/ar71xx-tiny
@@ -11,6 +11,8 @@ device d-link-dir-615-rev-c1 dir-615-c1 DIR615C1
 # TP-Link
 
 device tp-link-tl-wa701n-nd-v1 tl-wa701nd-v1
+
+device tp-link-tl-wa7210n-v2 tl-wa7210n-v2
 device tp-link-tl-wa7510n-v1 tl-wa7510n
 
 device tp-link-tl-wr703n-v1 tl-wr703n-v1


### PR DESCRIPTION
fixes https://github.com/freifunk-gluon/gluon/issues/894

As far as I know the sysupgrade is broken on 7510N. I expect that it is broken on 7210N, too.

The patch has not been tested on a device.