### PR TITLE
docs: fix typos in 2016.1 release notes

### DIFF
--- a/docs/releases/v2016.1.rst
+++ b/docs/releases/v2016.1.rst
@@ -175,9 +175,9 @@ Site changes
         mesh_vpn = {
           ifname = 'mesh-vpn',
           enabled = false,
-          limit_ingress = 3000,
           limit_egress = 200,
-        }
+          limit_ingress = 3000,
+        },
       }
 
     needs to be changed to
@@ -189,8 +189,8 @@ Site changes
 
         bandwidth_limit = {
           enabled = false,
-          ingress = 3000,
           egress = 200,
+          ingress = 3000,
         },
       }
 


### PR DESCRIPTION
adds missing trailing `,` in simple_tc section and changes the order of ingress and egress to default format used by Gluon