### PR TITLE
babel statuspage-api: make interfaces mesh protocol agnostic

### DIFF
--- a/package/gluon-status-page-api/Makefile
+++ b/package/gluon-status-page-api/Makefile
@@ -14,7 +14,7 @@ define Package/gluon-status-page-api
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=API for gluon-status-page
-  DEPENDS:=+gluon-core +uhttpd +sse-multiplex +gluon-neighbour-info +gluon-respondd +libiwinfo +libjson-c +libnl-tiny
+  DEPENDS:=+gluon-core +uhttpd +sse-multiplex +gluon-neighbour-info +gluon-respondd +libiwinfo +libjson-c +libnl-tiny +libubus-lua
 endef
 
 define Build/Prepare

--- a/package/gluon-status-page-api/luasrc/lib/gluon/status-page/www/cgi-bin/interfaces
+++ b/package/gluon-status-page-api/luasrc/lib/gluon/status-page/www/cgi-bin/interfaces
@@ -15,10 +15,10 @@ list = util.get_mesh_devices(uconn)
 ubus.close(uconn)
 interfaces = {}
 for _,ifname in ipairs(list) do
-    pcall(function()
-      local address = util.trim(fs.readfile('/sys/class/net/' .. ifname .. '/address'))
-      interfaces[ifname] = { address = address }
-    end)
+	pcall(function()
+		local address = util.trim(fs.readfile('/sys/class/net/' .. ifname .. '/address'))
+		interfaces[ifname] = { address = address }
+	end)
 end
 
 io.write(json.stringify(interfaces))

--- a/package/gluon-status-page-api/luasrc/lib/gluon/status-page/www/cgi-bin/interfaces
+++ b/package/gluon-status-page-api/luasrc/lib/gluon/status-page/www/cgi-bin/interfaces
@@ -1,27 +1,24 @@
 #!/usr/bin/lua
-
 util = require 'gluon.util'
-
 fs = require 'nixio.fs'
 json = require 'luci.jsonc'
+ubus = require 'ubus'
 
 io.write("Access-Control-Allow-Origin: *\n")
 io.write("Content-type: application/json\n\n")
 
-f = io.popen('batctl if')
-
+local uconn = ubus.connect()
+if not uconn then
+	error("Failed to connect to ubusd")
+end
+list = util.get_mesh_devices(uconn)
+ubus.close(uconn)
 interfaces = {}
-
-for line in f:lines() do
-  ifname = line:match('^(.-):')
-  if ifname ~= nil then
+for _,ifname in ipairs(list) do
     pcall(function()
       local address = util.trim(fs.readfile('/sys/class/net/' .. ifname .. '/address'))
       interfaces[ifname] = { address = address }
     end)
-  end
 end
-
-f:close()
 
 io.write(json.stringify(interfaces))


### PR DESCRIPTION
This PR will make /lib/gluon/status-page/www/cgi-bin/interfaces mesh-protocol-agnostic by utilizing gluon-util.get_mesh_devices()

Also indents will be fixed via a separate commit.