### PR TITLE
gluon-mesh-vpn-fastd: do not depend on mesh-protocol batman

### DIFF
--- a/package/gluon-mesh-vpn-fastd/Makefile
+++ b/package/gluon-mesh-vpn-fastd/Makefile
@@ -13,7 +13,7 @@ define Package/gluon-mesh-vpn-fastd
   SECTION:=gluon
   CATEGORY:=Gluon
   TITLE:=Support for connecting batman-adv meshes via fastd
-  DEPENDS:=+gluon-core +libgluonutil gluon-mesh-batman-adv +gluon-wan-dnsmasq +fastd +iptables +iptables-mod-extra +simple-tc
+  DEPENDS:=+gluon-core +libgluonutil +gluon-wan-dnsmasq +fastd +iptables +iptables-mod-extra +simple-tc
 endef
 
 define Build/Prepare


### PR DESCRIPTION
This prepares the gluon-mesh-vpn-fastd package for babel-use.