### PR TITLE
gluon-status-page-api: limit uhttp max_requests to 16 on devices with <48MB RAM (part 1/2  #1032)

### DIFF
--- a/package/gluon-status-page-api/files/lib/gluon/upgrade/500-status-page-api
+++ b/package/gluon-status-page-api/files/lib/gluon/upgrade/500-status-page-api
@@ -8,6 +8,15 @@ uci -q batch <<-EOF
 	delete uhttpd.main.listen_https
 
 	set uhttpd.main.home=/lib/gluon/status-page/www
-
-	set uhttpd.main.max_requests=32
 EOF
+
+RAM=$(grep MemTotal /proc/meminfo |awk '{print $2}')
+if [ $RAM -lt $((48*1024)) ]; then
+	echo "set uhttpd.main.max_requests=16"
+else
+	echo "set uhttpd.main.max_requests=32"
+fi |uci -q batch
+
+if [ -x /etc/init.d/rpcd ]; then
+	/etc/init.d/rpcd disable
+fi

--- a/package/gluon-status-page-api/files/lib/gluon/upgrade/500-status-page-api
+++ b/package/gluon-status-page-api/files/lib/gluon/upgrade/500-status-page-api
@@ -10,12 +10,12 @@ uci -q batch <<-EOF
 	set uhttpd.main.home=/lib/gluon/status-page/www
 EOF
 
-RAM=$(grep MemTotal /proc/meminfo |awk '{print $2}')
+RAM=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
 if [ $RAM -lt $((48*1024)) ]; then
-	echo "set uhttpd.main.max_requests=16"
+	uci set uhttpd.main.max_requests=16
 else
-	echo "set uhttpd.main.max_requests=32"
-fi |uci -q batch
+	uci set uhttpd.main.max_requests=32
+fi
 
 if [ -x /etc/init.d/rpcd ]; then
 	/etc/init.d/rpcd disable

--- a/package/gluon-status-page-api/files/lib/gluon/upgrade/500-status-page-api
+++ b/package/gluon-status-page-api/files/lib/gluon/upgrade/500-status-page-api
@@ -16,7 +16,3 @@ if [ $RAM -lt $((48*1024)) ]; then
 else
 	uci set uhttpd.main.max_requests=32
 fi
-
-if [ -x /etc/init.d/rpcd ]; then
-	/etc/init.d/rpcd disable
-fi


### PR DESCRIPTION
this will limit the uhttp max_requests to 16 saving even  slow tl-wr740 from being overloaded by statuspage-traffic.

This addresses one consideration in #1032  