### PR TITLE
gluon-core: limit memory that may be used by fq_codel to 1MB per AP o…

### DIFF
--- a/package/gluon-core/files/etc/hotplug.d/ieee80211/01-gluon-core-codel-memusage
+++ b/package/gluon-core/files/etc/hotplug.d/ieee80211/01-gluon-core-codel-memusage
@@ -1,7 +1,7 @@
 #!/bin/sh
 if [ "${ACTION}" = "add" ]; then
 
-	RAM=$(grep MemTotal /proc/meminfo |awk '{print $2}')
+	RAM=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
 	if [ "$RAM" -lt $((48*1024)) ]; then
 		echo "fq_memory_limit 1048576" > "/sys/kernel/debug/ieee80211/$DEVICENAME/aqm"
 	fi

--- a/package/gluon-core/files/etc/hotplug.d/ieee80211/01-gluon-core-codel-memusage
+++ b/package/gluon-core/files/etc/hotplug.d/ieee80211/01-gluon-core-codel-memusage
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ "${ACTION}" = "add" ]; then
+
+	RAM=$(grep MemTotal /proc/meminfo |awk '{print $2}')
+	if [ "$RAM" -lt $((48*1024)) ]; then
+		echo "fq_memory_limit 1048576" > "/sys/kernel/debug/ieee80211/$DEVICENAME/aqm"
+	fi
+fi


### PR DESCRIPTION
…n devices with less than 48MB RAM to avoid OOM