### PR TITLE
mvebu: remove wpad-mini

### DIFF
--- a/targets/mvebu
+++ b/targets/mvebu
@@ -1,2 +1,3 @@
 device linksys-wrt1200ac linksys-wrt1200ac
+packages '-wpad-mini' # clashes with hostapd-mini
 factory .img


### PR DESCRIPTION
As for [sunxi](https://github.com/freifunk-gluon/gluon/blob/master/targets/sunxi#L9) wpad-mini conflicts with hostapd-mini.