### PR TITLE
gluon-respondd: Use hotplug script for reload

### DIFF
--- a/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
+++ b/package/gluon-respondd/files/etc/hotplug.d/iface/10-gluon-respondd
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+[ "$ACTION" = "ifupdate" ] && exit
+
+exec /etc/init.d/gluon-respondd reload

--- a/package/gluon-respondd/files/etc/init.d/gluon-respondd
+++ b/package/gluon-respondd/files/etc/init.d/gluon-respondd
@@ -18,12 +18,3 @@ start_service() {
 	procd_set_param stderr 1
 	procd_close_instance
 }
-
-service_triggers() {
-	local script=$(readlink "$initscript")
-	local name=$(basename ${script:-$initscript})
-
-	procd_open_trigger
-	procd_add_raw_trigger "interface.*" 0 "/etc/init.d/$name" reload
-	procd_close_trigger
-}


### PR DESCRIPTION
Before, we used a procd netdev trigger, but that fired *way* too often (maybe once per router announcement received?), causing high load for nothing.

This basically reverts to the behaviour before commit d8bb978, only that the init script still handles argument collection.