### PR TITLE
bcm2708: prevent wpad-mini from conflicting with hostapd-mini

### DIFF
--- a/targets/brcm2708-bcm2708
+++ b/targets/brcm2708-bcm2708
@@ -1,3 +1,4 @@
 device raspberry-pi rpi
 factory -ext4-sdcard .img.gz
 sysupgrade -ext4-sdcard .img.gz
+packages '-wpad-mini' # clashes with hostapd-mini


### PR DESCRIPTION
This should fix the following error, as it did for sunxi and mvebu.

```
Collected errors:
 * check_data_file_clashes: Package wpad-mini wants to install file /scratch/hexa/build/gluon/lede/build_dir/target-arm_arm1176jzf-s+vfp_musl-1.1.16_eabi/linux-brcm2708_bcm2708/target-dir-2fbc7ff2/usr/sbin/hostapd
        But that file is already provided by package  * hostapd-mini
 * opkg_install_cmd: Cannot install package wpad-mini.
```