### PR TITLE
fixed: image file name creation for tp-link-tl-wr940n

### DIFF
--- a/targets/ar71xx-tiny
+++ b/targets/ar71xx-tiny
@@ -51,13 +51,13 @@ device tp-link-tl-wr941n-nd-v2 tl-wr941nd-v2
 device tp-link-tl-wr941n-nd-v3 tl-wr941nd-v3
 
 device tp-link-tl-wr941n-nd-v4 tl-wr941nd-v4
-alias tp-link-tl-wr940n-nd-v1
+alias tp-link-tl-wr940n-v1
 
 device tp-link-tl-wr941n-nd-v5 tl-wr941nd-v5
-alias tp-link-tl-wr940n-nd-v2
+alias tp-link-tl-wr940n-v2
 
 device tp-link-tl-wr941n-nd-v6 tl-wr941nd-v6
-alias tp-link-tl-wr940n-nd-v3
+alias tp-link-tl-wr940n-v3
 
 device tp-link-tl-wr940n-v4 tl-wr940n-v4
 factory -squashfs-factory${GLUON_REGION:+-${GLUON_REGION}} .bin


### PR DESCRIPTION
The WR940n doesn't has detachable antennas.