### PR TITLE
gluon-mesh-vpn-core: Fixed conditions for migration code

### DIFF
--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/400-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/400-mesh-vpn
@@ -62,10 +62,10 @@ uci:save('firewall')
 
 -- VPN migration
 local has_fastd = fs.access('/lib/gluon/mesh-vpn/fastd')
-local fastd_enabled = has_fastd and uci:get_bool("fastd", "mesh_vpn", "enabled")
+local fastd_enabled = uci:get_bool("fastd", "mesh_vpn", "enabled")
 
 local has_tunneldigger = fs.access('/lib/gluon/mesh-vpn/tunneldigger')
-local tunneldigger_enabled = has_fastd and uci:get_bool("tunneldigger", "mesh_vpn", "enabled")
+local tunneldigger_enabled = uci:get_bool("tunneldigger", "mesh_vpn", "enabled")
 
 local enabled = fastd_enabled or tunneldigger_enabled or false
 


### PR DESCRIPTION
VPN daemons were always disabled


This fixes the issue that was left in the previous pull request without moving the code to a new file or creating skeleton configs.

has_fastd and has_tunneldigger were incorrectly  used twice in defining the enabled variables and when setting the final value in UCI. 