### PR TITLE
gluon-core: Fixed bug which kept legacy VLAN interface definitions

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -95,6 +95,7 @@ local function configure_mesh(config, radio, index, suffix, disabled)
   local maclist = uci:get('wireless', name, 'maclist')
 
   uci:delete('network', name)
+  uci:delete('network', name .. '_vlan')
   uci:delete('wireless', name)
 
   if not config then


### PR DESCRIPTION
Nodes which upgraded from 2015.X in the past, kept old VLAN interface definitions in /etc/config/network.
This lead to a VLAN interface on mesh0 as the adhoc interfaces had the same name in the past.

This issue is only surfacing when migrating from adhoc to 802.11s and the nodes had 2015.X running in the past. I suspect that this bug is also present in 2016.2.X
