### PR TITLE
gluon-core: fix variable %v

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/500-opkg
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/500-opkg
@@ -8,13 +8,13 @@ local util = require 'gluon.util'
 local subst = {}
 
 
-local f = io.popen('. /etc/openwrt_release; echo "$DISTRIB_CODENAME"; echo "$DISTRIB_TARGET"; echo "$DISTRIB_ARCH"')
+local f = io.popen('. /etc/openwrt_release; echo "$DISTRIB_CODENAME"; echo "$DISTRIB_RELEASE"; echo "$DISTRIB_TARGET"; echo "$DISTRIB_ARCH"')
 subst['%%n'] = f:read()
+subst['%%v'] = f:read():gsub('-SNAPSHOT', '')
 subst['%%S'] = f:read()
 subst['%%A'] = f:read()
 f:close()
 
-subst['%%v'] = util.trim(fs.readfile('/etc/openwrt_version'))
 subst['%%GS'] = site.site_code
 subst['%%GV'] = util.trim(fs.readfile('/lib/gluon/gluon-version'))
 subst['%%GR'] = util.trim(fs.readfile('/lib/gluon/release'))


### PR DESCRIPTION
With LEDE the content of `/etc/openwrt_version` changed. It no longer contains a version string like `17.01` as it was with OpenWrt.

```
BusyBox v1.25.1 () built-in shell (ash)

     _________
    /        /\      _    ___ ___  ___
   /  LE    /  \    | |  | __|   \| __|
  /    DE  /    \   | |__| _|| |) | _|
 /________/  LE  \  |____|___|___/|___|                      lede-project.org
 \        \   DE /
  \    LE  \    /  -----------------------------------------------------------
   \  DE    \  /    Reboot (17.01-SNAPSHOT, r3290+11-1b94737824)
    \________\/    -----------------------------------------------------------

root@LEDE:~# cat /etc/openwrt_version 
r3290+11-1b94737824
```