### PR TITLE
Add Support for TP Link RE 450

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -180,6 +180,9 @@ packages $ATH10K_PACKAGES
 device tp-link-archer-c7-v2 archer-c7-v2
 packages $ATH10K_PACKAGES
 factory -squashfs-factory${GLUON_REGION:+-${GLUON_REGION}} .bin
+
+device tp-link-re450 re450
+packages $ATH10K_PACKAGES
 fi
 
 


### PR DESCRIPTION
Fixes #1084

Hardware is very similar to Archer C5v1 and C7v2.

Tested factory install and autoupdater.

IBSS Mesh on 2.4 and 5 GHz is working fine.

The only Ethernet Port is used for config mode and afterwards handled
as WAN Port.