### PR TITLE
LEDE: reenable multicast snooping

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
@@ -34,6 +34,8 @@ uci:section('network', 'interface', 'client', {
 	auto = true,
 	ipv6 = false,
 	macaddr = sysconfig.primary_mac,
+	igmp_snooping = true,
+	multicast_querier = true,
 })
 
 uci:save('network')

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/110-network
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/110-network
@@ -9,12 +9,12 @@ uci:section('network', 'interface', 'wan',
 	    {
 	      ifname = sysconfig.wan_ifname,
 	      type = 'bridge',
+	      igmp_snooping = true,
 	      multicast_querier = false,
 	      peerdns = false,
 	      auto = true,
 	    }
 )
-uci:delete('network', 'wan', 'igmp_snooping')
 
 if not uci:get('network', 'wan', 'proto') then
   uci:set('network', 'wan', 'proto', 'dhcp')


### PR DESCRIPTION
LEDE recently disabled multicast snooping by default:

https://git.lede-project.org/?p=project/netifd.git;a=commitdiff;h=52541140f8138e31958cdc3d7e42a4029fa6bbc9

Reenable it for Gluon as there have been no confirmed issues for
LEDE and no negative reports concerning Gluon v2016.2.x so far.

Closes #1025.