### PR TITLE
ar71xx-tiny: add TP LINK TL-WA730RE v1

### DIFF
--- a/targets/ar71xx-tiny
+++ b/targets/ar71xx-tiny
@@ -12,6 +12,8 @@ device d-link-dir-615-rev-c1 dir-615-c1 DIR615C1
 
 device tp-link-tl-wa701n-nd-v1 tl-wa701nd-v1
 
+device tp-link-tl-wa730re-v1 tl-wa730re-v1
+
 device tp-link-tl-wa7210n-v2 tl-wa7210n-v2
 device tp-link-tl-wa7510n-v1 tl-wa7510n
 


### PR DESCRIPTION
Already supported by OpenWRT and LEDE
* https://wiki.openwrt.org/toh/tp-link/tl-wa730re
* https://lede-project.org/toh/hwdata/tp-link/tp-link_tl-wa730re_v1

Test installation:
* upgrade TP LINK firmware to v2016.2.x (see backport below)
* upgrade v2016.2.x to master branch (via config mode)
* 802.11s mesh works
* client network works
* ssh works

Possible backport for v2016.2.x branch:
```
index a0ee43a..2cd195c 100644
--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -29,6 +29,10 @@ $(eval $(call GluonProfile,TLWA701))
 $(eval $(call GluonModel,TLWA701,tl-wa701n-v1,tp-link-tl-wa701n-nd-v1))
 $(eval $(call GluonModel,TLWA701,tl-wa701nd-v2,tp-link-tl-wa701n-nd-v2))
 
+# TL-WA730RE v1
+$(eval $(call GluonProfile,TLWA730RE))
+$(eval $(call GluonModel,TLWA730RE,tl-wa730rev1,tp-link-tl-wa730re-v1))
+
 # TL-WA7510 v1
 $(eval $(call GluonProfile,TLWA7510))
 $(eval $(call GluonModel,TLWA7510,tl-wa7510n,tp-link-tl-wa7510n-v1))
```