### PR TITLE
gluon-mesh-batman-adv: announce dns server if dns cache was configured

### DIFF
--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/radvd/arguments
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/radvd/arguments
@@ -1,3 +1,7 @@
 #!/usr/bin/lua
 local site = require "gluon.site_config"
-print("-i local-node -p " .. site.prefix6)
+io.write("-i local-node -p " .. site.prefix6)
+if site.dns and site.dns.servers then
+	io.write(" --rdnss " .. site.next_node.ip6)
+end
+io.write("\n")

--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/radvd/arguments
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/radvd/arguments
@@ -4,4 +4,3 @@ io.write("-i local-node -p " .. site.prefix6)
 if site.dns and site.dns.servers then
 	io.write(" --rdnss " .. site.next_node.ip6)
 end
-io.write("\n")


### PR DESCRIPTION
This allows us to resolve nextnode even if there is no upstream connection.
Also this allows us to use an ipv6 dns cache in l2 networks.