### PR TITLE
better upstream server description

### DIFF
--- a/docs/features/dns-cache.rst
+++ b/docs/features/dns-cache.rst
@@ -6,7 +6,8 @@ between node and gateway as small as possible. In order to do this, a
 dns-cache may be used on a node. The dnsmasq instance listening on port
 53 on the node will be reconfigured to answer requests, use a list of
 upstream servers and a specific cache size if the options listed below are
-added to site.conf. Upstream servers normally are the community's gateways.
+added to site.conf. Upstream servers are the DNS servers which are normally
+used by the nodes to resolve hostnames (e.g. gateways/supernodes).
 If they are set the node will cache as much DNS records as set with 
 'cacheentries' in RAM. All settings are optional, though if no dns server 
 is set, the configuration will not be altered by gluon-core.

--- a/docs/features/dns-cache.rst
+++ b/docs/features/dns-cache.rst
@@ -6,8 +6,10 @@ between node and gateway as small as possible. In order to do this, a
 dns-cache may be used on a node. The dnsmasq instance listening on port
 53 on the node will be reconfigured to answer requests, use a list of
 upstream servers and a specific cache size if the options listed below are
-added to site.conf. All settings are optional, though if no dns server is
-set, the configuration will not be altered by gluon-core.
+added to site.conf. Upstream servers normally are the community's gateways.
+If they are set the node will cache every DNS record in RAM. All settings 
+are optional, though if no dns server is set, the configuration will not 
+be altered by gluon-core.
 
 Besides caching dns requests from clients, the next_node-addresses are set to
 resolve to a configurable name that may optionally be placed in next_node.name.

--- a/docs/features/dns-cache.rst
+++ b/docs/features/dns-cache.rst
@@ -8,12 +8,19 @@ dns-cache may be used on a node. The dnsmasq instance listening on port
 upstream servers and a specific cache size if the options listed below are
 added to site.conf. Upstream servers are the DNS servers which are normally
 used by the nodes to resolve hostnames (e.g. gateways/supernodes).
-If they are set the node will cache as much DNS records as set with 
-'cacheentries' in RAM. All settings are optional, though if no dns server 
-is set, the configuration will not be altered by gluon-core.
 
-Besides caching dns requests from clients, the next_node-addresses are set to
-resolve to a configurable name that may optionally be placed in next_node.name.
+There are the following settings:
+    servers
+    cacheentries
+    
+If both options are set the node will cache as much DNS records as set with 
+'cacheentries' in RAM. The 'servers' list will be used to resolve the received 
+DNS-queries if the request cannot be answered from cache.
+If these settings do not exist, the cache is not intialized and RAM-usage will not increase.
+
+When next_node.name is set, an A-record and an AAAA-record for the 
+next-node-IP are placed in the dnsmasq configuration. This means that the content 
+of next_node.name may be resolved even without upstream connectivity.
 
 ::
 

--- a/docs/features/dns-cache.rst
+++ b/docs/features/dns-cache.rst
@@ -7,9 +7,9 @@ dns-cache may be used on a node. The dnsmasq instance listening on port
 53 on the node will be reconfigured to answer requests, use a list of
 upstream servers and a specific cache size if the options listed below are
 added to site.conf. Upstream servers normally are the community's gateways.
-If they are set the node will cache every DNS record in RAM. All settings 
-are optional, though if no dns server is set, the configuration will not 
-be altered by gluon-core.
+If they are set the node will cache as much DNS records as set with 
+'cacheentries' in RAM. All settings are optional, though if no dns server 
+is set, the configuration will not be altered by gluon-core.
 
 Besides caching dns requests from clients, the next_node-addresses are set to
 resolve to a configurable name that may optionally be placed in next_node.name.


### PR DESCRIPTION
Now its clear that upstreams severs normally means "community gateways".