### PR TITLE
ar71xx: added profile for UBNT Airgateway Pro and alias for Airgateway LR

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -196,6 +196,8 @@ ar71xx-generic
 * Ubiquiti
 
   - Air Gateway
+  - Air Gateway LR
+  - Air Gateway PRO
   - Air Router
   - Bullet M2/M5
   - Loco M2/M5

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -189,6 +189,10 @@ fi
 # Ubiquiti
 
 device ubiquiti-airgateway ubnt-air-gateway
+alias ubiquiti-airgateway-lr
+
+device ubiquiti-airgateway-pro ubnt-air-gateway-pro
+
 device ubiquiti-airrouter ubnt-airrouter
 
 device ubiquiti-bullet-m ubnt-bullet-m


### PR DESCRIPTION
The Airgateway LR is the same device as the normal Airgateway but with an detachable antenna. The Pro version is a cheap dual band device with only one radio. By default it uses the 2.4GHz config für the community. 
Test Device: https://meshviewer.chemnitz.freifunk.net/#!v:m;n:0418d6e6ad0d