### PR TITLE
gluon-mesh-vpn-fastd: allow outbound connections on fastd-ports

### DIFF
--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -55,6 +55,7 @@ uci:delete('fastd', 'mesh_vpn', 'user')
 
 
 local add_groups
+local ports = {}
 
 local function add_peer(group, name, config)
 	uci:section('fastd', 'peer', group .. '_peer_' .. name, {
@@ -64,6 +65,20 @@ local function add_peer(group, name, config)
 		key = config.key,
 		remote = config.remotes,
 	})
+
+	for k,r in ipairs(config.remotes)
+	do
+		for i in string.gmatch(r, "%S+")
+		do
+			if (tonumber(i))
+			then
+				if not isinset(tonumber(i),ports)
+				then
+					table.insert(ports, i)
+				end
+			end
+		end
+	end
 end
 
 local function add_group(name, config, parent)
@@ -98,7 +113,31 @@ function add_groups(prefix, groups, parent)
 	end
 end
 
+function isinset(needle, haystack)
+	for i,v in ipairs(haystack)
+	do
+		if (tonumber(v) == tonumber(needle))
+		then
+			return true
+		end
+	end
+	return false
+end
+
+
 add_groups('mesh_vpn', site.mesh_vpn.fastd.groups)
+
+for _,p in ipairs(ports)
+do
+	uci:section('firewall', 'rule', 'wan_fastd_' .. p, {
+		name = 'wan_fastd_' .. p,
+		dest = 'wan',
+		dest_port = p,
+		proto = 'udp',
+		target = 'ACCEPT',
+	})
+end
 
 
 uci:save('fastd')
+uci:save('firewall')


### PR DESCRIPTION
This will allow a stricter fireall in general like one is used in the babel networks.