### PR TITLE
ar71xx-add-openwrt-backport-support-for-TP-Link-TL-WR841ND-v12

### DIFF
--- a/patches/openwrt/0098-ar71xx-add-support-for-TP-Link-TL-WR841ND-v12.patch
+++ b/patches/openwrt/0098-ar71xx-add-support-for-TP-Link-TL-WR841ND-v12.patch
@@ -1,0 +1,38 @@
+From: Christian Breutkreutz <c.breutkreutz@freifunk-malente.de>
+Date: Mon, 24 Apr 2017 16:51:59 +0100
+Subject: ar71xx: add support for TP-Link TL-WR841ND v12
+
+Add support for TP-Link TL-WR841ND v12
+
+Signed-off-by: Christian Breutkreutz <c.breutkreutz@freifunk-malente.de>
+
+diff --git a/target/linux/ar71xx/image/Makefile b/target/linux/ar71xx/image/Makefile
+index 61e2212..29b33d0 100644
+--- a/target/linux/ar71xx/image/Makefile
++++ b/target/linux/ar71xx/image/Makefile
+@@ -619,6 +619,16 @@ define Device/tl-wr841n-v11
+     IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
+ endef
+
++define Device/tl-wr841n-v12
++    $(Device/tplink-4mlzma)
++    BOARDNAME := TL-WR841N-v12
++    DEVICE_PROFILE := TLWR841
++    TPLINK_HWID := 0x08410012
++    IMAGES += factory-us.bin factory-eu.bin
++    IMAGE/factory-us.bin := append-rootfs | mktplinkfw factory -C US
++    IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
++endef
++
+ define Device/tl-wr842n-v2
+     $(Device/tplink-8mlzma)
+     BOARDNAME := TL-WR842N-v2
+@@ -646,7 +656,7 @@ define Device/tl-wr847n-v8
+     DEVICE_PROFILE := TLWR841
+     TPLINK_HWID := 0x08470008
+ endef
+-TARGET_DEVICES += tl-wr841n-v8 tl-wr841n-v9 tl-wr841n-v10 tl-wr841n-v11 tl-wr842n-v2 tl-wr842n-v3 tl-wr843nd-v1 tl-wr847n-v8
++TARGET_DEVICES += tl-wr841n-v8 tl-wr841n-v9 tl-wr841n-v10 tl-wr841n-v11 tl-wr841n-v12 tl-wr842n-v2 tl-wr842n-v3 tl-wr843nd-v1 tl-wr847n-v8
+
+ define Device/tl-wr941nd-v5
+     $(Device/tplink-4mlzma)

--- a/patches/openwrt/0099-ar71xx-add-support-for-TP-Link-TL-WR841ND-v12.patch
+++ b/patches/openwrt/0099-ar71xx-add-support-for-TP-Link-TL-WR841ND-v12.patch
@@ -1,5 +1,5 @@
 From: Christian Breutkreutz <c.breutkreutz@freifunk-malente.de>
-Date: Mon, 24 Apr 2017 16:51:59 +0100
+Date: Mon, 03 May 2017 16:24:59 +0100
 Subject: ar71xx: add support for TP-Link TL-WR841ND v12
 
 Add support for TP-Link TL-WR841ND v12
@@ -16,7 +16,7 @@ index 61e2212..29b33d0 100644
 
 +define Device/tl-wr841n-v12
 +    $(Device/tplink-4mlzma)
-+    BOARDNAME := TL-WR841N-v12
++    BOARDNAME := TL-WR841N-v11
 +    DEVICE_PROFILE := TLWR841
 +    TPLINK_HWID := 0x08410012
 +    IMAGES += factory-us.bin factory-eu.bin

--- a/targets/ar71xx-generic/profiles.mk
+++ b/targets/ar71xx-generic/profiles.mk
@@ -77,9 +77,10 @@ $(eval $(call GluonModel,TLWR841,tl-wr841n-v8,tp-link-tl-wr841n-nd-v8))
 $(eval $(call GluonModel,TLWR841,tl-wr841n-v9,tp-link-tl-wr841n-nd-v9))
 $(eval $(call GluonModel,TLWR841,tl-wr841n-v10,tp-link-tl-wr841n-nd-v10))
 
-# TL-WR841N/ND v11
+# TL-WR841N/ND v11, v12
 $(eval $(call GluonProfile,TLWR841_REGION,,TLWR841))
 $(eval $(call GluonModel,TLWR841_REGION,tl-wr841n-v11,tp-link-tl-wr841n-nd-v11))
+$(eval $(call GluonModel,TLWR841_REGION,tl-wr841n-v12,tp-link-tl-wr841n-nd-v12))
 $(eval $(call GluonProfileFactorySuffix,TLWR841_REGION,-squashfs-factory$(if $(GLUON_REGION),-$(GLUON_REGION)),.bin))
 
 # TL-WR842N/ND v1, v2


### PR DESCRIPTION
I've written a patch for gluon v2016.2.x to support the v12 models.

Patch has been physically tested on a TL-WR841v12. It works fine.