### PR TITLE
add gluonShellDiet to remove all comment lines in shell files

### DIFF
--- a/package/gluon-ebtables/Makefile
+++ b/package/gluon-ebtables/Makefile
@@ -32,6 +32,7 @@ endef
 
 define Package/gluon-ebtables/install
 	$(CP) ./files/* $(1)/
+	./gluonShellDiet.sh $(1)/etc/init.d/*
 endef
 
 $(eval $(call BuildPackage,gluon-ebtables))

--- a/package/gluon-ebtables/gluonShellDiet.sh
+++ b/package/gluon-ebtables/gluonShellDiet.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# This script requires a file as argument (wildcards allowed) 
+# in which it will remove all comment lines that start with a hash '#'
+
+sed -i '/^\s*\#[^!].*/d; /^\s*\#$/d' $1


### PR DESCRIPTION
We can save some space on the nodes deleting all comment lines there, for example:

    $ cat /etc/init.d/*|grep '#'|grep -v '#!'|wc
       90       617      3850