### PR TITLE
gluon-client-bridge: change local_node interface to be part of client…

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
@@ -46,8 +46,8 @@ uci:section('firewall', 'zone', 'client', {
 	name = 'client',
 	network = {'client','local_node',},
 	conntrack = '1',
-	input = 'DROP',
-	output = 'DROP',
+	input = 'ACCEPT',
+	output = 'ACCEPT',
 	forward = 'DROP',
 })
 

--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
@@ -44,7 +44,8 @@ uci:save('network')
 uci:delete('firewall', 'client')
 uci:section('firewall', 'zone', 'client', {
 	name = 'client',
-	network = {'client'},
+	network = {'client','local_node',},
+	conntrack = '1',
 	input = 'DROP',
 	output = 'DROP',
 	forward = 'DROP',


### PR DESCRIPTION
… zone

otherwise traffoc to local_node will not be considered coming from a client. this would break l3-networks