### PR TITLE
gluon-web-admin: add option to show/hide password-login and add minimum password length

### DIFF
--- a/docs/package/gluon-web-admin.rst
+++ b/docs/package/gluon-web-admin.rst
@@ -1,0 +1,27 @@
+gluon-web-admin
+===============
+
+This package allows the user to set options like the password for ssh access
+within config mode. You can define in your ``site.conf`` whether it should be
+possible to access the nodes via ssh with a password or not and what the mimimum
+password length must be.
+
+site.conf
+---------
+
+config_mode.remote_login.show_password_form \: optional (defaults to ``false``)
+  If ``show_password_form`` is set to ``true``, the password section in
+  config mode is shown.
+  
+config_mode.remote_login.min_password_length \: optional (defaults to ``12``)
+  This sets the minimum allowed password length. Set this to ``1`` to
+  disable the length check.
+
+If you want to enable the password login you can use this example::
+
+  config_mode = {
+    remote_login = {
+      show_password_form = true, -- default false
+      min_password_length = 12
+    }
+  }

--- a/package/gluon-web-admin/Makefile
+++ b/package/gluon-web-admin/Makefile
@@ -39,4 +39,9 @@ define Package/gluon-web-admin/install
 	$(call GluonInstallI18N,gluon-web-admin,$(1))
 endef
 
+define Package/gluon-web-admin/postinst
+#!/bin/sh
+$(call GluonCheckSite,check_site.lua)
+endef
+
 $(eval $(call BuildPackage,gluon-web-admin))

--- a/package/gluon-web-admin/check_site.lua
+++ b/package/gluon-web-admin/check_site.lua
@@ -1,0 +1,4 @@
+if need_table('config_mode', nil, false) and need_table('config_mode.remote_login', nil, false) then
+  need_boolean('config_mode.remote_login.show_password_form', false)
+  need_number('config_mode.remote_login.min_password_length', false)
+end

--- a/package/gluon-web-admin/i18n/de.po
+++ b/package/gluon-web-admin/i18n/de.po
@@ -32,6 +32,9 @@ msgstr "Abbrechen"
 msgid "Confirmation"
 msgstr "Bestätigung"
 
+msgid "%u characters min."
+msgstr "Mindestens %u Zeichen"
+
 msgid "Continue"
 msgstr "Fortfahren"
 

--- a/package/gluon-web-admin/i18n/fr.po
+++ b/package/gluon-web-admin/i18n/fr.po
@@ -33,6 +33,9 @@ msgstr "Annuler"
 msgid "Confirmation"
 msgstr "Confirmation"
 
+msgid "%u characters min."
+msgstr "Au moins %u caractères"
+
 msgid "Continue"
 msgstr "Continuer"
 

--- a/package/gluon-web-admin/i18n/gluon-web-admin.pot
+++ b/package/gluon-web-admin/i18n/gluon-web-admin.pot
@@ -19,6 +19,9 @@ msgstr ""
 msgid "Confirmation"
 msgstr ""
 
+msgid "%u characters min."
+msgstr ""
+
 msgid "Continue"
 msgstr ""
 

--- a/package/gluon-web-admin/luasrc/lib/gluon/web/model/admin/remote.lua
+++ b/package/gluon-web-admin/luasrc/lib/gluon/web/model/admin/remote.lua
@@ -13,12 +13,13 @@ You may obtain a copy of the License at
 local nixio = require "nixio"
 local fs = require "nixio.fs"
 local util = require "gluon.util"
+local site = require 'gluon.site_config'
 
 local f_keys = Form(translate("SSH keys"), translate("You can provide your SSH keys here (one per line):"), 'keys')
 local s = f_keys:section(Section)
 local keys = s:option(TextValue, "keys")
-keys.wrap    = "off"
-keys.rows    = 5
+keys.wrap = "off"
+keys.rows = 5
 keys.default = fs.readfile("/etc/dropbear/authorized_keys") or ""
 
 function keys:write(value)
@@ -30,11 +31,19 @@ function keys:write(value)
 	end
 end
 
+local config=((site.config_mode or {}).remote_login or {})
+local min_password_length = config.min_password_length or 12
+local mintype = 'minlength(' .. min_password_length .. ')'
 
-local f_password = Form(translate("Password"),
-	translate(
-                "Alternatively, you can set a password to access your node. Please choose a secure password you don't use anywhere else.<br /><br />"
-                .. "If you set an empty password, login via password will be disabled. This is the default."
+if not config.show_password_form then
+	-- password login is disabled in site.conf
+	return f_keys	
+end
+
+local f_password = Form(translate("Password"), translate(
+	"Alternatively, you can set a password to access your node. Please choose a "
+	.. "secure password you don't use anywhere else.<br /><br />If you set an empty "
+	.. "password, login via password will be disabled. This is the default."
 	), 'password'
 )
 f_password.reset = false
@@ -43,12 +52,18 @@ local s = f_password:section(Section)
 
 local pw1 = s:option(Value, "pw1", translate("Password"))
 pw1.password = true
+pw1.optional = true
+pw1.datatype = mintype
 function pw1.cfgvalue()
 	return ''
 end
 
-local pw2 = s:option(Value, "pw2", translate("Confirmation"))
+local pw2 = s:option(Value, "pw2", translate("Confirmation"), 
+	min_password_length <= 1 and nil or translatef("%u characters min.", min_password_length)
+)
 pw2.password = true
+pw2.optional = true
+pw2.datatype = mintype
 function pw2.cfgvalue()
 	return ''
 end
@@ -93,7 +108,7 @@ function f_password:write()
 
 	local pw = pw1.data
 
-	if #pw > 0 then
+	if pw ~= nil and #pw > 0 then
 		if set_password(pw) then
 			f_password.message = translate("Password changed.")
 		else


### PR DESCRIPTION
Or maybe better min 12 characters?

It would be nice, if you get a verbose error message, if the pass is too short, but that needs some more work on gluon-web, i guess.

![pw](https://user-images.githubusercontent.com/1591563/27477720-477567c4-580d-11e7-8f9a-57b23d48cef9.png)

