### PR TITLE
ramips-rt305x: Add support for A5-V11

### DIFF
--- a/targets/ramips-rt305x
+++ b/targets/ramips-rt305x
@@ -5,3 +5,5 @@ factory
 
 device vocore-16M vocore-16M
 factory
+
+device a5-v11 a5-v11


### PR DESCRIPTION
Add support for A5-V11, a cheap chinese miniature router sold as "Mini 3G/4G Router"
Was already supported by LEDE.
Tested with 11s, seems to work flawlessly with gluon.
