### PR TITLE
Add support for GL.INet GL-AR300M

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -60,6 +60,8 @@ device gl-inet-6416a-v1 gl-inet-6416A-v1
 
 device gl-ar150 gl-ar150
 factory
+device gl-ar300m gl-ar300m
+factory
 
 
 # Linksys by Cisco


### PR DESCRIPTION
This PR adds support vor the GL-AR300M. The device has two flash chips, a 16MB NOR flash and a 128MB NAND flash. Currently only the NOR flash can be used with LEDE (and therefore Gluon) as support for the NAND flash is still missing.

After I applied the settings in the config mode I got these errors:
![error](https://user-images.githubusercontent.com/15052165/27565658-dd070ce6-5adf-11e7-919b-90b8438daca7.png)

However, everything seemed to be working fine after the node rebooted itself. It meshed instantly with my other node.
