### PR TITLE
[RFC] gluon-web-network: make poe_passthrough more generic

### DIFF
--- a/package/gluon-web-network/i18n/de.po
+++ b/package/gluon-web-network/i18n/de.po
@@ -22,6 +22,9 @@ msgstr "Deaktiviert"
 msgid "Enable PoE Passthrough"
 msgstr "PoE-Passthrough aktivieren"
 
+msgid "Enable PoE Power Port %s"
+msgstr "PoE-Ausgabe auf Port %s aktivieren"
+
 msgid "Enable meshing on the LAN interface"
 msgstr "Mesh auf dem LAN-Port aktivieren"
 

--- a/package/gluon-web-network/i18n/fr.po
+++ b/package/gluon-web-network/i18n/fr.po
@@ -22,6 +22,9 @@ msgstr "Désactivé"
 msgid "Enable PoE Passthrough"
 msgstr ""
 
+msgid "Enable PoE Power Port %s"
+msgstr ""
+
 msgid "Enable meshing on the LAN interface"
 msgstr "Activer le réseau MESH sur le port LAN"
 

--- a/package/gluon-web-network/i18n/gluon-web-network.pot
+++ b/package/gluon-web-network/i18n/gluon-web-network.pot
@@ -13,6 +13,9 @@ msgstr ""
 msgid "Enable PoE Passthrough"
 msgstr ""
 
+msgid "Enable PoE Power Port %s"
+msgstr ""
+
 msgid "Enable meshing on the LAN interface"
 msgstr ""
 

--- a/package/gluon-web-network/luasrc/lib/gluon/web/model/admin/network.lua
+++ b/package/gluon-web-network/luasrc/lib/gluon/web/model/admin/network.lua
@@ -128,7 +128,15 @@ uci:foreach("system", "gpio_switch", function(s)
 		if not section then
 			section = f:section(Section)
 		end
-		local poe = section:option(Flag, s[".name"], translate("Enable " .. s.name))
+
+		local port = s.name:match("^PoE Power Port(%d*)$")
+		local name
+		if port then
+			name = translatef("Enable PoE Power Port %s", port)
+		else
+			name = translate("Enable " .. s.name)
+		end
+		local poe = section:option(Flag, s[".name"], name)
 		poe.default = uci:get_bool("system", s[".name"], "value")
 
 		function poe:write(data)


### PR DESCRIPTION
Naming of POE passthroug section changed from `gpio_switch_poe_passthrough` (in OpenWRT) to `poe_passthrough` (in Lede). Therefore it is not possible to enable POE passthroug on a node which was initaly setup with Lede based gluon. (This is a bug in v2017.1.x)

This pull request fixes that issue and prepares `gluon-web-network` for future devices like the ubnt-erx-sfp, which has multiple POE ports.