### PR TITLE
add travis check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: bash
+
+addons:
+  apt:
+    packages:
+    - lua5.1
+    - luarocks
+  
+install:
+  - eval $(luarocks path --bin)
+  - luarocks install --local lua-cjson
+
+script:
+  - bash tests/validate_site.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,19 @@ addons:
     packages:
     - lua5.1
     - luarocks
-  
+    - git
+    - make
+    - gcc
+    - g++
+    - unzip
+    - libncurses5-dev
+    - zlib1g-dev
+    - subversion
+    - gawk
+    - bzip2
+    - libssl-dev
+    - wget
+
 install:
   - eval $(luarocks path --bin)
   - luarocks install --local lua-cjson

--- a/tests/validate_site.sh
+++ b/tests/validate_site.sh
@@ -5,3 +5,10 @@
 GLUON_SITEDIR="docs/site-example" lua5.1 scripts/site_config.lua
 
 bash -n scripts/*.sh
+
+cp -a docs/site-example site
+
+TARGET=ar71xx-generic
+make update GLUON_TARGET=$TARGET
+make clean GLUON_TARGET=$TARGET
+make GLUON_TARGET=$TARGET

--- a/tests/validate_site.sh
+++ b/tests/validate_site.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# checks if the site.conf is a valid lua dict
+
+GLUON_SITEDIR="docs/site-example" lua5.1 scripts/site_config.lua
+
+bash -n scripts/*.sh


### PR DESCRIPTION
This script adds a travis check for the site.conf in docs/site-example/ and checks all shell scripts for validity

Travis has to be added to the gluon repository in Settings->Integrations & services->Installed GitHub Apps

You wil see a green hook or a red X in the commit history. example: https://github.com/rubo77/gluon/commits/travis

(Klick the green hook for details)
