### PR TITLE
Gluon-mesh-vpn-core: Moved migration code to own script

### DIFF
--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/400-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/400-mesh-vpn
@@ -58,19 +58,3 @@ uci:section('firewall', 'include', 'mesh_vpn_dns', {
 })
 
 uci:save('firewall')
-
-
--- VPN migration
-local has_fastd = fs.access('/lib/gluon/mesh-vpn/fastd')
-local fastd_enabled = uci:get_bool("fastd", "mesh_vpn", "enabled")
-
-local has_tunneldigger = fs.access('/lib/gluon/mesh-vpn/tunneldigger')
-local tunneldigger_enabled = uci:get_bool("tunneldigger", "mesh_vpn", "enabled")
-
-local enabled = fastd_enabled or tunneldigger_enabled or false
-
-uci:set("fastd", "mesh_vpn", "enabled", has_fastd and enabled)
-uci:save("fastd")
-
-uci:set("tunneldigger", "mesh_vpn", "enabled", has_tunneldigger and enabled)
-uci:save("tunneldigger")

--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/420-mesh-vpn-migration
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/420-mesh-vpn-migration
@@ -1,0 +1,23 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site_config'
+local users = require 'gluon.users'
+local util = require 'gluon.util'
+local fs = require 'nixio.fs'
+
+local uci = require('simple-uci').cursor()
+
+-- VPN migration
+local has_fastd = fs.access('/lib/gluon/mesh-vpn/fastd')
+local fastd_enabled = uci:get_bool("fastd", "mesh_vpn", "enabled")
+
+local has_tunneldigger = fs.access('/lib/gluon/mesh-vpn/tunneldigger')
+local tunneldigger_enabled = uci:get_bool("tunneldigger", "mesh_vpn", "enabled")
+
+local enabled = fastd_enabled or tunneldigger_enabled or false
+
+uci:set("fastd", "mesh_vpn", "enabled", has_fastd and enabled)
+uci:save("fastd")
+
+uci:set("tunneldigger", "mesh_vpn", "enabled", has_tunneldigger and enabled)
+uci:save("tunneldigger")


### PR DESCRIPTION
It is mandatory that it runs after the initial configuration is in place.

This fixes #1187. Basically we are back to having the VPN migration code in its own script file as it has to run after the daemon configuation has been written. Otherwise we run into the problem that a section we want to enable is not yet existing when migrating from fastd <-> tunneldigger.