### PR TITLE
brcm2708: add target and platform for raspi3

### DIFF
--- a/targets/brcm2708-bcm2710
+++ b/targets/brcm2708-bcm2710
@@ -1,0 +1,3 @@
+device raspberry-pi-3 rpi-3
+factory -ext4-sdcard .img.gz
+sysupgrade -ext4-sdcard .img.gz

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -10,6 +10,7 @@ $(eval $(call GluonTarget,x86,64))
 
 ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,ar71xx,mikrotik)) # BROKEN: no sysupgrade support
+$(eval $(call GluonTarget,brcm2708,bcm2710)) # BROKEN: Untested
 $(eval $(call GluonTarget,ipq806x)) # BROKEN: Untested
 $(eval $(call GluonTarget,mvebu)) # BROKEN: No AP+IBSS or 11s support
 $(eval $(call GluonTarget,ramips,mt7621)) # BROKEN: No AP+IBSS support, 11s has high packet loss


### PR DESCRIPTION
This device has built in wifi we should include it at least for experiments.