### PR TITLE
brcm2708: drop wpad-mini as it clashes with hostapd-mini

### DIFF
--- a/targets/brcm2708-bcm2710
+++ b/targets/brcm2708-bcm2710
@@ -1,3 +1,4 @@
 device raspberry-pi-3 rpi-3
 factory -ext4-sdcard .img.gz
 sysupgrade -ext4-sdcard .img.gz
+packages '-wpad-mini' # clashes with hostapd-mini


### PR DESCRIPTION
Should correct this issue:

```
Collected errors:                                                 
 * check_data_file_clashes: Package wpad-mini wants to install file /scratch/hexa/build/gluon/lede/build_dir/target-arm_cortex-a53+neon-vfpv4_musl-1.1.16_eabi/linux-brcm2708_bcm2710/target-dir-2fbc7ff2/usr/sbi
n/hostapd                                              
        But that file is already provided by package  * hostapd-mini
 * opkg_install_cmd: Cannot install package wpad-mini.   
```