### PR TITLE
Update dns-cache.rst: next_node.name suggestion

### DIFF
--- a/docs/features/dns-cache.rst
+++ b/docs/features/dns-cache.rst
@@ -21,7 +21,10 @@ If these settings do not exist, the cache is not intialized and RAM usage will n
 
 When next_node.name is set, an A record and an AAAA record for the
 next-node IP address are placed in the dnsmasq configuration. This means that the content
-of next_node.name may be resolved even without upstream connectivity.
+of next_node.name may be resolved even without upstream connectivity. It is suggested to use
+the same name as the DNS server provides: e.g nextnode.yourdomain.net (This way the name also 
+works if client uses static DNS Servers). Hint: If next_node.name does not contain a dot some 
+browsers would open the searchpage instead.
 
 ::
 
@@ -31,7 +34,7 @@ of next_node.name may be resolved even without upstream connectivity.
   },
 
   next_node = {
-    name = 'nextnode',
+    name = 'nextnode.yourdomain.net',
     ip6 = '2001:db8:8::1',
     ip4 = '198.51.100.1',
   }


### PR DESCRIPTION
This commit adds a suggestion for next_node.name, changes the example to nextnode.yourdomain.net and adds a hint, that browsers may open the searchpage if the hostname does not contain a dot.