### PR TITLE
Doc: Adding GLUON_RELEASE for make manifest

### DIFF
--- a/docs/features/autoupdater.rst
+++ b/docs/features/autoupdater.rst
@@ -22,6 +22,11 @@ for updates hourly (at a random minute of the hour), but usually only updates du
 
 ``GLUON_PRIORITY`` may be an integer or a decimal fraction.
 
+If ``GLUON_RELEASE`` is used to override the release-string during ``make``
+the same value has to be passed to ``make manifest``. 
+Otherwise no checksums will be included in the manifest.
+
+
 Automated nightly builds
 ------------------------
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -185,6 +185,8 @@ GLUON_RELEASE
   Firmware release number: This string is displayed in the config mode, announced
   via respondd/alfred and used by the autoupdater to decide if a newer version
   is available.
+  The same GLUON_RELEASE has to be passed to ``make`` and ``make manifest`` to
+  generate a manifest for the given images.  
 
 GLUON_TARGET
   Target architecture to build.


### PR DESCRIPTION
Adding the fact that GLUON_RELEASE is needed with 'make manifest'
if it is used with 'make'.

This fact was mentioned in the v2017.1 release notes but is not (clearly)
mentioned inside other parts of the documentation.

Signed-off-by: Chrissi^ <chris@tinyhost.de>