### PR TITLE
ramips-mt7620: add new subtarget with some Gl.Inet devices

### DIFF
--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -1,0 +1,11 @@
+packages -wpad-mini hostapd-mini
+
+# GL Innovations
+device gl-mt300a gl-mt300a
+factory
+
+device gl-mt300n gl-mt300n
+factory
+
+device gl-mt750 gl-mt750
+factory

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -13,6 +13,7 @@ $(eval $(call GluonTarget,ar71xx,mikrotik)) # BROKEN: no sysupgrade support
 $(eval $(call GluonTarget,brcm2708,bcm2710)) # BROKEN: Untested
 $(eval $(call GluonTarget,ipq806x)) # BROKEN: Untested
 $(eval $(call GluonTarget,mvebu)) # BROKEN: No AP+IBSS or 11s support
+$(eval $(call GluonTarget,ramips,mt7620)) # BROKEN: No AP+IBSS support
 $(eval $(call GluonTarget,ramips,mt7621)) # BROKEN: No AP+IBSS support, 11s has high packet loss
 $(eval $(call GluonTarget,ramips,mt7628)) # BROKEN: No AP+IBSS support
 $(eval $(call GluonTarget,ramips,rt305x)) # BROKEN: No AP+IBSS support


### PR DESCRIPTION
the cheap devices are shipped with openwrt. wpad-mini is replaced with hostapd-mini. the wifi does not support ibss + ap but 802.11s + ap works fine.
test installation: http://meshviewer.chemnitz.freifunk.net/#!v:m;n:e4956e41902c