### PR TITLE
[RFC] Add pkg gluon-hoodselector from google summer of code 2016

### DIFF
--- a/package/gluon-hoodselector/Makefile
+++ b/package/gluon-hoodselector/Makefile
@@ -1,0 +1,30 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-hoodselector
+
+GLUON_VERSION = 3
+PKG_VERSION:=2
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include ../gluon.mk
+
+define Package/gluon-hoodselector
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=Automatically sorte routers into network hoods.
+  DEPENDS:=+gluon-site +gluon-mesh-batman-adv-15 @GLUON_MULTIDOMAIN
+  CONFLICTS:=+gluon-config-mode-domain-select
+endef
+
+define Package/gluon-hoodselector/description
+  This is the hoodselector. The hoodselector is one of the main components for
+  splitting a layer 2 mesh network into seperated network segments (hoods).
+  The job of the hoodselector is to automatically detect in which hood
+  the router is located based on geo settings or by scanning its environment.
+  Based on these informations the hoodselector should select a hood from a
+  list of known hoods (hoodlist) and adjust vpn, wireless and mesh on lan
+  configuration based on the settings given for the selected hood.
+endef
+
+$(eval $(call BuildPackageGluon,gluon-hoodselector))

--- a/package/gluon-hoodselector/check_site.lua
+++ b/package/gluon-hoodselector/check_site.lua
@@ -1,0 +1,37 @@
+need_string_match(in_domain({'domain_seed'}), '^' .. ('%x'):rep(64) .. '$')
+
+function need_nil(path)
+  need(path, function(val)
+    if val == nil then
+      return true
+    end
+    return false
+  end, true, "default hood should not contain shapes")
+  return nil
+end
+
+--Need to check if not default hood and does the default not contain shapes
+if this_domain() ~= need_string(in_site({'default_domain'})) then
+  local no_shapes = true
+  for _,shape in ipairs(need_table(in_domain({'hoodselector', 'shapes'}))) do
+    no_shapes = false
+    if #shape >= 2 then
+      for _, pos in ipairs(shape) do
+        if pos.lat == nil or not ( pos.lat < 90.0 and pos.lat > -90.0 ) then
+          need(in_domain({'hoodselector', 'shapes'}), function(err) return false end, true, "lat muss match a rage +/-90.0")
+        end
+        if pos.lon == nil or not ( pos.lon < 180.0 and pos.lon > -180.0 ) then
+          need(in_domain({'hoodselector', 'shapes'}), function(err) return false end, true, "lon muss match a rage +/-180.0")
+        end
+      end
+    end
+    if #shape < 2 then
+      need(in_domain({'hoodselector', 'shapes'}), function(err) return false end, true, "needs to have at lease 2 coordiantes for rectangular shapes.")
+    end
+  end
+  if no_shapes then
+    need(in_domain({'hoodselector', 'shapes'}), function(err) return false end, true, "no shapes are defined in hoods")
+  end
+else -- ente by default hood
+  need_nil(in_domain({'hoodselector', 'shapes'}))
+end

--- a/package/gluon-hoodselector/files/usr/lib/micron.d/hoodselector
+++ b/package/gluon-hoodselector/files/usr/lib/micron.d/hoodselector
@@ -1,0 +1,1 @@
+*/2 * * * * /usr/sbin/hoodselector

--- a/package/gluon-hoodselector/luasrc/usr/lib/lua/hoodselector/util.lua
+++ b/package/gluon-hoodselector/luasrc/usr/lib/lua/hoodselector/util.lua
@@ -1,0 +1,191 @@
+local fs = require 'nixio.fs'
+local json = require 'jsonc'
+local uci = require('simple-uci').cursor()
+local site = require 'gluon.site'
+
+local M = {}
+
+function M.split(s, delimiter)
+  local result = {};
+  for match in (s..delimiter):gmatch("(.-)"..delimiter) do
+    table.insert(result, match);
+  end
+  return result;
+end
+
+local PID = M.split(io.open("/proc/self/stat", 'r'):read('*a'), " ")[1]
+
+function M.log(msg)
+  if msg then
+    io.stdout:write(msg.."\n")
+    os.execute("logger hoodselector["..PID.."]: "..msg)
+  end
+end
+
+-- bool if direct VPN. The detection is realaise by searching the fastd network interface inside the originator table
+function M.directVPN(vpnIfaceList)
+  for _,vpnIface in ipairs(vpnIfaceList) do
+    local file = io.open("/sys/kernel/debug/batman_adv/bat0/originators", 'r')
+    if file ~= nil then
+      for outgoingIF in file:lines() do
+        -- escape special chars "[]-"
+        if outgoingIF:match(string.gsub("%[  " .. vpnIface .. "%]","%-", "%%-")) then
+          return true
+        end
+      end
+    end
+  end
+  return false
+end
+
+function M.fastd_installed()
+  if io.open("/usr/bin/fastd", 'r') ~= nil then
+    return true
+  end
+  return false
+end
+
+function M.tunneldigger_installed()
+  if io.open("/usr/bin/tunneldigger", 'r') ~= nil then
+    return true
+  end
+  return false
+end
+
+-- Get Geoposition. Return nil for no position
+function M.getGeolocation()
+  return {["lat"] = tonumber(uci:get('gluon-node-info', uci:get_first('gluon-node-info', 'location'), 'latitude')),
+  ["lon"] =  tonumber(uci:get('gluon-node-info', uci:get_first('gluon-node-info', 'location'), 'longitude')) }
+end
+
+function M.get_domains()
+  local list = {}
+  for domain_path in fs.glob('/lib/gluon/domains/*.json') do
+    table.insert(list, {
+      domain_code = domain_path:match('([^/]+)%.json$'),
+      domain = assert(json.load(domain_path)),
+    })
+  end
+  return list
+end
+
+-- Source with pseudocode: https://de.wikipedia.org/wiki/Punkt-in-Polygon-Test_nach_Jordan
+-- see also https://en.wikipedia.org/wiki/Point_in_polygon
+-- parameters: points A = (x_A,y_A), B = (x_B,y_B), C = (x_C,y_C)
+-- return value: −1 if the ray from A to the right bisects the edge [BC] (the lower vortex of [BC]
+-- is not seen as part of [BC]);
+--                0 if A is on [BC];
+--               +1 else
+function M.crossProdTest(x_A,y_A,x_B,y_B,x_C,y_C)
+  if y_A == y_B and y_B == y_C then
+    if (x_B <= x_A and x_A <= x_C) or (x_C <= x_A and x_A <= x_B) then
+      return 0
+    end
+    return 1
+  end
+  if not ((y_A == y_B) and (x_A == x_B)) then
+    if y_B > y_C then
+      -- swap B and C
+      local h = x_B
+      x_B = x_C
+      x_C = h
+      h = y_B
+      y_B = y_C
+      y_C = h
+    end
+    if (y_A <= y_B) or (y_A > y_C) then
+      return 1
+    end
+    local Delta = (x_B-x_A) * (y_C-y_A) - (y_B-y_A) * (x_C-x_A)
+    if Delta > 0 then
+      return 1
+    elseif Delta < 0 then
+      return -1
+    end
+  end
+  return 0
+end
+
+-- Source with pseudocode: https://de.wikipedia.org/wiki/Punkt-in-Polygon-Test_nach_Jordan
+-- see also: https://en.wikipedia.org/wiki/Point_in_polygon
+-- let P be a 2D Polygon and Q a 2D Point
+-- return value:  +1 if Q within P;
+--               −1 if Q outside of P;
+--                0 if Q on an edge of P
+function M.pointInPolygon(poly, point)
+  local t = -1
+  for i=1,#poly-1 do
+    t = t * M.crossProdTest(point.lon,point.lat,poly[i][2],poly[i][1],poly[i+1][2],poly[i+1][1])
+    if t == 0 then break end
+  end
+  return t
+end
+
+-- Return hood from the hood file based on geo position or nil if no real hood could be determined
+-- First check if an area has > 2 points and is hence a polygon. Else assume it is a rectangular
+-- box defined by two points (south-west and north-east)
+function M.getHoodByGeo(jhood,geo)
+  for _, hood in pairs(jhood) do
+    if hood.domain_code ~= site.default_domain() then
+    for _, area in pairs(hood.domain.hoodselector.shapes) do
+      if #area > 2 then
+        if (M.pointInPolygon(area,geo) == 1) then
+          return hood
+        end
+      else
+        if ( geo.lat >= area[1][1] and geo.lat < area[2][1] and geo.lon >= area[1][2]
+          and geo.lon < area[2][2] ) then
+          return hood
+        end
+      end
+    end
+    end
+  end
+  return nil
+end
+
+function M.set_hoodconfig(geoHood)
+  if uci:get('gluon', 'core', 'domain') ~= geoHood.domain_code then
+    uci:set('gluon', 'core', 'domain', geoHood.domain_code)
+    uci:save('gluon')
+    uci:commit('gluon') -- necessary?
+    os.execute('gluon-reconfigure')
+    io.stdout:write("Set hood \""..geoHood.domain.domain_names[geoHood.domain_code].."\"\n")
+    return true
+  end
+  return false
+end
+
+-- Return the default hood in the hood list.
+-- This method can return the following data:
+-- * default hood
+-- * nil if no default hood has been defined
+function M.getDefaultHood(jhood)
+  for _, h in pairs(jhood) do
+    if h.domain_code == site.default_domain() then
+      return h
+    end
+  end
+  return nil
+end
+
+function M.restart_services()
+  local procTBL = {
+    "fastd",
+    "tunneldigger",
+    "network",
+  }
+
+  for proc in ipairs(procTBL) do
+    if io.open("/etc/init.d/"..proc, 'r') ~= nil then
+      print(proc.." restarting ...")
+      os.execute("/etc/init.d/"..proc.." restart")
+    end
+  end
+  if io.open("/etc/config/wireless", 'r') then
+    print("wifi restarting ...")
+    os.execute("wifi")
+  end
+end
+
+return M

--- a/package/gluon-hoodselector/luasrc/usr/lib/lua/hoodselector/util.lua
+++ b/package/gluon-hoodselector/luasrc/usr/lib/lua/hoodselector/util.lua
@@ -115,7 +115,7 @@ end
 function M.pointInPolygon(poly, point)
   local t = -1
   for i=1,#poly-1 do
-    t = t * M.crossProdTest(point.lon,point.lat,poly[i][2],poly[i][1],poly[i+1][2],poly[i+1][1])
+    t = t * M.crossProdTest(point.lon,point.lat,poly[i].lon,poly[i].lat,poly[i+1].lon,poly[i+1].lat)
     if t == 0 then break end
   end
   return t
@@ -133,8 +133,8 @@ function M.getHoodByGeo(jhood,geo)
           return hood
         end
       else
-        if ( geo.lat >= area[1][1] and geo.lat < area[2][1] and geo.lon >= area[1][2]
-          and geo.lon < area[2][2] ) then
+        if ( geo.lat >= area[1].lat and geo.lat < area[2].lat and geo.lon >= area[1].lon
+          and geo.lon < area[2].lon ) then
           return hood
         end
       end
@@ -185,6 +185,511 @@ function M.restart_services()
   if io.open("/etc/config/wireless", 'r') then
     print("wifi restarting ...")
     os.execute("wifi")
+  end
+end
+
+function M.trim(s)
+  -- from PiL2 19.4
+  return (s:gsub("^%s*(.-)%s*$", "%1"))
+end
+
+--[[function M.get_batman_GW_interface()
+  for gw in io.open("/sys/kernel/debug/batman_adv/bat0/gateways", 'r'):lines() do
+    if gw:match("=>") then
+      return M.trim(gw:match("%[.-%]"):gsub("%[", ""):gsub("%]", ""))
+    end
+  end
+  return nil
+end]]
+
+-- Get a list of wifi devices return an emty table for no divices
+function M.getWifiDevices()
+  local radios = {}
+  uci:foreach('wireless', 'wifi-device',
+  function(s)
+    table.insert(radios, s['.name'])
+  end
+  )
+  return radios
+end
+
+function M.matchID(tp, h, ID)
+  if h.domain.wifi24 ~= nil then
+    if tp == "ibss" then
+      if h.domain.wifi24.ibss ~= nil then
+        if h.domain.wifi24.ibss.bssid ~= nil then
+          if ID:lower() == h.domain.wifi24.ibss.bssid:lower() then
+            return true
+          end
+        end
+      end
+    end
+    if tp == "11s" then
+      if h.domain.wifi24.mesh ~= nil then
+        if h.domain.wifi24.mesh.id ~= nil then
+          if ID:lower() == h.domain.wifi24.mesh.id:lower() then
+            return true
+          end
+        end
+      end
+    end
+  elseif h.domain.wifi5 ~= nil then
+    if tp == "ibss" then
+      if h.domain.wifi5.ibss ~= nil then
+        if h.domain.wifi5.ibss.bssid ~= nil then
+          if ID:lower() == h.domain.wifi5.ibss.bssid:lower() then
+            return true
+          end
+        end
+      end
+    end
+    if tp == "11s" then
+      if h.domain.wifi5.mesh ~= nil then
+        if h.domain.wifi5.mesh.id ~= nil then
+          if ID:lower() == h.domain.wifi5.mesh.id:lower() then
+            return true
+          end
+        end
+      end
+    end
+  end
+  return false
+end
+
+-- Return hood from the hood file based on a given BSSID. nil if no matching hood could be found
+function M.gethoodByBssid(jhood, bssid)
+  for _, h in pairs(jhood) do
+    if M.matchID("ibss", h, bssid) then
+      return h
+    end
+  end
+  return nil
+end
+
+function M.gethoodByMeshID(jhood, meshid)
+  for _, h in pairs(jhood) do
+    if M.matchID("11s", h, meshid) then
+      return h
+    end
+  end
+  return nil
+end
+
+function M.getHoodByRadio(iface,jhood)
+  for _, radio in ipairs(M.getWifiDevices()) do
+    local ifname = uci:get('wireless', 'ibss_' .. radio, 'ifname')
+    if ifname == iface then
+      return M.gethoodByBssid(jhood, uci:get('wireless', 'ibss_' .. radio, 'bssid'))
+    end
+    ifname = uci:get('wireless', 'mesh_' .. radio, 'ifname')
+    if ifname == iface then
+      return M.gethoodByMeshID(jhood, uci:get('wireless', 'mesh_' .. radio, 'mesh_id'))
+    end
+  end
+  return nil
+end
+
+-- get signal strength
+function M.scan_filter_quality(scan_str, redirect)
+  local tmp_quality = redirect
+  if scan_str:match("signal:") then
+    tmp_quality = M.split(scan_str, " ")[2]
+    tmp_quality = M.split(tmp_quality, "%.")[1]
+    if tmp_quality:match("-") then
+      tmp_quality = M.split(tmp_quality, "-")[2]
+    end
+    tmp_quality = tonumber(tmp_quality:match("(%d%d)"))
+  end
+  return tmp_quality
+end
+
+function M.ibss_scan(radio,ifname,networks)
+  local wireless_scan = string.format("iw %s scan", ifname)
+  local row = {}
+  local isIBSS = ""
+  row["radio"] = radio
+  row["method"] = "ibss"
+  -- loop through each line in the output of iw
+  for wifiscan in io.popen(wireless_scan, 'r'):lines() do
+    wifiscan = M.trim(wifiscan)
+    -- get bssid
+    if wifiscan:match("BSS (%w+:%w+:%w+:%w+:%w+:%w+)") then
+      row["bssid"] = wifiscan:match("(%w+:%w+:%w+:%w+:%w+:%w+)")
+      row["frequency"] = nil
+      isIBSS = ""
+      row["quality"] = nil
+      row["ssid"] = nil
+    end
+
+    -- get frequency
+    if wifiscan:match("freq") then
+      row["frequency"] = M.split(wifiscan, ":")[2]
+      if row["frequency"] ~= nil then
+        row["frequency"] = M.trim(row["frequency"])
+        isIBSS = ""
+        row["quality"] = nil
+        row["ssid"] = nil
+      end
+    end
+
+    --get ibss capability
+    if wifiscan:match("capability:") then
+      isIBSS = M.split(wifiscan, ':')[2]
+      isIBSS = M.split(isIBSS, ' ')[2]
+      if(isIBSS ~= nil) then
+        isIBSS = M.trim(isIBSS)
+        row["quality"] = nil
+        row["ssid"] = nil
+      end
+    end
+
+    row["quality"] = M.scan_filter_quality(wifiscan, row["quality"])
+
+    -- get ssid
+    if wifiscan:match("SSID:") then
+      row["ssid"] = M.split(wifiscan, "SSID:")[2]
+      if(row["ssid"] ~= nil) then
+        row["ssid"] = M.trim(row["ssid"])
+      end
+    end
+
+    -- the following line matches a new network in the output of iw
+    if (row["bssid"] ~= nil and row["quality"] ~= nil and row["ssid"] ~= nil
+      and row["frequency"] ~= nil and isIBSS == "IBSS") then
+      table.insert(networks, row)
+      row = {}
+      row["radio"] = radio
+      row["method"] = "ibss"
+      isIBSS = ""
+    end
+  end
+  return networks
+end
+
+function M.mesh_scan(radio,ifname,networks)
+  local wireless_scan = string.format("iw %s scan", ifname)
+  local row = {}
+  row["radio"] = radio
+  row["method"] = "11s"
+  -- loop through each line in the output of iw
+  for wifiscan in io.popen(wireless_scan, 'r'):lines() do
+    wifiscan = M.trim(wifiscan)
+
+    -- get frequency
+    if wifiscan:match("freq") then
+      row["frequency"] = M.split(wifiscan, ":")[2]
+      if row["frequency"] ~= nil then
+        row["frequency"] = M.trim(row["frequency"])
+        row["quality"] = nil
+        row["meshid"] = nil
+      end
+    end
+
+    row["quality"] = M.scan_filter_quality(wifiscan, row["quality"])
+
+    -- get mesh-ID
+    if wifiscan:match("MESH ID:") then
+      row["meshid"] = M.split(wifiscan, "MESH ID:")[2]
+      if row["meshid"] ~= nil then
+        row["meshid"] = M.trim(row["meshid"])
+      end
+    end
+    -- the following line matches a new network in the output of iw
+    if(row["meshid"] ~= nil and row["quality"] ~= nil and row["frequency"] ~= nil) then
+      table.insert(networks, row)
+      row = {}
+      row["radio"] = radio
+      row["method"] = "11s"
+    end
+  end
+  return networks
+end
+
+-- Scans for wireless networks and returns a two dimensional array containing
+-- wireless mesh neighbour networks and their properties.
+-- The array is sorted descending by signal strength (strongest signal
+-- first, usually the local signal of the wireless chip of the router)
+function M.wlan_list_sorted()
+  local networks = {}
+  for _, radio in ipairs(M.getWifiDevices()) do
+    local ifname = uci:get('wireless', 'ibss_' .. radio, 'ifname')
+    if ifname ~= nil then
+      --do ibss scan
+      networks = M.ibss_scan(radio,ifname,networks)
+    end
+    ifname = uci:get('wireless', 'mesh_' .. radio, 'ifname')
+    if ifname ~= nil then
+      --do mesh scan
+      networks = M.mesh_scan(radio,ifname,networks)
+    end
+  end
+  if next(networks) then
+    table.sort(networks, function(a,b) return a["quality"] < b["quality"] end)
+  end
+  return networks
+end
+
+function M.filter_default_hood_wlan_networks(default_hood, wlan_list)
+  for i=#wlan_list,1,-1 do
+    if wlan_list[i].method == "ibss" then
+      if M.matchID("ibss", default_hood, wlan_list[i].bssid) then
+        table.remove(wlan_list, i)
+      end
+    elseif wlan_list[i].method == "11s" then
+      if M.matchID("11s", default_hood, wlan_list[i].meshid) then
+        table.remove(wlan_list, i)
+      end
+    end
+  end
+  return wlan_list
+end
+
+function M.filter_wlan_redundancy(list)
+  local flag = {}
+  local ret = {}
+  for _, element in ipairs(list) do
+    if element.method == "ibss" then
+      if not flag[element.bssid] then
+        ret[#ret+1] = element
+        flag[element.bssid] = true
+      end
+    end
+    if element.method == "11s" then
+      if not flag[element.meshid] then
+        ret[#ret+1] = element
+        flag[element.meshid] = true
+      end
+    end
+  end
+  return ret
+end
+
+-- this method removes the wireless network of the router itself
+-- from the wlan_list
+function M.filter_my_wlan_network(wlan_list)
+  for i=#wlan_list,1,-1 do
+    local bssid = uci:get('wireless', 'ibss_' .. wlan_list[i].radio, 'bssid')
+    if bssid ~= nil and wlan_list[i].method == "ibss" then
+      if string.lower(wlan_list[i].bssid) == string.lower(bssid) then
+        table.remove(wlan_list, i)
+      end
+    else
+      local mesh = uci:get('wireless', 'mesh_' .. wlan_list[i].radio, 'mesh_id')
+      if mesh ~= nil and wlan_list[i].method == "11s" then
+        if string.lower(wlan_list[i].meshid) == string.lower(mesh) then
+          table.remove(wlan_list, i)
+        end
+      end
+    end
+  end
+  return wlan_list
+end
+
+function M.fastd_installed()
+  if io.open("/usr/bin/fastd", 'r') ~= nil then
+    return true
+  end
+  return false
+end
+
+function M.tunneldigger_installed()
+  if io.open("/usr/bin/tunneldigger", 'r') ~= nil then
+    return true
+  end
+  return false
+end
+
+function M.vpn_stop()
+  -- check if fastd installed
+  if M.fastd_installed() then
+    if uci:get_bool('fastd','mesh_vpn','enabled') then
+      os.execute('/etc/init.d/fastd stop')
+      io.stdout:write('Fastd stoped.\n')
+    end
+  end
+  -- check if tunneldigger installed
+  if M.tunneldigger_installed() then
+    if uci:get_bool('tunneldigger','mesh_vpn','enabled') then
+      os.execute('/etc/init.d/tunneldigger stop')
+      io.stdout:write('Tunneldigger stoped.\n')
+    end
+  end
+end
+
+-- boolean check if batman-adv has gateways
+function M.batmanHasGateway()
+  local file = io.open("/sys/kernel/debug/batman_adv/bat0/gateways", 'r')
+  if file ~= nil then
+    for gw in file:lines() do
+      if gw:match("Bit") then
+        return true
+      end
+    end
+  end
+  return false
+end
+
+function M.sleep(n)
+  os.execute("sleep " .. tonumber(n))
+end
+
+function M.test_batman_mesh_networks(sorted_wlan_list)
+  -- remove the ap network(s) because we cannot change
+  -- the settings of the adhoc network if a ap network is still operating
+  for iface in io.popen(string.format("iw dev"),'r'):lines() do
+    if iface:match("Interface") then
+      iface = M.trim(M.split(iface, "Interface")[2])
+      if not ( iface:match("ibss") or iface:match("mesh")) then
+        os.execute("iw dev "..iface.." del")
+      end
+    end
+  end
+  for _, wireless in pairs(sorted_wlan_list) do
+    local ibss = uci:get('wireless', 'ibss_' .. wireless["radio"], 'ifname')
+    local mesh = uci:get('wireless', 'mesh_' .. wireless["radio"], 'ifname')
+    if wireless.method == "ibss" then
+      io.stdout:write("Testing IBSS "..wireless["bssid"].."...\n")
+      -- leave the current adhoc network
+      os.execute("iw dev "..ibss.." ibss leave 2> /dev/null")
+      -- leave mesh as well to avoid hood shortcuts while testing
+      if mesh ~= nil then
+        os.execute("iw dev "..mesh.." mesh leave 2> /dev/null")
+      end
+      -- setup the adhoc network we want to test
+      os.execute("iw dev "..ibss.." ibss join "..uci:get('wireless', 'ibss_'..
+      wireless["radio"], 'ssid').." "..wireless["frequency"].." "..wireless["bssid"])
+    end
+    if wireless.method == "11s" then
+      io.stdout:write("Testing MESH "..wireless["meshid"].."...\n")
+      -- leave the current mesh network
+      os.execute("iw dev "..mesh.." mesh leave 2> /dev/null")
+      if ibss ~= nil then
+        os.execute("iw dev "..ibss.." ibss leave 2> /dev/null")
+      end
+      -- setup the mesh network we want to test
+      os.execute("iw dev "..mesh.." mesh join "..wireless["meshid"].." freq "..wireless["frequency"])
+    end
+    -- sleep 30 seconds till the connection is fully setup
+    local c = 0;
+    while(not M.batmanHasGateway()) do
+      if(c >= 30) then break end
+      M.sleep(1)
+      c = c +1;
+    end
+    if c < 30 then
+      local msg = "found gateways on: "
+      local ret = {}
+      if wireless.method == "ibss" then
+        ret["method"] = "ibss"
+        ret["bssid"] = wireless["bssid"]
+        print(msg..ret["bssid"])
+        return ret
+      end
+      if wireless.method == "11s" then
+        ret["method"] = "11s"
+        ret["meshid"] = wireless["meshid"]
+        print(msg..ret["meshid"])
+        return ret
+      end
+    end
+  end
+  return nil
+end
+
+function M.brclient_restart()
+  os.execute('ifconfig br-client down')
+  os.execute('ifconfig br-client up')
+  io.stdout:write('Interface br-client restarted.\n')
+end
+
+function M.vpn_start()
+  if M.fastd_installed() then
+    if uci:get_bool('fastd','mesh_vpn','enabled') then
+      os.execute('/etc/init.d/fastd start')
+      io.stdout:write('Fastd started.\n')
+    end
+  end
+  if M.tunneldigger_installed() then
+    if uci:get_bool('tunneldigger','mesh_vpn','enabled') then
+      os.execute('/etc/init.d/tunneldigger start')
+      io.stdout:write('Tunneldigger started.\n')
+    end
+  end
+  M.brclient_restart()
+end
+
+function M.wireless_restart()
+  os.execute('wifi')
+  io.stdout:write('Wireless restarted.\n')
+end
+
+function M.get_batman_mesh_network(sorted_wlan_list, defaultHood)
+  io.stdout:write('Testing neighbouring adhoc networks for batman advanced gw connection.\n')
+  io.stdout:write('The following wireless networks have been found:\n')
+  for _, network in pairs(sorted_wlan_list) do
+    if network["method"] == "ibss" then
+      print(network["quality"].."\t"..network["method"].."\t"..network["radio"]..
+      "\t"..network["ssid"].."\t"..network["bssid"].."\t"..network["frequency"])
+    end
+    if network["method"] == "11s" then
+      print(network["quality"].."\t"..network["method"].."\t"..network["radio"]..
+      "\t"..network["meshid"].."\t"..network["frequency"])
+    end
+  end
+
+  -- we dont want to test the default hood because if there is no other
+  -- hood present we will connect to the default hood anyway
+  sorted_wlan_list = M.filter_default_hood_wlan_networks(defaultHood, sorted_wlan_list)
+  -- we dont want to test duplicated networks
+  sorted_wlan_list = M.filter_wlan_redundancy(sorted_wlan_list)
+  -- we dont want to get tricked by our signal
+  sorted_wlan_list = M.filter_my_wlan_network(sorted_wlan_list)
+
+  io.stdout:write('After filtering we will test the following wireless networks:\n')
+  for _, network in pairs(sorted_wlan_list) do
+    if network["method"] == "ibss" then
+      print(network["quality"].."\t"..network["method"].."\t"..network["radio"].."\t"..
+      network["ssid"].."\t    "..network["bssid"].."\t"..network["frequency"])
+    end
+    if network["method"] == "11s" then
+      print(network["quality"].."\t"..network["method"].."\t"..network["radio"].."\t"..
+      network["meshid"].."    \t"..network["frequency"])
+    end
+  end
+
+  local ID = nil
+  if(next(sorted_wlan_list)) then
+    io.stdout:write("Prepare configuration for testing wireless networks...\n")
+    -- Notice:
+    -- we will use iw for testing the wireless networks because using iw does
+    -- not need any changes inside the uci config. This approach allows the
+    -- router to automatically reset to previous configuration in case
+    -- someone disconnects the router from power during test.
+
+    -- stop vpn to prevent two hoods from beeing connected in case
+    -- the router gets internet unexpectedly during test.
+    M.vpn_stop()
+    ID = M.test_batman_mesh_networks(sorted_wlan_list)
+    M.vpn_start()
+    M.wireless_restart()
+    io.stdout:write("Finished testing wireless networks, restored previous configuration\n")
+  end
+
+  return ID
+end
+
+function M.vpn_disable()
+  if M.fastd_installed() then
+    if uci:get_bool('fastd','mesh_vpn','enabled') then
+      os.execute('/etc/init.d/fastd disable')
+      io.stdout:write('Fastd disabled.\n')
+    end
+  end
+  if M.tunneldigger_installed() then
+    if uci:get_bool('tunneldigger','mesh_vpn','enabled') then
+      os.execute('/etc/init.d/tunneldigger disable')
+      io.stdout:write('Tunneldigger disabled.\n')
+    end
   end
 end
 

--- a/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
+++ b/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
@@ -1,0 +1,182 @@
+#!/usr/bin/lua
+
+-- PID file to ensure the hoodselector isn't running parallel
+local pidPath="/var/run/hoodselector.pid"
+
+local uci = require('simple-uci').cursor()
+local hoodutil = require("hoodselector.util")
+
+if io.open(pidPath, "r") ~=nil then
+  hoodutil.log("The hoodselector is still running.")
+  os.exit(1)
+else
+  if io.open(pidPath, "w") ==nil then
+    hoodutil.log("Can`t create pid file on "..pidPath)
+    os.exit(1)
+  end
+end
+
+-- Program terminating function including removing of PID file
+local function exit(exc)
+  if io.open(pidPath, "r") ~=nil then
+    os.remove(pidPath)
+  end
+  os.exit(tonumber(exc))
+end
+
+-- initialization done
+
+local function get_mesh_vpn_interface()
+  local ret = {}
+  if hoodutil.fastd_installed() then
+    local vpnifac = uci:get('fastd', 'mesh_vpn_backbone', 'net')
+    if vpnifac  ~= nil then
+      vpnifac = vpnifac:gsub("%_",'-')
+      table.insert(ret,vpnifac)
+    else
+      hoodutil.log("fastd uci config broken! abort...")
+      exit(1)
+    end
+  end
+  if hoodutil.tunneldigger_installed() then
+    local vpnifac = uci:get('tunneldigger', 'mesh_vpn', 'interface')
+    if vpnifac  ~= nil then
+      table.insert(ret,vpnifac)
+    else
+      hoodutil.log("tunneldigger uci config broken! abort...")
+      exit(1)
+    end
+  end
+  return ret
+end
+
+-- INITIALIZE AND PREPARE DATA --
+-- read hoodfile...
+local jhood = hoodutil.get_domains()
+
+-- get defaul hood
+local defaultHood = hoodutil.getDefaultHood(jhood)
+
+
+-- VPN MODE
+-- If we have a VPN connection then we will try to get the routers location and
+-- select the hood coresponding to our location.
+-- If no hood for the location has been defined, we will select
+-- the default hood.
+-- If we can not get our routers location, we will fallback to scan mode.
+if hoodutil.directVPN(get_mesh_vpn_interface()) then
+  io.stdout:write('VPN connection found.\n')
+  local geo = hoodutil.getGeolocation()
+  if geo.lat ~= nil and geo.lon ~= nil then
+    io.stdout:write('Position found.\n')
+    local geoHood = hoodutil.getHoodByGeo(jhood, geo)
+    if geoHood ~= nil then
+      if hoodutil.set_hoodconfig(geoHood) then
+        hoodutil.restart_services() -- TMP solution
+        io.stdout:write('Hood set by VPN mode.\n')
+      end
+      exit(0)
+    end
+    io.stdout:write('No hood has been defined for current position.\n')
+    if hoodutil.set_hoodconfig(defaultHood) then
+      hoodutil.restart_services() -- TMP solution
+      io.stdout:write('Hood set by VPN mode.\n')
+    end
+    exit(0)
+  else
+    io.stdout:write('No position found\n')
+  end
+else
+  io.stdout:write('No VPN connection found\n')
+end
+
+--[[
+
+if hoodutil.batmanHasGateway() then
+441   io.stdout:write('Batman gateways found\n')
+442   local gw_intf = {}
+443   table.insert(gw_intf,hoodutil.get_batman_GW_interface())
+444
+445   if next(gw_intf) then
+446     -- wifi interface
+447     local bssidHood = hoodutil.get_radio_to_bssid(radios,gw_intf[1], jhood)
+448     if bssidHood ~= nil then
+449       --check if hood inside geo pos
+450       local geo = hoodutil.getGeolocation()
+451       if geo.lat ~= nil and geo.lon ~= nil then
+452        io.stdout:write('Position found.\n')
+453        local geoHood = hoodutil.getHoodByGeo(jhood, geo)
+454        if geoHood ~= nil then
+455          if string.format(hash.md5(table.tostring(bssidHood))) ~=
+               string.format(hash.md5(table.tostring(geoHood))) then
+456            io.stdout:write('Geo hood and bssid hood are not equal, do wifi scan...\n')
+457            local sortedWlanList = hoodutil.wlan_list_sorted(radios, mesh_prefix)
+458            for i=#sortedWlanList,1,-1 do
+459              if(string.lower(geoHood.bssid) ~= string.lower(sortedWlanList[i].bssid)) then
+460               table.remove(sortedWlanList, i)
+461              end
+462            end
+463            if next(sortedWlanList) then
+464              io.stdout:write('Try to switch back in our real hood!\n')
+465              io.stdout:write('After filtering we will test the following wireless networks:\n')
+466              for _, network in pairs(sortedWlanList) do
+467               print(network["quality"].."\t"..network["frequency"].."\t"..network["bssid"].."\t"..network["ssid"])
+468              end
+469              io.stdout:write("Prepare configuration for testing wireless networks...\n")
+470              local bssid = hoodutil.test_batman_mesh_networks(sortedWlanList, mesh_prefix)
+471              hoodutil.wireless_restart()
+472              io.stdout:write("Finished testing wireless networks, restored previous configuration\n")
+473              if bssid ~= nil then
+474               set_hoodconfig(geoHood, mesh_prefix, radios)
+475               hoodutil.vpn_enable()
+476               hoodutil.vpn_start()
+477               io.stdout:write('Set Geo Hood by Gateway mode\n')
+478               write_molwm(geoHood, radios)
+479               exit(0)
+480              else
+481               io.stdout:write('No neighboring freifunk batman advanced mesh found.\n')
+482              end
+483            else
+484              io.stdout:write('No networks left after filtering!\n')
+485            end --end next(sortedWlanList)
+486          else
+487            io.stdout:write('Geo hood are equal to bssid hood no wifi scan necessary.\n')
+488          end --end bssidHood ~= geoHood
+489        else
+490          io.stdout:write('No hood has been defined for current position.\n')
+491        end --end geoHood ~= nil
+492       else
+493        io.stdout:write('No position found.\n')
+494       end --end geo.lat ~= nil and geo.lon ~= nil
+495       set_hoodconfig(bssidHood, mesh_prefix, radios)
+496       io.stdout:write('Hood set by batmanHasGateway mode, GW source is wifi\n')
+497       write_molwm(bssidHood,radios)
+498       exit(0)
+499     end --end bssidHood ~= nil
+500
+501     -- mesh lan or wan interface
+502     if hoodutil.mesh_lan_wan(gw_intf[1]) then
+503       -- if mesh_lan/wan try to get hood by selected bssid of neightbour vpnRouters
+504       local neighbourBssid = hoodutil.molw_get_bssid(gw_intf)
+505       if neighbourBssid ~= nil then
+506         bssidHood = hoodutil.gethoodByBssid(jhood, neighbourBssid)
+507         if bssidHood ~= nil then
+508           set_hoodconfig(bssidHood, mesh_prefix, radios)
+509           io.stdout:write('Hood set by batmanHasGateway mode, GW source is mesh on lan/wan\n')
+510           molwmtable["md5hash"] = "\"" .. string.format(hash.md5(table.tostring(bssidHood))) .. "\""
+511           molwmtable["hoodname"] = "\"" .. bssidHood["name"] .. "\""
+512           molwmtable["bssid"] = "\"" .. bssidHood["bssid"] .. "\""
+513           molwm_to_file()
+514           exit(0)
+515         end
+516       end
+517     end
+518   end --end next(gw_intf)
+519   local currendHood = hoodutil.getCurrentHood(jhood)
+520   if currendHood ~= nil then
+521     write_molwm(currendHood,radios)
+522   end
+523 end
+--]]
+
+exit(0) -- Debug

--- a/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
+++ b/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
@@ -179,4 +179,12 @@ if hoodutil.batmanHasGateway() then
 523 end
 --]]
 
-exit(0) -- Debug
+-- DEFAULT-HOOD MODE
+-- If we do NOT have a VPN connection and no other freifunk mesh nodes found in our network ENV
+-- then we set the default hood.
+io.stdout:write("ENV does not give enough information\n")
+if hoodutil.set_hoodconfig(defaultHood) then
+  hoodutil.restart_services() -- TMP solution
+  io.stdout:write('Hood set by default-hood mode.\n')
+end
+exit(0)

--- a/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
+++ b/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
@@ -5,6 +5,7 @@ local pidPath="/var/run/hoodselector.pid"
 
 local uci = require('simple-uci').cursor()
 local hoodutil = require("hoodselector.util")
+local hash = require("hash")
 
 if io.open(pidPath, "r") ~=nil then
   hoodutil.log("The hoodselector is still running.")
@@ -50,6 +51,41 @@ local function get_mesh_vpn_interface()
   return ret
 end
 
+function table.val_to_str ( v )
+  if "string" == type( v ) then
+    v = string.gsub( v, "\n", "\\n" )
+    if string.match( string.gsub(v,"[^'\"]",""), '^"+$' ) then
+      return "'" .. v .. "'"
+    end
+    return '"' .. string.gsub(v,'"', '\\"' ) .. '"'
+  else
+    return "table" == type( v ) and table.tostring( v ) or tostring( v )
+  end
+end
+
+function table.key_to_str ( k )
+  if "string" == type( k ) and string.match( k, "^[_%a][_%a%d]*$" ) then
+    return k
+  else
+    return "[" .. table.val_to_str( k ) .. "]"
+  end
+end
+
+function table.tostring( tbl )
+  local result, done = {}, {}
+  for k, v in ipairs( tbl ) do
+    table.insert( result, table.val_to_str( v ) )
+    done[ k ] = true
+  end
+  for k, v in pairs( tbl ) do
+    if not done[ k ] then
+      table.insert( result, table.key_to_str( k ) .. "=" .. table.val_to_str( v ) )
+    end
+  end
+  return "{" .. table.concat( result, "," ) .. "}"
+end
+
+
 -- INITIALIZE AND PREPARE DATA --
 -- read hoodfile...
 local jhood = hoodutil.get_domains()
@@ -57,13 +93,12 @@ local jhood = hoodutil.get_domains()
 -- get defaul hood
 local defaultHood = hoodutil.getDefaultHood(jhood)
 
-
 -- VPN MODE
 -- If we have a VPN connection then we will try to get the routers location and
 -- select the hood coresponding to our location.
 -- If no hood for the location has been defined, we will select
 -- the default hood.
--- If we can not get our routers location, we will fallback to scan mode.
+-- If we can not get our routers location, we will continure to next mode.
 if hoodutil.directVPN(get_mesh_vpn_interface()) then
   io.stdout:write('VPN connection found.\n')
   local geo = hoodutil.getGeolocation()
@@ -84,6 +119,9 @@ if hoodutil.directVPN(get_mesh_vpn_interface()) then
     end
     exit(0)
   else
+    -- The hoodselector should continure with next states because thier can be other
+    -- VPN routers in the local mesh network which provides a possition and therfore
+    -- have set a geo base hood.
     io.stdout:write('No position found\n')
   end
 else
@@ -91,21 +129,47 @@ else
 end
 
 --[[
+-- GATEWAY MODE
+-- If a node have batman-adv GWs ensure config is validate to current hood.
+-- Furthermore is a node is connected to a neigbour hood check if its geo base hood avalable.
+local gw_intf = hoodutil.get_batman_GW_interface()
+if gw_intf ~= nil then
+  io.stdout:write('Batman gateways found\n')
+  -- We have to verify if the currend applyed setting
+  -- return currend applyed hood if source gw_intf a wifi interface
+  -- we have to check the hood explecit bw wifi source besause the
+  -- scan mode can apply an unknown hood by adapting the mesh id or
+  -- bssid with deaktivated VPNs(in case if a router will get a VPN
+  -- connection afterwards).
+  local currentHood = hoodutil.getHoodByRadio(gw_intf, jhood)
+  if currentHood ~= nil then
+    print("DEBUG: currentHood ~= nil")
+    -- Now we need check if the current seclected hood our geo base hood, otherwise search for
+    -- our geo base hood in the local network ENV
+    --check if hood inside geo pos
+    local geo = hoodutil.getGeolocation()
+    if geo.lat ~= nil and geo.lon ~= nil then
+      io.stdout:write('Position found.\n')
+      local geoHood = hoodutil.getHoodByGeo(jhood, geo)
+      if geoHood ~= nil then
+        print("DEBUG: geoHood ~= nil")
+        if string.format(hash.md5(table.tostring(currentHood))) ~=
+        string.format(hash.md5(table.tostring(geoHood))) then
+          io.stdout:write('Geo hood and current applyed hood are not equal, do wifi scan...\n')
+          local sortedWlanList = hoodutil.wlan_list_sorted()
+          for i=#sortedWlanList,1,-1 do
+            -- Filter all wifis whicht does not match the geo base hood
+--            if h.domain.wifi24 ~= nil then
+--              if h.domain.wifi24.ibss ~= nil then
+               print("foo")
+--             end
+--           end
+         end
+        end
+      end
+    end
+  end
 
-if hoodutil.batmanHasGateway() then
-441   io.stdout:write('Batman gateways found\n')
-442   local gw_intf = {}
-443   table.insert(gw_intf,hoodutil.get_batman_GW_interface())
-444
-445   if next(gw_intf) then
-446     -- wifi interface
-447     local bssidHood = hoodutil.get_radio_to_bssid(radios,gw_intf[1], jhood)
-448     if bssidHood ~= nil then
-449       --check if hood inside geo pos
-450       local geo = hoodutil.getGeolocation()
-451       if geo.lat ~= nil and geo.lon ~= nil then
-452        io.stdout:write('Position found.\n')
-453        local geoHood = hoodutil.getHoodByGeo(jhood, geo)
 454        if geoHood ~= nil then
 455          if string.format(hash.md5(table.tostring(bssidHood))) ~=
                string.format(hash.md5(table.tostring(geoHood))) then
@@ -170,14 +234,50 @@ if hoodutil.batmanHasGateway() then
 514           exit(0)
 515         end
 516       end
-517     end
-518   end --end next(gw_intf)
-519   local currendHood = hoodutil.getCurrentHood(jhood)
-520   if currendHood ~= nil then
-521     write_molwm(currendHood,radios)
-522   end
-523 end
---]]
+517     end]]
+--end -- end gw_intf
+
+-- SCAN MODE
+if next(hoodutil.getWifiDevices()) then
+  print("Entering SCAN MODE ...")
+  -- check if there exist a neighbouring freifunk batman advanced mesh
+  -- network with an active connection to a batman advanced gateway
+  local sortedWlanList = hoodutil.wlan_list_sorted()
+  if next(sortedWlanList) then
+    local ID = hoodutil.get_batman_mesh_network(sortedWlanList, defaultHood)
+    if ID ~= nil then
+      local scanHood = nil
+      if ID.method == "ibss" then
+        io.stdout:write("Neighoring freifunk batman advanced mesh with Bssid: "..ID.bssid.." found\n")
+        scanHood = hoodutil.gethoodByBssid(jhood, ID.bssid)
+      end
+      if ID.method == "11s" then
+        io.stdout:write("Neighoring freifunk batman advanced mesh with meshid: "..ID.meshid.." found\n")
+        scanHood = hoodutil.gethoodByMeshID(jhood, ID.meshid)
+      end
+      if scanHood ~= nil then
+        if hoodutil.set_hoodconfig(scanHood) then
+          hoodutil.restart_services() -- TMP solution
+          io.stdout:write('Hood set by scan mode\n')
+        end
+        exit(0)
+      end
+
+    -- if the wifi ID does not corespond to any hood, we disable all VPN and
+    -- just establish a wireless connection to the coresponding mesh. Furthermore
+    -- we set a unknown VXLAN ID to signalisize neibouring mesh on LAN/WAN nodes
+    -- that we have a gateway conection but does not know to which hood it is coresponding.
+    io.stdout:write("No hood has been found for this mesh ID\n")
+    --hoodutil.vpn_stop()
+    --hoodutil.vpn_disable()
+    --TBD
+    -- some idea was to collect neigbouhood informations like VXLAN ID over respondd
+    end
+  end
+end
+
+--Radio less mode
+-- TBD
 
 -- DEFAULT-HOOD MODE
 -- If we do NOT have a VPN connection and no other freifunk mesh nodes found in our network ENV


### PR DESCRIPTION
**This MR is now just for tracking!**

This patch contains the hoodselector and a domain.conf as an example.

The hoodselector is a software that creates decentralized, semi automated ISO OSI layer 2 network segmentation for batman-adv layer 2 routing networks. This program reads the geobased sub-networks called hoods(gluon domains) from the above mentioned domain configurations. The decision of choosing the right hood is made on following points: first, the hoodselector checks, if the router has a VPN connection. If it has, then its checks, if a geoposition was set on the router. Knowing the position of the router the hoodselector can find the right hood, because each hood is defined with geocoordinates. If the Router doesn't have a VPN connection e.g. as a mesh only router, the hoodselector triggers a WIFI scan and searches for neighboured mesh routers in other hoods. If there is an other router with a different BSSID/mesh ID but with the same mesh SSID, the router chooses it’s hood based on the neighboured BSSID. Ah deeper explanaton can be found here:
[Monitoring and quality assurance of open wifi networks out of client view](https://blog.freifunk.net/2016/05/23/monitoring-and-quality-assurance-open-wifi-networks-out-client-view/)

[Monitoring and quality assurance of open wifi networks out of client view (midterm evaluation)](https://blog.freifunk.net/2016/06/19/monitoring-and-quality-assurance-open-wifi-networks-out-client-view-midterm-evaluation/)

[Monitoring and quality assurance of open wifi networks out of client view (final evaluation)](https://blog.freifunk.net/2016/08/22/monitoring-and-quality-assurance-open-wifi-networks-out-client-view-final-evaluation/)

In the Nordwest Freifunk Community we already had deployed the hood networks since august 2016
Our current active hoods can be seen on the [Lutscher Lupe](https://srv11.ffnw.de/#/%7B%22overlays%22:%5B%22Nodes%22,%22Links%22,%22Clients%22,%22Hoods%22%5D,%22pos_lat%22:52.94201777829491,%22pos_lng%22:8.827514648437502,%22zoom%22:8%7D)

**This MR reference to #789 and replace #997** 

desired state diagram:
![hoodselector](https://user-images.githubusercontent.com/3101274/31919900-e8e8755c-b865-11e7-9c63-f9ebe0114122.jpeg)

established state diagram:
![gluon-hoodselector](https://user-images.githubusercontent.com/3101274/39938877-af47dfc2-5554-11e8-84e4-ed5ba9c1da1f.jpeg)

- [x] '''check_site.lua''' validate default domain to do not have shapes.

- [x] '''check_site.lua''' validate non default domain to have rectangular shapes.

- [x] '''check_site.lua''' validate non default domain to have polygon shapes.

- [x] migrate VPN MODE to use site/domain configurations.

- [ ] migrate GATEWAY MODE to use site/domain configurations.

- [x] migrate SCAN MODE for known hoods to use site/domain configurations.

- [ ] SCAN MODE: discuss how to handle unknown hoods?
      - try getting hood informations via respondd over unknown mehs ID?

- [ ] migrate RADIO LESS MODE  to use site/domain configurations.

- [ ] migrate DEFAULT HOOD MODE to use site/domain configurations.

X  Use iwinfo lua lib instead of external call [ISSUE](https://git.ffnw.de/ffnw-firmware/packages/issues/114) and [MR](https://git.ffnw.de/ffnw-firmware/packages/merge_requests/63)
