### PR TITLE
libgluonutil: add function that returns the mesh-prefix from site.conf

### DIFF
--- a/package/libgluonutil/src/libgluonutil.c
+++ b/package/libgluonutil/src/libgluonutil.c
@@ -27,7 +27,7 @@
 #include "libgluonutil.h"
 
 #include <json-c/json.h>
-
+#include <arpa/inet.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -108,6 +108,38 @@ struct json_object * gluonutil_wrap_and_free_string(char *str) {
 	free(str);
 	return ret;
 }
+
+
+bool gluonutil_get_mesh_prefix(struct in6_addr *result) {
+	struct json_object *site = gluonutil_load_site_config();
+	if (!site)
+		return false;
+
+	struct json_object *node_prefix = NULL;
+	if (!json_object_object_get_ex(site, "node_prefix6", &node_prefix)) {
+		json_object_put(site);
+		return false;
+	}
+
+	const char *str_prefix = json_object_get_string(node_prefix);
+	if (!str_prefix) {
+		json_object_put(site);
+		return false;
+	}
+
+	char *prefix_addr = strndup(str_prefix, strchrnul(str_prefix, '/')-str_prefix);
+
+	int rc = inet_pton(AF_INET6, prefix_addr, result);
+
+	free(prefix_addr);
+	json_object_put(site);
+
+	if (rc != 1 )
+		return false;
+
+	return true;
+}
+
 
 struct json_object * gluonutil_load_site_config(void) {
 	return json_object_from_file("/lib/gluon/site.json");

--- a/package/libgluonutil/src/libgluonutil.h
+++ b/package/libgluonutil/src/libgluonutil.h
@@ -27,10 +27,15 @@
 #ifndef _LIBGLUON_LIBGLUON_H_
 #define _LIBGLUON_LIBGLUON_H_
 
+#include <netinet/in.h>
+#include <stdbool.h>
+
+
 char * gluonutil_read_line(const char *filename);
 char * gluonutil_get_sysconfig(const char *key);
 char * gluonutil_get_node_id(void);
 char * gluonutil_get_interface_address(const char *ifname);
+bool gluonutil_get_mesh_prefix(struct in6_addr *retval);
 
 struct json_object * gluonutil_wrap_string(const char *str);
 struct json_object * gluonutil_wrap_and_free_string(char *str);


### PR DESCRIPTION
This function will allow to calculate the node-IP. currently it is only used in the babel PR but it migh be interesting for wider use as well.

