### PR TITLE
config allow more width in style for input fields and selectboxes

### DIFF
--- a/package/gluon-web-theme/sass/cascade.scss
+++ b/package/gluon-web-theme/sass/cascade.scss
@@ -351,7 +351,7 @@ input[type=image] {
 select,
 input[type=text],
 input[type=password] {
-  width: 20em;
+  min-width: 20em;
 }
 
 input.gluon-button {


### PR DESCRIPTION
With the limited `width` selectboxes did not resize to the maximum width if there were options that are longer than 20em