### PR TITLE
ar71xx: add TP-Link Archer C25

### DIFF
--- a/patches/lede/0038-ar71xx-add-uImageArcher-to-tp-link.mk.patch
+++ b/patches/lede/0038-ar71xx-add-uImageArcher-to-tp-link.mk.patch
@@ -1,0 +1,29 @@
+From: Andreas Ziegler <github@andreas-ziegler.de>
+Date: Sun, 6 Aug 2017 16:27:53 +0200
+Subject: ar71xx: add uImageArcher to tp-link.mk
+
+backport from e39dc8d823c86559eedbbdcee5f5c14b827fed0f
+ar71xx: add support to TP-Link Archer C59v1 and C60v1
+
+Based-on-patch-by: Henryk Heisig <hyniu@o2.pl>
+Signed-off-by: Andreas Ziegler <github@andreas-ziegler.de>
+
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index 312152f33a3c3b996a1530f0f9365b3d78966314..b62ef3f20859e56423ee9d2a54d90b67642010c8 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -45,6 +45,14 @@ define Build/mktplinkfw-kernel
+ 	@mv $@.new $@
+ endef
+ 
++define Build/uImageArcher
++	mkimage -A $(LINUX_KARCH) \
++		-O linux -T kernel \
++		-C $(1) -a $(KERNEL_LOADADDR) -e $(if $(KERNEL_ENTRY),$(KERNEL_ENTRY),$(KERNEL_LOADADDR)) \
++		-n '$(call toupper,$(LINUX_KARCH)) LEDE Linux-$(LINUX_VERSION)' -d $@ $@.new
++	@mv $@.new $@
++endef
++
+ define Device/tplink
+   TPLINK_HWREV := 0x1
+   TPLINK_HEADER_VERSION := 1

--- a/patches/lede/0039-ar71xx-add-support-for-TP-Link-Archer-C25-v1.patch
+++ b/patches/lede/0039-ar71xx-add-support-for-TP-Link-Archer-C25-v1.patch
@@ -1,0 +1,444 @@
+From: Ludwig Thomeczek <ledesrc@wxorx.net>
+Date: Sat, 22 Apr 2017 18:21:47 +0200
+Subject: ar71xx: add support for TP-Link Archer C25 v1
+
+The TP-Link Archer C25 is a low-cost dual-band router.
+
+Specification:
+
+- CPU: Atheros QCA9561 775 MHz
+- RAM: 64 MB
+- Flash: 8 MB
+- Wifi: 3x3 2.4 GHz (integrated), 1x1 5 GHz QCA9887
+- NET: 5x 10/100 Mbps Ethernet
+
+Some LEDs are controlled by an additional 74HC595 chip.
+
+Signed-off-by: Ludwig Thomeczek <ledesrc@wxorx.net>
+[minor code style fixes, boards alphabetical order fixes,
+reworked commit message]
+Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 833522f27b61ac2208c2862bc0f29f34dea5e701..e1efb561b33da4dcfcb82ee953cd888170476dfb 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -53,6 +53,15 @@ ap121f)
+ 	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth0"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
+ 	;;
++archer-c25-v1)
++	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
++	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
++	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
++	ucidef_set_led_switch "lan1" "LAN1" "$board:green:lan1" "switch0" "0x10"
++	ucidef_set_led_switch "lan2" "LAN2" "$board:green:lan2" "switch0" "0x08"
++	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "0x04"
++	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x02"
++	;;
+ arduino-yun)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "arduino:blue:wlan" "phy0tpt"
+ 	ucidef_set_led_usbdev "usb" "USB" "arduino:white:usb" "1-1.1"
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index cb707f6169f48a9390b622cb26e8fab8de94e4bb..24ead87850f13346ea4be4f9bfb5582e64a2c4ad 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -122,6 +122,7 @@ ar71xx_setup_interfaces()
+ 	a60|\
+ 	alfa-ap96|\
+ 	alfa-nx|\
++	archer-c25-v1|\
+ 	dr344|\
+ 	gl-ar150|\
+ 	gl-ar300m|\
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index bc2fc2f774c4f2f0bbfa6e43d9b9a55e9b63153d..38cc5d7853c79f2a7800a387310a95abb3b4de1b 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -50,6 +50,7 @@ get_status_led() {
+ 	ap135-020)
+ 		status_led="ap135:green:status"
+ 		;;
++	archer-c25-v1|\
+ 	mr12|\
+ 	mr16|\
+ 	nbg6616|\
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index b3e23c9a8f8c56870ef36fb55ae52e6b5ea61134..68f90de802ddd18e09a1da39c0d56292eea9489c 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -92,6 +92,7 @@ case "$FIRMWARE" in
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
+ 		;;
++	archer-c25-v1|\
+ 	tl-wdr6500-v2)
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index bf365988acbd332d5eb4b2f6fb9e7744f8c1b817..46711af2b26159ebb105fa97cd8a85bb9c00911a 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -460,6 +460,9 @@ ar71xx_board_detect() {
+ 	*AP90Q)
+ 		name="ap90q"
+ 		;;
++	*"Archer C25 v1")
++		name="archer-c25-v1"
++		;;
+ 	*"Archer C5")
+ 		name="archer-c5"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index 21ad2a617db2fe4ff5801aba3a7fae5ba103570a..e65f6e2f7594ba373fbc9a26620859b9005c8532 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -206,6 +206,7 @@ platform_check_image() {
+ 	ap121f|\
+ 	ap132|\
+ 	ap90q|\
++	archer-c25-v1|\
+ 	bullet-m|\
+ 	c-55|\
+ 	carambola2|\
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index a8622454b421c1c74a8a71134b53c50399114aa5..e10401d42ae06506f82f2f5538fbc7df79fd4c65 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -51,6 +51,7 @@ CONFIG_ATH79_MACH_AP152=y
+ # CONFIG_ATH79_MACH_AP81 is not set
+ CONFIG_ATH79_MACH_AP90Q=y
+ CONFIG_ATH79_MACH_AP96=y
++CONFIG_ATH79_MACH_ARCHER_C25_V1=y
+ CONFIG_ATH79_MACH_ARCHER_C7=y
+ CONFIG_ATH79_MACH_ARDUINO_YUN=y
+ CONFIG_ATH79_MACH_AW_NR580=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+index 58d7e435362e0bac105e8183206e593329e4ae96..fb2afb965c4641df7cdcaf0920f2d56b3717fa9b 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+@@ -1234,6 +1234,16 @@ config ATH79_MACH_BSB
+ 	select ATH79_DEV_USB
+ 	select ATH79_DEV_WMAC
+ 
++config ATH79_MACH_ARCHER_C25_V1
++	bool "TP-LINK Archer C25 v1 support"
++	select SOC_QCA956X
++	select ATH79_DEV_AP9X_PCI if PCI
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_WMAC
++
+ config ATH79_MACH_ARCHER_C7
+ 	bool "TP-LINK Archer C5/C7/TL-WDR4900 v2 board support"
+ 	select SOC_QCA955X
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Makefile b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+index 7aee76019552e14ebdbf7bea357859dedb1a5bbb..3365a43ce16fc77b3212b39b92081efe678e8803 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+@@ -56,6 +56,7 @@ obj-$(CONFIG_ATH79_MACH_AP147)			+= mach-ap147.o
+ obj-$(CONFIG_ATH79_MACH_AP152)			+= mach-ap152.o
+ obj-$(CONFIG_ATH79_MACH_AP90Q)			+= mach-ap90q.o
+ obj-$(CONFIG_ATH79_MACH_AP96)			+= mach-ap96.o
++obj-$(CONFIG_ATH79_MACH_ARCHER_C25_V1)		+= mach-archer-c25-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7.o
+ obj-$(CONFIG_ATH79_MACH_ARDUINO_YUN)		+= mach-arduino-yun.o
+ obj-$(CONFIG_ATH79_MACH_AW_NR580)		+= mach-aw-nr580.o
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c25-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c25-v1.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..a0f001cb49af5aa501c6825c40f3a98ab99503b2
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c25-v1.c
+@@ -0,0 +1,227 @@
++/*
++ *  TP-Link Archer C25 v1 board support
++ *
++ *  Copyright (C) 2017 Ludwig Thomeczek <ledesrc@wxorx.net>
++ *  based on mach-archer-c60/C59-v1.c
++ *  Copyright (C) 2016 Henryk Heisig <hyniu@o2.pl>
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under the terms of the GNU General Public License version 2 as published
++ *  by the Free Software Foundation.
++ */
++#include <linux/platform_device.h>
++#include <linux/ath9k_platform.h>
++#include <linux/ar8216_platform.h>
++#include <asm/mach-ath79/ar71xx_regs.h>
++#include <linux/gpio.h>
++
++#include "common.h"
++#include "dev-m25p80.h"
++#include "machtypes.h"
++#include "pci.h"
++#include "dev-ap9x-pci.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-spi.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++#include <linux/spi/spi_gpio.h>
++#include <linux/spi/74x164.h>
++
++#define ARCHER_C25_GPIO_SHIFT_OE	21 /* OE,   Output Enable */
++#define ARCHER_C25_GPIO_SHIFT_SER	14 /* DS,   Data Serial Input */
++#define ARCHER_C25_GPIO_SHIFT_SRCLK	15 /* SHCP, Shift Reg Clock Input */
++#define ARCHER_C25_GPIO_SHIFT_SRCLR	19 /* MR,   Master Reset */
++#define ARCHER_C25_GPIO_SHIFT_RCLK	16 /* STCP, Storage Reg Clock Input */
++
++#define ARCHER_C25_74HC_GPIO_BASE		QCA956X_GPIO_COUNT
++#define ARCHER_C25_74HC_GPIO_LED_WAN_AMBER	27
++#define ARCHER_C25_74HC_GPIO_LED_WAN_GREEN	28
++#define ARCHER_C25_74HC_GPIO_LED_WLAN2		29
++#define ARCHER_C25_74HC_GPIO_LED_WLAN5		30
++#define ARCHER_C25_74HC_GPIO_LED_LAN1		23
++#define ARCHER_C25_74HC_GPIO_LED_LAN2		24
++#define ARCHER_C25_74HC_GPIO_LED_LAN3		25
++#define ARCHER_C25_74HC_GPIO_LED_LAN4		26
++
++#define ARCHER_C25_V1_SSR_BIT_0			0
++#define ARCHER_C25_V1_SSR_BIT_1			1
++#define ARCHER_C25_V1_SSR_BIT_2			2
++#define ARCHER_C25_V1_SSR_BIT_3			3
++#define ARCHER_C25_V1_SSR_BIT_4			4
++#define ARCHER_C25_V1_SSR_BIT_5			5
++#define ARCHER_C25_V1_SSR_BIT_6			6
++#define ARCHER_C25_V1_SSR_BIT_7			7
++
++
++#define ARCHER_C25_V1_KEYS_POLL_INTERVAL	20
++#define ARCHER_C25_V1_KEYS_DEBOUNCE_INTERVAL	\
++					(3 * ARCHER_C25_V1_KEYS_POLL_INTERVAL)
++
++#define ARCHER_C25_V1_GPIO_BTN_RESET		1
++#define ARCHER_C25_V1_GPIO_BTN_RFKILL		22
++
++#define ARCHER_C25_V1_GPIO_LED_POWER		17
++#define ARCHER_C25_V1_GPIO_LED_WPS		2
++
++#define ARCHER_C25_V1_WMAC_CALDATA_OFFSET	0x1000
++
++static struct spi_gpio_platform_data archer_c25_v1_spi_data = {
++	.sck		= ARCHER_C25_GPIO_SHIFT_SRCLK,
++	.miso		= SPI_GPIO_NO_MISO,
++	.mosi		= ARCHER_C25_GPIO_SHIFT_SER,
++	.num_chipselect	= 1,
++};
++
++static u8 archer_c25_v1_ssr_initdata[] __initdata = {
++	BIT(ARCHER_C25_V1_SSR_BIT_7) |
++	BIT(ARCHER_C25_V1_SSR_BIT_6) |
++	BIT(ARCHER_C25_V1_SSR_BIT_5) |
++	BIT(ARCHER_C25_V1_SSR_BIT_4) |
++	BIT(ARCHER_C25_V1_SSR_BIT_3) |
++	BIT(ARCHER_C25_V1_SSR_BIT_2) |
++	BIT(ARCHER_C25_V1_SSR_BIT_1)
++};
++
++static struct gen_74x164_chip_platform_data archer_c25_v1_ssr_data = {
++	.base = ARCHER_C25_74HC_GPIO_BASE,
++	.num_registers = ARRAY_SIZE(archer_c25_v1_ssr_initdata),
++	.init_data = archer_c25_v1_ssr_initdata,
++};
++
++static struct platform_device archer_c25_v1_spi_device = {
++	.name		= "spi_gpio",
++	.id		= 1,
++	.dev = {
++		.platform_data = &archer_c25_v1_spi_data,
++	},
++};
++
++static struct spi_board_info archer_c25_v1_spi_info[] = {
++	{
++		.bus_num		= 1,
++		.chip_select		= 0,
++		.max_speed_hz		= 10000000,
++		.modalias		= "74x164",
++		.platform_data		= &archer_c25_v1_ssr_data,
++		.controller_data	= (void *) ARCHER_C25_GPIO_SHIFT_RCLK,
++	},
++};
++
++static struct gpio_led archer_c25_v1_leds_gpio[] __initdata = {
++	{
++		.name		= "archer-c25-v1:green:power",
++		.gpio		= ARCHER_C25_V1_GPIO_LED_POWER,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c25-v1:green:wps",
++		.gpio		= ARCHER_C25_V1_GPIO_LED_WPS,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c25-v1:green:wlan2g",
++		.gpio		= ARCHER_C25_74HC_GPIO_LED_WLAN2,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c25-v1:green:wlan5g",
++		.gpio		= ARCHER_C25_74HC_GPIO_LED_WLAN5,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c25-v1:green:lan1",
++		.gpio		= ARCHER_C25_74HC_GPIO_LED_LAN1,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c25-v1:green:lan2",
++		.gpio		= ARCHER_C25_74HC_GPIO_LED_LAN2,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c25-v1:green:lan3",
++		.gpio		= ARCHER_C25_74HC_GPIO_LED_LAN3,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c25-v1:green:lan4",
++		.gpio		= ARCHER_C25_74HC_GPIO_LED_LAN4,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c25-v1:green:wan",
++		.gpio		=  ARCHER_C25_74HC_GPIO_LED_WAN_GREEN,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c25-v1:amber:wan",
++		.gpio		=  ARCHER_C25_74HC_GPIO_LED_WAN_AMBER,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button archer_c25_v1_gpio_keys[] __initdata = {
++	{
++		.desc			= "Reset button",
++		.type			= EV_KEY,
++		.code			= KEY_RESTART,
++		.debounce_interval	= ARCHER_C25_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C25_V1_GPIO_BTN_RESET,
++		.active_low		= 1,
++	}, {
++		.desc			= "RFKILL button",
++		.type			= EV_KEY,
++		.code			= KEY_RFKILL,
++		.debounce_interval	= ARCHER_C25_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C25_V1_GPIO_BTN_RFKILL,
++		.active_low		= 1,
++	},
++};
++
++static void __init archer_c25_v1_setup(void)
++{
++	u8 *mac = (u8 *) KSEG1ADDR(0x1f7e0008);
++	u8 *art = (u8 *) KSEG1ADDR(0x1f7f0000);
++
++	ath79_register_m25p80(NULL);
++
++	spi_register_board_info(archer_c25_v1_spi_info,
++				ARRAY_SIZE(archer_c25_v1_spi_info));
++
++	platform_device_register(&archer_c25_v1_spi_device);
++
++	gpio_request_one(ARCHER_C25_GPIO_SHIFT_OE,
++			 GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED,
++			 "LED control");
++
++	gpio_request_one(ARCHER_C25_GPIO_SHIFT_SRCLR,
++			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++			 "LED reset");
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c25_v1_leds_gpio),
++				 archer_c25_v1_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, ARCHER_C25_V1_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(archer_c25_v1_gpio_keys),
++					archer_c25_v1_gpio_keys);
++
++	ath79_register_mdio(0, 0x0);
++	ath79_register_mdio(1, 0x0);
++
++	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 0);
++	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 1);
++
++	/* WAN port */
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_mask = BIT(4);
++	ath79_register_eth(0);
++
++	/* LAN ports */
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_switch_data.phy_poll_mask |= BIT(4);
++	ath79_switch_data.phy4_mii_en = 1;
++	ath79_register_eth(1);
++
++	ath79_register_wmac(art + ARCHER_C25_V1_WMAC_CALDATA_OFFSET, mac);
++	ap91_pci_init(NULL, NULL);
++}
++
++MIPS_MACHINE(ATH79_MACH_ARCHER_C25_V1, "ARCHER-C25-V1", "TP-LINK Archer C25 v1",
++	     archer_c25_v1_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index a12685cd11a7a6cefe9b69991a5e41db55ccea85..8864e0deda57b926e88dceebd26056a2f8099380 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -40,6 +40,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_AP152,			/* Atheros AP152 reference board */
+ 	ATH79_MACH_AP90Q,			/* YunCore AP90Q */
+ 	ATH79_MACH_AP96,			/* Atheros AP96 */
++	ATH79_MACH_ARCHER_C25_V1,		/* TP-LINK Archer C25 V1 board */
+ 	ATH79_MACH_ARCHER_C5,			/* TP-LINK Archer C5 board */
+ 	ATH79_MACH_ARCHER_C7,			/* TP-LINK Archer C7 board */
+ 	ATH79_MACH_ARCHER_C7_V2,		/* TP-LINK Archer C7 V2 board */
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index b62ef3f20859e56423ee9d2a54d90b67642010c8..056445dd3fdcb3a6cf6278dc3f075e83a00c662e 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -103,6 +103,22 @@ $(Device/tplink)
+   IMAGE_SIZE := 15872k
+ endef
+ 
++define Device/archer-c25-v1
++  DEVICE_TITLE := TP-LINK Archer C25 v1
++  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887
++  BOARDNAME := ARCHER-C25-V1
++  TPLINK_BOARD_NAME := ARCHER-C25-V1
++  DEVICE_PROFILE := ARCHERC25V1
++  IMAGE_SIZE := 7808k
++  LOADER_TYPE := elf
++  KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
++  IMAGES := sysupgrade.bin factory.bin
++  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
++  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
++  MTDPARTS := spi0.0:128k(factory-uboot)ro,64k(u-boot)ro,1536k(kernel),6272k(rootfs),128k(config)ro,64k(art)ro,7808k@0x30000(firmware)
++endef
++TARGET_DEVICES += archer-c25-v1
++
+ define Device/cpe510-520
+   DEVICE_TITLE := TP-LINK CPE510/520
+   DEVICE_PACKAGES := rssileds
+diff --git a/target/linux/ar71xx/mikrotik/config-default b/target/linux/ar71xx/mikrotik/config-default
+index f8d255fd87b8c53511b34b42f4117422218219fe..376835a703f91532300d0dd7c8ef66704acc6e05 100644
+--- a/target/linux/ar71xx/mikrotik/config-default
++++ b/target/linux/ar71xx/mikrotik/config-default
+@@ -16,6 +16,7 @@
+ # CONFIG_ATH79_MACH_AP152 is not set
+ # CONFIG_ATH79_MACH_AP90Q is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
++# CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+ # CONFIG_ATH79_MACH_ARDUINO_YUN is not set
+ # CONFIG_ATH79_MACH_AW_NR580 is not set
+diff --git a/target/linux/ar71xx/nand/config-default b/target/linux/ar71xx/nand/config-default
+index c1b5e61c3e9e5f02979584f72621f5e54cde2e36..62be218e33cc6366ea89f363983f36523c419650 100644
+--- a/target/linux/ar71xx/nand/config-default
++++ b/target/linux/ar71xx/nand/config-default
+@@ -9,6 +9,7 @@
+ # CONFIG_ATH79_MACH_AP136 is not set
+ # CONFIG_ATH79_MACH_AP147 is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
++# CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+ # CONFIG_ATH79_MACH_AW_NR580 is not set
+ # CONFIG_ATH79_MACH_CAP324 is not set

--- a/patches/lede/0040-firmware-utils-tplink-safeloader-add-TP-Link-Archer-C25-v1.patch
+++ b/patches/lede/0040-firmware-utils-tplink-safeloader-add-TP-Link-Archer-C25-v1.patch
@@ -1,0 +1,102 @@
+From: Ludwig Thomeczek <ledesrc@wxorx.net>
+Date: Sat, 13 May 2017 11:40:48 +0200
+Subject: firmware-utils: tplink-safeloader: add TP-Link Archer C25 v1
+
+This adds the necessary firmware layout definitions for the Archer C25.
+It has an addtional partition containing some static data ("extra-para")
+without which no factory flash is possible, therefore put_data() has been
+added.
+
+Signed-off-by: Ludwig Thomeczek <ledesrc@wxorx.net>
+
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index 4e3d2058b286fb7220e5a8308dcdfb25626a1b59..7617566829e159ae9fec00d5de95919a0fb234c6 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -293,6 +293,48 @@ static struct device_info boards[] = {
+ 		.last_sysupgrade_partition = "file-system"
+ 	},
+ 
++	/** Firmware layout for the C25v1 */
++	{
++		.id = "ARCHER-C25-V1",
++		.support_list =
++			"SupportList:\n"
++			"{product_name:ArcherC25,product_ver:1.0.0,special_id:00000000}\n"
++			"{product_name:ArcherC25,product_ver:1.0.0,special_id:55530000}\n"
++			"{product_name:ArcherC25,product_ver:1.0.0,special_id:45550000}\n",
++		.support_trail = '\x00',
++		.soft_ver = "soft_ver:1.0.0\n",
++
++		/**
++		    We use a bigger os-image partition than the stock images (and thus
++		    smaller file-system), as our kernel doesn't fit in the stock firmware's
++		    1MB os-image.
++		*/
++		.partitions = {
++			{"factory-boot", 0x00000, 0x20000},
++			{"fs-uboot", 0x20000, 0x10000},
++			{"os-image", 0x30000, 0x180000},	/* Stock: base 0x30000 size 0x100000 */
++			{"file-system", 0x1b0000, 0x620000},	/* Stock: base 0x130000 size 0x6a0000 */
++			{"user-config", 0x7d0000, 0x04000},
++			{"default-mac", 0x7e0000, 0x00100},
++			{"device-id", 0x7e0100, 0x00100},
++			{"extra-para", 0x7e0200, 0x00100},
++			{"pin", 0x7e0300, 0x00100},
++			{"support-list", 0x7e0400, 0x00400},
++			{"soft-version", 0x7e0800, 0x00400},
++			{"product-info", 0x7e0c00, 0x01400},
++			{"partition-table", 0x7e2000, 0x01000},
++			{"profile", 0x7e3000, 0x01000},
++			{"default-config", 0x7e4000, 0x04000},
++			{"merge-config", 0x7ec000, 0x02000},
++			{"qos-db", 0x7ee000, 0x02000},
++			{"radio", 0x7f0000, 0x10000},
++			{NULL, 0, 0}
++		},
++
++		.first_sysupgrade_partition = "os-image",
++		.last_sysupgrade_partition = "file-system",
++	},
++
+ 	/** Firmware layout for the C5 */
+ 	{
+ 		.id = "ARCHER-C5-V2",
+@@ -615,6 +657,15 @@ static struct image_partition_entry read_file(const char *part_name, const char
+ 	return entry;
+ }
+ 
++/** Creates a new image partition from arbitrary data */
++static struct image_partition_entry put_data(const char *part_name, const char *datain, size_t len) {
++
++	struct image_partition_entry entry = alloc_image_partition(part_name, len);
++
++	memcpy(entry.data, datain, len);
++
++	return entry;
++}
+ 
+ /**
+    Copies a list of image partitions into an image buffer and generates the image partition table while doing so
+@@ -796,7 +847,8 @@ static void build_image(const char *output,
+ 		bool add_jffs2_eof,
+ 		bool sysupgrade,
+ 		const struct device_info *info) {
+-	struct image_partition_entry parts[6] = {};
++
++	struct image_partition_entry parts[7] = {};
+ 
+ 	parts[0] = make_partition_table(info->partitions);
+ 	parts[1] = make_soft_version(rev);
+@@ -804,6 +856,11 @@ static void build_image(const char *output,
+ 	parts[3] = read_file("os-image", kernel_image, false);
+ 	parts[4] = read_file("file-system", rootfs_image, add_jffs2_eof);
+ 
++	if (strcasecmp(info->id, "ARCHER-C25-V1") == 0) {
++		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00};
++		parts[5] = put_data("extra-para", mdat, 11);
++	}
++
+ 	size_t len;
+ 	void *image;
+ 	if (sysupgrade)

--- a/patches/lede/0041-firmware-utils-tplink-safeloader-support-strings-as-soft_version.patch
+++ b/patches/lede/0041-firmware-utils-tplink-safeloader-support-strings-as-soft_version.patch
@@ -1,0 +1,152 @@
+From: Jan Niehusmann <jan@gondor.com>
+Date: Fri, 19 May 2017 09:42:24 +0200
+Subject: firmware-utils: tplink-safeloader: support strings as soft_version
+
+Some TP-Link routers (C25, C59, C60) contain a version string instead
+of a binary structure in the soft_version partition.
+
+Flashing LEDE from the original firmware's GUI, this version string
+taken from the soft_ver partition of the firmware image is written to
+the router's config partition.
+
+When using tftp recovery to go back to the original Archer C25 firmware,
+a version check compares that version to the version of the firmware to
+be flashed.
+
+Without proper contents in the config partition, reverting to the
+original firmware fails.
+
+Therefore, write the string "soft_ver:1.0.0\n" to that soft_ver
+partition.
+
+Signed-off-by: Jan Niehusmann <jan@gondor.com>
+
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index 7617566829e159ae9fec00d5de95919a0fb234c6..24684268b1a3fe491c4eb876a5ebefc700f2e56e 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -75,6 +75,7 @@ struct device_info {
+ 	const char *vendor;
+ 	const char *support_list;
+ 	char support_trail;
++	const char *soft_ver;
+ 	const struct flash_partition_entry partitions[MAX_PARTITIONS+1];
+ 	const char *first_sysupgrade_partition;
+ 	const char *last_sysupgrade_partition;
+@@ -130,6 +131,7 @@ static struct device_info boards[] = {
+ 			"CPE220(TP-LINK|US|N300-2):1.1\r\n"
+ 			"CPE220(TP-LINK|EU|N300-2):1.1\r\n",
+ 		.support_trail = '\xff',
++		.soft_ver = NULL,
+ 
+ 		.partitions = {
+ 			{"fs-uboot", 0x00000, 0x20000},
+@@ -167,6 +169,7 @@ static struct device_info boards[] = {
+ 			"CPE520(TP-LINK|US|N300-5):1.1\r\n"
+ 			"CPE520(TP-LINK|EU|N300-5):1.1\r\n",
+ 		.support_trail = '\xff',
++		.soft_ver = NULL,
+ 
+ 		.partitions = {
+ 			{"fs-uboot", 0x00000, 0x20000},
+@@ -198,6 +201,7 @@ static struct device_info boards[] = {
+ 			"WBS210(TP-LINK|US|N300-2):1.20\r\n"
+ 			"WBS210(TP-LINK|EU|N300-2):1.20\r\n",
+ 		.support_trail = '\xff',
++		.soft_ver = NULL,
+ 
+ 		.partitions = {
+ 			{"fs-uboot", 0x00000, 0x20000},
+@@ -229,6 +233,7 @@ static struct device_info boards[] = {
+ 			"WBS510(TP-LINK|US|N300-5):1.20\r\n"
+ 			"WBS510(TP-LINK|EU|N300-5):1.20\r\n",
+ 		.support_trail = '\xff',
++		.soft_ver = NULL,
+ 
+ 		.partitions = {
+ 			{"fs-uboot", 0x00000, 0x20000},
+@@ -259,6 +264,7 @@ static struct device_info boards[] = {
+ 			"SupportList:\r\n"
+ 			"{product_name:Archer C2600,product_ver:1.0.0,special_id:00000000}\r\n",
+ 		.support_trail = '\x00',
++		.soft_ver = NULL,
+ 
+ 		.partitions = {
+ 			{"SBL1", 0x00000, 0x20000},
+@@ -345,6 +351,7 @@ static struct device_info boards[] = {
+ 			"product_ver:2.0.0,"
+ 			"special_id:00000000}\r\n",
+ 		.support_trail = '\x00',
++		.soft_ver = NULL,
+ 
+ 		.partitions = {
+ 			{"fs-uboot", 0x00000, 0x40000},
+@@ -379,6 +386,7 @@ static struct device_info boards[] = {
+ 			"product_ver:1.0.0,"
+ 			"special_id:00000000}\n",
+ 		.support_trail = '\x00',
++		.soft_ver = NULL,
+ 
+ 		.partitions = {
+ 			{"fs-uboot", 0x00000, 0x40000},
+@@ -411,6 +419,7 @@ static struct device_info boards[] = {
+ 			"SupportList:\r\n"
+ 			"EAP120(TP-LINK|UN|N300-2):1.0\r\n",
+ 		.support_trail = '\xff',
++		.soft_ver = NULL,
+ 
+ 		.partitions = {
+ 			{"fs-uboot", 0x00000, 0x20000},
+@@ -440,6 +449,7 @@ static struct device_info boards[] = {
+ 			"SupportList:\n"
+ 			"{product_name:TL-WR1043ND,product_ver:4.0.0,special_id:45550000}\n",
+ 		.support_trail = '\x00',
++		.soft_ver = NULL,
+ 
+ 		/**
+ 		    We use a bigger os-image partition than the stock images (and thus
+@@ -483,6 +493,7 @@ static struct device_info boards[] = {
+ 			"{product_name:RE450,product_ver:1.0.0,special_id:4B520000}\r\n"
+ 			"{product_name:RE450,product_ver:1.0.0,special_id:55534100}\r\n",
+ 		.support_trail = '\x00',
++		.soft_ver = NULL,
+ 
+ 		/**
+ 		   The flash partition table for RE450;
+@@ -611,6 +622,23 @@ static struct image_partition_entry make_soft_version(uint32_t rev) {
+ 	return entry;
+ }
+ 
++static struct image_partition_entry make_soft_version_from_string(const char *soft_ver) {
++	/** String length _including_ the terminating zero byte */
++	uint32_t ver_len = strlen(soft_ver) + 1;
++	/** Partition contains 64 bit header, the version string, and one additional null byte */
++	size_t partition_len = 2*sizeof(uint32_t) + ver_len + 1;
++	struct image_partition_entry entry = alloc_image_partition("soft-version", partition_len);
++
++	uint32_t *len = (uint32_t *)entry.data;
++	len[0] = htonl(ver_len);
++	len[1] = 0;
++	memcpy(&len[2], soft_ver, ver_len);
++
++	entry.data[partition_len - 1] = 0;
++
++	return entry;
++}
++
+ /** Generates the support-list partition */
+ static struct image_partition_entry make_support_list(const struct device_info *info) {
+ 	size_t len = strlen(info->support_list);
+@@ -851,7 +879,11 @@ static void build_image(const char *output,
+ 	struct image_partition_entry parts[7] = {};
+ 
+ 	parts[0] = make_partition_table(info->partitions);
+-	parts[1] = make_soft_version(rev);
++	if (info->soft_ver)
++		parts[1] = make_soft_version_from_string(info->soft_ver);
++	else
++		parts[1] = make_soft_version(rev);
++
+ 	parts[2] = make_support_list(info);
+ 	parts[3] = read_file("os-image", kernel_image, false);
+ 	parts[4] = read_file("file-system", rootfs_image, add_jffs2_eof);

--- a/patches/lede/0042-add-CONFIG_GPIO_74X164-and-CONFIG_SPI_GPIO-for-Archer-C25.patch
+++ b/patches/lede/0042-add-CONFIG_GPIO_74X164-and-CONFIG_SPI_GPIO-for-Archer-C25.patch
@@ -1,0 +1,30 @@
+From: Andreas Ziegler <github@andreas-ziegler.de>
+Date: Thu, 3 Aug 2017 03:34:19 +0200
+Subject: add CONFIG_GPIO_74X164 and CONFIG_SPI_GPIO for Archer C25
+
+backport from e39dc8d823c86559eedbbdcee5f5c14b827fed0f
+introduced for Archer C59/C60
+
+Based-on-patch-by: Henryk Heisig <hyniu@o2.pl>
+Signed-off-by: Andreas Ziegler <github@andreas-ziegler.de>
+
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index e10401d42ae06506f82f2f5538fbc7df79fd4c65..c82fcf09228be7063967f2517e0942651234afb8 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -272,6 +272,7 @@ CONFIG_GENERIC_TIME_VSYSCALL=y
+ CONFIG_GPIOLIB=y
+ CONFIG_GPIOLIB_IRQCHIP=y
+ CONFIG_GPIO_DEVRES=y
++CONFIG_GPIO_74X164=y
+ # CONFIG_GPIO_LATCH is not set
+ CONFIG_GPIO_NXP_74HC153=y
+ CONFIG_GPIO_PCF857X=y
+@@ -429,6 +430,7 @@ CONFIG_SOC_QCA956X=y
+ CONFIG_SPI=y
+ CONFIG_SPI_ATH79=y
+ CONFIG_SPI_BITBANG=y
++CONFIG_SPI_GPIO=y
+ CONFIG_SPI_MASTER=y
+ # CONFIG_SPI_RB4XX is not set
+ # CONFIG_SPI_VSC7385 is not set

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -1,10 +1,12 @@
 ATH10K_PACKAGES=
+ATH10K_PACKAGES_QCA9887=
 
 if [ "$GLUON_ATH10K_MESH" = '11s' ]; then
 	ATH10K_PACKAGES='-kmod-ath10k kmod-ath10k-ct'
 fi
 if [ "$GLUON_ATH10K_MESH" = 'ibss' ]; then
 	ATH10K_PACKAGES='-kmod-ath10k kmod-ath10k-ct -ath10k-firmware-qca988x ath10k-firmware-qca988x-ct'
+	ATH10K_PACKAGES_QCA9887='-kmod-ath10k kmod-ath10k-ct -ath10k-firmware-qca9887 ath10k-firmware-qca9887-ct'
 fi
 
 
@@ -180,6 +182,11 @@ packages $ATH10K_PACKAGES
 device tp-link-archer-c7-v2 archer-c7-v2
 packages $ATH10K_PACKAGES
 factory -squashfs-factory${GLUON_REGION:+-${GLUON_REGION}} .bin
+
+if [ "$BROKEN" ]; then
+device tp-link-archer-c25-v1 archer-c25-v1 # instability with 5GHz mesh in some environments
+packages $ATH10K_PACKAGES_QCA9887
+fi
 
 device tp-link-re450 re450
 packages $ATH10K_PACKAGES


### PR DESCRIPTION
This patchset adds support for the device TP-Link Archer C25

copy&paste from LEDE PR done by @Brother-Lal : ( https://github.com/lede-project/source/pull/1069 )
> The TP-Link Archer C25 is a low-cost Dualband Router:
> CPU: Atheros QCA9561 775 Mhz
> RAM: 64 MB
> Flash: 8MB
> Wifi: 3x3 2.4Ghz integrated
> 1x1 5 Ghz QCA9887
> NET: 5x 10/100 Mbps Ethernet
> Some LEDS are controlled by an additional 74HC595 chip.

in addition to the patches by Brother-Lal, i had to backport patches that were originally developed by others for devices like Archer C59/C60 but are also needed for the C25

this patchset has been build & run-tested with factory and sysupgrade.

although some people (including me) have no problems with this device, others reported frequent reboots in certain environments when 5 GHz is enabled. therefore, this device is marked as BROKEN as discussed on IRC.

fixes #1123 