### PR TITLE
[WIP] new package gluon-config-mode-domain-select

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ Several Freifunk communities in Germany use Gluon as the foundation of their Fre
 
    package/gluon-client-bridge
    package/gluon-config-mode-contact-info
+   package/gluon-config-mode-domain-select
    package/gluon-config-mode-geo-location
    package/gluon-ebtables-filter-multicast
    package/gluon-ebtables-filter-ra-dhcp

--- a/docs/package/gluon-config-mode-domain-select.rst
+++ b/docs/package/gluon-config-mode-domain-select.rst
@@ -1,0 +1,19 @@
+gluon-config-mode-domain-select
+===============================
+This package provides a drop-down list for the config mode to select the domain
+the node will be placed in. If the selection has changed the upgrade scripts in
+``/lib/gluon/upgrade/`` are triggered to update the nodes configuration.
+
+Hiding domains could be useful for default or testing domains, which should not
+be accidentally selected by a node operater.
+
+domains/*.conf
+---------------------
+
+hide_domain \: optional (defaults to false)
+    - ``false`` shows this domain in drop-down list
+    - ``true`` hides this domain
+
+Example::
+
+  hide_domain = true

--- a/docs/site-example/i18n/de.po
+++ b/docs/site-example/i18n/de.po
@@ -16,6 +16,15 @@ msgstr ""
 "Freifunk-Knoten. Fülle das folgende Formular deinen Vorstellungen "
 "entsprechend aus und sende es ab."
 
+msgid "gluon-config-mode:domain"
+msgstr "Domäne"
+
+msgid "gluon-config-mode:domain-select"
+msgstr ""
+"Hier hast du die Möglichkeit, die Mesh-Domäne, in der sich dein Knoten "
+"befindet, auszuwählen. Bitte denke daran, dass sich dein Knoten nur mit den "
+"Knoten der ausgewählten Domäne verbinden kann."
+
 msgid "gluon-config-mode:pubkey"
 msgstr ""
 "<p>Dies ist der öffentliche Schlüssel deines Freifunk-Knotens. Erst nachdem "

--- a/docs/site-example/i18n/en.po
+++ b/docs/site-example/i18n/en.po
@@ -15,6 +15,15 @@ msgstr ""
 "Welcome to the setup wizard of your new Freifunk Alpha Centauri node. "
 "Please fill out the following form and submit it."
 
+msgid "gluon-config-mode:domain"
+msgstr "Domain"
+
+msgid "gluon-config-mode:domain-select"
+msgstr ""
+"Here you have the possibility of selecting the mesh domain in which your node "
+"is placed. Please keep in mind that your router only connects with the nodes "
+"of the selected domain"
+
 msgid "gluon-config-mode:pubkey"
 msgstr ""
 "<p>This is your Freifunk node's public key. The node won't be able to "

--- a/docs/site-example/i18n/fr.po
+++ b/docs/site-example/i18n/fr.po
@@ -16,6 +16,12 @@ msgstr ""
 "Freifunk. Remplissez le formulaire suivant en fonction de vos besoins "
 "et enregistrez le"
 
+msgid "gluon-config-mode:domain"
+msgstr "Domaine"
+
+msgid "gluon-config-mode:domain-select"
+msgstr ""
+
 msgid "gluon-config-mode:pubkey"
 msgstr ""
 "<p>Ceci est la clé publique de votre nœud Freifunk. Seulment après que la clé soit "

--- a/docs/site-example/i18n/gluon-site.pot
+++ b/docs/site-example/i18n/gluon-site.pot
@@ -4,6 +4,12 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "gluon-config-mode:welcome"
 msgstr ""
 
+msgid "gluon-config-mode:domain"
+msgstr ""
+
+msgid "gluon-config-mode:domain-select"
+msgstr ""
+
 msgid "gluon-config-mode:pubkey"
 msgstr ""
 

--- a/package/gluon-config-mode-domain-select/Makefile
+++ b/package/gluon-config-mode-domain-select/Makefile
@@ -1,0 +1,42 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-config-mode-domain-select
+PKG_VERSION:=1
+
+PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)
+
+include ../gluon.mk
+
+PKG_CONFIG_DEPENDS += $(GLUON_I18N_CONFIG)
+
+
+define Package/gluon-config-mode-domain-select
+  SECTION:=gluon
+  CATEGORY:=Gluon
+  TITLE:=UI for changing the node-config
+  DEPENDS:=+gluon-config-mode-core @GLUON_MULTIDOMAIN
+endef
+
+define Build/Prepare
+	mkdir -p $(PKG_BUILD_DIR)
+endef
+
+define Build/Configure
+endef
+
+define Build/Compile
+	$(call GluonBuildI18N,gluon-config-mode-domain-select,i18n)
+	$(call GluonSrcDiet,./luasrc,$(PKG_BUILD_DIR)/luadest/)
+endef
+
+define Package/gluon-config-mode-domain-select/install
+	$(CP) $(PKG_BUILD_DIR)/luadest/* $(1)/
+	$(call GluonInstallI18N,gluon-config-mode-domain-select,$(1))
+endef
+
+define Package/gluon-config-domain-select/postinst
+#!/bin/sh
+$(call GluonCheckSite,check_site.lua)
+endef
+
+$(eval $(call BuildPackage,gluon-config-mode-domain-select))

--- a/package/gluon-config-mode-domain-select/check_site.lua
+++ b/package/gluon-config-mode-domain-select/check_site.lua
@@ -1,0 +1,1 @@
+need_boolean(in_domain({'hide_domain'}), false)

--- a/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
+++ b/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
@@ -1,6 +1,7 @@
 return function(form, uci)
 	local fs = require 'nixio.fs'
 	local json = require 'jsonc'
+	local site = require 'gluon.site'
 
 	local function get_domain_list()
 		local list = {}
@@ -19,13 +20,15 @@ return function(form, uci)
 
 	local s = form:section(Section, nil, translate('gluon-config-mode:domain-select'))
 	local o = s:option(ListValue, 'domain', translate('gluon-config-mode:domain'))
+	local domain_code = uci:get('gluon', 'core', 'domain')
+	local configured = uci:get_bool('gluon-setup-mode', uci:get_first('gluon-setup-mode','setup_mode'), 'configured') or (domain_code ~= site.default_domain())
 
-	if uci:get_bool('gluon-setup-mode', uci:get_first('gluon-setup-mode','setup_mode'), 'configured')  then
-		o.default = uci:get('gluon', 'core', 'domain')
+	if configured then
+		o.default = domain_code
 	end
 
 	for _, domain in pairs(get_domain_list()) do
-		if not domain.hide_domain then
+		if not domain.hide_domain or (configured and domain.domain_code == domain_code) then
 			o:value(domain.domain_code, domain.domain_name)
 		end
 	end

--- a/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
+++ b/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
@@ -1,17 +1,15 @@
 return function(form, uci)
-	local site = require 'gluon.site'
-	local path = '/lib/gluon/domains'
 	local fs = require 'nixio.fs'
 	local json = require 'jsonc'
 
 	local function get_domain_list()
 		local list = {}
-		for domain_path in fs.glob(path .. '/*.json') do
-			local domain_code = domain_path:match(path .. '/(.*)%.json$')
+		for domain_path in fs.glob('/lib/gluon/domains/*.json') do
+			local domain_code = domain_path:match('([^/]+)%.json$')
 			local domain = assert(json.load(domain_path))
 			table.insert(list, {
 				domain_code = domain_code,
-				domain_name = (domain.domain_names or {})[domain_code],
+				domain_name = domain.domain_names[domain_code],
 				hide_domain = domain.hide_domain or False,
 			})
 		end

--- a/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
+++ b/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
@@ -1,0 +1,42 @@
+return function(form, uci)
+	local site = require 'gluon.site'
+	local path = '/lib/gluon/domains'
+	local fs = require 'nixio.fs'
+	local json = require 'jsonc'
+
+	local function get_domain_list()
+		local list = {}
+		for domain_path in fs.glob(path .. '/*.json') do
+			local domain_code = domain_path:match(path .. '/(.*)%.json$')
+			local domain = assert(json.load(domain_path))
+			table.insert(list, {
+				domain_code = domain_code,
+				domain_name = (domain.domain_names or {})[domain_code],
+				hide_domain = domain.hide_domain or False,
+			})
+		end
+		table.sort(list, function(a,b) return a.domain_name < b.domain_name end)
+		return list
+	end
+
+	local s = form:section(Section, nil, translate('gluon-config-mode:domain-select'))
+	local o = s:option(ListValue, 'domain', translate('gluon-config-mode:domain'))
+
+	if uci:get_bool('gluon-setup-mode', uci:get_first('gluon-setup-mode','setup_mode'), 'configured')  then
+		o.default = uci:get('gluon', 'core', 'domain')
+	end
+
+	for _, domain in pairs(get_domain_list()) do
+		if not domain.hide_domain then
+			o:value(domain.domain_code, domain.domain_name)
+		end
+	end
+
+	function o:write(data)
+		uci:set('gluon', 'core', 'domain', data)
+		uci:save('gluon')
+		os.execute('gluon-reconfigure')
+	end
+
+	return {'gluon'}
+end


### PR DESCRIPTION
First draft for gluon-config-mode-domain-select. (depends on #1216)

ToDo:

- [x] get config generation working after changing the domain (done, but I don't like the approach)
- [x] sort list by `domain_name`
- [x]  get it working with aliases (need to be tested)
- [ ] maybe integrate `get_domain_list()` to `gluon.site`
- [ ] evtl. eintragen in `https://github.com/freifunk-gluon/gluon/blob/master/package/feature`