### PR TITLE
Add site.conf option for fastd peer upgrade

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -213,6 +213,9 @@ mesh_vpn
 
     You can set syslog_level from verbose (default) to warn to reduce syslog output.
 
+    To make sure that old peer groups are not retained after sysupgrade (e.g. updating from firmware
+    from another community) set delete_old_peers to `true`.
+
     The `tunneldigger` section is used to define the *tunneldigger* broker list.
 
     **Note:** It doesn't make sense to include both `fastd` and `tunneldigger`
@@ -230,6 +233,7 @@ mesh_vpn
           methods = {'salsa2012+umac'},
           -- configurable = true,
           -- syslog_level = 'warn',
+          -- delete_old_peers = false,
           groups = {
             backbone = {
               -- Limit number of connected peers from this group

--- a/package/gluon-mesh-vpn-fastd/check_site.lua
+++ b/package/gluon-mesh-vpn-fastd/check_site.lua
@@ -1,6 +1,7 @@
 local fastd_methods = {'salsa2012+gmac', 'salsa2012+umac', 'null+salsa2012+gmac', 'null+salsa2012+umac', 'null'}
 need_array_of('mesh_vpn.fastd.methods', fastd_methods)
 need_boolean('mesh_vpn.fastd.configurable', false)
+need_boolean('mesh_vpn.fastd.delete_old_peers', false)
 
 need_one_of('mesh_vpn.fastd.syslog_level', {'error', 'warn', 'info', 'verbose', 'debug', 'debug2'}, false)
 

--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -92,6 +92,19 @@ function add_groups(prefix, groups, parent)
 	end
 end
 
+
+if site.mesh_vpn.fastd.delete_old_peers then
+	uci:delete_all('fastd', 'peer_group', function(group)
+		if group.net == 'mesh_vpn' then
+			uci:delete_all('fastd', 'peer',	function(peer)
+				return (peer.group == group)
+			end)
+
+			return true
+		end
+	end)
+end
+
 add_groups('mesh_vpn', site.mesh_vpn.fastd.groups())
 
 


### PR DESCRIPTION
> The site.conf option `delete_old_peers` removes old peer entries with uci option "net" mesh_vpn
> and their corresponding groups recursively.

Shouldn't this resolve #557?