### PR TITLE
[RFC] Add site.conf option for fastd peer upgrade

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -292,6 +292,13 @@ mesh_vpn
 
     You can set syslog_level from verbose (default) to warn to reduce syslog output.
 
+    While performing a sysupgrade fastd retains existing peer group and peer configurations to allow
+    incremental addition of peers and peer groups by default. This behaviour might be unwanted.
+    To make sure that fastd's peers and peer groups from previous firmware versions are removed 
+    (except those defined by the node2node VPN feature) set `sysupgrade_remove_old_peers` to `true`.
+    To remove peers and groups defined by the node2node VPN feature (which have ``n2n_vpn`` in their 
+    names) set `sysupgrade_remove_n2n_peers` to `true`.
+
     The `tunneldigger` section is used to define the *tunneldigger* broker list.
 
     **Note:** It doesn't make sense to include both `fastd` and `tunneldigger`
@@ -313,6 +320,8 @@ mesh_vpn
           methods = {'salsa2012+umac'},
           -- configurable = true,
           -- syslog_level = 'warn',
+          -- sysupgrade_remove_old_peers = false,
+          -- sysupgrade_remove_n2n_peers = false,
           groups = {
             backbone = {
               -- Limit number of connected peers from this group

--- a/package/gluon-mesh-vpn-fastd/check_site.lua
+++ b/package/gluon-mesh-vpn-fastd/check_site.lua
@@ -1,6 +1,8 @@
 local fastd_methods = {'salsa2012+gmac', 'salsa2012+umac', 'null+salsa2012+gmac', 'null+salsa2012+umac', 'null'}
 need_array_of({'mesh_vpn', 'fastd', 'methods'}, fastd_methods)
 need_boolean(in_site({'mesh_vpn', 'fastd', 'configurable'}), false)
+need_boolean('mesh_vpn.fastd.sysupgrade_remove_old_peers', false)
+need_boolean('mesh_vpn.fastd.sysupgrade_remove_n2n_peers', false)
 
 need_one_of(in_site({'mesh_vpn', 'fastd', 'syslog_level'}), {'error', 'warn', 'info', 'verbose', 'debug', 'debug2'}, false)
 

--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -92,6 +92,63 @@ function add_groups(prefix, groups, parent)
 	end
 end
 
+-- Checks if a peer or peer group entry belongs to the node2node VPN feature
+local function is_n2n(gp)
+	if gp and gp['.name']:find('n2n_vpn') then return true end
+	return false
+end
+
+--- Determine peers and peer groups from the old configuration that can be removed
+	-- @param group		Peer group as returned by uci:foreach or 'nil' for ALL
+	-- @param deln2n	Set 'true' for adding node2node VPN groups else 'false'
+	-- @return      	Array with first index being boolean indicating whether
+	--			any n2n peer groups have been restrained and second
+	--			being an array with the names of the items to delete.
+local function get_delgroups(group, deln2n)
+	if not deln2n and is_n2n(group) then
+		return false
+	end
+
+	local group_empty = true
+	local dellist = {}
+
+	if group then
+		uci:foreach('fastd', 'peer', function(peer)
+			if peer.group == group['.name'] then
+				if not deln2n and is_n2n(peer) then
+					group_empty = false
+				else
+					table.insert(dellist, peer['.name'])
+				end
+			end
+
+		end)
+	end
+
+	uci:foreach('fastd', 'peer_group', function(gr)
+		if gr.parent == group or gr.parent == group['.name'] then
+			local ret = get_delgroups(gr, deln2n)
+			for _, v in pairs(ret[2]) do table.insert(dellist, v) end
+			if ret[1] then
+				table.insert(dellist, gr['.name'])
+			else
+				group_empty = false
+			end
+		end
+
+	end)
+
+	return {group_empty, dellist}
+end
+
+if site.mesh_vpn.fastd.sysupgrade_remove_old_peers then
+	local del = get_delgroups(nil, site.mesh_vpn.fastd.sysupgrade_remove_n2n_peers)
+	for _, v in pairs(del[2]) do uci:delete('fastd', v) end
+elseif site.mesh_vpn.fastd.sysupgrade_remove_n2n_peers then
+	uci:delete_all('fastd', 'peer', is_n2n)
+	uci:delete_all('fastd', 'peer_group', is_n2n)
+end
+
 add_groups('mesh_vpn', site.mesh_vpn.fastd.groups())
 
 


### PR DESCRIPTION
> The site.conf option `delete_old_peers` removes old peer entries with uci option "net" mesh_vpn
> and their corresponding groups recursively.

Shouldn't this resolve #557?

BTW: Sorry for my inability to use Github. I don't like pull requests.