### PR TITLE
[RFC] Autoupdater: static update minute

### DIFF
--- a/package/gluon-autoupdater/luasrc/lib/gluon/upgrade/500-autoupdater
+++ b/package/gluon-autoupdater/luasrc/lib/gluon/upgrade/500-autoupdater
@@ -41,11 +41,16 @@ local seed1, seed2 = urandom:read(2):byte(1, 2)
 math.randomseed(seed1*0x100 + seed2)
 urandom:close()
 
--- Perform updates at a random time between 04:00 and 05:00, and once an hour
--- a fallback update (used after the regular updates haven't worked for
--- (priority+1) days after a firmware release, for example because the node
--- is always offline at night)
-local minute = math.random(0, 59)
+-- Perform updates at a random time between 04:00 and 05:00 in case no specific
+-- time is specified (gluon.autoupdater.minute), and once an hour a fallback
+-- update (used after the regular updates haven't worked for (priority+1) days
+-- after a firmware release, for example because the node is always offline at
+-- night)
+if not uci:get('gluon', 'autoupdater') then
+	uci:section('gluon', 'autoupdater', 'autoupdater')
+	uci:save('gluon')
+end
+local minute = uci:get('gluon', 'autoupdater', 'minute') or math.random(0, 59)
 
 local f = io.open('/usr/lib/micron.d/autoupdater', 'w')
 f:write(string.format('%i 4 * * * /usr/sbin/autoupdater\n', minute))

--- a/package/gluon-web-autoupdater/i18n/de.po
+++ b/package/gluon-web-autoupdater/i18n/de.po
@@ -18,3 +18,17 @@ msgstr "Branch"
 
 msgid "Enable"
 msgstr "Aktivieren"
+
+msgid "Minute"
+msgstr "Minute"
+
+msgid ""
+"This value forces the autoupdater to check for updates at the specified "
+"minute. Normally there is no need to set this value because it is selected "
+"automatically. You may want to set this to a specific value if you have "
+"multiple nodes which should not update at the same time."
+msgstr ""
+"Dieser Wert zwingt den Autoupdater, in der festgelegten Minute nach neuen "
+"Updates zu suchen. Normalerweise muss dieser Wert nicht gesetzt werden, da "
+"er automatisch gewählt wird. Wenn du jedoch mehrere Knoten betreibst und "
+"diese nicht zur gleichen Zeit updaten dürfen, könntest du diesen Wert setzen."

--- a/package/gluon-web-autoupdater/i18n/fr.po
+++ b/package/gluon-web-autoupdater/i18n/fr.po
@@ -18,3 +18,13 @@ msgstr "Branche"
 
 msgid "Enable"
 msgstr "Activer"
+
+msgid "Minute"
+msgstr "Minute"
+
+msgid ""
+"This value forces the autoupdater to check for updates at the specified "
+"minute. Normally there is no need to set this value because it is selected "
+"automatically. You may want to set this to a specific value if you have "
+"multiple nodes which should not update at the same time."
+msgstr ""

--- a/package/gluon-web-autoupdater/i18n/gluon-web-autoupdater.pot
+++ b/package/gluon-web-autoupdater/i18n/gluon-web-autoupdater.pot
@@ -9,3 +9,13 @@ msgstr ""
 
 msgid "Enable"
 msgstr ""
+
+msgid "Minute"
+msgstr ""
+
+msgid ""
+"This value forces the autoupdater to check for updates at the specified "
+"minute. Normally there is no need to set this value because it is selected "
+"automatically. You may want to set this to a specific value if you have "
+"multiple nodes which should not update at the same time."
+msgstr ""

--- a/package/gluon-web-autoupdater/luasrc/lib/gluon/web/model/admin/autoupdater.lua
+++ b/package/gluon-web-autoupdater/luasrc/lib/gluon/web/model/admin/autoupdater.lua
@@ -32,8 +32,34 @@ function o:write(data)
 	uci:set("autoupdater", autoupdater, "branch", data)
 end
 
+o = s:option(Value, "minute", translate("Minute"), translate(
+	"This value forces the autoupdater to check for updates at the "
+	.. "specified minute. Normally there is no need to set this value "
+	.. "because it is selected automatically. You may want to set this to "
+	.. "a specific value if you have multiple nodes which should not "
+	.. "update at the same time."
+))
+o.datatype = "irange(0, 59)"
+o.default = uci:get("gluon", "autoupdater", "minute")
+o.optional = true
+
+function o:write(data)
+	if data == uci:get("gluon", "autoupdater", "minute") then
+		return
+	end
+	uci:set("gluon", "autoupdater", "minute", data)
+
+	if data then
+		local f = io.open("/usr/lib/micron.d/autoupdater", "w")
+		f:write(string.format("%i 4 * * * /usr/sbin/autoupdater\n", data))
+		f:write(string.format("%i 0-3,5-23 * * * /usr/sbin/autoupdater --fallback\n", data))
+		f:close()
+	end
+end
+
 function f:write()
 	uci:commit("autoupdater")
+	uci:commit("gluon")
 end
 
 return f


### PR DESCRIPTION
This PR introduces the possibility to force the minute variable of the autoupdater cron job to a specific value.

- [x] add a description to the menu
- [x] limit value to [0-59]

~~competitive to #1259~~
EDIT: should be applied after 594f45d (#1216)