### PR TITLE
ramips-mt7621: add support for ZBT-WG3526

### DIFF
--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -8,3 +8,7 @@ device ubnt-erx ubnt-erx
 packages '-hostapd-mini'
 factory
 sysupgrade '.tar'
+
+# ZBT
+
+device zbt-wg3526 zbt-wg3526


### PR DESCRIPTION
This PR adds support for the ZBT-WG3526 to the ramips-mt7621 target

> Dual-Band Router
> CPU: MediaTek MT7621AT (2* 880MHz)
> RAM: 512 MB
> Flash: 16 MB
> Wifi 1: MT7603E 2x2 2.4Ghz bgn
> Wifi 2: MT7612E 2x2 5GHz an+ac
> NET: 5x 10/100/1000 Mbps Ethernet
> 4 external antennas (2 for each band)
> USB3 port

i did a build and run test.

this patch could be easily cherry-picked to the v2017.1.x branch

this PR is closely related to #962, which is about the 32MB version of this device