### PR TITLE
 docs: update ffho site repo

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -512,7 +512,7 @@ This is a non-exhaustive list of site-repos from various communities:
 * `site-ffgoe <https://github.com/freifunk-goettingen/site-ffgoe>`_ (Göttingen)
 * `site-ffgt-rhw <https://github.com/ffgtso/site-ffgt-rhw>`_ (Guetersloh)
 * `site-ffhh <https://github.com/freifunkhamburg/site-ffhh>`_ (Hamburg)
-* `site-ffho <https://git.c3pb.de/freifunk-pb/site-ffho>`_ (Hochstift)
+* `site-ffho <https://git.ffho.net/freifunkhochstift/ffho-site>`_ (Hochstift)
 * `site-ffhgw <https://github.com/lorenzo-greifswald/site-ffhgw>`_ (Greifswald)
 * `site-ffka <https://github.com/ffka/site-ffka>`_ (Karlsruhe)
 * `site-ffki <http://git.freifunk.in-kiel.de/ffki-site/>`_ (Kiel)


### PR DESCRIPTION
Backport to v2017.1.x
(cherry picked from commit 56d74e41c1c24421dae8799bc03811966d38dee0)