### PR TITLE
ramips-rt305x: add D-Link DIR-615 rev D1-D4

### DIFF
--- a/targets/ramips-rt305x
+++ b/targets/ramips-rt305x
@@ -11,7 +11,12 @@ factory
 
 device a5-v11 a5-v11
 
-
 # D-Link
 
 device d-link-dir-615-h1 dir-615-h1
+
+device d-link-dir-615-d dir-615-d
+alias d-link-dir-615-d1
+alias d-link-dir-615-d2
+alias d-link-dir-615-d3
+alias d-link-dir-615-d4


### PR DESCRIPTION
We have an ISP around Chemnitz who gave out these routers years ago. We got a request to support these for freifunk. Here it is: http://map.chemnitz.freifunk.net/#!v:m;n:002401c1a16c