### PR TITLE
ar71xx: add support for TP-Link Archer C58/C59/C60

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -39,7 +39,9 @@ elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2',
                                             'om5p', 'om5p-an',
                                             'om5p-ac', 'om5p-acv2'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
-elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c7'}) then
+elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1', 
+	                                    'archer-c59-v1', 'archer-c60-v1', 
+					    'archer-c7'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')
 end
 

--- a/patches/lede/0043-ar71xx-add-support-to-TP-Link-Archer-C59v1-and-C60v1.patch
+++ b/patches/lede/0043-ar71xx-add-support-to-TP-Link-Archer-C59v1-and-C60v1.patch
@@ -1,0 +1,776 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Tue, 27 Dec 2016 22:41:41 +0100
+Subject: ar71xx: add support to TP-Link Archer C59v1 and C60v1
+
+TP-Link Archer C59v1 is a dual-band AC1350 router, based on Qualcomm/Atheros
+QCA9561+QCA9886.
+
+Specification:
+
+- 775/650/258 MHz (CPU/DDR/AHB)
+- 128 MB of RAM (DDR2)
+- 16 MB of FLASH (SPI NOR)
+- 3T3R 2.4 GHz
+- 2T2R 5 GHz
+- 5x 10/100 Mbps Ethernet
+- USB 2.0 port
+- 8x LED (controled by 74HC595), 3x button
+- UART header on PCB
+
+TP-Link Archer C60v1 is a dual-band AC1350 router, based on Qualcomm/Atheros
+QCA9561+QCA9886.
+
+Specification:
+
+- 775/650/258 MHz (CPU/DDR/AHB)
+- 64 MB of RAM (DDR2)
+- 8 MB of FLASH (SPI NOR)
+- 3T3R 2.4 GHz
+- 2T2R 5 GHz
+- 5x 10/100 Mbps Ethernet
+- 7x LED, 2x button
+- UART header on PCB
+
+Currently not working:
+- Port LAN1 on C59, LAN4 on C60
+- WiFi 5GHz (missing ath10k firmware for QCA9886 chip)
+- Update from oficial web interface ( tplink-saveloader not support "product-info")
+
+Flash instruction:
+1. Set PC to fixed ip address 192.168.0.66
+2. Download lede-ar71xx-generic-archer-cXX-v1-squashfs-factory.bin
+and rename it to tp_recovery.bin
+3. Start a tftp server with the file tp_recovery.bin in its root directory
+4. Turn off the router
+5. Press and hold Reset button
+6. Turn on router with the reset button pressed and wait ~15 seconds
+7. Release the reset button and after a short time
+the firmware should be transferred from the tftp server
+8. Wait ~30 second to complete recovery.
+
+Flash instruction under U-Boot, using UART:
+
+1. tftp 0x81000000 lede-ar71xx-...-sysupgrade.bin
+2. erase 0x9f020000 +$filesize
+3. cp.b $fileaddr 0x9f020000 $filesize
+4. reset
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+[Jo-Philipp Wich: remove duplicate ATH79_MACH_ARCHER_C59/C60_V1 entries]
+Signed-off-by: Jo-Philipp Wich <jo@mein.io>
+
+Conflicts:
+	target/linux/ar71xx/base-files/etc/board.d/01_leds
+	target/linux/ar71xx/base-files/etc/diag.sh
+	target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+	target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+	target/linux/ar71xx/config-4.4
+	target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+	target/linux/ar71xx/files/arch/mips/ath79/Makefile
+	target/linux/ar71xx/image/tp-link.mk
+	target/linux/ar71xx/mikrotik/config-default
+	target/linux/ar71xx/nand/config-default
+	tools/firmware-utils/src/tplink-safeloader.c
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index e1efb561b33da4dcfcb82ee953cd888170476dfb..42d9d337a19eebcb3f8b5fb843f6b8a504efd0fa 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -62,6 +62,19 @@ archer-c25-v1)
+ 	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "0x04"
+ 	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x02"
+ 	;;
++archer-c59-v1|\
++archer-c60-v1)
++	ucidef_set_led_switch "lan" "LAN" "$board:green:lan" "switch0" "0x3C"
++	ucidef_set_led_switch "wan" "WAN" "$board:green:wan" "switch0" "0x02"
++	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
++	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
++
++	case "$board" in
++	archer-c59-v1)
++		ucidef_set_led_usbdev "usb" "USB" "$board:green:usb" "1-1"
++		;;
++	esac
++	;;
+ arduino-yun)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "arduino:blue:wlan" "phy0tpt"
+ 	ucidef_set_led_usbdev "usb" "USB" "arduino:white:usb" "1-1.1"
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 24ead87850f13346ea4be4f9bfb5582e64a2c4ad..148b02f07d6ed62c3c93e44dae27eaecdaa2019c 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -199,6 +199,11 @@ ar71xx_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
+ 		;;
++	archer-c59-v1|\
++	archer-c60-v1)
++		ucidef_add_switch "switch0" \
++			"0@eth0" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1" "1:wan"
++		;;
+ 	arduino-yun|\
+ 	dir-505-a1|\
+ 	tl-wa801nd-v3)
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 38cc5d7853c79f2a7800a387310a95abb3b4de1b..34d26c53b98d6ecc82f5cff967065fbc65fd7caa 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -51,6 +51,8 @@ get_status_led() {
+ 		status_led="ap135:green:status"
+ 		;;
+ 	archer-c25-v1|\
++	archer-c59-v1|\
++	archer-c60-v1|\
+ 	mr12|\
+ 	mr16|\
+ 	nbg6616|\
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 68f90de802ddd18e09a1da39c0d56292eea9489c..39cd6026270482866103c15885d913b48cea7e58 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -93,6 +93,8 @@ case "$FIRMWARE" in
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
+ 		;;
+ 	archer-c25-v1|\
++	archer-c59-v1|\
++	archer-c60-v1|\
+ 	tl-wdr6500-v2)
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 46711af2b26159ebb105fa97cd8a85bb9c00911a..948bb00d607c78ca1a5910e6d52f78a9486ebcc5 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -466,6 +466,12 @@ ar71xx_board_detect() {
+ 	*"Archer C5")
+ 		name="archer-c5"
+ 		;;
++	*"Archer C59 v1")
++		name="archer-c59-v1"
++		;;
++	*"Archer C60 v1")
++		name="archer-c60-v1"
++		;;
+ 	*"Archer C7")
+ 		name="archer-c7"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index e65f6e2f7594ba373fbc9a26620859b9005c8532..c294251f63489dbd2e859148cbceb3a4a625d1e7 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -207,6 +207,8 @@ platform_check_image() {
+ 	ap132|\
+ 	ap90q|\
+ 	archer-c25-v1|\
++	archer-c59-v1|\
++	archer-c60-v1|\
+ 	bullet-m|\
+ 	c-55|\
+ 	carambola2|\
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index c82fcf09228be7063967f2517e0942651234afb8..1b6527113b888d4023ee9abc2cb8134f7d5f2867 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -52,6 +52,8 @@ CONFIG_ATH79_MACH_AP152=y
+ CONFIG_ATH79_MACH_AP90Q=y
+ CONFIG_ATH79_MACH_AP96=y
+ CONFIG_ATH79_MACH_ARCHER_C25_V1=y
++CONFIG_ATH79_MACH_ARCHER_C59_V1=y
++CONFIG_ATH79_MACH_ARCHER_C60_V1=y
+ CONFIG_ATH79_MACH_ARCHER_C7=y
+ CONFIG_ATH79_MACH_ARDUINO_YUN=y
+ CONFIG_ATH79_MACH_AW_NR580=y
+@@ -271,6 +273,7 @@ CONFIG_GENERIC_SMP_IDLE_THREAD=y
+ CONFIG_GENERIC_TIME_VSYSCALL=y
+ CONFIG_GPIOLIB=y
+ CONFIG_GPIOLIB_IRQCHIP=y
++CONFIG_GPIO_74X164=y
+ CONFIG_GPIO_DEVRES=y
+ CONFIG_GPIO_74X164=y
+ # CONFIG_GPIO_LATCH is not set
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+index fb2afb965c4641df7cdcaf0920f2d56b3717fa9b..970ce2dbd4484e1c556fc55c5f37755d14738105 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+@@ -1244,6 +1244,27 @@ config ATH79_MACH_ARCHER_C25_V1
+ 	select ATH79_DEV_M25P80
+ 	select ATH79_DEV_WMAC
+ 
++config ATH79_MACH_ARCHER_C59_V1
++	bool "TP-LINK Archer C59 v1 support"
++	select SOC_QCA956X
++	select ATH79_DEV_AP9X_PCI if PCI
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_USB
++	select ATH79_DEV_WMAC
++
++config ATH79_MACH_ARCHER_C60_V1
++	bool "TP-LINK Archer C60 v1 support"
++	select SOC_QCA956X
++	select ATH79_DEV_AP9X_PCI if PCI
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_WMAC
++
+ config ATH79_MACH_ARCHER_C7
+ 	bool "TP-LINK Archer C5/C7/TL-WDR4900 v2 board support"
+ 	select SOC_QCA955X
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Makefile b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+index 3365a43ce16fc77b3212b39b92081efe678e8803..ab482671c24c39c2416e3e52644757447c0c6af7 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+@@ -57,6 +57,8 @@ obj-$(CONFIG_ATH79_MACH_AP152)			+= mach-ap152.o
+ obj-$(CONFIG_ATH79_MACH_AP90Q)			+= mach-ap90q.o
+ obj-$(CONFIG_ATH79_MACH_AP96)			+= mach-ap96.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C25_V1)		+= mach-archer-c25-v1.o
++obj-$(CONFIG_ATH79_MACH_ARCHER_C59_V1)		+= mach-archer-c59-v1.o
++obj-$(CONFIG_ATH79_MACH_ARCHER_C60_V1)		+= mach-archer-c60-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7.o
+ obj-$(CONFIG_ATH79_MACH_ARDUINO_YUN)		+= mach-arduino-yun.o
+ obj-$(CONFIG_ATH79_MACH_AW_NR580)		+= mach-aw-nr580.o
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..28353aa77b05078b895ab48cf6b1ae53abe98ce2
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+@@ -0,0 +1,223 @@
++/*
++ *  TP-Link Archer C59 v1 board support
++ *
++ *  Copyright (C) 2016 Henryk Heisig <hyniu@o2.pl>
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under the terms of the GNU General Public License version 2 as published
++ *  by the Free Software Foundation.
++ */
++#include <linux/platform_device.h>
++#include <linux/ath9k_platform.h>
++#include <linux/ar8216_platform.h>
++#include <asm/mach-ath79/ar71xx_regs.h>
++#include <linux/gpio.h>
++#include <linux/init.h>
++#include <linux/spi/spi_gpio.h>
++#include <linux/spi/74x164.h>
++
++#include "common.h"
++#include "dev-m25p80.h"
++#include "machtypes.h"
++#include "pci.h"
++#include "dev-ap9x-pci.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-spi.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++
++#define ARCHER_C59_V1_KEYS_POLL_INTERVAL	20
++#define ARCHER_C59_V1_KEYS_DEBOUNCE_INTERVAL	(3 * ARCHER_C59_V1_KEYS_POLL_INTERVAL)
++
++#define ARCHER_C59_V1_GPIO_BTN_RESET		21
++#define ARCHER_C59_V1_GPIO_BTN_RFKILL		2
++#define ARCHER_C59_V1_GPIO_BTN_WPS		1
++
++#define ARCHER_C59_V1_GPIO_USB_POWER		22
++
++#define ARCHER_C59_GPIO_SHIFT_OE		16
++#define ARCHER_C59_GPIO_SHIFT_SER		17
++#define ARCHER_C59_GPIO_SHIFT_SRCLK		18
++#define ARCHER_C59_GPIO_SHIFT_SRCLR		19
++#define ARCHER_C59_GPIO_SHIFT_RCLK		20
++
++#define ARCHER_C59_74HC_GPIO_BASE		QCA956X_GPIO_COUNT
++#define ARCHER_C59_74HC_GPIO_LED_POWER		23
++#define ARCHER_C59_74HC_GPIO_LED_WLAN2		24
++#define ARCHER_C59_74HC_GPIO_LED_WLAN5		25
++#define ARCHER_C59_74HC_GPIO_LED_LAN		26
++#define ARCHER_C59_74HC_GPIO_LED_WAN_GREEN	27
++#define ARCHER_C59_74HC_GPIO_LED_WAN_AMBER	28
++#define ARCHER_C59_74HC_GPIO_LED_WPS		29
++#define ARCHER_C59_74HC_GPIO_LED_USB		30
++
++#define ARCHER_C59_V1_SSR_BIT_0			0
++#define ARCHER_C59_V1_SSR_BIT_1			1
++#define ARCHER_C59_V1_SSR_BIT_2			2
++#define ARCHER_C59_V1_SSR_BIT_3			3
++#define ARCHER_C59_V1_SSR_BIT_4			4
++#define ARCHER_C59_V1_SSR_BIT_5			5
++#define ARCHER_C59_V1_SSR_BIT_6			6
++#define ARCHER_C59_V1_SSR_BIT_7			7
++
++#define ARCHER_C59_V1_WMAC_CALDATA_OFFSET	0x1000
++#define ARCHER_C59_V1_PCI_CALDATA_OFFSET	0x5000
++
++static struct gpio_led archer_c59_v1_leds_gpio[] __initdata = {
++	{
++		.name		= "archer-c59-v1:green:power",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_POWER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:wlan2g",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WLAN2,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:wlan5g",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WLAN5,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:lan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_LAN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:wan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WAN_GREEN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:amber:wan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WAN_AMBER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:wps",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WPS,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:usb",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_USB,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button archer_c59_v1_gpio_keys[] __initdata = {
++	{
++		.desc			= "Reset button",
++		.type			= EV_KEY,
++		.code			= KEY_RESTART,
++		.debounce_interval	= ARCHER_C59_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C59_V1_GPIO_BTN_RESET,
++		.active_low		= 1,
++	},
++	{
++		.desc			= "RFKILL button",
++		.type			= EV_KEY,
++		.code			= KEY_RFKILL,
++		.debounce_interval	= ARCHER_C59_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C59_V1_GPIO_BTN_RFKILL,
++		.active_low		= 1,
++	},
++	{
++		.desc			= "WPS button",
++		.type			= EV_KEY,
++		.code			= KEY_WPS_BUTTON,
++		.debounce_interval	= ARCHER_C59_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C59_V1_GPIO_BTN_WPS,
++		.active_low		= 1,
++	},
++};
++
++static struct spi_gpio_platform_data archer_c59_v1_spi_data = {
++	.sck		= ARCHER_C59_GPIO_SHIFT_SRCLK,
++	.miso		= SPI_GPIO_NO_MISO,
++	.mosi		= ARCHER_C59_GPIO_SHIFT_SER,
++	.num_chipselect = 1,
++};
++
++static u8 archer_c59_v1_ssr_initdata[] __initdata = {
++	BIT(ARCHER_C59_V1_SSR_BIT_7) |
++	BIT(ARCHER_C59_V1_SSR_BIT_6) |
++	BIT(ARCHER_C59_V1_SSR_BIT_5) |
++	BIT(ARCHER_C59_V1_SSR_BIT_4) |
++	BIT(ARCHER_C59_V1_SSR_BIT_3) |
++	BIT(ARCHER_C59_V1_SSR_BIT_2) |
++	BIT(ARCHER_C59_V1_SSR_BIT_1)
++};
++
++static struct gen_74x164_chip_platform_data archer_c59_v1_ssr_data = {
++	.base = ARCHER_C59_74HC_GPIO_BASE,
++	.num_registers = ARRAY_SIZE(archer_c59_v1_ssr_initdata),
++	.init_data = archer_c59_v1_ssr_initdata,
++};
++
++static struct platform_device archer_c59_v1_spi_device = {
++	.name		= "spi_gpio",
++	.id		= 1,
++	.dev = {
++		.platform_data = &archer_c59_v1_spi_data,
++	},
++};
++
++static struct spi_board_info archer_c59_v1_spi_info[] = {
++	{
++		.bus_num	= 1,
++		.chip_select	= 0,
++		.max_speed_hz	= 10000000,
++		.modalias	= "74x164",
++		.platform_data	=  &archer_c59_v1_ssr_data,
++		.controller_data = (void *) ARCHER_C59_GPIO_SHIFT_RCLK,
++	},
++};
++
++static void __init archer_c59_v1_setup(void)
++{
++	u8 *mac = (u8 *) KSEG1ADDR(0x1f010008);
++	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
++
++	ath79_register_m25p80(NULL);
++	spi_register_board_info(archer_c59_v1_spi_info,
++			   ARRAY_SIZE(archer_c59_v1_spi_info));
++	platform_device_register(&archer_c59_v1_spi_device);
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c59_v1_leds_gpio),
++				archer_c59_v1_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, ARCHER_C59_V1_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(archer_c59_v1_gpio_keys),
++					archer_c59_v1_gpio_keys);
++
++	ath79_register_mdio(1, 0x0);
++
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 0);
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_eth1_data.phy_mask = BIT(4);
++	ath79_register_eth(1);
++
++	ath79_register_wmac(art + ARCHER_C59_V1_WMAC_CALDATA_OFFSET, mac);
++	ap91_pci_init(art + ARCHER_C59_V1_PCI_CALDATA_OFFSET, NULL);
++
++
++	ath79_register_usb();
++	gpio_request_one(ARCHER_C59_V1_GPIO_USB_POWER,
++			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++			 "USB power");
++	gpio_request_one(ARCHER_C59_GPIO_SHIFT_OE,
++			 GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED,
++			 "LED control");
++	gpio_request_one(ARCHER_C59_GPIO_SHIFT_SRCLR,
++			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++			 "LED reset");
++}
++
++MIPS_MACHINE(ATH79_MACH_ARCHER_C59_V1, "ARCHER-C59-V1",
++	"TP-LINK Archer C59 v1", archer_c59_v1_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..78186f02cda0a231afda4e53a1d6ff696ecb6b4a
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
+@@ -0,0 +1,135 @@
++/*
++ *  TP-Link Archer C60 v1 board support
++ *
++ *  Copyright (C) 2016 Henryk Heisig <hyniu@o2.pl>
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under the terms of the GNU General Public License version 2 as published
++ *  by the Free Software Foundation.
++ */
++#include <linux/platform_device.h>
++#include <linux/ath9k_platform.h>
++#include <linux/ar8216_platform.h>
++#include <asm/mach-ath79/ar71xx_regs.h>
++#include <linux/gpio.h>
++
++#include "common.h"
++#include "dev-m25p80.h"
++#include "machtypes.h"
++#include "pci.h"
++#include "dev-ap9x-pci.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-spi.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++
++#define ARCHER_C60_V1_GPIO_LED_LAN		2
++#define ARCHER_C60_V1_GPIO_LED_POWER		16
++#define ARCHER_C60_V1_GPIO_LED_WLAN2		17
++#define ARCHER_C60_V1_GPIO_LED_WLAN5		18
++#define ARCHER_C60_V1_GPIO_LED_WPS		19
++#define ARCHER_C60_V1_GPIO_LED_WAN_GREEN	20
++#define ARCHER_C60_V1_GPIO_LED_WAN_AMBER	22
++
++
++#define ARCHER_C60_V1_KEYS_POLL_INTERVAL	20
++#define ARCHER_C60_V1_KEYS_DEBOUNCE_INTERVAL	(3 * ARCHER_C60_V1_KEYS_POLL_INTERVAL)
++
++#define ARCHER_C60_V1_GPIO_BTN_RESET		21
++#define ARCHER_C60_V1_GPIO_BTN_RFKILL		1
++
++
++
++#define ARCHER_C60_V1_WMAC_CALDATA_OFFSET	0x1000
++#define ARCHER_C60_V1_PCI_CALDATA_OFFSET	0x5000
++
++static struct gpio_led archer_c60_v1_leds_gpio[] __initdata = {
++	{
++		.name		= "archer-c60-v1:green:power",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_POWER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:wlan2g",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WLAN2,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:wlan5g",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WLAN5,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:lan",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_LAN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:wan",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WAN_GREEN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:amber:wan",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WAN_AMBER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:wps",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WPS,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button archer_c60_v1_gpio_keys[] __initdata = {
++	{
++		.desc			= "Reset button",
++		.type			= EV_KEY,
++		.code			= KEY_RESTART,
++		.debounce_interval	= ARCHER_C60_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C60_V1_GPIO_BTN_RESET,
++		.active_low		= 1,
++	},
++	{
++		.desc			= "RFKILL button",
++		.type			= EV_KEY,
++		.code			= KEY_RFKILL,
++		.debounce_interval	= ARCHER_C60_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C60_V1_GPIO_BTN_RFKILL,
++		.active_low		= 1,
++	},
++};
++
++static void __init archer_c60_v1_setup(void)
++{
++	u8 *mac = (u8 *) KSEG1ADDR(0x1f010008);
++	u8 *art = (u8 *) KSEG1ADDR(0x1f7f0000);
++
++	ath79_register_m25p80(NULL);
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c60_v1_leds_gpio),
++				archer_c60_v1_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, ARCHER_C60_V1_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(archer_c60_v1_gpio_keys),
++					archer_c60_v1_gpio_keys);
++
++	ath79_setup_qca956x_eth_cfg(QCA956X_ETH_CFG_SW_PHY_SWAP |
++				   QCA956X_ETH_CFG_SW_PHY_ADDR_SWAP);
++	ath79_register_mdio(1, 0x0);
++
++	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 0);
++
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_register_eth(1);
++
++	ath79_register_wmac(art + ARCHER_C60_V1_WMAC_CALDATA_OFFSET, mac);
++	ap91_pci_init(art + ARCHER_C60_V1_PCI_CALDATA_OFFSET, NULL);
++}
++
++MIPS_MACHINE(ATH79_MACH_ARCHER_C60_V1, "ARCHER-C60-V1",
++	"TP-LINK Archer C60 v1", archer_c60_v1_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 8864e0deda57b926e88dceebd26056a2f8099380..03268700fd51c7fea4064abb7af9fb8bf6041f5d 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -42,6 +42,8 @@ enum ath79_mach_type {
+ 	ATH79_MACH_AP96,			/* Atheros AP96 */
+ 	ATH79_MACH_ARCHER_C25_V1,		/* TP-LINK Archer C25 V1 board */
+ 	ATH79_MACH_ARCHER_C5,			/* TP-LINK Archer C5 board */
++	ATH79_MACH_ARCHER_C59_V1,		/* TP-LINK Archer C59 V1 board */
++	ATH79_MACH_ARCHER_C60_V1,		/* TP-LINK Archer C60 V1 board */
+ 	ATH79_MACH_ARCHER_C7,			/* TP-LINK Archer C7 board */
+ 	ATH79_MACH_ARCHER_C7_V2,		/* TP-LINK Archer C7 V2 board */
+ 	ATH79_MACH_ARDUINO_YUN,			/* Yun */
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index 6933654e575a1ef2c92e4c656696a479cba4c594..4718c9eaf25723ca77a6ec75043241a362100047 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -119,6 +119,36 @@ define Device/archer-c25-v1
+ endef
+ TARGET_DEVICES += archer-c25-v1
+ 
++define Device/archer-c59-v1
++  DEVICE_TITLE := TP-LINK Archer C59 v1
++  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k
++  BOARDNAME := ARCHER-C59-V1
++  TPLINK_BOARD_NAME := ARCHER-C59-V1
++  DEVICE_PROFILE := ARCHERC59V1
++  IMAGE_SIZE := 14528k
++  KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
++  IMAGES := sysupgrade.bin factory.bin
++  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
++  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
++  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1536k(kernel),12992k(rootfs),1664k(tplink)ro,64k(art)ro,14528k@0x20000(firmware)
++endef
++TARGET_DEVICES += archer-c59-v1
++
++define Device/archer-c60-v1
++  DEVICE_TITLE := TP-LINK Archer C60 v1
++  DEVICE_PACKAGES := kmod-ath10k
++  BOARDNAME := ARCHER-C60-V1
++  TPLINK_BOARD_NAME := ARCHER-C60-V1
++  DEVICE_PROFILE := ARCHERC60V1
++  IMAGE_SIZE := 7936k
++  KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
++  IMAGES := sysupgrade.bin factory.bin
++  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
++  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
++  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1344k(kernel),6592k(rootfs),64k(tplink)ro,64k(art)ro,7936k@0x20000(firmware)
++endef
++TARGET_DEVICES += archer-c60-v1
++
+ define Device/cpe510-520
+   DEVICE_TITLE := TP-LINK CPE510/520
+   DEVICE_PACKAGES := rssileds
+diff --git a/target/linux/ar71xx/mikrotik/config-default b/target/linux/ar71xx/mikrotik/config-default
+index 376835a703f91532300d0dd7c8ef66704acc6e05..a05f8b5ff903802d0de43c3b9aadcc6912852101 100644
+--- a/target/linux/ar71xx/mikrotik/config-default
++++ b/target/linux/ar71xx/mikrotik/config-default
+@@ -17,6 +17,8 @@
+ # CONFIG_ATH79_MACH_AP90Q is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C59_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C60_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+ # CONFIG_ATH79_MACH_ARDUINO_YUN is not set
+ # CONFIG_ATH79_MACH_AW_NR580 is not set
+diff --git a/target/linux/ar71xx/nand/config-default b/target/linux/ar71xx/nand/config-default
+index 62be218e33cc6366ea89f363983f36523c419650..b277ad2498c77b729e4aabb998ace7642d4ecfad 100644
+--- a/target/linux/ar71xx/nand/config-default
++++ b/target/linux/ar71xx/nand/config-default
+@@ -10,6 +10,8 @@
+ # CONFIG_ATH79_MACH_AP147 is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C59_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C60_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+ # CONFIG_ATH79_MACH_AW_NR580 is not set
+ # CONFIG_ATH79_MACH_CAP324 is not set
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index 24684268b1a3fe491c4eb876a5ebefc700f2e56e..dac7a2c4523294b58fe3402e871fa9d73059ad05 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -340,6 +340,44 @@ static struct device_info boards[] = {
+ 		.first_sysupgrade_partition = "os-image",
+ 		.last_sysupgrade_partition = "file-system",
+ 	},
++	
++	/** Firmware layout for the C59v1 */
++	{
++		.id	= "ARCHER-C59-V1",
++		.vendor	= "",
++		.support_list =
++			"SupportList:\r\n"
++			"{product_name:Archer C59,product_ver:1.0.0,special_id:00000000}\r\n"
++			"{product_name:Archer C59,product_ver:1.0.0,special_id:45550000}\r\n"
++			"{product_name:Archer C59,product_ver:1.0.0,special_id:55530000}\r\n",
++		.support_trail = '\x00',
++		.soft_ver = "soft_ver:1.0.0\n",
++
++		.partitions = {
++			{"fs-uboot", 0x00000, 0x10000},
++			{"default-mac", 0x10000, 0x00200},
++			{"pin", 0x10200, 0x00200},
++			{"device-id", 0x10400, 0x00100},
++			{"product-info", 0x10500, 0x0fb00},
++			{"os-image", 0x20000, 0x180000},
++			{"file-system", 0x1a0000, 0xcb0000},
++			{"partition-table", 0xe50000, 0x10000},
++			{"soft-version", 0xe60000, 0x10000},
++			{"support-list", 0xe70000, 0x10000},
++			{"profile", 0xe80000, 0x10000},
++			{"default-config", 0xe90000, 0x10000},
++			{"user-config", 0xea0000, 0x40000},
++			{"usb-config", 0xee0000, 0x10000},
++			{"certificate", 0xef0000, 0x10000},
++			{"qos-db", 0xf00000, 0x40000},
++			{"log", 0xfe0000, 0x10000},
++			{"radio", 0xff0000, 0x10000},
++			{NULL, 0, 0}
++		},
++
++		.first_sysupgrade_partition = "os-image",
++		.last_sysupgrade_partition = "file-system",
++	},
+ 
+ 	/** Firmware layout for the C5 */
+ 	{
+@@ -371,6 +409,40 @@ static struct device_info boards[] = {
+ 			{"radio", 0xff0000, 0x10000},
+ 			{NULL, 0, 0}
+ 		},
++		.first_sysupgrade_partition = "os-image",
++		.last_sysupgrade_partition = "file-system"
++	
++	},
++	/** Firmware layout for the C60v1 */
++	{
++		.id	= "ARCHER-C60-V1",
++		.vendor	= "",
++		.support_list =
++			"SupportList:\r\n"
++			"{product_name:Archer C60,product_ver:1.0.0,special_id:00000000}\r\n"
++			"{product_name:Archer C60,product_ver:1.0.0,special_id:45550000}\r\n"
++			"{product_name:Archer C60,product_ver:1.0.0,special_id:55530000}\r\n",
++		.support_trail = '\x00',
++		.soft_ver = "soft_ver:1.0.0\n",
++
++		.partitions = {
++			{"fs-uboot", 0x00000, 0x10000},
++			{"default-mac", 0x10000, 0x00200},
++			{"pin", 0x10200, 0x00200},
++			{"product-info", 0x10400, 0x00100},
++			{"partition-table", 0x10500, 0x00800},
++			{"soft-version", 0x11300, 0x00200},
++			{"support-list", 0x11500, 0x00100},
++			{"device-id", 0x11600, 0x00100},
++			{"profile", 0x11700, 0x03900},
++			{"default-config", 0x15000, 0x04000},
++			{"user-config", 0x19000, 0x04000},
++			{"os-image", 0x20000, 0x150000},
++			{"file-system", 0x170000, 0x678000},
++			{"certyficate", 0x7e8000, 0x08000},
++			{"radio", 0x7f0000, 0x10000},
++			{NULL, 0, 0}
++		},
+ 
+ 		.first_sysupgrade_partition = "os-image",
+ 		.last_sysupgrade_partition = "file-system"

--- a/patches/lede/0044-ar71xx-QCA956X-add-missing-register.patch
+++ b/patches/lede/0044-ar71xx-QCA956X-add-missing-register.patch
@@ -1,0 +1,162 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Fri, 6 Jan 2017 21:21:11 +0100
+Subject: ar71xx: QCA956X: add missing register
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+index 790c2d3396ffd0a0d00d13403b7f22e32863eef4..a8b19b68b2a46545fdd3ed6bdf14006f8a741185 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+@@ -686,7 +686,6 @@ static int __init ath79_setup_phy_if_mode(unsigned int id,
+ 		case ATH79_SOC_AR7241:
+ 		case ATH79_SOC_AR9330:
+ 		case ATH79_SOC_AR9331:
+-		case ATH79_SOC_QCA956X:
+ 		case ATH79_SOC_TP9343:
+ 			pdata->phy_if_mode = PHY_INTERFACE_MODE_GMII;
+ 			break;
+@@ -698,6 +697,7 @@ static int __init ath79_setup_phy_if_mode(unsigned int id,
+ 		case ATH79_SOC_AR9342:
+ 		case ATH79_SOC_AR9344:
+ 		case ATH79_SOC_QCA9533:
++		case ATH79_SOC_QCA956X:
+ 			switch (pdata->phy_if_mode) {
+ 			case PHY_INTERFACE_MODE_MII:
+ 			case PHY_INTERFACE_MODE_GMII:
+@@ -814,6 +814,27 @@ void __init ath79_setup_qca955x_eth_cfg(u32 mask)
+ 	iounmap(base);
+ }
+ 
++void __init ath79_setup_qca956x_eth_cfg(u32 mask)
++{
++	void __iomem *base;
++	u32 t;
++
++	base = ioremap(QCA956X_GMAC_BASE, QCA956X_GMAC_SIZE);
++
++	t = __raw_readl(base + QCA956X_GMAC_REG_ETH_CFG);
++
++	t &= ~(QCA956X_ETH_CFG_SW_ONLY_MODE |
++	       QCA956X_ETH_CFG_SW_PHY_SWAP);
++
++	t |= mask;
++
++	__raw_writel(t, base + QCA956X_GMAC_REG_ETH_CFG);
++	/* flush write */
++	__raw_readl(base + QCA956X_GMAC_REG_ETH_CFG);
++
++	iounmap(base);
++}
++
+ static int ath79_eth_instance __initdata;
+ void __init ath79_register_eth(unsigned int id)
+ {
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.h b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.h
+index 5a226e40284b6853b59812ffc791e0612c91fa9b..fb9e4f63c66ef9008e423007ecff02c93c321fb8 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.h
+@@ -49,5 +49,6 @@ void ath79_setup_ar933x_phy4_switch(bool mac, bool mdio);
+ void ath79_setup_ar934x_eth_cfg(u32 mask);
+ void ath79_setup_ar934x_eth_rx_delay(unsigned int rxd, unsigned int rxdv);
+ void ath79_setup_qca955x_eth_cfg(u32 mask);
++void ath79_setup_qca956x_eth_cfg(u32 mask);
+ 
+ #endif /* _ATH79_DEV_ETH_H */
+diff --git a/target/linux/ar71xx/files/arch/mips/include/asm/mach-ath79/ag71xx_platform.h b/target/linux/ar71xx/files/arch/mips/include/asm/mach-ath79/ag71xx_platform.h
+index 5fd352c638a75063945adadb64b1043cd81b506c..078fa157f242ce4350185d97a61ef5d1f3f16fc5 100644
+--- a/target/linux/ar71xx/files/arch/mips/include/asm/mach-ath79/ag71xx_platform.h
++++ b/target/linux/ar71xx/files/arch/mips/include/asm/mach-ath79/ag71xx_platform.h
+@@ -37,11 +37,13 @@ struct ag71xx_platform_data {
+ 	u8		is_ar724x:1;
+ 	u8		has_ar8216:1;
+ 	u8		use_flow_control:1;
++	u8		is_qca956x:1;
+ 
+ 	struct ag71xx_switch_platform_data *switch_data;
+ 
+ 	void		(*ddr_flush)(void);
+ 	void		(*set_speed)(int speed);
++	void		(*update_pll)(u32 pll_10, u32 pll_100, u32 pll_1000);
+ 
+ 	u32		fifo_cfg1;
+ 	u32		fifo_cfg2;
+diff --git a/target/linux/ar71xx/patches-4.4/622-MIPS-ath79-add-more-register-defines-for-QCA956x-SoC.patch b/target/linux/ar71xx/patches-4.4/622-MIPS-ath79-add-more-register-defines-for-QCA956x-SoC.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..dff354398cd2ab6556b13be9f7ce45f4d7f311e8
+--- /dev/null
++++ b/target/linux/ar71xx/patches-4.4/622-MIPS-ath79-add-more-register-defines-for-QCA956x-SoC.patch
+@@ -0,0 +1,38 @@
++--- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+++++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
++@@ -157,6 +157,10 @@
++ #define QCA956X_EHCI0_BASE	0x1b000000
++ #define QCA956X_EHCI1_BASE	0x1b400000
++ #define QCA956X_EHCI_SIZE	0x200
+++#define QCA956X_GMAC_SGMII_BASE	(AR71XX_APB_BASE + 0x00070000)
+++#define QCA956X_GMAC_SGMII_SIZE	0x64
+++#define QCA956X_PLL_BASE	(AR71XX_APB_BASE + 0x00050000)
+++#define QCA956X_PLL_SIZE	0x50
++ #define QCA956X_GMAC_BASE	(AR71XX_APB_BASE + 0x00070000)
++ #define QCA956X_GMAC_SIZE	0x64
++ 
++@@ -404,6 +408,7 @@
++ #define QCA956X_PLL_DDR_CONFIG_REG			0x08
++ #define QCA956X_PLL_DDR_CONFIG1_REG			0x0c
++ #define QCA956X_PLL_CLK_CTRL_REG			0x10
+++#define QCA956X_PLL_ETH_XMII_CONTROL_REG		0x30
++ 
++ #define QCA956X_PLL_CPU_CONFIG_REFDIV_SHIFT		12
++ #define QCA956X_PLL_CPU_CONFIG_REFDIV_MASK		0x1f
++@@ -1186,4 +1191,16 @@
++ #define QCA955X_ETH_CFG_TXE_DELAY_MASK	0x3
++ #define QCA955X_ETH_CFG_TXE_DELAY_SHIFT	20
++ 
+++/*
+++ * QCA956X GMAC Interface
+++ */
+++
+++#define QCA956X_GMAC_REG_ETH_CFG		0x00
+++
+++#define QCA956X_ETH_CFG_SW_ONLY_MODE		BIT(7)
+++#define QCA956X_ETH_CFG_SW_PHY_SWAP		    BIT(8)
+++#define QCA956X_ETH_CFG_SW_PHY_ADDR_SWAP	BIT(9)
+++#define QCA956X_ETH_CFG_SW_APB_ACCESS		BIT(10)
+++#define QCA956X_ETH_CFG_SW_ACC_MSB_FIRST	BIT(13)
+++
++ #endif /* __ASM_MACH_AR71XX_REGS_H */
+diff --git a/target/linux/ar71xx/patches-4.4/640-MIPS-ath79-add-QCA955x-wmac-reset.patch b/target/linux/ar71xx/patches-4.4/640-MIPS-ath79-add-QCA955x-wmac-reset.patch
+index add2992186ad1d82ce924d2f1ccdf3c36c390a3d..8aa5957a7152af27854f6f7c197120b8029cf9e8 100644
+--- a/target/linux/ar71xx/patches-4.4/640-MIPS-ath79-add-QCA955x-wmac-reset.patch
++++ b/target/linux/ar71xx/patches-4.4/640-MIPS-ath79-add-QCA955x-wmac-reset.patch
+@@ -20,7 +20,7 @@
+  #define AR71XX_UART_BASE	(AR71XX_APB_BASE + 0x00020000)
+  #define AR71XX_UART_SIZE	0x100
+  #define AR71XX_USB_CTRL_BASE	(AR71XX_APB_BASE + 0x00030000)
+-@@ -218,6 +218,9 @@
++@@ -222,6 +222,9 @@
+  #define QCA953X_DDR_REG_FLUSH_PCIE	0xa8
+  #define QCA953X_DDR_REG_FLUSH_WMAC	0xac
+  
+diff --git a/target/linux/ar71xx/patches-4.4/820-MIPS-ath79-add_gpio_function2_setup.patch b/target/linux/ar71xx/patches-4.4/820-MIPS-ath79-add_gpio_function2_setup.patch
+index 7db6ad361fa21252118e589195b0bc73222cf4f5..6b331587d157511a40fc1e46630c416a60565a0b 100644
+--- a/target/linux/ar71xx/patches-4.4/820-MIPS-ath79-add_gpio_function2_setup.patch
++++ b/target/linux/ar71xx/patches-4.4/820-MIPS-ath79-add_gpio_function2_setup.patch
+@@ -48,7 +48,7 @@ functions on the Arduino Yun.
+  	void __iomem *reg = ath79_gpio_get_function_reg();
+ --- a/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+ +++ b/arch/mips/include/asm/mach-ath79/ar71xx_regs.h
+-@@ -850,6 +850,7 @@
++@@ -855,6 +855,7 @@
+  #define AR71XX_GPIO_REG_INT_PENDING	0x20
+  #define AR71XX_GPIO_REG_INT_ENABLE	0x24
+  #define AR71XX_GPIO_REG_FUNC		0x28
+@@ -56,7 +56,7 @@ functions on the Arduino Yun.
+  
+  #define AR934X_GPIO_REG_OUT_FUNC0	0x2c
+  #define AR934X_GPIO_REG_OUT_FUNC1	0x30
+-@@ -974,6 +975,8 @@
++@@ -979,6 +980,8 @@
+  #define AR724X_GPIO_FUNC_UART_EN		BIT(1)
+  #define AR724X_GPIO_FUNC_JTAG_DISABLE		BIT(0)
+  

--- a/patches/lede/0045-ar71xx-fix-lan-ports-on-archer-C59-and-C60.patch
+++ b/patches/lede/0045-ar71xx-fix-lan-ports-on-archer-C59-and-C60.patch
@@ -1,0 +1,117 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Thu, 16 Feb 2017 15:22:49 +0100
+Subject: ar71xx: fix lan ports on archer C59 and C60
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 42d9d337a19eebcb3f8b5fb843f6b8a504efd0fa..81348c5ed74d292691f1aec6db9459d3280e2d45 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -64,8 +64,8 @@ archer-c25-v1)
+ 	;;
+ archer-c59-v1|\
+ archer-c60-v1)
+-	ucidef_set_led_switch "lan" "LAN" "$board:green:lan" "switch0" "0x3C"
+-	ucidef_set_led_switch "wan" "WAN" "$board:green:wan" "switch0" "0x02"
++	ucidef_set_led_switch "lan" "LAN" "$board:green:lan" "switch0" "0x1E"
++	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
+ 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
+ 
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 148b02f07d6ed62c3c93e44dae27eaecdaa2019c..7ddda1d5c2b6426557f845b6c595aa6a0fd32802 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -199,10 +199,15 @@ ar71xx_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
+ 		;;
+-	archer-c59-v1|\
++	archer-c59-v1)
++		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
++		ucidef_add_switch "switch0" \
++			"0@eth1" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
++		;;
+ 	archer-c60-v1)
++		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
+ 		ucidef_add_switch "switch0" \
+-			"0@eth0" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1" "1:wan"
++			"0@eth1" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4"
+ 		;;
+ 	arduino-yun|\
+ 	dir-505-a1|\
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+index 28353aa77b05078b895ab48cf6b1ae53abe98ce2..d55f9b9f75b38159ed7209aa5acd73ff31088b51 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+@@ -194,19 +194,33 @@ static void __init archer_c59_v1_setup(void)
+ 					ARRAY_SIZE(archer_c59_v1_gpio_keys),
+ 					archer_c59_v1_gpio_keys);
+ 
++	ath79_setup_qca956x_eth_cfg(QCA956X_ETH_CFG_SW_PHY_SWAP |
++				   QCA956X_ETH_CFG_SW_PHY_ADDR_SWAP);
++
++	ath79_register_mdio(0, 0x0);
+ 	ath79_register_mdio(1, 0x0);
+ 
+-	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 1);
+ 	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 0);
++
++	/* WAN port */
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_mask = BIT(0);
++	ath79_register_eth(0);
++
++	/* LAN ports */
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
+ 	ath79_eth1_data.speed = SPEED_1000;
+ 	ath79_eth1_data.duplex = DUPLEX_FULL;
+-	ath79_eth1_data.phy_mask = BIT(4);
++	ath79_switch_data.phy_poll_mask |= BIT(4);
++	ath79_switch_data.phy4_mii_en = 1;
+ 	ath79_register_eth(1);
+ 
+ 	ath79_register_wmac(art + ARCHER_C59_V1_WMAC_CALDATA_OFFSET, mac);
+ 	ap91_pci_init(art + ARCHER_C59_V1_PCI_CALDATA_OFFSET, NULL);
+ 
+-
+ 	ath79_register_usb();
+ 	gpio_request_one(ARCHER_C59_V1_GPIO_USB_POWER,
+ 			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
+index 78186f02cda0a231afda4e53a1d6ff696ecb6b4a..4d83fa737b9650935b4f7f985d58f471c38cd9da 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
+@@ -116,15 +116,25 @@ static void __init archer_c60_v1_setup(void)
+ 					ARRAY_SIZE(archer_c60_v1_gpio_keys),
+ 					archer_c60_v1_gpio_keys);
+ 
+-	ath79_setup_qca956x_eth_cfg(QCA956X_ETH_CFG_SW_PHY_SWAP |
+-				   QCA956X_ETH_CFG_SW_PHY_ADDR_SWAP);
++	ath79_register_mdio(0, 0x0);
+ 	ath79_register_mdio(1, 0x0);
+ 
+-	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 0);
++	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 0);
++	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 1);
+ 
++	/* WAN port */
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_mask = BIT(4);
++	ath79_register_eth(0);
++
++	/* LAN ports */
+ 	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
+ 	ath79_eth1_data.speed = SPEED_1000;
+ 	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_switch_data.phy_poll_mask |= BIT(4);
++	ath79_switch_data.phy4_mii_en = 1;
+ 	ath79_register_eth(1);
+ 
+ 	ath79_register_wmac(art + ARCHER_C60_V1_WMAC_CALDATA_OFFSET, mac);

--- a/patches/lede/0046-ar71xx-add-support-for-TP-Link-Archer-C58-v1.patch
+++ b/patches/lede/0046-ar71xx-add-support-for-TP-Link-Archer-C58-v1.patch
@@ -1,0 +1,413 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Fri, 16 Jun 2017 15:26:30 +0200
+Subject: ar71xx: add support for TP-Link Archer C58 v1
+
+TP-Link Archer C58 v1 is a dual-band AC1350 router, based on Qualcomm
+QCA9561 + QCA9886. It looks like Archer C59 v1 without USB port.
+
+Specification:
+
+- 775/650/258 MHz (CPU/DDR/AHB)
+- 64 MB of RAM (DDR2)
+- 8 MB of FLASH (SPI NOR)
+- 3T3R 2.4 GHz
+- 2T2R 5 GHz
+- 5x 10/100 Mbps Ethernet
+- 6x LED, 3x button
+- UART header on PCB, RX, TX at TP4+5 (backside)
+
+QCA9886 wlan needs pre_cal_data file and enable ieee80211 phy hotplug to
+patch macaddress.
+
+Flash instruction:
+
+Use "factory" image directly in vendor GUI.
+
+Recovery method:
+
+1. Set PC to fixed ip address 192.168.0.66/24.
+2. Download "lede-ar71xx-generic-archer-c58-v1-squashfs-factory.bin" and
+   rename it to "tp_recovery.bin".
+3. Start a tftp server with the file "tp_recovery.bin" in its root
+   directory.
+4. Turn off the router.
+5. Press and hold Reset button.
+6. Turn on router with the reset button pressed and wait ~15 seconds.
+7. Release the reset button and after a short time the firmware should
+   be transferred from the tftp server.
+8. Wait ~30 second to complete recovery.
+
+Flash instruction under U-Boot, using UART:
+
+tftp 0x81000000 lede-ar71xx-...-sysupgrade.bin
+erase 0x9f020000 +$filesize
+cp.b $fileaddr 0x9f020000 $filesize
+reset
+
+This commit is based on GitHub PR#1112
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 81348c5ed74d292691f1aec6db9459d3280e2d45..98dcbf35bca8533a99b8df9cfdd9676743bc6181 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -62,6 +62,7 @@ archer-c25-v1)
+ 	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "0x04"
+ 	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x02"
+ 	;;
++archer-c58-v1|\
+ archer-c59-v1|\
+ archer-c60-v1)
+ 	ucidef_set_led_switch "lan" "LAN" "$board:green:lan" "switch0" "0x1E"
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 7ddda1d5c2b6426557f845b6c595aa6a0fd32802..ae0f984dbb4b4481b6eec055a3cc4f9cd0ce2281 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -199,6 +199,7 @@ ar71xx_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
+ 		;;
++	archer-c58-v1|\
+ 	archer-c59-v1)
+ 		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
+ 		ucidef_add_switch "switch0" \
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 34d26c53b98d6ecc82f5cff967065fbc65fd7caa..7bcc8b6228869e127a39811f3ecf2140004a75f7 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -51,6 +51,7 @@ get_status_led() {
+ 		status_led="ap135:green:status"
+ 		;;
+ 	archer-c25-v1|\
++	archer-c58-v1|\
+ 	archer-c59-v1|\
+ 	archer-c60-v1|\
+ 	mr12|\
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 39cd6026270482866103c15885d913b48cea7e58..04d8bcca535fd341aa0af29cafc09c4f20980c3a 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -130,6 +130,13 @@ case "$FIRMWARE" in
+ 		;;
+ 	esac
+ 	;;
++"ath10k/pre-cal-pci-0000:00:00.0.bin")
++	case $board in
++	archer-c58-v1)
++		ath10kcal_extract "art" 20480 12064
++		;;
++	esac
++	;;
+ *)
+ 	exit 1
+ 	;;
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+new file mode 100644
+index 0000000000000000000000000000000000000000..7d2eca546d76b771b12026788510f73a293a9a93
+--- /dev/null
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+@@ -0,0 +1,21 @@
++#!/bin/ash
++
++[ "$ACTION" == "add" ] || exit 0
++
++PHYNBR=${DEVPATH##*/phy}
++
++[ -n $PHYNBR ] || exit 0
++
++. /lib/ar71xx.sh
++. /lib/functions/system.sh
++
++board=$(ar71xx_board_name)
++
++case "$board" in
++	archer-c58-v1)
++		echo $(macaddr_add $(mtd_get_mac_binary mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
++		;;
++	*)
++		;;
++esac
++
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 948bb00d607c78ca1a5910e6d52f78a9486ebcc5..1c23198b868125738c22e45260ee63ff195aed2c 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -466,6 +466,9 @@ ar71xx_board_detect() {
+ 	*"Archer C5")
+ 		name="archer-c5"
+ 		;;
++	*"Archer C58 v1")
++		name="archer-c58-v1"
++		;;
+ 	*"Archer C59 v1")
+ 		name="archer-c59-v1"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index c294251f63489dbd2e859148cbceb3a4a625d1e7..0b2ac5f6ffe298f0ea0b180a90afdba893391f90 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -207,6 +207,7 @@ platform_check_image() {
+ 	ap132|\
+ 	ap90q|\
+ 	archer-c25-v1|\
++	archer-c58-v1|\
+ 	archer-c59-v1|\
+ 	archer-c60-v1|\
+ 	bullet-m|\
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index 1b6527113b888d4023ee9abc2cb8134f7d5f2867..844900051b8072a330354d938f503a71d7d6b7f1 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -52,6 +52,7 @@ CONFIG_ATH79_MACH_AP152=y
+ CONFIG_ATH79_MACH_AP90Q=y
+ CONFIG_ATH79_MACH_AP96=y
+ CONFIG_ATH79_MACH_ARCHER_C25_V1=y
++CONFIG_ATH79_MACH_ARCHER_C58_V1=y
+ CONFIG_ATH79_MACH_ARCHER_C59_V1=y
+ CONFIG_ATH79_MACH_ARCHER_C60_V1=y
+ CONFIG_ATH79_MACH_ARCHER_C7=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+index 970ce2dbd4484e1c556fc55c5f37755d14738105..cbe345dd40ff080bf8b43347eb4ffdfd2f0c8a2e 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+@@ -1244,6 +1244,16 @@ config ATH79_MACH_ARCHER_C25_V1
+ 	select ATH79_DEV_M25P80
+ 	select ATH79_DEV_WMAC
+ 
++config ATH79_MACH_ARCHER_C58_V1
++	bool "TP-LINK Archer C58 v1 support"
++	select SOC_QCA956X
++	select ATH79_DEV_AP9X_PCI if PCI
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_WMAC
++
+ config ATH79_MACH_ARCHER_C59_V1
+ 	bool "TP-LINK Archer C59 v1 support"
+ 	select SOC_QCA956X
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Makefile b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+index ab482671c24c39c2416e3e52644757447c0c6af7..2e665c38a00bb71c62fb252114005afd9e0d7d80 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+@@ -57,6 +57,7 @@ obj-$(CONFIG_ATH79_MACH_AP152)			+= mach-ap152.o
+ obj-$(CONFIG_ATH79_MACH_AP90Q)			+= mach-ap90q.o
+ obj-$(CONFIG_ATH79_MACH_AP96)			+= mach-ap96.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C25_V1)		+= mach-archer-c25-v1.o
++obj-$(CONFIG_ATH79_MACH_ARCHER_C58_V1)		+= mach-archer-c59-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C59_V1)		+= mach-archer-c59-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C60_V1)		+= mach-archer-c60-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7.o
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+index d55f9b9f75b38159ed7209aa5acd73ff31088b51..f385d4a5a3148b83ee01007145e0eda2c0ef670f 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+@@ -1,7 +1,7 @@
+ /*
+- *  TP-Link Archer C59 v1 board support
++ *  TP-Link Archer C58/C59 v1 board support
+  *
+- *  Copyright (C) 2016 Henryk Heisig <hyniu@o2.pl>
++ *  Copyright (C) 2017 Henryk Heisig <hyniu@o2.pl>
+  *
+  *  This program is free software; you can redistribute it and/or modify it
+  *  under the terms of the GNU General Public License version 2 as published
+@@ -65,6 +65,44 @@
+ #define ARCHER_C59_V1_WMAC_CALDATA_OFFSET	0x1000
+ #define ARCHER_C59_V1_PCI_CALDATA_OFFSET	0x5000
+ 
++static struct gpio_led archer_c58_v1_leds_gpio[] __initdata = {
++	{
++		.name		= "archer-c58-v1:green:power",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_POWER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:wlan2g",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WLAN2,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:wlan5g",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WLAN5,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:lan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_LAN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:wan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WAN_GREEN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:amber:wan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WAN_AMBER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:wps",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WPS,
++		.active_low	= 1,
++	},
++};
++
+ static struct gpio_led archer_c59_v1_leds_gpio[] __initdata = {
+ 	{
+ 		.name		= "archer-c59-v1:green:power",
+@@ -177,7 +215,7 @@ static struct spi_board_info archer_c59_v1_spi_info[] = {
+ 	},
+ };
+ 
+-static void __init archer_c59_v1_setup(void)
++static void __init archer_c5x_v1_setup(void)
+ {
+ 	u8 *mac = (u8 *) KSEG1ADDR(0x1f010008);
+ 	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
+@@ -187,9 +225,6 @@ static void __init archer_c59_v1_setup(void)
+ 			   ARRAY_SIZE(archer_c59_v1_spi_info));
+ 	platform_device_register(&archer_c59_v1_spi_device);
+ 
+-	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c59_v1_leds_gpio),
+-				archer_c59_v1_leds_gpio);
+-
+ 	ath79_register_gpio_keys_polled(-1, ARCHER_C59_V1_KEYS_POLL_INTERVAL,
+ 					ARRAY_SIZE(archer_c59_v1_gpio_keys),
+ 					archer_c59_v1_gpio_keys);
+@@ -233,5 +268,22 @@ static void __init archer_c59_v1_setup(void)
+ 			 "LED reset");
+ }
+ 
++static void __init archer_c58_v1_setup(void)
++{
++	archer_c5x_v1_setup();
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c58_v1_leds_gpio),
++				archer_c58_v1_leds_gpio);
++}
++
++MIPS_MACHINE(ATH79_MACH_ARCHER_C58_V1, "ARCHER-C58-V1",
++	"TP-LINK Archer C58 v1", archer_c58_v1_setup);
++
++static void __init archer_c59_v1_setup(void)
++{
++	archer_c5x_v1_setup();
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c59_v1_leds_gpio),
++				archer_c59_v1_leds_gpio);
++}
++
+ MIPS_MACHINE(ATH79_MACH_ARCHER_C59_V1, "ARCHER-C59-V1",
+ 	"TP-LINK Archer C59 v1", archer_c59_v1_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 03268700fd51c7fea4064abb7af9fb8bf6041f5d..b6f7602b0e44880d0b93d42213b77d12e8861741 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -42,6 +42,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_AP96,			/* Atheros AP96 */
+ 	ATH79_MACH_ARCHER_C25_V1,		/* TP-LINK Archer C25 V1 board */
+ 	ATH79_MACH_ARCHER_C5,			/* TP-LINK Archer C5 board */
++	ATH79_MACH_ARCHER_C58_V1,		/* TP-LINK Archer C58 V1 board */
+ 	ATH79_MACH_ARCHER_C59_V1,		/* TP-LINK Archer C59 V1 board */
+ 	ATH79_MACH_ARCHER_C60_V1,		/* TP-LINK Archer C60 V1 board */
+ 	ATH79_MACH_ARCHER_C7,			/* TP-LINK Archer C7 board */
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index 4718c9eaf25723ca77a6ec75043241a362100047..d639b3e0ddb8dfd68aca6cd0305da3559fbec1a8 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -119,6 +119,21 @@ define Device/archer-c25-v1
+ endef
+ TARGET_DEVICES += archer-c25-v1
+ 
++define Device/archer-c58-v1
++  DEVICE_TITLE := TP-LINK Archer C58 v1
++  DEVICE_PACKAGES := kmod-ath10k
++  BOARDNAME := ARCHER-C58-V1
++  TPLINK_BOARD_NAME := ARCHER-C58-V1
++  DEVICE_PROFILE := ARCHERC58V1
++  IMAGE_SIZE := 7936k
++  KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
++  IMAGES := sysupgrade.bin factory.bin
++  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
++  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
++  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1344k(kernel),6592k(rootfs),64k(tplink)ro,64k(art)ro,7936k@0x20000(firmware)
++endef
++TARGET_DEVICES += archer-c58-v1
++
+ define Device/archer-c59-v1
+   DEVICE_TITLE := TP-LINK Archer C59 v1
+   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k
+diff --git a/target/linux/ar71xx/mikrotik/config-default b/target/linux/ar71xx/mikrotik/config-default
+index a05f8b5ff903802d0de43c3b9aadcc6912852101..019a957da89034aab24b193bfc226cc0b68b3bd8 100644
+--- a/target/linux/ar71xx/mikrotik/config-default
++++ b/target/linux/ar71xx/mikrotik/config-default
+@@ -17,6 +17,7 @@
+ # CONFIG_ATH79_MACH_AP90Q is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C58_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C59_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C60_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+diff --git a/target/linux/ar71xx/nand/config-default b/target/linux/ar71xx/nand/config-default
+index b277ad2498c77b729e4aabb998ace7642d4ecfad..1f49a976a17fd574c316dc3254993d184e37587f 100644
+--- a/target/linux/ar71xx/nand/config-default
++++ b/target/linux/ar71xx/nand/config-default
+@@ -10,6 +10,7 @@
+ # CONFIG_ATH79_MACH_AP147 is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C58_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C59_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C60_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index dac7a2c4523294b58fe3402e871fa9d73059ad05..1b2f51658d7720289b81187bbd53f7131c4ac103 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -340,7 +340,42 @@ static struct device_info boards[] = {
+ 		.first_sysupgrade_partition = "os-image",
+ 		.last_sysupgrade_partition = "file-system",
+ 	},
+-	
++
++	/** Firmware layout for the C58v1 */
++	{
++		.id	= "ARCHER-C58-V1",
++		.vendor	= "",
++		.support_list =
++			"SupportList:\r\n"
++			"{product_name:Archer C58,product_ver:1.0.0,special_id:00000000}\r\n"
++			"{product_name:Archer C58,product_ver:1.0.0,special_id:45550000}\r\n"
++			"{product_name:Archer C58,product_ver:1.0.0,special_id:55530000}\r\n",
++		.support_trail = '\x00',
++		.soft_ver = "soft_ver:1.0.0\n",
++
++		.partitions = {
++			{"fs-uboot", 0x00000, 0x10000},
++			{"default-mac", 0x10000, 0x00200},
++			{"pin", 0x10200, 0x00200},
++			{"product-info", 0x10400, 0x00100},
++			{"partition-table", 0x10500, 0x00800},
++			{"soft-version", 0x11300, 0x00200},
++			{"support-list", 0x11500, 0x00100},
++			{"device-id", 0x11600, 0x00100},
++			{"profile", 0x11700, 0x03900},
++			{"default-config", 0x15000, 0x04000},
++			{"user-config", 0x19000, 0x04000},
++			{"os-image", 0x20000, 0x150000},
++			{"file-system", 0x170000, 0x678000},
++			{"certyficate", 0x7e8000, 0x08000},
++			{"radio", 0x7f0000, 0x10000},
++			{NULL, 0, 0}
++		},
++
++		.first_sysupgrade_partition = "os-image",
++		.last_sysupgrade_partition = "file-system",
++	},
++
+ 	/** Firmware layout for the C59v1 */
+ 	{
+ 		.id	= "ARCHER-C59-V1",

--- a/patches/lede/0047-ath10k-firmware-update-repository-version.patch
+++ b/patches/lede/0047-ath10k-firmware-update-repository-version.patch
@@ -1,0 +1,21 @@
+From: blocktrron <blocktrron@users.noreply.github.com>
+Date: Sat, 18 Nov 2017 17:28:51 +0100
+Subject: ath10k-firmware: update repository version
+
+diff --git a/package/firmware/ath10k-firmware/Makefile b/package/firmware/ath10k-firmware/Makefile
+index 8bf5729fff16677ef6449498f1df3cda19272583..81dce0eb7aeee20e2ed3be4cc6699bf867487a96 100644
+--- a/package/firmware/ath10k-firmware/Makefile
++++ b/package/firmware/ath10k-firmware/Makefile
+@@ -8,9 +8,9 @@
+ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=ath10k-firmware
+-PKG_SOURCE_DATE:=2017-01-11
+-PKG_SOURCE_VERSION:=ab432c60437931a165f0aff1a6e3371f358b75dd
+-PKG_MIRROR_HASH:=e3188ecd4d7470d3cdde89fefa6258f9ec4f404b23558d1474e5014679b28101
++PKG_SOURCE_DATE:=2017-03-29
++PKG_SOURCE_VERSION:=956e2609b7e42c8c710bba10ef925a5be1be5137
++PKG_MIRROR_HASH:=25f724ff38c830281b3efba4a4ddffaae0c4bd8fea0f4c1061591229ff05535b
+ PKG_RELEASE:=1
+ 
+ PKG_SOURCE_PROTO:=git

--- a/patches/lede/0048-ath10k-firmware-add-qca9888-firmware.patch
+++ b/patches/lede/0048-ath10k-firmware-add-qca9888-firmware.patch
@@ -1,0 +1,55 @@
+From: John Crispin <john@phrozen.org>
+Date: Mon, 8 May 2017 08:51:46 +0200
+Subject: ath10k-firmware: add qca9888 firmware
+
+ath10k-firmware: add qca9888 firmware
+
+the firmware files for qca9888 were previously not packaged. add the meta
+information for doing so.
+
+Signed-off-by: John Crispin <john@phrozen.org>
+
+diff --git a/package/firmware/ath10k-firmware/Makefile b/package/firmware/ath10k-firmware/Makefile
+index 81dce0eb7aeee20e2ed3be4cc6699bf867487a96..aac8ee2b271678b03f58a6cb68beae6d53467dc1 100644
+--- a/package/firmware/ath10k-firmware/Makefile
++++ b/package/firmware/ath10k-firmware/Makefile
+@@ -32,6 +32,11 @@ $(Package/ath10k-firmware-default)
+   TITLE:=ath10k firmware for QCA9887 devices
+ endef
+ 
++define Package/ath10k-firmware-qca9888
++$(Package/ath10k-firmware-default)
++  TITLE:=ath10k firmware for QCA9888 devices
++endef
++
+ define Package/ath10k-firmware-qca9887-ct
+ $(Package/ath10k-firmware-default)
+   TITLE:=ath10k-CT firmware for QCA9887 devices
+@@ -240,6 +245,19 @@ define Package/ath10k-firmware-qca9887/install
+ 		$(1)/lib/firmware/ath10k/QCA9887/hw1.0/board.bin
+ endef
+ 
++define Package/ath10k-firmware-qca9888/install
++	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9888/hw2.0
++	$(INSTALL_DATA) \
++		$(PKG_BUILD_DIR)/QCA9888/hw2.0/board-2.bin \
++		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
++	$(INSTALL_DATA) \
++		$(PKG_BUILD_DIR)/QCA9888/hw2.0/board-2.bin \
++		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
++	$(INSTALL_DATA) \
++		$(PKG_BUILD_DIR)/QCA9888/hw2.0/firmware-5.bin_10.4-3.2-00072 \
++		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/firmware-5.bin
++endef
++
+ define Package/ath10k-firmware-qca988x/install
+ 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA988X/hw2.0
+ 	$(INSTALL_DATA) \
+@@ -328,6 +346,7 @@ define Package/ath10k-firmware-qca9984-ct/install
+ endef
+ 
+ $(eval $(call BuildPackage,ath10k-firmware-qca9887))
++$(eval $(call BuildPackage,ath10k-firmware-qca9888))
+ $(eval $(call BuildPackage,ath10k-firmware-qca988x))
+ $(eval $(call BuildPackage,ath10k-firmware-qca99x0))
+ $(eval $(call BuildPackage,ath10k-firmware-qca6174))

--- a/patches/lede/0049-ar71xx-Archer-C58-C59-C60-fix-qca9886-wireless-interface.patch
+++ b/patches/lede/0049-ar71xx-Archer-C58-C59-C60-fix-qca9886-wireless-interface.patch
@@ -1,0 +1,70 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Thu, 29 Jun 2017 15:20:31 +0200
+Subject: ar71xx: Archer C58/C59/C60 fix qca9886 wireless interface
+
+This commit fix 5GHz wireless interface used in Archer C58/C59/C60v1
+and set correctly MAC address on this interface.
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 04d8bcca535fd341aa0af29cafc09c4f20980c3a..669b8d3387702201270d5a889ee7c23f5c925ff4 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -132,7 +132,9 @@ case "$FIRMWARE" in
+ 	;;
+ "ath10k/pre-cal-pci-0000:00:00.0.bin")
+ 	case $board in
+-	archer-c58-v1)
++	archer-c58-v1|\
++	archer-c59-v1|\
++	archer-c60-v1)
+ 		ath10kcal_extract "art" 20480 12064
+ 		;;
+ 	esac
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+index 7d2eca546d76b771b12026788510f73a293a9a93..669b208231e43fe86e998c7202c133c86ae0bf8d 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+@@ -12,7 +12,9 @@ PHYNBR=${DEVPATH##*/phy}
+ board=$(ar71xx_board_name)
+ 
+ case "$board" in
+-	archer-c58-v1)
++	archer-c58-v1|\
++	archer-c59-v1|\
++	archer-c60-v1)
+ 		echo $(macaddr_add $(mtd_get_mac_binary mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
+ 		;;
+ 	*)
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index d639b3e0ddb8dfd68aca6cd0305da3559fbec1a8..e6c96fd89abcc3d78a58ef857ce12d82bc937be8 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -121,7 +121,7 @@ TARGET_DEVICES += archer-c25-v1
+ 
+ define Device/archer-c58-v1
+   DEVICE_TITLE := TP-LINK Archer C58 v1
+-  DEVICE_PACKAGES := kmod-ath10k
++  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9888
+   BOARDNAME := ARCHER-C58-V1
+   TPLINK_BOARD_NAME := ARCHER-C58-V1
+   DEVICE_PROFILE := ARCHERC58V1
+@@ -136,7 +136,7 @@ TARGET_DEVICES += archer-c58-v1
+ 
+ define Device/archer-c59-v1
+   DEVICE_TITLE := TP-LINK Archer C59 v1
+-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k
++  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k ath10k-firmware-qca9888
+   BOARDNAME := ARCHER-C59-V1
+   TPLINK_BOARD_NAME := ARCHER-C59-V1
+   DEVICE_PROFILE := ARCHERC59V1
+@@ -151,7 +151,7 @@ TARGET_DEVICES += archer-c59-v1
+ 
+ define Device/archer-c60-v1
+   DEVICE_TITLE := TP-LINK Archer C60 v1
+-  DEVICE_PACKAGES := kmod-ath10k
++  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9888
+   BOARDNAME := ARCHER-C60-V1
+   TPLINK_BOARD_NAME := ARCHER-C60-V1
+   DEVICE_PROFILE := ARCHERC60V1

--- a/patches/lede/0050-ar71xx-fix-board.bin-used-by-QCA9886-in-Archer-C58-C59-C60.patch
+++ b/patches/lede/0050-ar71xx-fix-board.bin-used-by-QCA9886-in-Archer-C58-C59-C60.patch
@@ -1,0 +1,19 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Thu, 29 Jun 2017 15:38:22 +0200
+Subject: ar71xx: fix board.bin used by QCA9886 in Archer C58/C59/C60
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 669b8d3387702201270d5a889ee7c23f5c925ff4..30f148655dd733aa33c1c5425a3b2735f44377da 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -136,6 +136,8 @@ case "$FIRMWARE" in
+ 	archer-c59-v1|\
+ 	archer-c60-v1)
+ 		ath10kcal_extract "art" 20480 12064
++		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
++			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+ 		;;
+ 	esac
+ 	;;

--- a/patches/lede/0051-ath10k-firmware-qca9888-firmware-remove-board.bin.patch
+++ b/patches/lede/0051-ath10k-firmware-qca9888-firmware-remove-board.bin.patch
@@ -1,0 +1,20 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Mon, 3 Jul 2017 23:59:54 +0200
+Subject: ath10k-firmware: qca9888 firmware: remove board.bin
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+
+diff --git a/package/firmware/ath10k-firmware/Makefile b/package/firmware/ath10k-firmware/Makefile
+index aac8ee2b271678b03f58a6cb68beae6d53467dc1..e8cc4b91c3f59f09e4281c7b36048dc66bd04f3b 100644
+--- a/package/firmware/ath10k-firmware/Makefile
++++ b/package/firmware/ath10k-firmware/Makefile
+@@ -250,9 +250,6 @@ define Package/ath10k-firmware-qca9888/install
+ 	$(INSTALL_DATA) \
+ 		$(PKG_BUILD_DIR)/QCA9888/hw2.0/board-2.bin \
+ 		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
+-	$(INSTALL_DATA) \
+-		$(PKG_BUILD_DIR)/QCA9888/hw2.0/board-2.bin \
+-		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+ 	$(INSTALL_DATA) \
+ 		$(PKG_BUILD_DIR)/QCA9888/hw2.0/firmware-5.bin_10.4-3.2-00072 \
+ 		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/firmware-5.bin

--- a/patches/lede/0052-ar71xx-C58-C59-fix-LAN1-working-incorrectly.patch
+++ b/patches/lede/0052-ar71xx-C58-C59-fix-LAN1-working-incorrectly.patch
@@ -1,0 +1,22 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Mon, 27 Nov 2017 04:19:38 +0100
+Subject: ar71xx: C58/C59 fix LAN1 working incorrectly
+
+This commit fixes LAN Port 1 not transferring data in case no
+other LAN Port has active link-state on TP-Link Archer C58/C59.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+index f385d4a5a3148b83ee01007145e0eda2c0ef670f..129aa53f304dd1a118ace9a2749855cb36f66cfc 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+@@ -249,7 +249,7 @@ static void __init archer_c5x_v1_setup(void)
+ 	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
+ 	ath79_eth1_data.speed = SPEED_1000;
+ 	ath79_eth1_data.duplex = DUPLEX_FULL;
+-	ath79_switch_data.phy_poll_mask |= BIT(4);
++	ath79_switch_data.phy_poll_mask |= BIT(0);
+ 	ath79_switch_data.phy4_mii_en = 1;
+ 	ath79_register_eth(1);
+ 

--- a/patches/lede/0053-ar71xx-omit-VLAN-from-Archer-C58-C59-LAN-interface.patch
+++ b/patches/lede/0053-ar71xx-omit-VLAN-from-Archer-C58-C59-LAN-interface.patch
@@ -1,0 +1,17 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Mon, 27 Nov 2017 04:33:40 +0100
+Subject: ar71xx: omit VLAN from Archer C58/C59 LAN interface
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index ae0f984dbb4b4481b6eec055a3cc4f9cd0ce2281..748ee94407f9e3be231fa3b7f50931eca4d1b0f4 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -201,7 +201,7 @@ ar71xx_setup_interfaces()
+ 		;;
+ 	archer-c58-v1|\
+ 	archer-c59-v1)
+-		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
++		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth1" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
+ 		;;

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -184,6 +184,16 @@ packages $ATH10K_PACKAGES
 factory -squashfs-factory${GLUON_REGION:+-${GLUON_REGION}} .bin
 
 if [ "$BROKEN" ]; then
+device tp-link-archer-c58-v1 archer-c58-v1
+fi
+
+device tp-link-archer-c59-v1 archer-c59-v1
+
+if [ "$BROKEN" ]; then
+device tp-link-archer-c60-v1 archer-c60-v1
+fi
+
+if [ "$BROKEN" ]; then
 device tp-link-archer-c25-v1 archer-c25-v1 # instability with 5GHz mesh in some environments
 packages $ATH10K_PACKAGES_QCA9887
 fi


### PR DESCRIPTION
This adds support for Archer C58/C59/C60.

Archer C58/C60 marked as broken, due to frequent crashing on activated 5GHz related to insufficient RAM. Working fine with disabled 5GHz. 

Archer C59 not affected (128MB instead of 64MB RAM)

closes #1122 

Currently not working:
 - IBSS meshing over 5GHz (possibly fixed in my ibss branch, needs testing)