### PR TITLE
ar71xx: add support for Archer C58/C59/C60

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -40,7 +40,9 @@ elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2',
                                             'om5p-ac', 'om5p-acv2',
                                             'archer-c7-v4'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
-elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c7'}) then
+elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1',
+                                            'archer-c59-v1', 'archer-c60-v1',
+                                            'archer-c7'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')
 end
 

--- a/patches/lede/0050-ar71xx-add-support-to-TP-Link-Archer-C59v1-and-C60v1.patch
+++ b/patches/lede/0050-ar71xx-add-support-to-TP-Link-Archer-C59v1-and-C60v1.patch
@@ -1,0 +1,757 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Tue, 27 Dec 2016 22:41:41 +0100
+Subject: ar71xx: add support to TP-Link Archer C59v1 and C60v1
+
+TP-Link Archer C59v1 is a dual-band AC1350 router, based on Qualcomm/Atheros
+QCA9561+QCA9886.
+
+Specification:
+
+- 775/650/258 MHz (CPU/DDR/AHB)
+- 128 MB of RAM (DDR2)
+- 16 MB of FLASH (SPI NOR)
+- 3T3R 2.4 GHz
+- 2T2R 5 GHz
+- 5x 10/100 Mbps Ethernet
+- USB 2.0 port
+- 8x LED (controled by 74HC595), 3x button
+- UART header on PCB
+
+TP-Link Archer C60v1 is a dual-band AC1350 router, based on Qualcomm/Atheros
+QCA9561+QCA9886.
+
+Specification:
+
+- 775/650/258 MHz (CPU/DDR/AHB)
+- 64 MB of RAM (DDR2)
+- 8 MB of FLASH (SPI NOR)
+- 3T3R 2.4 GHz
+- 2T2R 5 GHz
+- 5x 10/100 Mbps Ethernet
+- 7x LED, 2x button
+- UART header on PCB
+
+Currently not working:
+- Port LAN1 on C59, LAN4 on C60
+- WiFi 5GHz (missing ath10k firmware for QCA9886 chip)
+- Update from oficial web interface ( tplink-saveloader not support "product-info")
+
+Flash instruction:
+1. Set PC to fixed ip address 192.168.0.66
+2. Download lede-ar71xx-generic-archer-cXX-v1-squashfs-factory.bin
+and rename it to tp_recovery.bin
+3. Start a tftp server with the file tp_recovery.bin in its root directory
+4. Turn off the router
+5. Press and hold Reset button
+6. Turn on router with the reset button pressed and wait ~15 seconds
+7. Release the reset button and after a short time
+the firmware should be transferred from the tftp server
+8. Wait ~30 second to complete recovery.
+
+Flash instruction under U-Boot, using UART:
+
+1. tftp 0x81000000 lede-ar71xx-...-sysupgrade.bin
+2. erase 0x9f020000 +$filesize
+3. cp.b $fileaddr 0x9f020000 $filesize
+4. reset
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+[Jo-Philipp Wich: remove duplicate ATH79_MACH_ARCHER_C59/C60_V1 entries]
+Signed-off-by: Jo-Philipp Wich <jo@mein.io>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 47b90d9cb2f81936aed22cdf7d1f6d870d23c16e..8552cde564b3fbed9425f42d5331f95fe5c3aaa8 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -62,6 +62,19 @@ archer-c25-v1)
+ 	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "0x04"
+ 	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x02"
+ 	;;
++archer-c59-v1|\
++archer-c60-v1)
++	ucidef_set_led_switch "lan" "LAN" "$board:green:lan" "switch0" "0x3C"
++	ucidef_set_led_switch "wan" "WAN" "$board:green:wan" "switch0" "0x02"
++	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
++	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
++
++	case "$board" in
++	archer-c59-v1)
++		ucidef_set_led_usbdev "usb" "USB" "$board:green:usb" "1-1"
++		;;
++	esac
++	;;
+ arduino-yun)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "arduino:blue:wlan" "phy0tpt"
+ 	ucidef_set_led_usbdev "usb" "USB" "arduino:white:usb" "1-1.1"
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 86ac949bca12561536ce2c8adb190eb004c162e4..3abe1114ee31c79abb125b85119876c3d75bb7c0 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -205,6 +205,11 @@ ar71xx_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
+ 		;;
++	archer-c59-v1|\
++	archer-c60-v1)
++		ucidef_add_switch "switch0" \
++			"0@eth0" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1" "1:wan"
++		;;
+ 	arduino-yun|\
+ 	dir-505-a1|\
+ 	tl-wa801nd-v3)
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 97372bed0ea2fadfab10f22916a1e0d6a9c65725..3aa1f054d4f791545a8b6644f7bd24f64ed546a3 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -52,6 +52,8 @@ get_status_led() {
+ 		;;
+ 	archer-c25-v1|\
+ 	archer-c7-v4|\
++	archer-c59-v1|\
++	archer-c60-v1|\
+ 	mr12|\
+ 	mr16|\
+ 	nbg6616|\
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 607bbd2c0ec4b59ba569550e9e0e87b80c7ddddb..5dd1d69e7e163c938759ce476846e4d985184b7b 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -97,6 +97,8 @@ case "$FIRMWARE" in
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
+ 		;;
+ 	archer-c25-v1|\
++	archer-c59-v1|\
++	archer-c60-v1|\
+ 	tl-wdr6500-v2)
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index ddb8f0db80ed6eab39c832bfd893182d9f591ad4..780eda30d04b9bae0bf8dcf47a9cc49b19b810ca 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -469,6 +469,12 @@ ar71xx_board_detect() {
+ 	*"Archer C7 v4")
+ 		name="archer-c7-v4"
+ 		;;
++	*"Archer C59 v1")
++		name="archer-c59-v1"
++		;;
++	*"Archer C60 v1")
++		name="archer-c60-v1"
++		;;
+ 	*"Archer C7")
+ 		name="archer-c7"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index d414af969912894574e73e286ed5a3998532d34e..31b293ca3c07d2f26ff96037fab5a51bbe9e834c 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -208,6 +208,8 @@ platform_check_image() {
+ 	ap90q|\
+ 	archer-c25-v1|\
+ 	archer-c7-v4|\
++	archer-c59-v1|\
++	archer-c60-v1|\
+ 	bullet-m|\
+ 	c-55|\
+ 	carambola2|\
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index 57b6d2e541d7ef9dea8570ba8de72164d97b9775..5b33d48e52309b807dbdf2697524809ad08072ae 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -52,6 +52,8 @@ CONFIG_ATH79_MACH_AP152=y
+ CONFIG_ATH79_MACH_AP90Q=y
+ CONFIG_ATH79_MACH_AP96=y
+ CONFIG_ATH79_MACH_ARCHER_C25_V1=y
++CONFIG_ATH79_MACH_ARCHER_C59_V1=y
++CONFIG_ATH79_MACH_ARCHER_C60_V1=y
+ CONFIG_ATH79_MACH_ARCHER_C7=y
+ CONFIG_ATH79_MACH_ARDUINO_YUN=y
+ CONFIG_ATH79_MACH_AW_NR580=y
+@@ -272,6 +274,7 @@ CONFIG_GENERIC_SMP_IDLE_THREAD=y
+ CONFIG_GENERIC_TIME_VSYSCALL=y
+ CONFIG_GPIOLIB=y
+ CONFIG_GPIOLIB_IRQCHIP=y
++CONFIG_GPIO_74X164=y
+ CONFIG_GPIO_DEVRES=y
+ CONFIG_GPIO_74X164=y
+ # CONFIG_GPIO_LATCH is not set
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+index 0a25294c40b5e2d3be825554ec7246a50b9c029b..468d9b333e43814cbadec8d85a20ab94e5cd6d01 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+@@ -1244,6 +1244,27 @@ config ATH79_MACH_ARCHER_C25_V1
+ 	select ATH79_DEV_M25P80
+ 	select ATH79_DEV_WMAC
+ 
++config ATH79_MACH_ARCHER_C59_V1
++	bool "TP-LINK Archer C59 v1 support"
++	select SOC_QCA956X
++	select ATH79_DEV_AP9X_PCI if PCI
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_USB
++	select ATH79_DEV_WMAC
++
++config ATH79_MACH_ARCHER_C60_V1
++	bool "TP-LINK Archer C60 v1 support"
++	select SOC_QCA956X
++	select ATH79_DEV_AP9X_PCI if PCI
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_WMAC
++
+ config ATH79_MACH_ARCHER_C7
+ 	bool "TP-LINK Archer C5/C7/TL-WDR4900 v2 board support"
+ 	select SOC_QCA955X
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Makefile b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+index a0c73550eb0d5bf07ee731171be9e5ef9ff073e7..fbe7fcb0aebb6577b96c27088a158eb025f201cb 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+@@ -57,6 +57,8 @@ obj-$(CONFIG_ATH79_MACH_AP152)			+= mach-ap152.o
+ obj-$(CONFIG_ATH79_MACH_AP90Q)			+= mach-ap90q.o
+ obj-$(CONFIG_ATH79_MACH_AP96)			+= mach-ap96.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C25_V1)		+= mach-archer-c25-v1.o
++obj-$(CONFIG_ATH79_MACH_ARCHER_C59_V1)		+= mach-archer-c59-v1.o
++obj-$(CONFIG_ATH79_MACH_ARCHER_C60_V1)		+= mach-archer-c60-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7-v4.o
+ obj-$(CONFIG_ATH79_MACH_ARDUINO_YUN)		+= mach-arduino-yun.o
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..28353aa77b05078b895ab48cf6b1ae53abe98ce2
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+@@ -0,0 +1,223 @@
++/*
++ *  TP-Link Archer C59 v1 board support
++ *
++ *  Copyright (C) 2016 Henryk Heisig <hyniu@o2.pl>
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under the terms of the GNU General Public License version 2 as published
++ *  by the Free Software Foundation.
++ */
++#include <linux/platform_device.h>
++#include <linux/ath9k_platform.h>
++#include <linux/ar8216_platform.h>
++#include <asm/mach-ath79/ar71xx_regs.h>
++#include <linux/gpio.h>
++#include <linux/init.h>
++#include <linux/spi/spi_gpio.h>
++#include <linux/spi/74x164.h>
++
++#include "common.h"
++#include "dev-m25p80.h"
++#include "machtypes.h"
++#include "pci.h"
++#include "dev-ap9x-pci.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-spi.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++
++#define ARCHER_C59_V1_KEYS_POLL_INTERVAL	20
++#define ARCHER_C59_V1_KEYS_DEBOUNCE_INTERVAL	(3 * ARCHER_C59_V1_KEYS_POLL_INTERVAL)
++
++#define ARCHER_C59_V1_GPIO_BTN_RESET		21
++#define ARCHER_C59_V1_GPIO_BTN_RFKILL		2
++#define ARCHER_C59_V1_GPIO_BTN_WPS		1
++
++#define ARCHER_C59_V1_GPIO_USB_POWER		22
++
++#define ARCHER_C59_GPIO_SHIFT_OE		16
++#define ARCHER_C59_GPIO_SHIFT_SER		17
++#define ARCHER_C59_GPIO_SHIFT_SRCLK		18
++#define ARCHER_C59_GPIO_SHIFT_SRCLR		19
++#define ARCHER_C59_GPIO_SHIFT_RCLK		20
++
++#define ARCHER_C59_74HC_GPIO_BASE		QCA956X_GPIO_COUNT
++#define ARCHER_C59_74HC_GPIO_LED_POWER		23
++#define ARCHER_C59_74HC_GPIO_LED_WLAN2		24
++#define ARCHER_C59_74HC_GPIO_LED_WLAN5		25
++#define ARCHER_C59_74HC_GPIO_LED_LAN		26
++#define ARCHER_C59_74HC_GPIO_LED_WAN_GREEN	27
++#define ARCHER_C59_74HC_GPIO_LED_WAN_AMBER	28
++#define ARCHER_C59_74HC_GPIO_LED_WPS		29
++#define ARCHER_C59_74HC_GPIO_LED_USB		30
++
++#define ARCHER_C59_V1_SSR_BIT_0			0
++#define ARCHER_C59_V1_SSR_BIT_1			1
++#define ARCHER_C59_V1_SSR_BIT_2			2
++#define ARCHER_C59_V1_SSR_BIT_3			3
++#define ARCHER_C59_V1_SSR_BIT_4			4
++#define ARCHER_C59_V1_SSR_BIT_5			5
++#define ARCHER_C59_V1_SSR_BIT_6			6
++#define ARCHER_C59_V1_SSR_BIT_7			7
++
++#define ARCHER_C59_V1_WMAC_CALDATA_OFFSET	0x1000
++#define ARCHER_C59_V1_PCI_CALDATA_OFFSET	0x5000
++
++static struct gpio_led archer_c59_v1_leds_gpio[] __initdata = {
++	{
++		.name		= "archer-c59-v1:green:power",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_POWER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:wlan2g",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WLAN2,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:wlan5g",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WLAN5,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:lan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_LAN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:wan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WAN_GREEN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:amber:wan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WAN_AMBER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:wps",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WPS,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c59-v1:green:usb",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_USB,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button archer_c59_v1_gpio_keys[] __initdata = {
++	{
++		.desc			= "Reset button",
++		.type			= EV_KEY,
++		.code			= KEY_RESTART,
++		.debounce_interval	= ARCHER_C59_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C59_V1_GPIO_BTN_RESET,
++		.active_low		= 1,
++	},
++	{
++		.desc			= "RFKILL button",
++		.type			= EV_KEY,
++		.code			= KEY_RFKILL,
++		.debounce_interval	= ARCHER_C59_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C59_V1_GPIO_BTN_RFKILL,
++		.active_low		= 1,
++	},
++	{
++		.desc			= "WPS button",
++		.type			= EV_KEY,
++		.code			= KEY_WPS_BUTTON,
++		.debounce_interval	= ARCHER_C59_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C59_V1_GPIO_BTN_WPS,
++		.active_low		= 1,
++	},
++};
++
++static struct spi_gpio_platform_data archer_c59_v1_spi_data = {
++	.sck		= ARCHER_C59_GPIO_SHIFT_SRCLK,
++	.miso		= SPI_GPIO_NO_MISO,
++	.mosi		= ARCHER_C59_GPIO_SHIFT_SER,
++	.num_chipselect = 1,
++};
++
++static u8 archer_c59_v1_ssr_initdata[] __initdata = {
++	BIT(ARCHER_C59_V1_SSR_BIT_7) |
++	BIT(ARCHER_C59_V1_SSR_BIT_6) |
++	BIT(ARCHER_C59_V1_SSR_BIT_5) |
++	BIT(ARCHER_C59_V1_SSR_BIT_4) |
++	BIT(ARCHER_C59_V1_SSR_BIT_3) |
++	BIT(ARCHER_C59_V1_SSR_BIT_2) |
++	BIT(ARCHER_C59_V1_SSR_BIT_1)
++};
++
++static struct gen_74x164_chip_platform_data archer_c59_v1_ssr_data = {
++	.base = ARCHER_C59_74HC_GPIO_BASE,
++	.num_registers = ARRAY_SIZE(archer_c59_v1_ssr_initdata),
++	.init_data = archer_c59_v1_ssr_initdata,
++};
++
++static struct platform_device archer_c59_v1_spi_device = {
++	.name		= "spi_gpio",
++	.id		= 1,
++	.dev = {
++		.platform_data = &archer_c59_v1_spi_data,
++	},
++};
++
++static struct spi_board_info archer_c59_v1_spi_info[] = {
++	{
++		.bus_num	= 1,
++		.chip_select	= 0,
++		.max_speed_hz	= 10000000,
++		.modalias	= "74x164",
++		.platform_data	=  &archer_c59_v1_ssr_data,
++		.controller_data = (void *) ARCHER_C59_GPIO_SHIFT_RCLK,
++	},
++};
++
++static void __init archer_c59_v1_setup(void)
++{
++	u8 *mac = (u8 *) KSEG1ADDR(0x1f010008);
++	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
++
++	ath79_register_m25p80(NULL);
++	spi_register_board_info(archer_c59_v1_spi_info,
++			   ARRAY_SIZE(archer_c59_v1_spi_info));
++	platform_device_register(&archer_c59_v1_spi_device);
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c59_v1_leds_gpio),
++				archer_c59_v1_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, ARCHER_C59_V1_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(archer_c59_v1_gpio_keys),
++					archer_c59_v1_gpio_keys);
++
++	ath79_register_mdio(1, 0x0);
++
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 0);
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_eth1_data.phy_mask = BIT(4);
++	ath79_register_eth(1);
++
++	ath79_register_wmac(art + ARCHER_C59_V1_WMAC_CALDATA_OFFSET, mac);
++	ap91_pci_init(art + ARCHER_C59_V1_PCI_CALDATA_OFFSET, NULL);
++
++
++	ath79_register_usb();
++	gpio_request_one(ARCHER_C59_V1_GPIO_USB_POWER,
++			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++			 "USB power");
++	gpio_request_one(ARCHER_C59_GPIO_SHIFT_OE,
++			 GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED,
++			 "LED control");
++	gpio_request_one(ARCHER_C59_GPIO_SHIFT_SRCLR,
++			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++			 "LED reset");
++}
++
++MIPS_MACHINE(ATH79_MACH_ARCHER_C59_V1, "ARCHER-C59-V1",
++	"TP-LINK Archer C59 v1", archer_c59_v1_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..78186f02cda0a231afda4e53a1d6ff696ecb6b4a
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
+@@ -0,0 +1,135 @@
++/*
++ *  TP-Link Archer C60 v1 board support
++ *
++ *  Copyright (C) 2016 Henryk Heisig <hyniu@o2.pl>
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under the terms of the GNU General Public License version 2 as published
++ *  by the Free Software Foundation.
++ */
++#include <linux/platform_device.h>
++#include <linux/ath9k_platform.h>
++#include <linux/ar8216_platform.h>
++#include <asm/mach-ath79/ar71xx_regs.h>
++#include <linux/gpio.h>
++
++#include "common.h"
++#include "dev-m25p80.h"
++#include "machtypes.h"
++#include "pci.h"
++#include "dev-ap9x-pci.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-spi.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++
++#define ARCHER_C60_V1_GPIO_LED_LAN		2
++#define ARCHER_C60_V1_GPIO_LED_POWER		16
++#define ARCHER_C60_V1_GPIO_LED_WLAN2		17
++#define ARCHER_C60_V1_GPIO_LED_WLAN5		18
++#define ARCHER_C60_V1_GPIO_LED_WPS		19
++#define ARCHER_C60_V1_GPIO_LED_WAN_GREEN	20
++#define ARCHER_C60_V1_GPIO_LED_WAN_AMBER	22
++
++
++#define ARCHER_C60_V1_KEYS_POLL_INTERVAL	20
++#define ARCHER_C60_V1_KEYS_DEBOUNCE_INTERVAL	(3 * ARCHER_C60_V1_KEYS_POLL_INTERVAL)
++
++#define ARCHER_C60_V1_GPIO_BTN_RESET		21
++#define ARCHER_C60_V1_GPIO_BTN_RFKILL		1
++
++
++
++#define ARCHER_C60_V1_WMAC_CALDATA_OFFSET	0x1000
++#define ARCHER_C60_V1_PCI_CALDATA_OFFSET	0x5000
++
++static struct gpio_led archer_c60_v1_leds_gpio[] __initdata = {
++	{
++		.name		= "archer-c60-v1:green:power",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_POWER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:wlan2g",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WLAN2,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:wlan5g",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WLAN5,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:lan",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_LAN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:wan",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WAN_GREEN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:amber:wan",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WAN_AMBER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c60-v1:green:wps",
++		.gpio		= ARCHER_C60_V1_GPIO_LED_WPS,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button archer_c60_v1_gpio_keys[] __initdata = {
++	{
++		.desc			= "Reset button",
++		.type			= EV_KEY,
++		.code			= KEY_RESTART,
++		.debounce_interval	= ARCHER_C60_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C60_V1_GPIO_BTN_RESET,
++		.active_low		= 1,
++	},
++	{
++		.desc			= "RFKILL button",
++		.type			= EV_KEY,
++		.code			= KEY_RFKILL,
++		.debounce_interval	= ARCHER_C60_V1_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= ARCHER_C60_V1_GPIO_BTN_RFKILL,
++		.active_low		= 1,
++	},
++};
++
++static void __init archer_c60_v1_setup(void)
++{
++	u8 *mac = (u8 *) KSEG1ADDR(0x1f010008);
++	u8 *art = (u8 *) KSEG1ADDR(0x1f7f0000);
++
++	ath79_register_m25p80(NULL);
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c60_v1_leds_gpio),
++				archer_c60_v1_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, ARCHER_C60_V1_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(archer_c60_v1_gpio_keys),
++					archer_c60_v1_gpio_keys);
++
++	ath79_setup_qca956x_eth_cfg(QCA956X_ETH_CFG_SW_PHY_SWAP |
++				   QCA956X_ETH_CFG_SW_PHY_ADDR_SWAP);
++	ath79_register_mdio(1, 0x0);
++
++	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 0);
++
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_register_eth(1);
++
++	ath79_register_wmac(art + ARCHER_C60_V1_WMAC_CALDATA_OFFSET, mac);
++	ap91_pci_init(art + ARCHER_C60_V1_PCI_CALDATA_OFFSET, NULL);
++}
++
++MIPS_MACHINE(ATH79_MACH_ARCHER_C60_V1, "ARCHER-C60-V1",
++	"TP-LINK Archer C60 v1", archer_c60_v1_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index e4623fd08836d59ad4e79e96f02e75e502a55ca6..9fbf354e44992f4dff43df0fb0ea99c344801d97 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -42,6 +42,8 @@ enum ath79_mach_type {
+ 	ATH79_MACH_AP96,			/* Atheros AP96 */
+ 	ATH79_MACH_ARCHER_C25_V1,		/* TP-LINK Archer C25 V1 board */
+ 	ATH79_MACH_ARCHER_C5,			/* TP-LINK Archer C5 board */
++	ATH79_MACH_ARCHER_C59_V1,		/* TP-LINK Archer C59 V1 board */
++	ATH79_MACH_ARCHER_C60_V1,		/* TP-LINK Archer C60 V1 board */
+ 	ATH79_MACH_ARCHER_C7,			/* TP-LINK Archer C7 board */
+ 	ATH79_MACH_ARCHER_C7_V2,		/* TP-LINK Archer C7 V2 board */
+ 	ATH79_MACH_ARCHER_C7_V4,		/* TP-LINK Archer C7 V4 board */
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index 27d6c73454aef96e5da47033ec664d2caffca1d5..9e4aa8ea30aedba8050a77ebdcfc8f0034cc14d1 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -119,6 +119,36 @@ define Device/archer-c25-v1
+ endef
+ TARGET_DEVICES += archer-c25-v1
+ 
++define Device/archer-c59-v1
++  DEVICE_TITLE := TP-LINK Archer C59 v1
++  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k
++  BOARDNAME := ARCHER-C59-V1
++  TPLINK_BOARD_NAME := ARCHER-C59-V1
++  DEVICE_PROFILE := ARCHERC59V1
++  IMAGE_SIZE := 14528k
++  KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
++  IMAGES := sysupgrade.bin factory.bin
++  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
++  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
++  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1536k(kernel),12992k(rootfs),1664k(tplink)ro,64k(art)ro,14528k@0x20000(firmware)
++endef
++TARGET_DEVICES += archer-c59-v1
++
++define Device/archer-c60-v1
++  DEVICE_TITLE := TP-LINK Archer C60 v1
++  DEVICE_PACKAGES := kmod-ath10k
++  BOARDNAME := ARCHER-C60-V1
++  TPLINK_BOARD_NAME := ARCHER-C60-V1
++  DEVICE_PROFILE := ARCHERC60V1
++  IMAGE_SIZE := 7936k
++  KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
++  IMAGES := sysupgrade.bin factory.bin
++  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
++  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
++  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1344k(kernel),6592k(rootfs),64k(tplink)ro,64k(art)ro,7936k@0x20000(firmware)
++endef
++TARGET_DEVICES += archer-c60-v1
++
+ define Device/cpe510-520
+   DEVICE_TITLE := TP-LINK CPE510/520
+   DEVICE_PACKAGES := rssileds
+diff --git a/target/linux/ar71xx/mikrotik/config-default b/target/linux/ar71xx/mikrotik/config-default
+index f5af38a726f5ce33391223a4dbeb2fc0a8cac613..3f6884dcf44c83f9867e4e9936caa79c0abc5dc1 100644
+--- a/target/linux/ar71xx/mikrotik/config-default
++++ b/target/linux/ar71xx/mikrotik/config-default
+@@ -17,6 +17,8 @@
+ # CONFIG_ATH79_MACH_AP90Q is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C59_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C60_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+ # CONFIG_ATH79_MACH_ARDUINO_YUN is not set
+ # CONFIG_ATH79_MACH_AW_NR580 is not set
+diff --git a/target/linux/ar71xx/nand/config-default b/target/linux/ar71xx/nand/config-default
+index 5c18f5d594d625f91ff10e21ddc5af2b3b4d768f..a50099aca12aafdcb27f4f2b77ca2a5ce4b4d6f2 100644
+--- a/target/linux/ar71xx/nand/config-default
++++ b/target/linux/ar71xx/nand/config-default
+@@ -10,6 +10,8 @@
+ # CONFIG_ATH79_MACH_AP147 is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C59_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C60_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+ # CONFIG_ATH79_MACH_AW_NR580 is not set
+ # CONFIG_ATH79_MACH_CAP324 is not set
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index fec830c23ce6707755ddefc849f195872be1e877..aeebf8e0bbdc3ec53c42d5cc01a3ffe892b46804 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -376,6 +376,79 @@ static struct device_info boards[] = {
+ 		.last_sysupgrade_partition = "file-system"
+ 	},
+ 
++	/** Firmware layout for the C59v1 */
++	{
++		.id	= "ARCHER-C59-V1",
++		.vendor	= "",
++		.support_list =
++			"SupportList:\r\n"
++			"{product_name:Archer C59,product_ver:1.0.0,special_id:00000000}\r\n"
++			"{product_name:Archer C59,product_ver:1.0.0,special_id:45550000}\r\n"
++			"{product_name:Archer C59,product_ver:1.0.0,special_id:55530000}\r\n",
++		.support_trail = '\x00',
++		.soft_ver = "soft_ver:1.0.0\n",
++
++		.partitions = {
++			{"fs-uboot", 0x00000, 0x10000},
++			{"default-mac", 0x10000, 0x00200},
++			{"pin", 0x10200, 0x00200},
++			{"device-id", 0x10400, 0x00100},
++			{"product-info", 0x10500, 0x0fb00},
++			{"os-image", 0x20000, 0x180000},
++			{"file-system", 0x1a0000, 0xcb0000},
++			{"partition-table", 0xe50000, 0x10000},
++			{"soft-version", 0xe60000, 0x10000},
++			{"support-list", 0xe70000, 0x10000},
++			{"profile", 0xe80000, 0x10000},
++			{"default-config", 0xe90000, 0x10000},
++			{"user-config", 0xea0000, 0x40000},
++			{"usb-config", 0xee0000, 0x10000},
++			{"certificate", 0xef0000, 0x10000},
++			{"qos-db", 0xf00000, 0x40000},
++			{"log", 0xfe0000, 0x10000},
++			{"radio", 0xff0000, 0x10000},
++			{NULL, 0, 0}
++		},
++
++		.first_sysupgrade_partition = "os-image",
++		.last_sysupgrade_partition = "file-system",
++	},
++
++	/** Firmware layout for the C60v1 */
++	{
++		.id	= "ARCHER-C60-V1",
++		.vendor	= "",
++		.support_list =
++			"SupportList:\r\n"
++			"{product_name:Archer C60,product_ver:1.0.0,special_id:00000000}\r\n"
++			"{product_name:Archer C60,product_ver:1.0.0,special_id:45550000}\r\n"
++			"{product_name:Archer C60,product_ver:1.0.0,special_id:55530000}\r\n",
++		.support_trail = '\x00',
++		.soft_ver = "soft_ver:1.0.0\n",
++
++		.partitions = {
++			{"fs-uboot", 0x00000, 0x10000},
++			{"default-mac", 0x10000, 0x00200},
++			{"pin", 0x10200, 0x00200},
++			{"product-info", 0x10400, 0x00100},
++			{"partition-table", 0x10500, 0x00800},
++			{"soft-version", 0x11300, 0x00200},
++			{"support-list", 0x11500, 0x00100},
++			{"device-id", 0x11600, 0x00100},
++			{"profile", 0x11700, 0x03900},
++			{"default-config", 0x15000, 0x04000},
++			{"user-config", 0x19000, 0x04000},
++			{"os-image", 0x20000, 0x150000},
++			{"file-system", 0x170000, 0x678000},
++			{"certyficate", 0x7e8000, 0x08000},
++			{"radio", 0x7f0000, 0x10000},
++			{NULL, 0, 0}
++		},
++
++		.first_sysupgrade_partition = "os-image",
++		.last_sysupgrade_partition = "file-system",
++	},
++
+ 	/** Firmware layout for the C7 */
+ 	{
+ 		.id = "ARCHER-C7-V4",

--- a/patches/lede/0051-ar71xx-fix-lan-ports-on-archer-C59-and-C60.patch
+++ b/patches/lede/0051-ar71xx-fix-lan-ports-on-archer-C59-and-C60.patch
@@ -1,0 +1,128 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Thu, 16 Feb 2017 15:22:49 +0100
+Subject: ar71xx: fix lan ports on archer C59 and C60
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 8552cde564b3fbed9425f42d5331f95fe5c3aaa8..5c6b47d0249c979934d61078e16759fc22aa41c7 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -64,8 +64,8 @@ archer-c25-v1)
+ 	;;
+ archer-c59-v1|\
+ archer-c60-v1)
+-	ucidef_set_led_switch "lan" "LAN" "$board:green:lan" "switch0" "0x3C"
+-	ucidef_set_led_switch "wan" "WAN" "$board:green:wan" "switch0" "0x02"
++	ucidef_set_led_switch "lan" "LAN" "$board:green:lan" "switch0" "0x1E"
++	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
+ 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
+ 
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 3abe1114ee31c79abb125b85119876c3d75bb7c0..933ed22815ee076c98a83173aad143c010c9a131 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -206,9 +206,15 @@ ar71xx_setup_interfaces()
+ 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
+ 		;;
+ 	archer-c59-v1|\
++	rb-450g)
++		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
++		ucidef_add_switch "switch0" \
++			"0@eth1" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
++		;;
+ 	archer-c60-v1)
++		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
+ 		ucidef_add_switch "switch0" \
+-			"0@eth0" "2:lan:4" "3:lan:3" "4:lan:2" "5:lan:1" "1:wan"
++			"0@eth1" "1:lan:1" "2:lan:2" "3:lan:3" "4:lan:4"
+ 		;;
+ 	arduino-yun|\
+ 	dir-505-a1|\
+@@ -370,11 +376,6 @@ ar71xx_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "5@eth1"
+ 		;;
+-	rb-450g)
+-		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+-		ucidef_add_switch "switch0" \
+-			"0@eth1" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
+-		;;
+ 	routerstation-pro)
+ 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+ 		ucidef_add_switch "switch0" \
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+index 28353aa77b05078b895ab48cf6b1ae53abe98ce2..d55f9b9f75b38159ed7209aa5acd73ff31088b51 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+@@ -194,19 +194,33 @@ static void __init archer_c59_v1_setup(void)
+ 					ARRAY_SIZE(archer_c59_v1_gpio_keys),
+ 					archer_c59_v1_gpio_keys);
+ 
++	ath79_setup_qca956x_eth_cfg(QCA956X_ETH_CFG_SW_PHY_SWAP |
++				   QCA956X_ETH_CFG_SW_PHY_ADDR_SWAP);
++
++	ath79_register_mdio(0, 0x0);
+ 	ath79_register_mdio(1, 0x0);
+ 
+-	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 1);
+ 	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 0);
++
++	/* WAN port */
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_mask = BIT(0);
++	ath79_register_eth(0);
++
++	/* LAN ports */
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
+ 	ath79_eth1_data.speed = SPEED_1000;
+ 	ath79_eth1_data.duplex = DUPLEX_FULL;
+-	ath79_eth1_data.phy_mask = BIT(4);
++	ath79_switch_data.phy_poll_mask |= BIT(4);
++	ath79_switch_data.phy4_mii_en = 1;
+ 	ath79_register_eth(1);
+ 
+ 	ath79_register_wmac(art + ARCHER_C59_V1_WMAC_CALDATA_OFFSET, mac);
+ 	ap91_pci_init(art + ARCHER_C59_V1_PCI_CALDATA_OFFSET, NULL);
+ 
+-
+ 	ath79_register_usb();
+ 	gpio_request_one(ARCHER_C59_V1_GPIO_USB_POWER,
+ 			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
+index 78186f02cda0a231afda4e53a1d6ff696ecb6b4a..4d83fa737b9650935b4f7f985d58f471c38cd9da 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c60-v1.c
+@@ -116,15 +116,25 @@ static void __init archer_c60_v1_setup(void)
+ 					ARRAY_SIZE(archer_c60_v1_gpio_keys),
+ 					archer_c60_v1_gpio_keys);
+ 
+-	ath79_setup_qca956x_eth_cfg(QCA956X_ETH_CFG_SW_PHY_SWAP |
+-				   QCA956X_ETH_CFG_SW_PHY_ADDR_SWAP);
++	ath79_register_mdio(0, 0x0);
+ 	ath79_register_mdio(1, 0x0);
+ 
+-	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 0);
++	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 0);
++	ath79_init_mac(ath79_eth1_data.mac_addr, mac, 1);
+ 
++	/* WAN port */
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_mask = BIT(4);
++	ath79_register_eth(0);
++
++	/* LAN ports */
+ 	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
+ 	ath79_eth1_data.speed = SPEED_1000;
+ 	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_switch_data.phy_poll_mask |= BIT(4);
++	ath79_switch_data.phy4_mii_en = 1;
+ 	ath79_register_eth(1);
+ 
+ 	ath79_register_wmac(art + ARCHER_C60_V1_WMAC_CALDATA_OFFSET, mac);

--- a/patches/lede/0052-ar71xx-add-support-for-TP-Link-Archer-C58-v1.patch
+++ b/patches/lede/0052-ar71xx-add-support-for-TP-Link-Archer-C58-v1.patch
@@ -1,0 +1,411 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Fri, 16 Jun 2017 15:26:30 +0200
+Subject: ar71xx: add support for TP-Link Archer C58 v1
+
+TP-Link Archer C58 v1 is a dual-band AC1350 router, based on Qualcomm
+QCA9561 + QCA9886. It looks like Archer C59 v1 without USB port.
+
+Specification:
+
+- 775/650/258 MHz (CPU/DDR/AHB)
+- 64 MB of RAM (DDR2)
+- 8 MB of FLASH (SPI NOR)
+- 3T3R 2.4 GHz
+- 2T2R 5 GHz
+- 5x 10/100 Mbps Ethernet
+- 6x LED, 3x button
+- UART header on PCB, RX, TX at TP4+5 (backside)
+
+QCA9886 wlan needs pre_cal_data file and enable ieee80211 phy hotplug to
+patch macaddress.
+
+Flash instruction:
+
+Use "factory" image directly in vendor GUI.
+
+Recovery method:
+
+1. Set PC to fixed ip address 192.168.0.66/24.
+2. Download "lede-ar71xx-generic-archer-c58-v1-squashfs-factory.bin" and
+   rename it to "tp_recovery.bin".
+3. Start a tftp server with the file "tp_recovery.bin" in its root
+   directory.
+4. Turn off the router.
+5. Press and hold Reset button.
+6. Turn on router with the reset button pressed and wait ~15 seconds.
+7. Release the reset button and after a short time the firmware should
+   be transferred from the tftp server.
+8. Wait ~30 second to complete recovery.
+
+Flash instruction under U-Boot, using UART:
+
+tftp 0x81000000 lede-ar71xx-...-sysupgrade.bin
+erase 0x9f020000 +$filesize
+cp.b $fileaddr 0x9f020000 $filesize
+reset
+
+This commit is based on GitHub PR#1112
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 5c6b47d0249c979934d61078e16759fc22aa41c7..f9483e9a706fbd98ce6a42e968bc0d31e9da5c84 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -62,6 +62,7 @@ archer-c25-v1)
+ 	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "0x04"
+ 	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x02"
+ 	;;
++archer-c58-v1|\
+ archer-c59-v1|\
+ archer-c60-v1)
+ 	ucidef_set_led_switch "lan" "LAN" "$board:green:lan" "switch0" "0x1E"
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 933ed22815ee076c98a83173aad143c010c9a131..57bc912aa5ede22a3fad4af6a1deb00c33f17cf8 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -205,6 +205,7 @@ ar71xx_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth1" "2:lan" "3:lan" "4:lan" "5:lan" "6@eth0" "1:wan"
+ 		;;
++	archer-c58-v1|\
+ 	archer-c59-v1|\
+ 	rb-450g)
+ 		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 3aa1f054d4f791545a8b6644f7bd24f64ed546a3..382500b75ee6dc1fe1126fb3121f4ae205c901d4 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -52,6 +52,7 @@ get_status_led() {
+ 		;;
+ 	archer-c25-v1|\
+ 	archer-c7-v4|\
++	archer-c58-v1|\
+ 	archer-c59-v1|\
+ 	archer-c60-v1|\
+ 	mr12|\
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 5dd1d69e7e163c938759ce476846e4d985184b7b..538c86e4743109f7665096da32620d7862248aea 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -134,6 +134,13 @@ case "$FIRMWARE" in
+ 		;;
+ 	esac
+ 	;;
++"ath10k/pre-cal-pci-0000:00:00.0.bin")
++	case $board in
++	archer-c58-v1)
++		ath10kcal_extract "art" 20480 12064
++		;;
++	esac
++	;;
+ *)
+ 	exit 1
+ 	;;
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+new file mode 100644
+index 0000000000000000000000000000000000000000..7d2eca546d76b771b12026788510f73a293a9a93
+--- /dev/null
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+@@ -0,0 +1,21 @@
++#!/bin/ash
++
++[ "$ACTION" == "add" ] || exit 0
++
++PHYNBR=${DEVPATH##*/phy}
++
++[ -n $PHYNBR ] || exit 0
++
++. /lib/ar71xx.sh
++. /lib/functions/system.sh
++
++board=$(ar71xx_board_name)
++
++case "$board" in
++	archer-c58-v1)
++		echo $(macaddr_add $(mtd_get_mac_binary mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
++		;;
++	*)
++		;;
++esac
++
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 780eda30d04b9bae0bf8dcf47a9cc49b19b810ca..a6cce7f42b43863f5bddade8ab6a0631c919beb1 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -469,6 +469,9 @@ ar71xx_board_detect() {
+ 	*"Archer C7 v4")
+ 		name="archer-c7-v4"
+ 		;;
++	*"Archer C58 v1")
++		name="archer-c58-v1"
++		;;
+ 	*"Archer C59 v1")
+ 		name="archer-c59-v1"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index 31b293ca3c07d2f26ff96037fab5a51bbe9e834c..4a586ca523dcd65d0abbbab14e979f6f1bfee34e 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -208,6 +208,7 @@ platform_check_image() {
+ 	ap90q|\
+ 	archer-c25-v1|\
+ 	archer-c7-v4|\
++	archer-c58-v1|\
+ 	archer-c59-v1|\
+ 	archer-c60-v1|\
+ 	bullet-m|\
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index 5b33d48e52309b807dbdf2697524809ad08072ae..396a4fa02adb37c6e5f9f7f1cc40fd1014361654 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -52,6 +52,7 @@ CONFIG_ATH79_MACH_AP152=y
+ CONFIG_ATH79_MACH_AP90Q=y
+ CONFIG_ATH79_MACH_AP96=y
+ CONFIG_ATH79_MACH_ARCHER_C25_V1=y
++CONFIG_ATH79_MACH_ARCHER_C58_V1=y
+ CONFIG_ATH79_MACH_ARCHER_C59_V1=y
+ CONFIG_ATH79_MACH_ARCHER_C60_V1=y
+ CONFIG_ATH79_MACH_ARCHER_C7=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+index 468d9b333e43814cbadec8d85a20ab94e5cd6d01..4c9012acc6b4c40d88ffc8752086cac86b9b9c92 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+@@ -1244,6 +1244,16 @@ config ATH79_MACH_ARCHER_C25_V1
+ 	select ATH79_DEV_M25P80
+ 	select ATH79_DEV_WMAC
+ 
++config ATH79_MACH_ARCHER_C58_V1
++	bool "TP-LINK Archer C58 v1 support"
++	select SOC_QCA956X
++	select ATH79_DEV_AP9X_PCI if PCI
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_WMAC
++
+ config ATH79_MACH_ARCHER_C59_V1
+ 	bool "TP-LINK Archer C59 v1 support"
+ 	select SOC_QCA956X
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Makefile b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+index fbe7fcb0aebb6577b96c27088a158eb025f201cb..8408894669dc5f14f05701359073ef233a1b89f0 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+@@ -57,6 +57,7 @@ obj-$(CONFIG_ATH79_MACH_AP152)			+= mach-ap152.o
+ obj-$(CONFIG_ATH79_MACH_AP90Q)			+= mach-ap90q.o
+ obj-$(CONFIG_ATH79_MACH_AP96)			+= mach-ap96.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C25_V1)		+= mach-archer-c25-v1.o
++obj-$(CONFIG_ATH79_MACH_ARCHER_C58_V1)		+= mach-archer-c59-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C59_V1)		+= mach-archer-c59-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C60_V1)		+= mach-archer-c60-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7.o
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+index d55f9b9f75b38159ed7209aa5acd73ff31088b51..f385d4a5a3148b83ee01007145e0eda2c0ef670f 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+@@ -1,7 +1,7 @@
+ /*
+- *  TP-Link Archer C59 v1 board support
++ *  TP-Link Archer C58/C59 v1 board support
+  *
+- *  Copyright (C) 2016 Henryk Heisig <hyniu@o2.pl>
++ *  Copyright (C) 2017 Henryk Heisig <hyniu@o2.pl>
+  *
+  *  This program is free software; you can redistribute it and/or modify it
+  *  under the terms of the GNU General Public License version 2 as published
+@@ -65,6 +65,44 @@
+ #define ARCHER_C59_V1_WMAC_CALDATA_OFFSET	0x1000
+ #define ARCHER_C59_V1_PCI_CALDATA_OFFSET	0x5000
+ 
++static struct gpio_led archer_c58_v1_leds_gpio[] __initdata = {
++	{
++		.name		= "archer-c58-v1:green:power",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_POWER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:wlan2g",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WLAN2,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:wlan5g",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WLAN5,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:lan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_LAN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:wan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WAN_GREEN,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:amber:wan",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WAN_AMBER,
++		.active_low	= 1,
++	},
++	{
++		.name		= "archer-c58-v1:green:wps",
++		.gpio		= ARCHER_C59_74HC_GPIO_LED_WPS,
++		.active_low	= 1,
++	},
++};
++
+ static struct gpio_led archer_c59_v1_leds_gpio[] __initdata = {
+ 	{
+ 		.name		= "archer-c59-v1:green:power",
+@@ -177,7 +215,7 @@ static struct spi_board_info archer_c59_v1_spi_info[] = {
+ 	},
+ };
+ 
+-static void __init archer_c59_v1_setup(void)
++static void __init archer_c5x_v1_setup(void)
+ {
+ 	u8 *mac = (u8 *) KSEG1ADDR(0x1f010008);
+ 	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
+@@ -187,9 +225,6 @@ static void __init archer_c59_v1_setup(void)
+ 			   ARRAY_SIZE(archer_c59_v1_spi_info));
+ 	platform_device_register(&archer_c59_v1_spi_device);
+ 
+-	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c59_v1_leds_gpio),
+-				archer_c59_v1_leds_gpio);
+-
+ 	ath79_register_gpio_keys_polled(-1, ARCHER_C59_V1_KEYS_POLL_INTERVAL,
+ 					ARRAY_SIZE(archer_c59_v1_gpio_keys),
+ 					archer_c59_v1_gpio_keys);
+@@ -233,5 +268,22 @@ static void __init archer_c59_v1_setup(void)
+ 			 "LED reset");
+ }
+ 
++static void __init archer_c58_v1_setup(void)
++{
++	archer_c5x_v1_setup();
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c58_v1_leds_gpio),
++				archer_c58_v1_leds_gpio);
++}
++
++MIPS_MACHINE(ATH79_MACH_ARCHER_C58_V1, "ARCHER-C58-V1",
++	"TP-LINK Archer C58 v1", archer_c58_v1_setup);
++
++static void __init archer_c59_v1_setup(void)
++{
++	archer_c5x_v1_setup();
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c59_v1_leds_gpio),
++				archer_c59_v1_leds_gpio);
++}
++
+ MIPS_MACHINE(ATH79_MACH_ARCHER_C59_V1, "ARCHER-C59-V1",
+ 	"TP-LINK Archer C59 v1", archer_c59_v1_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 9fbf354e44992f4dff43df0fb0ea99c344801d97..72c1e38c74707aba8fbd3aebc36f35becabd4987 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -42,6 +42,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_AP96,			/* Atheros AP96 */
+ 	ATH79_MACH_ARCHER_C25_V1,		/* TP-LINK Archer C25 V1 board */
+ 	ATH79_MACH_ARCHER_C5,			/* TP-LINK Archer C5 board */
++	ATH79_MACH_ARCHER_C58_V1,		/* TP-LINK Archer C58 V1 board */
+ 	ATH79_MACH_ARCHER_C59_V1,		/* TP-LINK Archer C59 V1 board */
+ 	ATH79_MACH_ARCHER_C60_V1,		/* TP-LINK Archer C60 V1 board */
+ 	ATH79_MACH_ARCHER_C7,			/* TP-LINK Archer C7 board */
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index 9e4aa8ea30aedba8050a77ebdcfc8f0034cc14d1..557bcdab2237a03957313cc3cda471a9fe3a3706 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -119,6 +119,21 @@ define Device/archer-c25-v1
+ endef
+ TARGET_DEVICES += archer-c25-v1
+ 
++define Device/archer-c58-v1
++  DEVICE_TITLE := TP-LINK Archer C58 v1
++  DEVICE_PACKAGES := kmod-ath10k
++  BOARDNAME := ARCHER-C58-V1
++  TPLINK_BOARD_NAME := ARCHER-C58-V1
++  DEVICE_PROFILE := ARCHERC58V1
++  IMAGE_SIZE := 7936k
++  KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
++  IMAGES := sysupgrade.bin factory.bin
++  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
++  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
++  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1344k(kernel),6592k(rootfs),64k(tplink)ro,64k(art)ro,7936k@0x20000(firmware)
++endef
++TARGET_DEVICES += archer-c58-v1
++
+ define Device/archer-c59-v1
+   DEVICE_TITLE := TP-LINK Archer C59 v1
+   DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k
+diff --git a/target/linux/ar71xx/mikrotik/config-default b/target/linux/ar71xx/mikrotik/config-default
+index 3f6884dcf44c83f9867e4e9936caa79c0abc5dc1..23e862762600f0724a37fe1a390d4d09639c472c 100644
+--- a/target/linux/ar71xx/mikrotik/config-default
++++ b/target/linux/ar71xx/mikrotik/config-default
+@@ -17,6 +17,7 @@
+ # CONFIG_ATH79_MACH_AP90Q is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C58_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C59_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C60_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+diff --git a/target/linux/ar71xx/nand/config-default b/target/linux/ar71xx/nand/config-default
+index a50099aca12aafdcb27f4f2b77ca2a5ce4b4d6f2..c11ccfe29795d013776870cf21fb6ca8d907af1b 100644
+--- a/target/linux/ar71xx/nand/config-default
++++ b/target/linux/ar71xx/nand/config-default
+@@ -10,6 +10,7 @@
+ # CONFIG_ATH79_MACH_AP147 is not set
+ # CONFIG_ATH79_MACH_AP96 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C25_V1 is not set
++# CONFIG_ATH79_MACH_ARCHER_C58_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C59_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C60_V1 is not set
+ # CONFIG_ATH79_MACH_ARCHER_C7 is not set
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index aeebf8e0bbdc3ec53c42d5cc01a3ffe892b46804..67e2c4475bbd468bd20915767a481711ae872a3a 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -376,6 +376,41 @@ static struct device_info boards[] = {
+ 		.last_sysupgrade_partition = "file-system"
+ 	},
+ 
++	/** Firmware layout for the C58v1 */
++	{
++		.id	= "ARCHER-C58-V1",
++		.vendor	= "",
++		.support_list =
++			"SupportList:\r\n"
++			"{product_name:Archer C58,product_ver:1.0.0,special_id:00000000}\r\n"
++			"{product_name:Archer C58,product_ver:1.0.0,special_id:45550000}\r\n"
++			"{product_name:Archer C58,product_ver:1.0.0,special_id:55530000}\r\n",
++		.support_trail = '\x00',
++		.soft_ver = "soft_ver:1.0.0\n",
++
++		.partitions = {
++			{"fs-uboot", 0x00000, 0x10000},
++			{"default-mac", 0x10000, 0x00200},
++			{"pin", 0x10200, 0x00200},
++			{"product-info", 0x10400, 0x00100},
++			{"partition-table", 0x10500, 0x00800},
++			{"soft-version", 0x11300, 0x00200},
++			{"support-list", 0x11500, 0x00100},
++			{"device-id", 0x11600, 0x00100},
++			{"profile", 0x11700, 0x03900},
++			{"default-config", 0x15000, 0x04000},
++			{"user-config", 0x19000, 0x04000},
++			{"os-image", 0x20000, 0x150000},
++			{"file-system", 0x170000, 0x678000},
++			{"certyficate", 0x7e8000, 0x08000},
++			{"radio", 0x7f0000, 0x10000},
++			{NULL, 0, 0}
++		},
++
++		.first_sysupgrade_partition = "os-image",
++		.last_sysupgrade_partition = "file-system",
++	},
++
+ 	/** Firmware layout for the C59v1 */
+ 	{
+ 		.id	= "ARCHER-C59-V1",

--- a/patches/lede/0053-ath10k-firmware-update-repository.patch
+++ b/patches/lede/0053-ath10k-firmware-update-repository.patch
@@ -1,0 +1,21 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 11 Jan 2018 21:17:15 +0100
+Subject: ath10k-firmware: update repository
+
+diff --git a/package/firmware/ath10k-firmware/Makefile b/package/firmware/ath10k-firmware/Makefile
+index 8bf5729fff16677ef6449498f1df3cda19272583..81dce0eb7aeee20e2ed3be4cc6699bf867487a96 100644
+--- a/package/firmware/ath10k-firmware/Makefile
++++ b/package/firmware/ath10k-firmware/Makefile
+@@ -8,9 +8,9 @@
+ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=ath10k-firmware
+-PKG_SOURCE_DATE:=2017-01-11
+-PKG_SOURCE_VERSION:=ab432c60437931a165f0aff1a6e3371f358b75dd
+-PKG_MIRROR_HASH:=e3188ecd4d7470d3cdde89fefa6258f9ec4f404b23558d1474e5014679b28101
++PKG_SOURCE_DATE:=2017-03-29
++PKG_SOURCE_VERSION:=956e2609b7e42c8c710bba10ef925a5be1be5137
++PKG_MIRROR_HASH:=25f724ff38c830281b3efba4a4ddffaae0c4bd8fea0f4c1061591229ff05535b
+ PKG_RELEASE:=1
+ 
+ PKG_SOURCE_PROTO:=git

--- a/patches/lede/0054-ath10k-firmware-add-qca9888-firmware.patch
+++ b/patches/lede/0054-ath10k-firmware-add-qca9888-firmware.patch
@@ -1,0 +1,53 @@
+From: John Crispin <john@phrozen.org>
+Date: Mon, 8 May 2017 08:51:46 +0200
+Subject: ath10k-firmware: add qca9888 firmware
+
+the firmware files for qca9888 were previously not packaged. add the meta
+information for doing so.
+
+Signed-off-by: John Crispin <john@phrozen.org>
+
+diff --git a/package/firmware/ath10k-firmware/Makefile b/package/firmware/ath10k-firmware/Makefile
+index 81dce0eb7aeee20e2ed3be4cc6699bf867487a96..aac8ee2b271678b03f58a6cb68beae6d53467dc1 100644
+--- a/package/firmware/ath10k-firmware/Makefile
++++ b/package/firmware/ath10k-firmware/Makefile
+@@ -32,6 +32,11 @@ $(Package/ath10k-firmware-default)
+   TITLE:=ath10k firmware for QCA9887 devices
+ endef
+ 
++define Package/ath10k-firmware-qca9888
++$(Package/ath10k-firmware-default)
++  TITLE:=ath10k firmware for QCA9888 devices
++endef
++
+ define Package/ath10k-firmware-qca9887-ct
+ $(Package/ath10k-firmware-default)
+   TITLE:=ath10k-CT firmware for QCA9887 devices
+@@ -240,6 +245,19 @@ define Package/ath10k-firmware-qca9887/install
+ 		$(1)/lib/firmware/ath10k/QCA9887/hw1.0/board.bin
+ endef
+ 
++define Package/ath10k-firmware-qca9888/install
++	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA9888/hw2.0
++	$(INSTALL_DATA) \
++		$(PKG_BUILD_DIR)/QCA9888/hw2.0/board-2.bin \
++		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
++	$(INSTALL_DATA) \
++		$(PKG_BUILD_DIR)/QCA9888/hw2.0/board-2.bin \
++		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
++	$(INSTALL_DATA) \
++		$(PKG_BUILD_DIR)/QCA9888/hw2.0/firmware-5.bin_10.4-3.2-00072 \
++		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/firmware-5.bin
++endef
++
+ define Package/ath10k-firmware-qca988x/install
+ 	$(INSTALL_DIR) $(1)/lib/firmware/ath10k/QCA988X/hw2.0
+ 	$(INSTALL_DATA) \
+@@ -328,6 +346,7 @@ define Package/ath10k-firmware-qca9984-ct/install
+ endef
+ 
+ $(eval $(call BuildPackage,ath10k-firmware-qca9887))
++$(eval $(call BuildPackage,ath10k-firmware-qca9888))
+ $(eval $(call BuildPackage,ath10k-firmware-qca988x))
+ $(eval $(call BuildPackage,ath10k-firmware-qca99x0))
+ $(eval $(call BuildPackage,ath10k-firmware-qca6174))

--- a/patches/lede/0055-ar71xx-fix-board.bin-used-by-QCA9886-in-Archer-C58-C59-C60.patch
+++ b/patches/lede/0055-ar71xx-fix-board.bin-used-by-QCA9886-in-Archer-C58-C59-C60.patch
@@ -1,0 +1,20 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Thu, 29 Jun 2017 15:38:22 +0200
+Subject: ar71xx: fix board.bin used by QCA9886 in Archer C58/C59/C60
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+(cherry picked from commit e917e51bf91fc7cb5085bda5e67d62520801f9cc)
+
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 538c86e4743109f7665096da32620d7862248aea..cfdc20455d61c3900473f57c3267b1a3fd10e150 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -138,6 +138,8 @@ case "$FIRMWARE" in
+ 	case $board in
+ 	archer-c58-v1)
+ 		ath10kcal_extract "art" 20480 12064
++		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
++			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+ 		;;
+ 	esac
+ 	;;

--- a/patches/lede/0056-ar71xx-Archer-C58-C59-C60-fix-qca9886-wireless-interface.patch
+++ b/patches/lede/0056-ar71xx-Archer-C58-C59-C60-fix-qca9886-wireless-interface.patch
@@ -1,0 +1,71 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Thu, 29 Jun 2017 15:20:31 +0200
+Subject: ar71xx: Archer C58/C59/C60 fix qca9886 wireless interface
+
+This commit fix 5GHz wireless interface used in Archer C58/C59/C60v1
+and set correctly MAC address on this interface.
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+(cherry picked from commit 34958c826915cf864833ed8ba6e5b49d44c6cb41)
+
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index cfdc20455d61c3900473f57c3267b1a3fd10e150..91bdf0d3c591516f58030b165052b3dd2751314f 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -136,7 +136,9 @@ case "$FIRMWARE" in
+ 	;;
+ "ath10k/pre-cal-pci-0000:00:00.0.bin")
+ 	case $board in
+-	archer-c58-v1)
++	archer-c58-v1|\
++	archer-c59-v1|\
++	archer-c60-v1)
+ 		ath10kcal_extract "art" 20480 12064
+ 		ln -sf /lib/firmware/ath10k/pre-cal-pci-0000\:00\:00.0.bin \
+ 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+index 7d2eca546d76b771b12026788510f73a293a9a93..669b208231e43fe86e998c7202c133c86ae0bf8d 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/ieee80211/10_fix_wifi_mac
+@@ -12,7 +12,9 @@ PHYNBR=${DEVPATH##*/phy}
+ board=$(ar71xx_board_name)
+ 
+ case "$board" in
+-	archer-c58-v1)
++	archer-c58-v1|\
++	archer-c59-v1|\
++	archer-c60-v1)
+ 		echo $(macaddr_add $(mtd_get_mac_binary mac 8)  $(($PHYNBR - 1)) ) > /sys${DEVPATH}/macaddress
+ 		;;
+ 	*)
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index 557bcdab2237a03957313cc3cda471a9fe3a3706..ed45866fcbe8d35af663799a91b09b5c8fd613bc 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -121,7 +121,7 @@ TARGET_DEVICES += archer-c25-v1
+ 
+ define Device/archer-c58-v1
+   DEVICE_TITLE := TP-LINK Archer C58 v1
+-  DEVICE_PACKAGES := kmod-ath10k
++  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9888
+   BOARDNAME := ARCHER-C58-V1
+   TPLINK_BOARD_NAME := ARCHER-C58-V1
+   DEVICE_PROFILE := ARCHERC58V1
+@@ -136,7 +136,7 @@ TARGET_DEVICES += archer-c58-v1
+ 
+ define Device/archer-c59-v1
+   DEVICE_TITLE := TP-LINK Archer C59 v1
+-  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k
++  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-ledtrig-usbport kmod-ath10k ath10k-firmware-qca9888
+   BOARDNAME := ARCHER-C59-V1
+   TPLINK_BOARD_NAME := ARCHER-C59-V1
+   DEVICE_PROFILE := ARCHERC59V1
+@@ -151,7 +151,7 @@ TARGET_DEVICES += archer-c59-v1
+ 
+ define Device/archer-c60-v1
+   DEVICE_TITLE := TP-LINK Archer C60 v1
+-  DEVICE_PACKAGES := kmod-ath10k
++  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9888
+   BOARDNAME := ARCHER-C60-V1
+   TPLINK_BOARD_NAME := ARCHER-C60-V1
+   DEVICE_PROFILE := ARCHERC60V1

--- a/patches/lede/0057-ath10k-firmware-qca9888-firmware-remove-board.bin.patch
+++ b/patches/lede/0057-ath10k-firmware-qca9888-firmware-remove-board.bin.patch
@@ -1,0 +1,20 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Mon, 3 Jul 2017 23:59:54 +0200
+Subject: ath10k-firmware: qca9888 firmware: remove board.bin
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+
+diff --git a/package/firmware/ath10k-firmware/Makefile b/package/firmware/ath10k-firmware/Makefile
+index aac8ee2b271678b03f58a6cb68beae6d53467dc1..e8cc4b91c3f59f09e4281c7b36048dc66bd04f3b 100644
+--- a/package/firmware/ath10k-firmware/Makefile
++++ b/package/firmware/ath10k-firmware/Makefile
+@@ -250,9 +250,6 @@ define Package/ath10k-firmware-qca9888/install
+ 	$(INSTALL_DATA) \
+ 		$(PKG_BUILD_DIR)/QCA9888/hw2.0/board-2.bin \
+ 		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/board-2.bin
+-	$(INSTALL_DATA) \
+-		$(PKG_BUILD_DIR)/QCA9888/hw2.0/board-2.bin \
+-		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+ 	$(INSTALL_DATA) \
+ 		$(PKG_BUILD_DIR)/QCA9888/hw2.0/firmware-5.bin_10.4-3.2-00072 \
+ 		$(1)/lib/firmware/ath10k/QCA9888/hw2.0/firmware-5.bin

--- a/patches/lede/0058-ar71xx-C58-C59-fix-LAN1-working-incorrectly.patch
+++ b/patches/lede/0058-ar71xx-C58-C59-fix-LAN1-working-incorrectly.patch
@@ -1,0 +1,22 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Mon, 27 Nov 2017 04:19:38 +0100
+Subject: ar71xx: C58/C59 fix LAN1 working incorrectly
+
+This commit fixes LAN Port 1 not transferring data in case no
+other LAN Port has active link-state on TP-Link Archer C58/C59.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+index f385d4a5a3148b83ee01007145e0eda2c0ef670f..129aa53f304dd1a118ace9a2749855cb36f66cfc 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c59-v1.c
+@@ -249,7 +249,7 @@ static void __init archer_c5x_v1_setup(void)
+ 	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
+ 	ath79_eth1_data.speed = SPEED_1000;
+ 	ath79_eth1_data.duplex = DUPLEX_FULL;
+-	ath79_switch_data.phy_poll_mask |= BIT(4);
++	ath79_switch_data.phy_poll_mask |= BIT(0);
+ 	ath79_switch_data.phy4_mii_en = 1;
+ 	ath79_register_eth(1);
+ 

--- a/patches/lede/0059-ar71xx-omit-VLAN-from-Archer-C58-C59-LAN-interface.patch
+++ b/patches/lede/0059-ar71xx-omit-VLAN-from-Archer-C58-C59-LAN-interface.patch
@@ -1,0 +1,17 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 11 Jan 2018 21:23:30 +0100
+Subject: ar71xx: omit VLAN from Archer C58/C59 LAN interface
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 57bc912aa5ede22a3fad4af6a1deb00c33f17cf8..1690172b5dfac1e1aa278c38c27ba64cfd61ade0 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -208,7 +208,7 @@ ar71xx_setup_interfaces()
+ 	archer-c58-v1|\
+ 	archer-c59-v1|\
+ 	rb-450g)
+-		ucidef_set_interfaces_lan_wan "eth1.1" "eth0"
++		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth1" "1:lan:1" "2:lan:4" "3:lan:3" "4:lan:2"
+ 		;;

--- a/patches/lede/0060-ar71xx-increase-kernel-partition-size-for-some-TP-Link-boards.patch
+++ b/patches/lede/0060-ar71xx-increase-kernel-partition-size-for-some-TP-Link-boards.patch
@@ -1,0 +1,64 @@
+From: Henryk Heisig <hyniu@o2.pl>
+Date: Fri, 27 Oct 2017 00:23:17 +0200
+Subject: ar71xx: increase kernel partition size for some TP-Link boards
+
+This patch increases kernel partition size and re-enables image
+generation for below TP-Link boards:
+
+- archer-c58-v1
+- archer-c60-v1
+- tl-wr902ac-v1
+- tl-wr942n-v1
+
+Signed-off-by: Henryk Heisig <hyniu@o2.pl>
+[commit message and title reworded]
+Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index ed45866fcbe8d35af663799a91b09b5c8fd613bc..be7e846c88f9ebbb8a4e4840e690d7864386bf64 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -130,7 +130,7 @@ define Device/archer-c58-v1
+   IMAGES := sysupgrade.bin factory.bin
+   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
+   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
+-  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1344k(kernel),6592k(rootfs),64k(tplink)ro,64k(art)ro,7936k@0x20000(firmware)
++  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,7936k(firmware),64k(tplink)ro,64k(art)ro
+ endef
+ TARGET_DEVICES += archer-c58-v1
+ 
+@@ -160,7 +160,7 @@ define Device/archer-c60-v1
+   IMAGES := sysupgrade.bin factory.bin
+   IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade
+   IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
+-  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,1344k(kernel),6592k(rootfs),64k(tplink)ro,64k(art)ro,7936k@0x20000(firmware)
++  MTDPARTS := spi0.0:64k(u-boot)ro,64k(mac)ro,7936k(firmware),64k(tplink)ro,64k(art)ro
+ endef
+ TARGET_DEVICES += archer-c60-v1
+ 
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index 67e2c4475bbd468bd20915767a481711ae872a3a..11ff2e56e19ec3780f988baf7257810530165b23 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -400,8 +400,8 @@ static struct device_info boards[] = {
+ 			{"profile", 0x11700, 0x03900},
+ 			{"default-config", 0x15000, 0x04000},
+ 			{"user-config", 0x19000, 0x04000},
+-			{"os-image", 0x20000, 0x150000},
+-			{"file-system", 0x170000, 0x678000},
++			{"os-image", 0x20000, 0x180000},
++			{"file-system", 0x1a0000, 0x648000},
+ 			{"certyficate", 0x7e8000, 0x08000},
+ 			{"radio", 0x7f0000, 0x10000},
+ 			{NULL, 0, 0}
+@@ -473,8 +473,8 @@ static struct device_info boards[] = {
+ 			{"profile", 0x11700, 0x03900},
+ 			{"default-config", 0x15000, 0x04000},
+ 			{"user-config", 0x19000, 0x04000},
+-			{"os-image", 0x20000, 0x150000},
+-			{"file-system", 0x170000, 0x678000},
++			{"os-image", 0x20000, 0x180000},
++			{"file-system", 0x1a0000, 0x648000},
+ 			{"certyficate", 0x7e8000, 0x08000},
+ 			{"radio", 0x7f0000, 0x10000},
+ 			{NULL, 0, 0}

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -192,6 +192,18 @@ device tp-link-archer-c25-v1 archer-c25-v1 # instability with 5GHz mesh in some 
 packages $ATH10K_PACKAGES_QCA9887
 fi
 
+if [ "$BROKEN" ]; then
+device tp-link-archer-c58-v1 archer-c58-v1
+fi
+
+if [ "$BROKEN" ] || [ "$GLUON_WLAN_MESH" = '11s' ]; then
+device tp-link-archer-c59-v1 archer-c59-v1 
+fi
+
+if [ "$BROKEN" ]; then
+device tp-link-archer-c60-v1 archer-c60-v1
+fi
+
 device tp-link-re450 re450
 packages $ATH10K_PACKAGES
 fi


### PR DESCRIPTION
Reopened due to accidental branch-deletion, see #1275 

This adds support for Archer C58/C59/C60.

Archer C58/C60 marked as broken, due to frequent crashing on activated 5GHz related to insufficient RAM. Working fine with disabled 5GHz.

Archer C59 not affected (128MB instead of 64MB RAM)

closes #1122

Currently not working:
- IBSS meshing on 5GHz (possibly fixed in my ibss branch, needs testing)
