### PR TITLE
gluon-core: Firewall: allow Multicast Listener Query/Report/Done on mesh and client zone

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/140-firewall-rules
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/140-firewall-rules
@@ -15,7 +15,6 @@ end
 uci:foreach('firewall', 'zone', reject_input_on_wan)
 
 -- the client zone is set up by gluon-client-bridge
---
 uci:section('firewall', 'zone', 'mesh', {
 	name = 'mesh',
 	network = {},
@@ -35,13 +34,12 @@ for _, zone in ipairs({ 'wan', 'local_client', 'mesh' }) do
 	})
 end
 
-
--- allow icmp in/out/forward on all relevant zones
+-- allow icmp in/out on all relevant zones
 for _, zone in ipairs ({ 'mesh', 'local_client' } ) do
 	uci:section('firewall', 'rule',  zone .. '_ICMPv6_in', {
 		src = zone,
 		proto = 'icmp',
-		icmp_type = {'echo-request', 'echo-reply', 'destination-unreachable', 'packet-too-big', 'time-exceeded', 'bad-header', 'unknown-header-type', 'router-solicitation', 'neighbour-solicitation', 'router-advertisement', 'neighbour-advertisement', },
+		icmp_type = {'echo-request', 'echo-reply', 'destination-unreachable', 'packet-too-big', 'time-exceeded', 'bad-header', 'unknown-header-type', 'router-solicitation', 'neighbour-solicitation', 'router-advertisement', 'neighbour-advertisement', '130/0', '131/0', '132/0' },
 		limit = '1000/sec',
 		family = 'ipv6',
 		target = 'ACCEPT',
@@ -50,7 +48,7 @@ for _, zone in ipairs ({ 'mesh', 'local_client' } ) do
 	uci:section('firewall', 'rule', zone .. '_ICMPv6_out', {
 		dest = zone,
 		proto = 'icmp',
-		icmp_type = {'echo-request', 'echo-reply', 'destination-unreachable', 'packet-too-big', 'time-exceeded', 'bad-header', 'unknown-header-type', 'router-solicitation', 'neighbour-solicitation', 'router-advertisement', 'neighbour-advertisement' },
+		icmp_type = {'echo-request', 'echo-reply', 'destination-unreachable', 'packet-too-big', 'time-exceeded', 'bad-header', 'unknown-header-type', 'router-solicitation', 'neighbour-solicitation', 'router-advertisement', 'neighbour-advertisement', '130/0', '131/0', '132/0' },
 		limit = '1000/sec',
 		family = 'ipv6',
 		target = 'ACCEPT',


### PR DESCRIPTION
this will allow more icmp6 trafic in the mesh an local-client zone.
This is meant to fix #1282 