### PR TITLE
gluon-core: save firewall when setting dns config

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
@@ -42,6 +42,6 @@ if next_node.name and next_node.ip6 then
 else
 	uci:delete('dhcp', 'domain', 'nextnode6')
 end
-
+uci:save('firewall')
 uci:save('dhcp')
 uci:save('firewall')


### PR DESCRIPTION
When changing the firewall, it is sensible to save them in the same script.