### PR TITLE
Allow multiple names for nextnode - breaks current site.conf

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -83,6 +83,7 @@
   -- connected to using a known IP address.
   next_node = {
     -- anycast IPs of all nodes
+    -- name = { 'nextnode.location.community.example.org', 'nextnode', 'nn' },
     ip4 = '10.xxx.0.xxx',
     ip6 = 'fdxx:xxxx:xxxx::xxxx',
   },

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -163,6 +163,7 @@ next_node \: package
     ::
 
       next_node = {
+        name = { 'nextnode.location.community.example.org', 'nextnode', 'nn' },
         ip4 = '10.23.42.1',
         ip6 = 'fdca:ffee:babe:1::1',
         mac = '16:41:95:40:f7:dc'
@@ -172,7 +173,8 @@ next_node \: package
     omitted, there will be no IPv4 or IPv6 anycast address. The MAC address
     defaults to ``16:41:95:40:f7:dc``; this value usually doesn't need to be
     changed, but it can be adjusted to match existing deployments that use a
-    different value.
+    different value. Each entry in the ``name``-field will be resolved as the
+    ipv4 and ipv6-address.
 
 mesh \: optional
     Options specific to routing protocols.

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -173,8 +173,13 @@ next_node \: package
     omitted, there will be no IPv4 or IPv6 anycast address. The MAC address
     defaults to ``16:41:95:40:f7:dc``; this value usually doesn't need to be
     changed, but it can be adjusted to match existing deployments that use a
-    different value. Each entry in the ``name``-field will be resolved as the
+    different value. Each entry in the ``name``-field will be resolved to the
     ipv4 and ipv6-address.
+    For this to work, clients must use the next-node as their resolver. In
+    batman-based networks this requires setting the central dhcp server to
+    deliver this address as DNS-server via DHCP-option. When running a radvd
+    inside the network, this should be set to deliver the next-node
+    ipv6-address via rdnss.
 
 mesh \: optional
     Options specific to routing protocols.

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -174,12 +174,12 @@ next_node \: package
     defaults to ``16:41:95:40:f7:dc``; this value usually doesn't need to be
     changed, but it can be adjusted to match existing deployments that use a
     different value. Each entry in the ``name``-field will be resolved to the
-    ipv4 and ipv6-address.
+    IPv4 and IPv6-address.
     For this to work, clients must use the next-node as their resolver. In
-    batman-based networks this requires setting the central dhcp server to
-    deliver this address as DNS-server via DHCP-option. When running a radvd
+    batman-based networks this requires setting the central DHCP server to
+    deliver this address as DNS server via DHCP option. When running a radvd
     inside the network, this should be set to deliver the next-node
-    ipv6-address via rdnss.
+    IPv6-address via rdnss.
 
 mesh \: optional
     Options specific to routing protocols.

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -70,6 +70,12 @@ if need_table({'dns'}, nil, false) then
 	need_number({'dns', 'cacheentries'}, false)
 end
 
+if need_table('next_node', nil, false) then
+	need_string_match('next_node.ip6', '^[%x:]+$', false)
+	need_string_match('next_node.ip4', '^%d+.%d+.%d+.%d+$', false)
+	need_string_array('next_node.name', false)
+end
+
 need_string_match(in_domain({'next_node', 'ip6'}), '^[%x:]+$', false)
 need_string_match(in_domain({'next_node', 'ip4'}), '^%d+.%d+.%d+.%d+$', false)
 

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -70,12 +70,7 @@ if need_table({'dns'}, nil, false) then
 	need_number({'dns', 'cacheentries'}, false)
 end
 
-if need_table('next_node', nil, false) then
-	need_string_match('next_node.ip6', '^[%x:]+$', false)
-	need_string_match('next_node.ip4', '^%d+.%d+.%d+.%d+$', false)
-	need_string_array('next_node.name', false)
-end
-
+need_string_array(in_domain({'next_node', 'name'}), false)
 need_string_match(in_domain({'next_node', 'ip6'}), '^[%x:]+$', false)
 need_string_match(in_domain({'next_node', 'ip4'}), '^%d+.%d+.%d+.%d+$', false)
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
@@ -33,10 +33,8 @@ local function set_dns_record(name, ip, sectionname)
 	})
 end
 
-uci:foreach("dhcp", "domain", function(s)
-	if (s['.name'] and string.match(s['.name'], "^nextnode[46]_")) then
-		uci:delete("dhcp", s['.name'])
-	end
+uci:delete_all('dhcp', 'domain', function(s)
+	return (s['.name'] and string.match(s['.name'], "^nextnode[46]"))
 end)
 
 for i, name in ipairs(next_node.name or {}) do

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
@@ -34,10 +34,8 @@ local function set_dns_record(name, ip, sectionname)
 end
 
 uci:foreach("dhcp", "domain", function(s)
-	for key, value in pairs(s) do
-		if (key == ".name" and string.gmatch(value, "^nextnode[46]")) then
-			uci:delete("dhcp", value)
-		end
+	if (s['.name'] and string.match(s['.name'], "^nextnode[46]_")) then
+		uci:delete("dhcp", s['.name'])
 	end
 end)
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
@@ -25,22 +25,25 @@ if dns.servers then
 	})
 end
 
-if next_node.name and next_node.ip4 then
-	uci:section('dhcp', 'domain', 'nextnode4', {
-		name = next_node.name,
-		ip = next_node.ip4,
+local function set_dns_record(name, ip, sectionname)
+	if not ip then return end
+	uci:section('dhcp', 'domain', sectionname, {
+		name = name,
+		ip = ip,
 	})
-else
-	uci:delete('dhcp', 'domain', 'nextnode4')
 end
 
-if next_node.name and next_node.ip6 then
-	uci:section('dhcp', 'domain', 'nextnode6', {
-		name = next_node.name,
-		ip = next_node.ip6,
-	})
-else
-	uci:delete('dhcp', 'domain', 'nextnode6')
+uci:foreach("dhcp", "domain", function(s)
+	for key, value in pairs(s) do
+		if (key == ".name" and string.gmatch(value, "^nextnode[46]")) then
+			uci:delete("dhcp", value)
+		end
+	end
+end)
+
+for i, name in ipairs(next_node.name or {}) do
+	set_dns_record(name, next_node.ip4, 'nextnode4_' .. i)
+	set_dns_record(name, next_node.ip6, 'nextnode6_' .. i)
 end
 
 uci:save('dhcp')


### PR DESCRIPTION
This will allow us to specify more than one name to resolve to the nextnode-IPs