### PR TITLE
gluon-respondd: firewall should allow access for devices in zone local_client

### DIFF
--- a/package/gluon-respondd/luasrc/lib/gluon/upgrade/400-respondd-firewall
+++ b/package/gluon-respondd/luasrc/lib/gluon/upgrade/400-respondd-firewall
@@ -15,10 +15,10 @@ uci:section('firewall', 'rule', 'wan_respondd', {
 	target = 'ACCEPT',
 })
 
--- Allow respondd-access on client_local
+-- Allow respondd-access for local clients
 uci:section('firewall', 'rule', 'client_respondd', {
 	name = 'client_respondd',
-	src = 'client_local',
+	src = 'local_client',
 	src_ip = 'fe80::/64',
 	dest_port = '1001',
 	proto = 'udp',


### PR DESCRIPTION
at the moment the rule is broken because it refers to a zone that does not exist meaning that respondd cannot be queried directly from the client-zone.

This PR changes that.