### PR TITLE
modules: update url to chaos calmer git repository after upstream move

### DIFF
--- a/modules
+++ b/modules
@@ -1,6 +1,6 @@
 GLUON_FEEDS='openwrt gluon routing luci'
 
-OPENWRT_REPO=git://github.com/openwrt/openwrt.git
+OPENWRT_REPO=git://github.com/openwrt/chaos_calmer.git
 OPENWRT_COMMIT=0f757bd2606971252f901ef3faf4dbd0086315f7
 OPENWRT_BRANCH=chaos_calmer
 


### PR DESCRIPTION
due to the LEDE / OpenWRT merge the original chaos calmer branch was moved to a separate git repository. this commit updates the url to fix the build process