### PR TITLE
v2017.1.x: Backport support for Archer C7 v4

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -166,7 +166,7 @@ ar71xx-generic
 * TP-Link
 
   - Archer C5 (v1) [#ath10k]_
-  - Archer C7 (v2) [#ath10k]_
+  - Archer C7 (v2, v4) [#ath10k]_
   - CPE210 (v1.0, v1.1)
   - CPE220 (v1.1)
   - CPE510 (v1.0, v1.1)

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -37,7 +37,8 @@ elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2',
                                             'om2p-hs', 'om2p-hsv2', 'om2p-hsv3',
                                             'om2p-lc',
                                             'om5p', 'om5p-an',
-                                            'om5p-ac', 'om5p-acv2'}) then
+                                            'om5p-ac', 'om5p-acv2',
+                                            'archer-c7-v4'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c7'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')

--- a/patches/lede/0044-ar71xx-add-support-for-TP-LINK-Archer-C7-v4.patch
+++ b/patches/lede/0044-ar71xx-add-support-for-TP-LINK-Archer-C7-v4.patch
@@ -1,0 +1,533 @@
+From: Felix Fietkau <nbd@nbd.name>
+Date: Tue, 25 Jul 2017 13:32:47 +0200
+Subject: ar71xx: add support for TP-LINK Archer C7 v4
+
+TP-Link Archer C7 v4 is a dual-band AC1750 router, based on Qualcomm/Atheros
+QCA9561+QCA9888.
+
+Specification:
+
+- 775/650/258 MHz (CPU/DDR/AHB)
+- 128 MB of RAM (DDR2)
+- 16 MB of FLASH (SPI NOR)
+- 3T3R 2.4 GHz
+- 3T3R 5 GHz
+- 5x 10/100/1000 Mbps Ethernet
+- 7x LED, 2x button
+- UART header on PCB
+
+Flash instruction:
+1. Upload lede-ar71xx-generic-archer-c7-v4-squashfs-factory.bin via Web interface
+
+Flash instruction using TFTP recovery:
+1. Set PC to fixed ip address 192.168.0.66
+2. Download lede-ar71xx-generic-archer-c7-v4-squashfs-factory.bin
+and rename it to ArcherC7v4_tp_recovery.bin
+3. Start a tftp server with the file tp_recovery.bin in its root directory
+4. Turn off the router
+5. Press and hold Reset button
+6. Turn on router with the reset button pressed and wait ~15 seconds
+7. Release the reset button and after a short time
+the firmware should be transferred from the tftp server
+8. Wait ~30 second to complete recovery.
+
+Flash instruction under U-Boot, using UART:
+
+1. tftp 0x81000000 lede-ar71xx-...-sysupgrade.bin
+2. erase 0x9f040000 +$filesize
+3. cp.b $fileaddr 0x9f040000 $filesize
+4. reset
+
+Signed-off-by: Felix Fietkau <nbd@nbd.name>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index e67b5e38561e841b88e486341950c52e1d454322..44b1c2837e8392596eed14b4bc0d761042109715 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -53,7 +53,8 @@ ap121f)
+ 	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth0"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
+ 	;;
+-archer-c25-v1)
++archer-c25-v1|\
++archer-c7-v4)
+ 	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
+ 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
+@@ -61,6 +62,12 @@ archer-c25-v1)
+ 	ucidef_set_led_switch "lan2" "LAN2" "$board:green:lan2" "switch0" "0x08"
+ 	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "0x04"
+ 	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x02"
++	case "$board" in
++		archer-c7-v4)
++			ucidef_set_led_usbdev "usb1" "USB1" "$board:green:usb1" "1-1"
++			ucidef_set_led_usbdev "usb2" "USB2" "$board:green:usb2" "2-1"
++		;;
++	esac
+ 	;;
+ arduino-yun)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "arduino:blue:wlan" "phy0tpt"
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 27a0266923743d4856919b9c8772a40e59febe83..b8452d79cb7f0f856f60ad3050cc9627d2536213 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -380,6 +380,7 @@ ar71xx_setup_interfaces()
+ 		ucidef_set_interface_wan "eth0"
+ 		ucidef_set_interface_raw "wlan" "wlan0" "dhcp"
+ 		;;
++	archer-c7-v4|\
+ 	tl-wdr4300|\
+ 	tl-wr1041n-v2)
+ 		ucidef_add_switch "switch0" \
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 61db387c9ecefd7090c25a5f5d75fdbf65a44d65..97372bed0ea2fadfab10f22916a1e0d6a9c65725 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -51,6 +51,7 @@ get_status_led() {
+ 		status_led="ap135:green:status"
+ 		;;
+ 	archer-c25-v1|\
++	archer-c7-v4|\
+ 	mr12|\
+ 	mr16|\
+ 	nbg6616|\
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 68f90de802ddd18e09a1da39c0d56292eea9489c..96b8f6b9a4bdd6a1609a819e72ade315bccfb3c0 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -92,6 +92,7 @@ case "$FIRMWARE" in
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
+ 		;;
++	archer-c7-v4|\
+ 	archer-c25-v1|\
+ 	tl-wdr6500-v2)
+ 		ath10kcal_extract "art" 20480 2116
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index de6042b202bbd07e64833743933be1cbaf1ed495..ddb8f0db80ed6eab39c832bfd893182d9f591ad4 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -466,6 +466,9 @@ ar71xx_board_detect() {
+ 	*"Archer C5")
+ 		name="archer-c5"
+ 		;;
++	*"Archer C7 v4")
++		name="archer-c7-v4"
++		;;
+ 	*"Archer C7")
+ 		name="archer-c7"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index e748a2559cdb3a0ca6618429b0f613a656e39388..d414af969912894574e73e286ed5a3998532d34e 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -207,6 +207,7 @@ platform_check_image() {
+ 	ap132|\
+ 	ap90q|\
+ 	archer-c25-v1|\
++	archer-c7-v4|\
+ 	bullet-m|\
+ 	c-55|\
+ 	carambola2|\
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+index 7ad5419f51ec9909d8b59f33178221a7d81ec184..0a25294c40b5e2d3be825554ec7246a50b9c029b 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+@@ -1247,6 +1247,7 @@ config ATH79_MACH_ARCHER_C25_V1
+ config ATH79_MACH_ARCHER_C7
+ 	bool "TP-LINK Archer C5/C7/TL-WDR4900 v2 board support"
+ 	select SOC_QCA955X
++	select SOC_QCA956X
+ 	select ATH79_DEV_AP9X_PCI if PCI
+ 	select ATH79_DEV_ETH
+ 	select ATH79_DEV_GPIO_BUTTONS
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Makefile b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+index 3365a43ce16fc77b3212b39b92081efe678e8803..a0c73550eb0d5bf07ee731171be9e5ef9ff073e7 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+@@ -58,6 +58,7 @@ obj-$(CONFIG_ATH79_MACH_AP90Q)			+= mach-ap90q.o
+ obj-$(CONFIG_ATH79_MACH_AP96)			+= mach-ap96.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C25_V1)		+= mach-archer-c25-v1.o
+ obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7.o
++obj-$(CONFIG_ATH79_MACH_ARCHER_C7)		+= mach-archer-c7-v4.o
+ obj-$(CONFIG_ATH79_MACH_ARDUINO_YUN)		+= mach-arduino-yun.o
+ obj-$(CONFIG_ATH79_MACH_AW_NR580)		+= mach-aw-nr580.o
+ obj-$(CONFIG_ATH79_MACH_BHR_4GRV2)		+= mach-bhr-4grv2.o
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v4.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v4.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..64955c79945c0b2c28d5a93be6e45662200e60ed
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v4.c
+@@ -0,0 +1,260 @@
++
++/*
++ * Atheros ARCHER_C7 reference board support
++ *
++ * Copyright (c) 2017 Felix Fietkau <nbd@nbd.name>
++ * Copyright (c) 2014 The Linux Foundation. All rights reserved.
++ * Copyright (c) 2012 Gabor Juhos <juhosg@openwrt.org>
++ *
++ * Permission to use, copy, modify, and/or distribute this software for any
++ * purpose with or without fee is hereby granted, provided that the above
++ * copyright notice and this permission notice appear in all copies.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
++ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
++ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
++ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
++ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
++ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
++ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
++ *
++ */
++
++#include <linux/platform_device.h>
++#include <linux/ath9k_platform.h>
++#include <linux/ar8216_platform.h>
++#include <linux/proc_fs.h>
++#include <linux/gpio.h>
++#include <linux/spi/spi_gpio.h>
++#include <linux/spi/74x164.h>
++
++#include <asm/mach-ath79/ar71xx_regs.h>
++
++#include "common.h"
++#include "dev-m25p80.h"
++#include "machtypes.h"
++#include "pci.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-spi.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++
++
++#define ARCHER_C7_GPIO_SHIFT_OE		1
++#define ARCHER_C7_GPIO_SHIFT_SER	14
++#define ARCHER_C7_GPIO_SHIFT_SRCLK	15
++#define ARCHER_C7_GPIO_SHIFT_RCLK	16
++#define ARCHER_C7_GPIO_SHIFT_SRCLR	21
++
++#define ARCHER_C7_GPIO_BTN_RESET	5
++#define ARCHER_C7_GPIO_BTN_WPS_WIFI	2
++
++#define ARCHER_C7_GPIO_LED_WLAN5	9
++#define ARCHER_C7_GPIO_LED_POWER	6
++#define ARCHER_C7_GPIO_LED_USB1		7
++#define ARCHER_C7_GPIO_LED_USB2		8
++
++#define ARCHER_C7_74HC_GPIO_BASE	QCA956X_GPIO_COUNT
++#define ARCHER_C7_GPIO_LED_WPS		(ARCHER_C7_74HC_GPIO_BASE + 0)
++#define ARCHER_C7_GPIO_LED_LAN1		(ARCHER_C7_74HC_GPIO_BASE + 1)
++#define ARCHER_C7_GPIO_LED_LAN2		(ARCHER_C7_74HC_GPIO_BASE + 2)
++#define ARCHER_C7_GPIO_LED_LAN3		(ARCHER_C7_74HC_GPIO_BASE + 3)
++#define ARCHER_C7_GPIO_LED_LAN4		(ARCHER_C7_74HC_GPIO_BASE + 4)
++#define ARCHER_C7_GPIO_LED_WAN_GREEN	(ARCHER_C7_74HC_GPIO_BASE + 5)
++#define ARCHER_C7_GPIO_LED_WAN_AMBER	(ARCHER_C7_74HC_GPIO_BASE + 6)
++#define ARCHER_C7_GPIO_LED_WLAN2	(ARCHER_C7_74HC_GPIO_BASE + 7)
++
++#define ARCHER_C7_KEYS_POLL_INTERVAL        20     /* msecs */
++#define ARCHER_C7_KEYS_DEBOUNCE_INTERVAL    (3 * ARCHER_C7_KEYS_POLL_INTERVAL)
++
++#define ARCHER_C7_MAC0_OFFSET               0
++#define ARCHER_C7_MAC1_OFFSET               6
++#define ARCHER_C7_WMAC_CALDATA_OFFSET       0x1000
++
++#define ARCHER_C7_GPIO_MDC			3
++#define ARCHER_C7_GPIO_MDIO			4
++
++static struct spi_gpio_platform_data archer_c7_v4_spi_data = {
++	.sck		= ARCHER_C7_GPIO_SHIFT_SRCLK,
++	.miso		= SPI_GPIO_NO_MISO,
++	.mosi		= ARCHER_C7_GPIO_SHIFT_SER,
++	.num_chipselect	= 1,
++};
++
++static u8 archer_c7_v4_ssr_initdata __initdata = 0xff;
++
++static struct gen_74x164_chip_platform_data archer_c7_v4_ssr_data = {
++	.base = ARCHER_C7_74HC_GPIO_BASE,
++	.num_registers = 1,
++	.init_data = &archer_c7_v4_ssr_initdata,
++};
++
++static struct platform_device archer_c7_v4_spi_device = {
++	.name		= "spi_gpio",
++	.id		= 1,
++	.dev = {
++		.platform_data = &archer_c7_v4_spi_data,
++	},
++};
++
++static struct spi_board_info archer_c7_v4_spi_info[] = {
++	{
++		.bus_num		= 1,
++		.chip_select		= 0,
++		.max_speed_hz		= 10000000,
++		.modalias		= "74x164",
++		.platform_data		= &archer_c7_v4_ssr_data,
++		.controller_data	= (void *) ARCHER_C7_GPIO_SHIFT_RCLK,
++	},
++};
++
++static struct gpio_led archer_c7_v4_leds_gpio[] __initdata = {
++	{
++		.name		= "archer-c7-v4:green:power",
++		.gpio		= ARCHER_C7_GPIO_LED_POWER,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:wps",
++		.gpio		= ARCHER_C7_GPIO_LED_WPS,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:wlan2g",
++		.gpio		= ARCHER_C7_GPIO_LED_WLAN2,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:wlan5g",
++		.gpio		= ARCHER_C7_GPIO_LED_WLAN5,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:lan1",
++		.gpio		= ARCHER_C7_GPIO_LED_LAN1,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:lan2",
++		.gpio		= ARCHER_C7_GPIO_LED_LAN2,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:lan3",
++		.gpio		= ARCHER_C7_GPIO_LED_LAN3,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:lan4",
++		.gpio		= ARCHER_C7_GPIO_LED_LAN4,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:wan",
++		.gpio		=  ARCHER_C7_GPIO_LED_WAN_GREEN,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:amber:wan",
++		.gpio		=  ARCHER_C7_GPIO_LED_WAN_AMBER,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:usb1",
++		.gpio		=  ARCHER_C7_GPIO_LED_USB1,
++		.active_low	= 1,
++	}, {
++		.name		= "archer-c7-v4:green:usb2",
++		.gpio		=  ARCHER_C7_GPIO_LED_USB2,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button archer_c7_v4_gpio_keys[] __initdata = {
++        {
++                .desc           = "WPS and WIFI button",
++                .type           = EV_KEY,
++                .code           = KEY_WPS_BUTTON,
++                .debounce_interval = ARCHER_C7_KEYS_DEBOUNCE_INTERVAL,
++                .gpio           = ARCHER_C7_GPIO_BTN_WPS_WIFI,
++                .active_low     = 1,
++        },
++        {
++                .desc           = "Reset button",
++                .type           = EV_KEY,
++                .code           = KEY_RESTART,
++                .debounce_interval = ARCHER_C7_KEYS_DEBOUNCE_INTERVAL,
++                .gpio           = ARCHER_C7_GPIO_BTN_RESET,
++                .active_low     = 1,
++        },
++};
++
++static struct ar8327_pad_cfg archer_c7_v4_ar8337_pad0_cfg = {
++	.mode = AR8327_PAD_MAC_SGMII,
++	.sgmii_delay_en = true,
++};
++
++static struct ar8327_platform_data archer_c7_v4_ar8337_data = {
++	.pad0_cfg = &archer_c7_v4_ar8337_pad0_cfg,
++	.port0_cfg = {
++		.force_link = 1,
++		.speed = AR8327_PORT_SPEED_1000,
++		.duplex = 1,
++		.txpause = 1,
++		.rxpause = 1,
++	},
++};
++
++static struct mdio_board_info archer_c7_v4_mdio0_info[] = {
++	{
++		.bus_id = "ag71xx-mdio.0",
++		.phy_addr = 0,
++		.platform_data = &archer_c7_v4_ar8337_data,
++	},
++};
++
++
++static void __init archer_c7_v4_setup(void)
++{
++	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
++	u8 *mac = (u8 *) KSEG1ADDR(0x1ff00008);
++
++	ath79_register_m25p80(NULL);
++
++	spi_register_board_info(archer_c7_v4_spi_info,
++				ARRAY_SIZE(archer_c7_v4_spi_info));
++
++	platform_device_register(&archer_c7_v4_spi_device);
++
++	gpio_request_one(ARCHER_C7_GPIO_SHIFT_OE,
++			 GPIOF_OUT_INIT_LOW | GPIOF_EXPORT_DIR_FIXED,
++			 "LED control");
++
++	gpio_request_one(ARCHER_C7_GPIO_SHIFT_SRCLR,
++			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++			 "LED reset");
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(archer_c7_v4_leds_gpio),
++				archer_c7_v4_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, ARCHER_C7_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(archer_c7_v4_gpio_keys),
++					archer_c7_v4_gpio_keys);
++
++	ath79_register_usb();
++
++	ath79_gpio_output_select(ARCHER_C7_GPIO_MDC, QCA956X_GPIO_OUT_MUX_GE0_MDC);
++	ath79_gpio_output_select(ARCHER_C7_GPIO_MDIO, QCA956X_GPIO_OUT_MUX_GE0_MDO);
++
++	ath79_register_mdio(0, 0x0);
++
++	mdiobus_register_board_info(archer_c7_v4_mdio0_info,
++				    ARRAY_SIZE(archer_c7_v4_mdio0_info));
++
++	ath79_register_wmac(art + ARCHER_C7_WMAC_CALDATA_OFFSET, mac);
++	ath79_register_pci();
++
++	/* GMAC0 is connected to an AR8337 switch */
++	ath79_init_mac(ath79_eth0_data.mac_addr, mac, 0);
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_SGMII;
++	ath79_eth0_data.speed = SPEED_1000;
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_mask = BIT(0);
++	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
++	ath79_register_eth(0);
++}
++
++MIPS_MACHINE(ATH79_MACH_ARCHER_C7_V4, "ARCHER-C7-V4", "TP-LINK Archer C7 v4",
++	     archer_c7_v4_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 9cb4a7f2e1df641232289721b676a9b0149c76e5..e4623fd08836d59ad4e79e96f02e75e502a55ca6 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -44,6 +44,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_ARCHER_C5,			/* TP-LINK Archer C5 board */
+ 	ATH79_MACH_ARCHER_C7,			/* TP-LINK Archer C7 board */
+ 	ATH79_MACH_ARCHER_C7_V2,		/* TP-LINK Archer C7 V2 board */
++	ATH79_MACH_ARCHER_C7_V4,		/* TP-LINK Archer C7 V4 board */
+ 	ATH79_MACH_ARDUINO_YUN,			/* Yun */
+ 	ATH79_MACH_AW_NR580,			/* AzureWave AW-NR580 */
+ 	ATH79_MACH_BHR_4GRV2,			/* Buffalo BHR-4GRV2 */
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index 5be7cbfbd4ab7d73d679d52d2581459250e04302..27d6c73454aef96e5da47033ec664d2caffca1d5 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -298,6 +298,22 @@ define Device/archer-c7-v2
+     IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
+ endef
+ 
++define Device/archer-c7-v4
++  DEVICE_TITLE := TP-LINK Archer C7 v4
++  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca988x
++  BOARDNAME := ARCHER-C7-V4
++  TPLINK_BOARD_NAME := ARCHER-C7-V4
++  IMAGE_SIZE := 15104k
++  LOADER_TYPE := elf
++  KERNEL := kernel-bin | patch-cmdline | lzma | uImageArcher lzma
++  IMAGES := sysupgrade.bin factory.bin
++  IMAGE/sysupgrade.bin := append-rootfs | tplink-safeloader sysupgrade | \
++	append-metadata | check-size $$$$(IMAGE_SIZE)
++  IMAGE/factory.bin := append-rootfs | tplink-safeloader factory
++  MTDPARTS := spi0.0:128k(factory-uboot)ro,128k(u-boot)ro,1536k(kernel),13568k(rootfs),960k(config)ro,64k(art)ro,15104k@0x40000(firmware)
++  SUPPORTED_DEVICES := archer-c7-v4
++endef
++
+ define Device/archer-c7-v2-il
+     $(Device/tplink-16mlzma)
+     DEVICE_TITLE := TP-LINK Archer C7 v2 IL
+@@ -316,7 +332,7 @@ define Device/tl-wdr7500-v3
+     DEVICE_PROFILE := ARCHERC7
+     TPLINK_HWID := 0x75000003
+ endef
+-TARGET_DEVICES += archer-c5-v1 archer-c7-v1 archer-c7-v2 archer-c7-v2-il tl-wdr7500-v3
++TARGET_DEVICES += archer-c5-v1 archer-c7-v1 archer-c7-v2 archer-c7-v2-il archer-c7-v4 tl-wdr7500-v3
+ 
+ define Device/tl-mr10u-v1
+     $(Device/tplink-4mlzma)
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index 478d5d8e9b43bbe37694732c138048c8fe8d807c..fec830c23ce6707755ddefc849f195872be1e877 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -376,6 +376,49 @@ static struct device_info boards[] = {
+ 		.last_sysupgrade_partition = "file-system"
+ 	},
+ 
++	/** Firmware layout for the C7 */
++	{
++		.id = "ARCHER-C7-V4",
++		.support_list =
++			"SupportList:\n"
++			"{product_name:Archer C7,product_ver:4.0.0,special_id:45550000}\n"
++			"{product_name:Archer C7,product_ver:4.0.0,special_id:55530000}\n"
++			"{product_name:Archer C7,product_ver:4.0.0,special_id:43410000}\n",
++		.support_trail = '\x00',
++		.soft_ver = "soft_ver:1.0.0\n",
++
++		/**
++		    We use a bigger os-image partition than the stock images (and thus
++		    smaller file-system), as our kernel doesn't fit in the stock firmware's
++		    1MB os-image.
++		*/
++		.partitions = {
++			{"factory-boot", 0x00000, 0x20000},
++			{"fs-uboot", 0x20000, 0x20000},
++			{"os-image", 0x40000, 0x180000},	/* Stock: base 0x40000 size 0x120000 */
++			{"file-system", 0x1c0000, 0xd40000},	/* Stock: base 0x160000 size 0xda0000 */
++			{"default-mac", 0xf00000, 0x00200},
++			{"pin", 0xf00200, 0x00200},
++			{"device-id", 0xf00400, 0x00100},
++			{"product-info", 0xf00500, 0x0fb00},
++			{"soft-version", 0xf10000, 0x00100},
++			{"extra-para", 0xf11000, 0x01000},
++			{"support-list", 0xf12000, 0x0a000},
++			{"profile", 0xf1c000, 0x04000},
++			{"default-config", 0xf20000, 0x10000},
++			{"user-config", 0xf30000, 0x40000},
++			{"qos-db", 0xf70000, 0x40000},
++			{"certificate", 0xfb0000, 0x10000},
++			{"partition-table", 0xfc0000, 0x10000},
++			{"log", 0xfd0000, 0x20000},
++			{"radio", 0xff0000, 0x10000},
++			{NULL, 0, 0}
++		},
++
++		.first_sysupgrade_partition = "os-image",
++		.last_sysupgrade_partition = "file-system",
++	},
++
+ 	/** Firmware layout for the C9 */
+ 	{
+ 		.id = "ARCHERC9",
+@@ -929,6 +972,9 @@ static void build_image(const char *output,
+ 	    strcasecmp(info->id, "TLWR1043NV5") == 0) {
+ 		const char mdat[11] = {0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00};
+ 		parts[5] = put_data("extra-para", mdat, 11);
++	} else if (strcasecmp(info->id, "ARCHER-C7-V4") == 0) {
++		const char mdat[11] = {0x01, 0x00, 0x00, 0x02, 0x00, 0x00, 0xca, 0x00, 0x01, 0x00, 0x00};
++		parts[5] = put_data("extra-para", mdat, 11);
+ 	}
+ 
+ 	size_t len;

--- a/patches/lede/0045-ar71xx-fix-TP-Link-Archer-C7-v4-switch-LEDs.patch
+++ b/patches/lede/0045-ar71xx-fix-TP-Link-Archer-C7-v4-switch-LEDs.patch
@@ -1,0 +1,72 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 16 Dec 2017 15:43:02 +0100
+Subject: ar71xx: fix TP-Link Archer C7 v4 switch LEDs
+
+This fixes wrong switch LEDs on TP-Link Archer C7 v4.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 44b1c2837e8392596eed14b4bc0d761042109715..47b90d9cb2f81936aed22cdf7d1f6d870d23c16e 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -53,8 +53,7 @@ ap121f)
+ 	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth0"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
+ 	;;
+-archer-c25-v1|\
+-archer-c7-v4)
++archer-c25-v1)
+ 	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
+ 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
+@@ -62,12 +61,6 @@ archer-c7-v4)
+ 	ucidef_set_led_switch "lan2" "LAN2" "$board:green:lan2" "switch0" "0x08"
+ 	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "0x04"
+ 	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x02"
+-	case "$board" in
+-		archer-c7-v4)
+-			ucidef_set_led_usbdev "usb1" "USB1" "$board:green:usb1" "1-1"
+-			ucidef_set_led_usbdev "usb2" "USB2" "$board:green:usb2" "2-1"
+-		;;
+-	esac
+ 	;;
+ arduino-yun)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "arduino:blue:wlan" "phy0tpt"
+@@ -635,6 +628,17 @@ archer-c7)
+ 	ucidef_set_led_wlan "wlan2g" "WLAN2G" "tp-link:blue:wlan2g" "phy1tpt"
+ 	ucidef_set_led_wlan "wlan5g" "WLAN5G" "tp-link:blue:wlan5g" "phy0tpt"
+ 	;;
++archer-c7-v4)
++	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan2g" "phy1tpt"
++	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:green:wlan5g" "phy0tpt"
++	ucidef_set_led_switch "wan" "WAN" "$board:green:wan" "switch0" "0x02"
++	ucidef_set_led_switch "lan1" "LAN1" "$board:green:lan1" "switch0" "0x04"
++	ucidef_set_led_switch "lan2" "LAN2" "$board:green:lan2" "switch0" "0x08"
++	ucidef_set_led_switch "lan3" "LAN3" "$board:green:lan3" "switch0" "0x10"
++	ucidef_set_led_switch "lan4" "LAN4" "$board:green:lan4" "switch0" "0x20"
++	ucidef_set_led_usbdev "usb1" "USB1" "$board:green:usb1" "1-1"
++	ucidef_set_led_usbdev "usb2" "USB2" "$board:green:usb2" "2-1"
++	;;
+ tl-wpa8630)
+ 	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth0"
+ 	ucidef_set_led_netdev "wlan" "WLAN" "$board:green:wlan" "wlan1"
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v4.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v4.c
+index 64955c79945c0b2c28d5a93be6e45662200e60ed..9688b015356cb766c5966be2190e1aae29420d8d 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v4.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-archer-c7-v4.c
+@@ -58,10 +58,10 @@
+ 
+ #define ARCHER_C7_74HC_GPIO_BASE	QCA956X_GPIO_COUNT
+ #define ARCHER_C7_GPIO_LED_WPS		(ARCHER_C7_74HC_GPIO_BASE + 0)
+-#define ARCHER_C7_GPIO_LED_LAN1		(ARCHER_C7_74HC_GPIO_BASE + 1)
+-#define ARCHER_C7_GPIO_LED_LAN2		(ARCHER_C7_74HC_GPIO_BASE + 2)
+-#define ARCHER_C7_GPIO_LED_LAN3		(ARCHER_C7_74HC_GPIO_BASE + 3)
+-#define ARCHER_C7_GPIO_LED_LAN4		(ARCHER_C7_74HC_GPIO_BASE + 4)
++#define ARCHER_C7_GPIO_LED_LAN4		(ARCHER_C7_74HC_GPIO_BASE + 1)
++#define ARCHER_C7_GPIO_LED_LAN3		(ARCHER_C7_74HC_GPIO_BASE + 2)
++#define ARCHER_C7_GPIO_LED_LAN2		(ARCHER_C7_74HC_GPIO_BASE + 3)
++#define ARCHER_C7_GPIO_LED_LAN1		(ARCHER_C7_74HC_GPIO_BASE + 4)
+ #define ARCHER_C7_GPIO_LED_WAN_GREEN	(ARCHER_C7_74HC_GPIO_BASE + 5)
+ #define ARCHER_C7_GPIO_LED_WAN_AMBER	(ARCHER_C7_74HC_GPIO_BASE + 6)
+ #define ARCHER_C7_GPIO_LED_WLAN2	(ARCHER_C7_74HC_GPIO_BASE + 7)

--- a/patches/lede/0046-ar71xx-fix-Archer-C7-5GHz-MAC-address.patch
+++ b/patches/lede/0046-ar71xx-fix-Archer-C7-5GHz-MAC-address.patch
@@ -1,0 +1,36 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 19 Dec 2017 02:32:47 +0100
+Subject: ar71xx: fix Archer C7 5GHz MAC-address
+
+The TP-Link firmware uses (primary_mac-1) as MAC-address
+for the 5GHz WiFi. This applies the same behaviour to LEDE.
+
+Currently, the MAC-address is retrieved from eth1, which
+does not exist on the Archer C7 v4. As a result from this,
+every C7 v4 with LEDE carries the same MAC-Address on the 5GHz WiFi.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 96b8f6b9a4bdd6a1609a819e72ade315bccfb3c0..607bbd2c0ec4b59ba569550e9e0e87b80c7ddddb 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -47,6 +47,10 @@ board=$(ar71xx_board_name)
+ case "$FIRMWARE" in
+ "ath10k/cal-pci-0000:00:00.0.bin")
+ 	case $board in
++	archer-c7-v4)
++		ath10kcal_extract "art" 20480 2116
++		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -1)
++		;;
+ 	cf-e380ac-v1|\
+ 	cf-e380ac-v2|\
+ 	dlan-pro-1200-ac|\
+@@ -92,7 +96,6 @@ case "$FIRMWARE" in
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) -2)
+ 		;;
+-	archer-c7-v4|\
+ 	archer-c25-v1|\
+ 	tl-wdr6500-v2)
+ 		ath10kcal_extract "art" 20480 2116

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -184,6 +184,9 @@ device tp-link-archer-c7-v2 archer-c7-v2
 packages $ATH10K_PACKAGES
 factory -squashfs-factory${GLUON_REGION:+-${GLUON_REGION}} .bin
 
+device tp-link-archer-c7-v4 archer-c7-v4
+packages $ATH10K_PACKAGES
+
 if [ "$BROKEN" ]; then
 device tp-link-archer-c25-v1 archer-c25-v1 # instability with 5GHz mesh in some environments
 packages $ATH10K_PACKAGES_QCA9887


### PR DESCRIPTION
Backports support for WR1043N v5, Archer C7 v4 and patches for QCA953x/956x rx buffer stalls to v2017.1.x.