### PR TITLE
gluon-client-bridge: move IPv4 local subnet route to br-client

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/310-gluon-client-bridge-local-node
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/310-gluon-client-bridge-local-node
@@ -23,8 +23,7 @@ uci:section('network', 'device', 'local_node_dev', {
 local ip4, ip6
 
 if next_node.ip4 then
-	local plen = site.prefix4():match('/%d+$')
-	ip4 = next_node.ip4 .. plen
+	ip4 = next_node.ip4 .. '/32'
 end
 
 if next_node.ip6 then

--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
@@ -25,6 +25,12 @@ uci:section('network', 'interface', 'client', {
 
 uci:delete('network', 'client_lan')
 
+uci:delete('network', 'local_node_route')
+uci:section('network', 'route', 'local_node_route', {
+	interface = 'client',
+	target = site.prefix4(),
+})
+
 uci:delete('network', 'local_node_route6')
 uci:section('network', 'route6', 'local_node_route6', {
 	interface = 'client',


### PR DESCRIPTION
This patch moves the prefix4 subnet route from the local-node veth
device to br-client (while keeping the next node ipv4 address on the
local node device).

This is in preparation to allow routing over the br-client interface
later.