### PR TITLE
gluon-mesh-vpn-fastd: add public key to nodeinfo provider

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -198,6 +198,12 @@ mesh_vpn
     defines the MTU of the VPN interface, determining a proper MTU value is described
     in the :ref:`FAQ <faq-mtu>`.
 
+    By default information that could be used to associate client traffic with a nodes
+    IP address is not advertised to protect the nodes privacy. This usually requires
+    the attacker to be able to observe the link over which the tunnel flows.
+    If this is of no concern in your threat-model this behaviour can be disabled by
+    setting *pubkey_privacy* to `false`.
+
     The `fastd` section configures settings specific to the *fastd* VPN
     implementation.
 

--- a/package/gluon-mesh-vpn-core/check_site.lua
+++ b/package/gluon-mesh-vpn-core/check_site.lua
@@ -1,5 +1,6 @@
 need_boolean(in_site({'mesh_vpn', 'enabled'}), false)
 need_number({'mesh_vpn', 'mtu'})
+need_boolean(in_site({'mesh_vpn', 'pubkey_privacy'}), false)
 
 need_boolean(in_site({'mesh_vpn', 'bandwidth_limit', 'enabled'}), false)
 need_number(in_site({'mesh_vpn', 'bandwidth_limit', 'ingress'}), false)

--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -44,7 +44,6 @@ uci:section('fastd', 'fastd', 'mesh_vpn', {
 	method = methods,
 	packet_mark = 1,
 	status_socket = '/var/run/fastd.mesh_vpn.socket',
-	pubkey_privacy = site.mesh_vpn.pubkey_privacy(true),
 })
 uci:delete('fastd', 'mesh_vpn', 'user')
 

--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -44,6 +44,7 @@ uci:section('fastd', 'fastd', 'mesh_vpn', {
 	method = methods,
 	packet_mark = 1,
 	status_socket = '/var/run/fastd.mesh_vpn.socket',
+	pubkey_privacy = site.mesh_vpn.pubkey_privacy(true),
 })
 uci:delete('fastd', 'mesh_vpn', 'user')
 


### PR DESCRIPTION
We are using the fastd exporter (https://github.com/freifunk-darmstadt/fastd-exporter) for Prometheus statistics and since the only stable key to link the graphs with other respondd data is the public key I propose adding it to the nodeinfo response.

Gotcha: The code is largely duplicated from the `get_fastd_version` function above it.