### PR TITLE
gluon-core: fix issue with legacy mesh on mesh_lan

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/220-interface-lan
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/220-interface-lan
@@ -17,7 +17,6 @@ uci:section('network', 'interface', 'mesh_lan', {
 	igmp_snooping = false,
 	proto         = 'gluon_wired',
 	index         = 4,
-	legacy        = old_proto == 'gluon_mesh',
 })
 
 if sysconfig.lan_ifname:match(' ') then


### PR DESCRIPTION
When running gluon-reconfigure (and not upgrading from 2017.1.x) the removed line leads to legacy=0.
fixes #1322