### PR TITLE
sunxi: LeMaker Banana Pi: remove BROKEN

### DIFF
--- a/targets/sunxi
+++ b/targets/sunxi
@@ -3,6 +3,13 @@ sysupgrade -ext4-sdcard .img.gz
 
 
 device lemaker-banana-pi sun7i-a20-bananapi
+
+if [ "$BROKEN" ]; then
+
+# WiFi chip not supported
 device lemaker-banana-pro sun7i-a20-bananapro
 
+# AP+IBSS or 11s not working
 device lamobo-r1 sun7i-a20-lamobo-r1
+
+fi

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -7,6 +7,7 @@ $(eval $(call GluonTarget,brcm2708,bcm2708))
 $(eval $(call GluonTarget,brcm2708,bcm2709))
 $(eval $(call GluonTarget,mpc85xx,generic))
 $(eval $(call GluonTarget,ramips,mt7621))
+$(eval $(call GluonTarget,sunxi))
 $(eval $(call GluonTarget,x86,generic))
 $(eval $(call GluonTarget,x86,geode))
 $(eval $(call GluonTarget,x86,64))
@@ -22,5 +23,4 @@ $(eval $(call GluonTarget,ar71xx,mikrotik)) # BROKEN: no sysupgrade support
 $(eval $(call GluonTarget,brcm2708,bcm2710)) # BROKEN: Untested
 $(eval $(call GluonTarget,ipq806x)) # BROKEN: Untested
 $(eval $(call GluonTarget,mvebu)) # BROKEN: No AP+IBSS or 11s support
-$(eval $(call GluonTarget,sunxi)) # BROKEN: Untested
 endif


### PR DESCRIPTION
Since the crashes described in https://github.com/freifunk-gluon/gluon/issues/680 are fixed I tested all three Banana Pi Models and everything looks fine. As the WiFi chip of the Pro model is not supported and IBSS/11s is not working with the R1 Model they are still marked as BROKEN.