### PR TITLE
ar71xx: remove bs-partition ro-flag for UniFi AC

### DIFF
--- a/patches/lede/0067-ar71xx-remove-bs-partition-ro-flag-for-UniFi-AC.patch
+++ b/patches/lede/0067-ar71xx-remove-bs-partition-ro-flag-for-UniFi-AC.patch
@@ -1,0 +1,27 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 6 Feb 2018 19:44:36 +0100
+Subject: ar71xx: remove bs-partition ro-flag for UniFi AC
+
+This removes the read-only flag from the bs (bootselect) partition
+on UniFi AC devices. This allows to correct the indicator from which
+partition the device is booting its kernel from.
+
+See also:
+ - https://github.com/freifunk-gluon/gluon/issues/1301
+ - https://bugs.lede-project.org/index.php?do=details&task_id=662
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ar71xx/image/ubnt.mk b/target/linux/ar71xx/image/ubnt.mk
+index 68fe8ad301c8f694f65b7ba717b09b15f5c71ff7..65ed708459e7e6026713437430fc248c692cd070 100644
+--- a/target/linux/ar71xx/image/ubnt.mk
++++ b/target/linux/ar71xx/image/ubnt.mk
+@@ -82,7 +82,7 @@ define Device/ubnt-unifiac
+   DEVICE_PACKAGES := kmod-usb-core kmod-usb-ohci kmod-usb2
+   DEVICE_PROFILE := UBNT
+   IMAGE_SIZE := 7744k
+-  MTDPARTS = spi0.0:384k(u-boot)ro,64k(u-boot-env)ro,7744k(firmware),7744k(ubnt-airos)ro,128k(bs)ro,256k(cfg)ro,64k(EEPROM)ro
++  MTDPARTS = spi0.0:384k(u-boot)ro,64k(u-boot-env)ro,7744k(firmware),7744k(ubnt-airos)ro,128k(bs),256k(cfg)ro,64k(EEPROM)ro
+   IMAGES := sysupgrade.bin
+   IMAGE/sysupgrade.bin = append-kernel | pad-to $$$$(BLOCKSIZE) | append-rootfs | pad-rootfs | check-size $$$$(IMAGE_SIZE)
+ endef


### PR DESCRIPTION
This removes the read-only flag from the bs (bootselect) partition
on UniFi AC devices. This allows to correct the indicator from which
partition the device is booting its kernel from.

See also:
 - freifunk-gluon/gluon#1301
 - https://github.com/openwrt/openwrt/pull/727
 - https://bugs.lede-project.org/index.php?do=details&task_id=662