### PR TITLE
ar71xx-generic: set unifi-ac-lr alias on ac-lite

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -198,6 +198,8 @@ ar71xx-generic
   - Rocket M2/M5 XW
   - UniFi AP
   - UniFi AP AC Lite [#ath10k]_
+  - UniFi AP AC Mesh [#ath10k]_
+  - UniFi AP AC LR [#ath10k]_
   - UniFi AP AC Pro [#ath10k]_
   - UniFi AP LR
   - UniFi AP Pro

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -269,6 +269,7 @@ fi
 if [ "$ATH10K_PACKAGES" ]; then
 device ubiquiti-unifi-ac-lite ubnt-unifiac-lite
 alias ubiquiti-unifi-ac-mesh
+alias ubiquiti-unifi-ac-lr
 packages $ATH10K_PACKAGES
 factory
 


### PR DESCRIPTION
Add alias for Ubiquiti unifi AP AC LR

close #1114 