### PR TITLE
gluon-respondd: add information from /proc/stat to "statistics"

### DIFF
--- a/package/gluon-respondd/src/respondd.c
+++ b/package/gluon-respondd/src/respondd.c
@@ -229,7 +229,7 @@ static struct json_object * get_stat(void) {
 
 		if (!strcmp(label, "cpu")) {
 			unsigned long long user, nice, system, idle, iowait, irq, softirq;
-			if(sscanf(line, "%*s %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64,
+			if (sscanf(line, "%*s %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64,
 			          &user, &nice, &system, &idle, &iowait, &irq, &softirq) != 7)
 				goto invalid_stat_format;
 
@@ -246,25 +246,25 @@ static struct json_object * get_stat(void) {
 			json_object_object_add(stat, "cpu", cpu);
 		} else if (!strcmp(label, "ctxt")) {
 			unsigned long long ctxt;
-			if(sscanf(line, "%*s %"SCNu64, &ctxt) != 1)
+			if (sscanf(line, "%*s %"SCNu64, &ctxt) != 1)
 				goto invalid_stat_format;
 
 			json_object_object_add(stat, "ctxt", json_object_new_int64(ctxt));
 		} else if (!strcmp(label, "intr")) {
 			unsigned long long total_intr;
-			if(sscanf(line, "%*s %"SCNu64, &total_intr) != 1)
+			if (sscanf(line, "%*s %"SCNu64, &total_intr) != 1)
 				goto invalid_stat_format;
 
 			json_object_object_add(stat, "intr", json_object_new_int64(total_intr));
 		} else if (!strcmp(label, "softirq")) {
 			unsigned long long total_softirq;
-			if(sscanf(line, "%*s %"SCNu64, &total_softirq) != 1)
+			if (sscanf(line, "%*s %"SCNu64, &total_softirq) != 1)
 				goto invalid_stat_format;
 
 			json_object_object_add(stat, "softirq", json_object_new_int64(total_softirq));
 		} else if (!strcmp(label, "processes")) {
 			unsigned long long processes;
-			if(sscanf(line, "%*s %"SCNu64, &processes) != 1)
+			if (sscanf(line, "%*s %"SCNu64, &processes) != 1)
 				goto invalid_stat_format;
 
 			json_object_object_add(stat, "processes", json_object_new_int64(processes));

--- a/package/gluon-respondd/src/respondd.c
+++ b/package/gluon-respondd/src/respondd.c
@@ -35,6 +35,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <time.h>
+#include <inttypes.h>
 
 #include <sys/vfs.h>
 
@@ -228,7 +229,7 @@ static struct json_object * get_stat(void) {
 
 		if (!strcmp(label, "cpu")) {
 			unsigned long long user, nice, system, idle, iowait, irq, softirq;
-			if(sscanf(line, "%*s %llu %llu %llu %llu %llu %llu %llu",
+			if(sscanf(line, "%*s %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64" %"SCNu64,
 			          &user, &nice, &system, &idle, &iowait, &irq, &softirq) != 7)
 				goto invalid_stat_format;
 
@@ -245,25 +246,25 @@ static struct json_object * get_stat(void) {
 			json_object_object_add(stat, "cpu", cpu);
 		} else if (!strcmp(label, "ctxt")) {
 			unsigned long long ctxt;
-			if(sscanf(line, "%*s %llu", &ctxt) != 1)
+			if(sscanf(line, "%*s %"SCNu64, &ctxt) != 1)
 				goto invalid_stat_format;
 
 			json_object_object_add(stat, "ctxt", json_object_new_int64(ctxt));
 		} else if (!strcmp(label, "intr")) {
 			unsigned long long total_intr;
-			if(sscanf(line, "%*s %llu", &total_intr) != 1)
+			if(sscanf(line, "%*s %"SCNu64, &total_intr) != 1)
 				goto invalid_stat_format;
 
 			json_object_object_add(stat, "intr", json_object_new_int64(total_intr));
 		} else if (!strcmp(label, "softirq")) {
 			unsigned long long total_softirq;
-			if(sscanf(line, "%*s %llu", &total_softirq) != 1)
+			if(sscanf(line, "%*s %"SCNu64, &total_softirq) != 1)
 				goto invalid_stat_format;
 
 			json_object_object_add(stat, "softirq", json_object_new_int64(total_softirq));
 		} else if (!strcmp(label, "processes")) {
 			unsigned long long processes;
-			if(sscanf(line, "%*s %llu", &processes) != 1)
+			if(sscanf(line, "%*s %"SCNu64, &processes) != 1)
 				goto invalid_stat_format;
 
 			json_object_object_add(stat, "processes", json_object_new_int64(processes));


### PR DESCRIPTION
This commit adds information about:
- how cpu time is spent since boot in jiffies (1/100*sek) (cpu)
    - the value is summed for all cores, so in 10 seconds the
      summed values will increase by 4000, if the cpu has
      4 cores
- context switches since boot (ctxt)
- interrupt counters since boot (intr, softirq)
- forks since boot (processes)

``` json
    { "stat": {
       "cpu": {
         "user": 219403,
         "nice": 1714,
         "system": 75159,
         "idle": 2727739,
         "iowait": 2943,
         "irq": 0,
         "softirq": 571
       },
       "intr": 8426340,
       "ctxt": 50992590,
       "processes": 10549,
       "softirq": 5161884
    } }
```