### PR TITLE
gluon-config-mode-domain-select: allow hiding of individual domain codes

### DIFF
--- a/package/gluon-config-mode-domain-select/check_site.lua
+++ b/package/gluon-config-mode-domain-select/check_site.lua
@@ -1,1 +1,2 @@
 need_boolean(in_domain({'hide_domain'}), false)
+need_array_of(in_domain({'hide_domain_codes'}), table_keys(need_table(in_domain({'domain_names'}), nil, true)), false)

--- a/package/gluon-config-mode-domain-select/check_site.lua
+++ b/package/gluon-config-mode-domain-select/check_site.lua
@@ -1,2 +1,3 @@
 need_boolean(in_domain({'hide_domain'}), false)
-need_array_of(in_domain({'hide_domain_codes'}), table_keys(need_table(in_domain({'domain_names'}), nil, true)), false)
+valid_domain_codes = table_keys(need_table(in_domain({'domain_names'})))
+need_array_of(in_domain({'hide_domain_codes'}), valid_domain_codes, false)

--- a/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
+++ b/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
@@ -9,12 +9,23 @@ return function(form, uci)
 	local configured = uci:get_first('gluon-setup-mode','setup_mode', 'configured') == '1' or (selected_domain ~= site.default_domain())
 
 	local function get_domain_list()
+		local function hidden_domain_code(domain, code)
+			if domain.hide_domain_codes ~= nil then
+				for _, hidden_code in ipairs(domain.hide_domain_codes) do
+					if code == hidden_code then
+						return true
+					end
+				end
+			end
+			return false
+		end
+
 		local list = {}
 		for domain_path in fs.glob('/lib/gluon/domains/*.json') do
 			local domain_code = domain_path:match('([^/]+)%.json$')
 			local domain = assert(json.load(domain_path))
 
-			if not domain.hide_domain or (configured and domain.domain_code == selected_domain) then
+			if (not domain.hide_domain and not hidden_domain_code(domain, domain_code)) or (configured and domain.domain_code == selected_domain) then
 				table.insert(list, {
 					domain_code = domain_code,
 					domain_name = domain.domain_names[domain_code],

--- a/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
+++ b/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
@@ -25,7 +25,7 @@ return function(form, uci)
 			local domain_code = domain_path:match('([^/]+)%.json$')
 			local domain = assert(json.load(domain_path))
 
-			if (not domain.hide_domain and not hidden_domain_code(domain, domain_code)) or (configured and domain.domain_code == selected_domain) then
+			if (not domain.hide_domain and not hidden_domain_code(domain, domain_code)) or (configured and domain_code == selected_domain) then
 				table.insert(list, {
 					domain_code = domain_code,
 					domain_name = domain.domain_names[domain_code],

--- a/scripts/check_site.lua
+++ b/scripts/check_site.lua
@@ -71,6 +71,14 @@ local function array_to_string(array)
 	return '[' .. table.concat(array, ', ') .. ']'
 end
 
+function table_keys(tbl)
+	local keys = {}
+	for k, _ in pairs(tbl) do
+		keys[#keys + 1] = k
+	end
+	return keys
+end
+
 
 local loadpath
 


### PR DESCRIPTION
Allow hiding invidiual domain codes and names from the config mode drop-down.