### PR TITLE
Domain fix for tunneldigger and mesh eth interfaces

### DIFF
--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -70,10 +70,10 @@ if need_table({'dns'}, nil, false) then
 	need_number({'dns', 'cacheentries'}, false)
 end
 
-need_string_array(in_domain({'next_node', 'name'}), false)
+need_string_array({'next_node', 'name'}, false)
 need_string_match(in_domain({'next_node', 'ip6'}), '^[%x:]+$', false)
 need_string_match(in_domain({'next_node', 'ip4'}), '^%d+.%d+.%d+.%d+$', false)
 
-need_boolean(in_site({'mesh_on_wan'}), false)
-need_boolean(in_site({'mesh_on_lan'}), false)
-need_boolean(in_site({'single_as_lan'}), false)
+need_boolean({'mesh_on_wan'}, false)
+need_boolean({'mesh_on_lan'}, false)
+need_boolean({'single_as_lan'}, false)

--- a/package/gluon-mesh-vpn-tunneldigger/check_site.lua
+++ b/package/gluon-mesh-vpn-tunneldigger/check_site.lua
@@ -1,1 +1,1 @@
-need_string_array({'mesh_vpn', 'tunneldigger', 'brokers'})
+need_string_array(in_domain({'mesh_vpn', 'tunneldigger', 'brokers'}))


### PR DESCRIPTION
* Allow tunneldigger configurations only in domains.
* Allow mesh_on_wan, mesh_on_lan and single_as_lan in both site and domain configurations.