### PR TITLE
gluon-ebtables-limit-arp: do not add multicast addresses to filter

### DIFF
--- a/package/gluon-ebtables-limit-arp/src/gluon-arp-limiter.c
+++ b/package/gluon-ebtables-limit-arp/src/gluon-arp-limiter.c
@@ -248,6 +248,9 @@ static void ebt_tl_update(void)
 			break;
 		}
 
+		if (mac_is_multicast(&mac))
+			continue;
+
 		ebt_add_mac(&mac);
 	}
 

--- a/package/gluon-ebtables-limit-arp/src/mac.h
+++ b/package/gluon-ebtables-limit-arp/src/mac.h
@@ -16,4 +16,9 @@ struct mac_addr {
 int mac_aton(const char *cp, struct  mac_addr *mac);
 char *mac_ntoa(struct mac_addr *mac);
 
+static inline int mac_is_multicast(struct mac_addr *addr)
+{
+	return addr->storage[0] & 0x01;
+}
+
 #endif /* _MAC_H_ */


### PR DESCRIPTION
With the batman-adv multicast support compiled back in again we end up
with multicast addresses in the batman-adv translation table.

Currently we wrongly interpret multicast addresses returned by TT as a
unique host, too, which adds them with a source address filter to
ebtables as well. However, the source address of an ethernet frames is
never supposed to be a multicat one.

This leads to unnecessary entries in ebtables. Fixing this by ignoring
those MAC addreses returned by TT which have the multicast bit set.