### PR TITLE
x86: add packages: leds, sensors, gpio, usb, wifi and tools

### DIFF
--- a/targets/x86-64
+++ b/targets/x86-64
@@ -1,7 +1,18 @@
 config 'CONFIG_VDI_IMAGES=y'
 config 'CONFIG_VMDK_IMAGES=y'
+
+ATH10K_PACKAGES='kmod-ath10k-ct ath10k-firmware-qca9887 ath10k-firmware-qca988x'
+if [ "$GLUON_WLAN_MESH" = 'ibss' ]; then
+	ATH10K_PACKAGES='kmod-ath10k-ct ath10k-firmware-qca9887-ct ath10k-firmware-qca988x-ct'
+fi
+
 packages 'kmod-3c59x' 'kmod-8139cp' 'kmod-8139too' 'kmod-e100' 'kmod-e1000' 'kmod-e1000e' 'kmod-forcedeth' 'kmod-igb' 'kmod-natsemi' 'kmod-ne2k-pci'
 packages 'kmod-pcnet32' 'kmod-r8169' 'kmod-sis900' 'kmod-sky2' 'kmod-tg3' 'kmod-tulip' 'kmod-via-rhine' 'kmod-via-velocity'
+packages 'kmod-ath9k'
+packages $ATH10K_PACKAGES
+packages 'kmod-gpio-button-hotplug' 'kmod-gpio-nct5104d' 'kmod-hwmon-core' 'kmod-hwmon-k10temp' 'kmod-leds-gpio' 'kmod-leds-apu2' 'kmod-sp5100_tco'
+packages 'kmod-usb-core' 'kmod-usb-ohci' 'kmod-usb2' 'kmod-usb3' 'kmod-usb-serial'
+packages 'bash' 'wget-nossl'
 
 factory_image x86-64 combined-ext4 .img.gz
 factory_image x86-64 combined-ext4 .vdi

--- a/targets/x86-generic
+++ b/targets/x86-generic
@@ -1,7 +1,18 @@
 config 'CONFIG_VDI_IMAGES=y'
 config 'CONFIG_VMDK_IMAGES=y'
+
+ATH10K_PACKAGES='kmod-ath10k-ct ath10k-firmware-qca9887 ath10k-firmware-qca988x'
+if [ "$GLUON_WLAN_MESH" = 'ibss' ]; then
+	ATH10K_PACKAGES='kmod-ath10k-ct ath10k-firmware-qca9887-ct ath10k-firmware-qca988x-ct'
+fi
+
 packages 'kmod-3c59x' 'kmod-8139cp' 'kmod-8139too' 'kmod-e100' 'kmod-e1000' 'kmod-e1000e' 'kmod-forcedeth' 'kmod-igb' 'kmod-natsemi' 'kmod-ne2k-pci'
 packages 'kmod-pcnet32' 'kmod-r8169' 'kmod-sis900' 'kmod-sky2' 'kmod-tg3' 'kmod-tulip' 'kmod-via-rhine' 'kmod-via-velocity'
+packages 'kmod-ath9k'
+packages $ATH10K_PACKAGES
+packages 'kmod-gpio-button-hotplug' 'kmod-gpio-nct5104d' 'kmod-hwmon-core' 'kmod-hwmon-k10temp' 'kmod-leds-gpio' 'kmod-leds-apu2' 'kmod-sp5100_tco'
+packages 'kmod-usb-core' 'kmod-usb-ohci' 'kmod-usb2' 'kmod-usb3' 'kmod-usb-serial'
+packages 'bash' 'wget-nossl'
 
 factory_image x86-generic combined-ext4 .img.gz
 factory_image x86-generic combined-ext4 .vdi


### PR DESCRIPTION
as we have enough space on x86 devices (but no individual profiles) i'd like to add some packages to the x86 target which are useful especially for the pcengines APU2 device.
those are build and run tested on this device.

i'm not really interested in discussions about single packages, so please just name the ones i have to remove from the pull request, if you have doubts about some.