### PR TITLE
v2017.1.x: Backport board detection for UBNT AC-Mesh

### DIFF
--- a/patches/lede/0043-ar71xx-add-board-detection-for-UBNT-AC-Mesh.patch
+++ b/patches/lede/0043-ar71xx-add-board-detection-for-UBNT-AC-Mesh.patch
@@ -1,0 +1,48 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sun, 25 Feb 2018 12:09:38 +0100
+Subject: ar71xx: add board detection for UBNT AC-Mesh
+
+This commit adds correct model detection for UniFi
+AC-Mesh. Previously said device was incorrectly detected
+as UniFi AC-Lite.
+
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 59ede17653bbb1994ce9fa734c86c877aedf67e4..05c25e11e4a6a2e05df9779d25309ad0e676a729 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -98,6 +98,27 @@ ubnt_xm_board_detect() {
+ 	[ -z "$model" ] || AR71XX_MODEL="${model}${magic:3:1}"
+ }
+ 
++ubnt_ac_lite_get_mtd_part_magic() {
++	ar71xx_get_mtd_offset_size_format EEPROM 12 2 %02x
++}
++
++ubnt_ac_lite_board_detect() {
++	local model
++	local magic
++
++	magic="$(ubnt_ac_lite_get_mtd_part_magic)"
++	case ${magic:0:4} in
++	"e517")
++		model="Ubiquiti UniFi-AC-LITE"
++		;;
++	"e557")
++		model="Ubiquiti UniFi-AC-MESH"
++		;;
++	esac
++
++	[ -z "$model" ] || AR71XX_MODEL="${model}"
++}
++
+ cybertan_get_hw_magic() {
+ 	local part
+ 
+@@ -1120,6 +1111,7 @@ ar71xx_board_detect() {
+ 		;;
+ 	*"UniFi-AC-LITE")
+ 		name="unifiac-lite"
++		ubnt_ac_lite_board_detect
+ 		;;
+ 	*"UniFi-AC-PRO")
+ 		name="unifiac-pro"

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -246,6 +246,7 @@ fi
 
 if [ "$ATH10K_PACKAGES" ]; then
 device ubiquiti-unifi-ac-lite ubnt-unifiac-lite
+alias ubiquiti-unifi-ac-mesh
 packages $ATH10K_PACKAGES
 factory
 


### PR DESCRIPTION
This PR backports the Ubiquiti UniFi AC MESH detection code and adds an alias for it.