### PR TITLE
ramips-mt7621: add support for Ubiquiti EdgePoint R6

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -302,6 +302,7 @@ ramips-mt7621
 
   - EdgeRouter X
   - EdgeRouter X-SFP
+  - EdgePoint R6
 
 ramips-mt7628
 ^^^^^^^^^^^^^

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -34,6 +34,7 @@ factory
 sysupgrade '.tar'
 
 device ubnt-erx-sfp ubnt-erx-sfp
+alias ubnt-ep-r6
 packages '-hostapd-mini'
 factory
 sysupgrade '.tar'


### PR DESCRIPTION
this adds support for the Ubiquiti EdgePoint R6 which uses exactly the same hardware as the Ubiquiti EdgeRouter X-SFP
source: https://openwrt.org/toh/ubiquiti/ubiquiti_edgerouter_x_er-x_ka