### PR TITLE
v2017.1.x: Add support for TP-Link WR940n v6

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -255,7 +255,7 @@ ar71xx-tiny
   - TL-WR743N/ND (v1, v2)
   - TL-WR841N/ND (v3, v5, v7, v8, v9, v10, v11, v12)
   - TL-WR843N/ND (v1)
-  - TL-WR940N (v1, v2, v3, v4, v5)
+  - TL-WR940N (v1, v2, v3, v4, v5, v6)
   - TL-WR941ND (v2, v3, v4, v5, v6)
 
 brcm2708-bcm2708

--- a/patches/lede/0047-ar71xx-add-support-for-TP-Link-TL-WR940N-v6.patch
+++ b/patches/lede/0047-ar71xx-add-support-for-TP-Link-TL-WR940N-v6.patch
@@ -1,0 +1,233 @@
+From: Robert Marko <robimarko@gmail.com>
+Date: Wed, 21 Feb 2018 13:15:17 +0100
+Subject: ar71xx: add support for TP-Link TL-WR940N v6
+
+Add support for TL-WR940N v6 board. It is pretty much the same as v5
+except they only left WAN LED and removed other ones.
+
+Installation: flash factory image through WEB UI or use TFTP.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index e67b5e38561e841b88e486341950c52e1d454322..3e8ed9982c9993055cd9ca487dab0993639314cf 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -645,6 +645,9 @@ tl-wr941nd-v6)
+ 	ucidef_set_led_switch "lan4" "LAN4" "tp-link:blue:lan4" "switch0" "0x02"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "tp-link:blue:wlan" "phy0tpt"
+ 	;;
++tl-wr940n-v6)
++	ucidef_set_led_netdev "wan" "WAN" "tp-link:blue:wan" "eth0"
++	;;
+ tl-wr841n-v9|\
+ tl-wr841n-v11|\
+ tl-wr842n-v3)
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 454abe6a5005621967dd96e0282e7bce2a0b127e..1c8c3e9ebb468beafa0946891628779d5f6648d1 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -285,6 +285,7 @@ ar71xx_setup_interfaces()
+ 	tl-wdr6500-v2|\
+ 	tl-wr841n-v8|\
+ 	tl-wr940n-v4|\
++	tl-wr940n-v6|\
+ 	tl-wr941nd-v5|\
+ 	tl-wr941nd-v6|\
+ 	wnr1000-v2|\
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 61db387c9ecefd7090c25a5f5d75fdbf65a44d65..7b4ab62f9c675c9ac8d35e71728fbe82dc7c9c5a 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -393,6 +393,9 @@ get_status_led() {
+ 	tl-wr941nd-v6)
+ 		status_led="tp-link:blue:system"
+ 		;;
++	tl-wr940n-v6)
++		status_led="tp-link:orange:diag"
++		;;
+ 	tl-wr841n-v9)
+ 		status_led="tp-link:green:qss"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 6282420da534542b26e375d4db7c4a9f4b515a1e..32123832ad023ffdd2416ba759b37c5541be1628 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -1088,6 +1088,9 @@ ar71xx_board_detect() {
+ 	*TL-WR941ND)
+ 		name="tl-wr941nd"
+ 		;;
++	*"TL-WR940N v6")
++		name="tl-wr940n-v6"
++		;;
+ 	*"TL-WR941N/ND v5")
+ 		name="tl-wr941nd-v5"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index 774e3c8964ef724d1efbae56434aeaa9f1c298a4..8fc61321b16d2d3d9f02f6d13980d2db4b519962 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -439,6 +439,7 @@ platform_check_image() {
+ 	tl-wr941nd-v5|\
+ 	tl-wr941nd-v6|\
+ 	tl-wr940n-v4|\
++	tl-wr940n-v6|\
+ 	tl-wr941nd)
+ 		local magic_ver="0100"
+ 
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr940n-v4.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr940n-v4.c
+index d693b947c843d2a74cd252503fa8bf68b20da4ab..b530622d9f00b8ce3b906ad5fe62de019d82763a 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr940n-v4.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-tl-wr940n-v4.c
+@@ -1,5 +1,5 @@
+ /*
+- *  TP-LINK TL-WR940N v4 board support
++ *  TP-LINK TL-WR940N v4 and v6 board support
+  *
+  *  Copyright (C) 2016 David Lutz <kpanic@ff3l.net>
+  *
+@@ -32,12 +32,15 @@
+ #define TL_WR940N_V4_GPIO_LED_LAN1		8
+ #define TL_WR940N_V4_GPIO_LED_WLAN		7
+ #define TL_WR940N_V4_GPIO_LED_SYSTEM		5
++/* WR940N v6 specific GPIO*/
++#define TL_WR940N_V6_GPIO_LED_DIAG_ORANGE	15
++#define TL_WR940N_V6_GPIO_LED_WAN_BLUE		14
+ 
+ #define TL_WR940N_V4_GPIO_BTN_RESET		1
+ #define TL_WR940N_V4_GPIO_BTN_RFKILL		2
+ 
+-#define TL_WR940N_V4_KEYS_POLL_INTERVAL	20
+-#define TL_WR940N_V4_KEYS_DEBOUNCE_INTERVAL	(3 * TL_WR940N_V4_KEYS_POLL_INTERVAL)
++#define TL_WR940N_KEYS_POLL_INTERVAL		20
++#define TL_WR940N_KEYS_DEBOUNCE_INTERVAL	(3 * TL_WR940N_KEYS_POLL_INTERVAL)
+ 
+ 
+ static struct gpio_led tl_wr940n_v4_leds_gpio[] __initdata = {
+@@ -93,43 +96,49 @@ static struct gpio_keys_button tl_wr940n_v4_gpio_keys[] __initdata = {
+ 		.desc		= "Reset button",
+ 		.type		= EV_KEY,
+ 		.code		= KEY_RESTART,
+-		.debounce_interval = TL_WR940N_V4_KEYS_DEBOUNCE_INTERVAL,
++		.debounce_interval = TL_WR940N_KEYS_DEBOUNCE_INTERVAL,
+ 		.gpio		= TL_WR940N_V4_GPIO_BTN_RESET,
+ 		.active_low	= 1,
+ 	}, {
+ 		.desc		= "RFKILL button",
+ 		.type		= EV_KEY,
+ 		.code		= KEY_RFKILL,
+-		.debounce_interval = TL_WR940N_V4_KEYS_DEBOUNCE_INTERVAL,
++		.debounce_interval = TL_WR940N_KEYS_DEBOUNCE_INTERVAL,
+ 		.gpio		= TL_WR940N_V4_GPIO_BTN_RFKILL,
+ 		.active_low	= 1,
+ 	}
+ };
+ 
++static struct gpio_led tl_wr940n_v6_leds_gpio[] __initdata = {
++	{
++		.name		= "tp-link:blue:wan",
++		.gpio		= TL_WR940N_V6_GPIO_LED_WAN_BLUE,
++		.active_low	= 1,
++	},
++	{
++		.name		= "tp-link:orange:diag",
++		.gpio		= TL_WR940N_V6_GPIO_LED_DIAG_ORANGE,
++		.active_low	= 0,
++	},
++};
++
+ 
+-static const char *tl_wr940n_v4_part_probes[] = {
++static const char *tl_wr940n_part_probes[] = {
+ 	"tp-link",
+ 	NULL,
+ };
+ 
+-static struct flash_platform_data tl_wr940n_v4_flash_data = {
+-	.part_probes	= tl_wr940n_v4_part_probes,
++static struct flash_platform_data tl_wr940n_flash_data = {
++	.part_probes	= tl_wr940n_part_probes,
+ };
+ 
+ 
+-static void __init tl_wr940n_v4_setup(void)
++static void __init tl_wr940n_setup(void)
+ {
+ 	u8 *mac = (u8 *) KSEG1ADDR(0x1f01fc00);
+ 	u8 *ee = (u8 *) KSEG1ADDR(0x1fff1000);
+ 
+-	ath79_register_m25p80(&tl_wr940n_v4_flash_data);
+-
+-	ath79_register_leds_gpio(-1, ARRAY_SIZE(tl_wr940n_v4_leds_gpio),
+-				 tl_wr940n_v4_leds_gpio);
+-
+-	ath79_register_gpio_keys_polled(-1, TL_WR940N_V4_KEYS_POLL_INTERVAL,
+-					ARRAY_SIZE(tl_wr940n_v4_gpio_keys),
+-					tl_wr940n_v4_gpio_keys);
++	ath79_register_m25p80(&tl_wr940n_flash_data);
+ 
+ 	ath79_register_mdio(0, 0x0);
+ 
+@@ -145,5 +154,31 @@ static void __init tl_wr940n_v4_setup(void)
+ 
+ }
+ 
++static void __init tl_wr940n_v4_setup(void)
++{
++	tl_wr940n_setup();
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(tl_wr940n_v4_leds_gpio),
++				 tl_wr940n_v4_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, TL_WR940N_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(tl_wr940n_v4_gpio_keys),
++					tl_wr940n_v4_gpio_keys);
++}
++
++static void __init tl_wr940n_v6_setup(void)
++{
++	tl_wr940n_setup();
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(tl_wr940n_v6_leds_gpio),
++				 tl_wr940n_v6_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, TL_WR940N_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(tl_wr940n_v4_gpio_keys),
++					tl_wr940n_v4_gpio_keys);
++}
++
+ MIPS_MACHINE(ATH79_MACH_TL_WR940N_V4, "TL-WR940N-v4", "TP-LINK TL-WR940N v4",
+ 	     tl_wr940n_v4_setup);
++MIPS_MACHINE(ATH79_MACH_TL_WR940N_V6, "TL-WR940N-v6", "TP-LINK TL-WR940N v6",
++	     tl_wr940n_v6_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 9cb4a7f2e1df641232289721b676a9b0149c76e5..880a45b02e259e770042650f74abe3e924c040a3 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -237,6 +237,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_TL_WR941ND_V5,		/* TP-LINK TL-WR941ND v5 */
+ 	ATH79_MACH_TL_WR941ND_V6,		/* TP-LINK TL-WR941ND v6 */
+ 	ATH79_MACH_TL_WR940N_V4,		/* TP-LINK TL-WR940N v4 */
++	ATH79_MACH_TL_WR940N_V6,		/* TP-LINK TL-WR940N v6 */
+ 	ATH79_MACH_TUBE2H,			/* Alfa Network Tube2H */
+ 	ATH79_MACH_UBNT_AIRGW,			/* Ubiquiti AirGateway */
+ 	ATH79_MACH_UBNT_AIRGWP,			/* Ubiquiti AirGateway Pro */
+diff --git a/target/linux/ar71xx/image/tp-link.mk b/target/linux/ar71xx/image/tp-link.mk
+index 5be7cbfbd4ab7d73d679d52d2581459250e04302..c6545b8f5904f31d7b2b0e942f3dda74e2c1400b 100644
+--- a/target/linux/ar71xx/image/tp-link.mk
++++ b/target/linux/ar71xx/image/tp-link.mk
+@@ -796,6 +796,14 @@ define Device/tl-wr940n-v4
+     IMAGE/factory-eu.bin := append-rootfs | mktplinkfw factory -C EU
+ endef
+ 
++define Device/tl-wr940n-v6
++  $(Device/tl-wr940n-v4)
++  DEVICE_TITLE := TP-LINK TL-WR940N v6
++  BOARDNAME := TL-WR940N-v6
++  TPLINK_HWID := 0x09400006
++endef
++TARGET_DEVICES += tl-wr940n-v6
++
+ # Chinese version (unlike European) is similar to the TL-WDR3500
+ define Device/tl-wr941nd-v6-cn
+     $(Device/tplink-4mlzma)

--- a/targets/ar71xx-tiny
+++ b/targets/ar71xx-tiny
@@ -65,6 +65,9 @@ device tp-link-tl-wr940n-v4 tl-wr940n-v4
 alias tp-link-tl-wr940n-v5
 factory -squashfs-factory${GLUON_REGION:+-${GLUON_REGION}} .bin
 
+device tp-link-tl-wr940n-v6 tl-wr940n-v6
+factory -squashfs-factory${GLUON_REGION:+-${GLUON_REGION}} .bin
+
 device tp-link-tl-wa730re-v1 tl-wa730re-v1
 
 device tp-link-tl-wa750re-v1 tl-wa750re-v1


### PR DESCRIPTION
This PR backports support for TP-Link WR940n ~~v5 &~~ v6 to v2017.1.x.

~~v5 just adds an alias to v4. The commit got cherry-picked from master.~~
v6 got backported from openwrt master.

My v6 device is still on its way, thus meaning this PR is untested as of now.