### PR TITLE
ar71xx: add support for AVM Fritz!Box 4020

### DIFF
--- a/patches/lede/0083-build-move-lzma2eva-build-step-to-image-commands.mk.patch
+++ b/patches/lede/0083-build-move-lzma2eva-build-step-to-image-commands.mk.patch
@@ -1,0 +1,50 @@
+From: Mathias Kresin <dev@kresin.me>
+Date: Sat, 25 Mar 2017 19:18:37 +0100
+Subject: build: move lzma2eva build step to image-commands.mk
+
+Move it to image-commands.mk so that it can used by other targets with
+eva based boards as well.
+
+Signed-off-by: Mathias Kresin <dev@kresin.me>
+
+diff --git a/include/image-commands.mk b/include/image-commands.mk
+index ec35e0fcfe97d9d98c731459d1f1681d2bcfe5ad..19d98feefe02b6deb43735ccd436aac39fc0a8ab 100644
+--- a/include/image-commands.mk
++++ b/include/image-commands.mk
+@@ -11,6 +11,11 @@ define Build/uImage
+ 	mv $@.new $@
+ endef
+ 
++define Build/eva-image
++	$(STAGING_DIR_HOST)/bin/lzma2eva $(KERNEL_LOADADDR) $(KERNEL_LOADADDR) $@ $@.new
++	mv $@.new $@
++endef
++
+ define Build/netgear-chk
+ 	$(STAGING_DIR_HOST)/bin/mkchkimg \
+ 		-o $@.new \
+diff --git a/target/linux/lantiq/image/Makefile b/target/linux/lantiq/image/Makefile
+index a96e528aab2c5c5c95f01b087f589cecc57c6e51..2cac925bfd95fedd5f76f30e72300cc0fd7d37a9 100644
+--- a/target/linux/lantiq/image/Makefile
++++ b/target/linux/lantiq/image/Makefile
+@@ -20,9 +20,8 @@ else
+   UBIFS_OPTS := -m 2048 -e 126KiB -c 4096
+ endif
+ 
+-define Build/eva-image
+-	lzma2eva $(KERNEL_LOADADDR) $(KERNEL_LOADADDR) $@ $@.new
+-	( dd if=$@.new bs=64k conv=sync; cat ./eva.dummy.squashfs; ) > $@
++define Build/append-avm-fakeroot
++	cat ./eva.dummy.squashfs >> $@
+ endef
+ 
+ define Build/dgn3500-sercom-footer
+@@ -104,6 +103,8 @@ endef
+ 
+ define Device/AVM
+   KERNEL := kernel-bin | append-dtb | lzma | eva-image
++  IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | append-avm-fakeroot | \
++	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
+ endef
+ 
+ ifeq ($(SUBTARGET),xway_legacy)

--- a/patches/lede/0084-ar71xx-add-support-for-Fritz-Box-4020.patch
+++ b/patches/lede/0084-ar71xx-add-support-for-Fritz-Box-4020.patch
@@ -1,0 +1,572 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 24 Apr 2018 19:52:13 +0200
+Subject: ar71xx: add support for Fritz!Box 4020
+
+This commit adds support for the AVM Fritz!Box 4020 WiFi-router.
+
+SoC:   Qualcomm Atheros QCA9561 (Dragonfly) 750MHz
+RAM:   Winbond W971GG6KB-25
+FLASH: Macronix MX25L12835F
+WiFi:  QCA9561 b/g/n 3x3 450Mbit/s
+USB:   1x USB 2.0
+IN:    WPS button, WiFi button
+OUT:   Power LED green, Internet LED green, WLAN LED green,
+       LAN LED green, INFO LED green, INFO LED red
+UART:  Header Next to Black metal shield
+       Pinout is 3.3V - RX - TX - GND (Square Pad is 3.3V)
+       The Serial setting is 115200-8-N-1.
+
+Tested and working:
+ - Ethernet (LAN + WAN)
+ - WiFi (correct MAC)
+ - Installation via EVA bootloader
+ - OpenWRT sysupgrade
+ - Buttons
+ - LEDs
+
+Not working:
+ - USB port
+
+Installation via EVA:
+In the first seconds after Power is connected, the bootloader will
+listen for FTP connections on 169.254.157.1 (Might also be 192.168.178.1). Firmware can be uploaded
+like following:
+
+  ftp> quote USER adam2
+  ftp> quote PASS adam2
+  ftp> binary
+  ftp> debug
+  ftp> passive
+  ftp> quote MEDIA FLSH
+  ftp> put openwrt-sysupgrade.bin mtd1
+
+Note that this procedure might take up to two minutes. After transfer is
+complete you need to powercycle the device to boot OpenWRT.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/include/image-commands.mk b/include/image-commands.mk
+index 19d98feefe02b6deb43735ccd436aac39fc0a8ab..7e77b878361ef5a4f6278733d25b0a1fed0ce5ff 100644
+--- a/include/image-commands.mk
++++ b/include/image-commands.mk
+@@ -16,6 +16,16 @@ define Build/eva-image
+ 	mv $@.new $@
+ endef
+ 
++define Build/append-squashfs-fakeroot-be
++	rm -rf $@.fakefs $@.fakesquashfs
++	mkdir $@.fakefs
++	$(STAGING_DIR_HOST)/bin/mksquashfs-lzma \
++		$@.fakefs $@.fakesquashfs \
++		-noappend -root-owned -be -nopad -b 65536 \
++		$(if $(SOURCE_DATE_EPOCH),-fixed-time $(SOURCE_DATE_EPOCH))
++	cat $@.fakesquashfs >> $@
++endef
++
+ define Build/netgear-chk
+ 	$(STAGING_DIR_HOST)/bin/mkchkimg \
+ 		-o $@.new \
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index f9483e9a706fbd98ce6a42e968bc0d31e9da5c84..e8b13af7c24dea86519c962fa6381fd75971e8b9 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -305,6 +305,12 @@ dlan-pro-1200-ac)
+ 	ucidef_set_led_gpio "plcw" "dLAN" "devolo:status:dlan" "17" "0"
+ 	ucidef_set_led_gpio "plcr" "dLAN" "devolo:error:dlan" "16" "0"
+ 	;;
++fritz4020)
++	ucidef_set_led_default "power" "Power" "$board:green:power" "1"
++	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth1"
++	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
++	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
++	;;
+ gl-ar150|\
+ gl-ar300|\
+ gl-ar300m|\
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 1690172b5dfac1e1aa278c38c27ba64cfd61ade0..1018ab4449f896d565b57ecbdc73b7e3d7fbe486 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -207,6 +207,7 @@ ar71xx_setup_interfaces()
+ 		;;
+ 	archer-c58-v1|\
+ 	archer-c59-v1|\
++	fritz4020|\
+ 	rb-450g)
+ 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+ 		ucidef_add_switch "switch0" \
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+index 945167bee6f7dad76bc650a2bb8a7a71f96b738d..7cb708ebe2e9e7546f165022233d17224905a49c 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+@@ -40,6 +40,24 @@ ath9k_ubi_eeprom_extract() {
+ 		ath9k_eeprom_die "failed to extract from $ubi"
+ }
+ 
++ath9k_eeprom_extract_reverse() {
++	local part=$1
++	local offset=$2
++	local count=$3
++	local mtd
++	local reversed
++	local caldata
++
++	mtd=$(find_mtd_chardev "$part")
++	reversed=$(hexdump -v -s $offset -n $count -e '/1 "%02x "' $mtd)
++
++	for byte in $reversed; do
++		caldata="\x${byte}${caldata}"
++	done
++
++	printf "%b" "$caldata" > /lib/firmware/$FIRMWARE
++}
++
+ ath9k_patch_firmware_mac() {
+ 	local mac=$1
+ 
+@@ -58,6 +76,9 @@ case "$FIRMWARE" in
+ 		ath9k_eeprom_extract "art" 4096 2048
+ 		ath9k_patch_firmware_mac $(macaddr_add $(mtd_get_mac_binary art 0) +1)
+ 		;;
++	fritz4020)
++		ath9k_eeprom_extract_reverse "urlader" 5441 1088
++		;;
+ 	mr18)
+ 		. /lib/upgrade/nand.sh
+ 
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 59ede17653bbb1994ce9fa734c86c877aedf67e4..a815ffe07322c20cddaa3c4f97e3bf62a3cf15ec 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -638,6 +638,9 @@ ar71xx_board_detect() {
+ 		name="gl-inet"
+ 		gl_inet_board_detect
+ 		;;
++	*"FRITZ!Box 4020")
++		name="fritz4020"
++		;;
+ 	*"GL AR150")
+ 		name="gl-ar150"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index 5e8a06a7ae70ec349693c09deedbfce41a52cfc2..491b5d5a98b44844f14441d4024f2ad9667186e0 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -612,6 +612,9 @@ platform_check_image() {
+ 
+ 		return 0;
+ 		;;
++	fritz4020)
++		return 0
++		;;
+ 	esac
+ 
+ 	echo "Sysupgrade is not yet supported on $board."
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index 396a4fa02adb37c6e5f9f7f1cc40fd1014361654..45bf500643837a7270b45e32b22225c06c5fb841 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -106,6 +106,7 @@ CONFIG_ATH79_MACH_ESR1750=y
+ CONFIG_ATH79_MACH_ESR900=y
+ CONFIG_ATH79_MACH_EW_DORIN=y
+ CONFIG_ATH79_MACH_F9K1115V2=y
++CONFIG_ATH79_MACH_FRITZ4020=y
+ CONFIG_ATH79_MACH_GL_AR150=y
+ CONFIG_ATH79_MACH_GL_AR300=y
+ CONFIG_ATH79_MACH_GL_AR300M=y
+@@ -373,6 +374,7 @@ CONFIG_MTD_PHYSMAP=y
+ CONFIG_MTD_REDBOOT_DIRECTORY_BLOCK=-2
+ CONFIG_MTD_REDBOOT_PARTS=y
+ CONFIG_MTD_SPI_NOR=y
++CONFIG_MTD_SPLIT_EVA_FW=y 
+ CONFIG_MTD_SPLIT_FIRMWARE=y
+ CONFIG_MTD_SPLIT_LZMA_FW=y
+ CONFIG_MTD_SPLIT_SEAMA_FW=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+index 4c9012acc6b4c40d88ffc8752086cac86b9b9c92..46366e0d922808e5e14fed0f2b5409cda11afd26 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+@@ -1918,3 +1918,12 @@ config ATH79_MACH_TL_WPA8630
+ 	select ATH79_DEV_LEDS_GPIO
+ 	select ATH79_DEV_M25P80
+ 	select ATH79_DEV_WMAC
++
++config ATH79_MACH_FRITZ4020
++	bool "AVM FRITZ!Box 4020 support"
++	select SOC_QCA956X
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_USB
++	select ATH79_DEV_M25P80
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Makefile b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+index 8408894669dc5f14f05701359073ef233a1b89f0..29c9c65bc122c0d02839adf1abb61dcda0795fb6 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+@@ -111,6 +111,7 @@ obj-$(CONFIG_ATH79_MACH_ESR1750)		+= mach-esr1750.o
+ obj-$(CONFIG_ATH79_MACH_ESR900)			+= mach-esr900.o
+ obj-$(CONFIG_ATH79_MACH_EW_DORIN)		+= mach-ew-dorin.o
+ obj-$(CONFIG_ATH79_MACH_F9K1115V2)		+= mach-f9k1115v2.o
++obj-$(CONFIG_ATH79_MACH_FRITZ4020)		+= mach-fritz4020.o
+ obj-$(CONFIG_ATH79_MACH_GL_AR150)		+= mach-gl-ar150.o
+ obj-$(CONFIG_ATH79_MACH_GL_AR300)		+= mach-gl-ar300.o
+ obj-$(CONFIG_ATH79_MACH_GL_AR300M)		+= mach-gl-ar300m.o
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+index 427de6a50d0fcbc9dae11f8e6921194c0a5b09ed..5f971ea32d35035617229076b7a7fc30ed4d2dcc 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.c
+@@ -1224,6 +1224,15 @@ void __init ath79_parse_ascii_mac(char *mac_str, u8 *mac)
+ 	}
+ }
+ 
++void __init ath79_extract_mac_reverse(u8 *ptr, u8 *out)
++{
++	int i;
++
++	for (i = 0; i < ETH_ALEN; i++) {
++		out[i] = ptr[ETH_ALEN-i-1];
++	}
++}
++
+ static void __init ath79_set_mac_base_ascii(char *str)
+ {
+ 	u8 mac[ETH_ALEN];
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.h b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.h
+index fb9e4f63c66ef9008e423007ecff02c93c321fb8..4d78260fbe35db20f8dc6dd245abcd0cbb275477 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/dev-eth.h
+@@ -18,6 +18,7 @@ struct platform_device;
+ 
+ extern unsigned char ath79_mac_base[] __initdata;
+ void ath79_parse_ascii_mac(char *mac_str, u8 *mac);
++void ath79_extract_mac_reverse(u8 *ptr, u8 *out);
+ void ath79_init_mac(unsigned char *dst, const unsigned char *src,
+ 		    int offset);
+ void ath79_init_local_mac(unsigned char *dst, const unsigned char *src);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-fritz4020.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-fritz4020.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..ed7f9a8b3ead80dbbe7f8d27c7dd5ecf0543d733
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-fritz4020.c
+@@ -0,0 +1,242 @@
++/*
++ *  AVM FRITZ!Box 4020 board support
++ *
++ *  Copyright (C) 2018 David Bauer <mail@david-bauer.net>
++ *
++ *  This program is free software; you can redistribute it and/or modify it
++ *  under the terms of the GNU General Public License version 2 as published
++ *  by the Free Software Foundation.
++ */
++
++#include <linux/init.h>
++#include <linux/ath9k_platform.h>
++#include <linux/etherdevice.h>
++#include <linux/gpio.h>
++#include <linux/platform_device.h>
++
++#include <linux/mtd/mtd.h>
++#include <linux/mtd/partitions.h>
++#include <linux/platform_data/mdio-gpio.h>
++#include <linux/spi/spi_gpio.h>
++#include <linux/spi/74x164.h>
++
++#include <asm/mach-ath79/ath79.h>
++#include <asm/mach-ath79/ar71xx_regs.h>
++
++#include "common.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-m25p80.h"
++#include "dev-spi.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++#include "machtypes.h"
++
++
++#define FRITZ4020_GPIO_SHIFT_SER			19   /* DS,   Data Serial Input */
++#define FRITZ4020_GPIO_SHIFT_SRCLK			20 /* SHCP, Shift Reg Clock Input */
++
++#define FRITZ4020_SSR_BIT_0				0
++#define FRITZ4020_SSR_BIT_1				1
++#define FRITZ4020_SSR_BIT_2				2
++#define FRITZ4020_SSR_BIT_3				3
++#define FRITZ4020_SSR_BIT_4				4
++#define FRITZ4020_SSR_BIT_5				5
++#define FRITZ4020_SSR_BIT_6				6
++#define FRITZ4020_SSR_BIT_7				7
++
++#define FRITZ4020_74HC_GPIO_BASE			32
++#define FRITZ4020_74HC_GPIO_LED_LAN			(FRITZ4020_74HC_GPIO_BASE + 0)
++#define FRITZ4020_74HC_GPIO_LED_INFO_RED		(FRITZ4020_74HC_GPIO_BASE + 1)
++#define FRITZ4020_74HC_GPIO_LED_POWER			(FRITZ4020_74HC_GPIO_BASE + 2)
++#define FRITZ4020_74HC_GPIO_LED_WLAN			(FRITZ4020_74HC_GPIO_BASE + 3)
++#define FRITZ4020_74HC_GPIO_LED_WAN			(FRITZ4020_74HC_GPIO_BASE + 4)
++#define FRITZ4020_74HC_GPIO_USB_RST			(FRITZ4020_74HC_GPIO_BASE + 5)
++#define FRITZ4020_74HC_GPIO_LED_INFO			(FRITZ4020_74HC_GPIO_BASE + 6)
++
++
++#define FRITZ4020_GPIO_BTN_WPS				2
++#define FRITZ4020_GPIO_BTN_WLAN				21
++#define FRITZ4020_KEYS_POLL_INTERVAL			20 /* msecs */
++#define FRITZ4020_KEYS_DEBOUNCE_INTERVAL		(3 * FRITZ4020_KEYS_POLL_INTERVAL)
++
++#define FRTIZ4020_OFFSET_URLADER_WIFI_MAC_REVERSE	0x1979
++
++
++static struct spi_gpio_platform_data fritz4020_spi_data = {
++	.sck		= FRITZ4020_GPIO_SHIFT_SRCLK,
++	.miso		= SPI_GPIO_NO_MISO,
++	.mosi		= FRITZ4020_GPIO_SHIFT_SER,
++	.num_chipselect	= 1,
++};
++
++static u8 fritz4020_ssr_initdata[] = {
++	BIT(FRITZ4020_SSR_BIT_7) |
++	BIT(FRITZ4020_SSR_BIT_6) |
++	BIT(FRITZ4020_SSR_BIT_5) |
++	BIT(FRITZ4020_SSR_BIT_4) |
++	BIT(FRITZ4020_SSR_BIT_3) |
++	BIT(FRITZ4020_SSR_BIT_2) |
++	BIT(FRITZ4020_SSR_BIT_1)
++};
++
++static struct gen_74x164_chip_platform_data fritz4020_ssr_data = {
++	.base = FRITZ4020_74HC_GPIO_BASE,
++	.num_registers = ARRAY_SIZE(fritz4020_ssr_initdata),
++	.init_data = fritz4020_ssr_initdata,
++};
++
++static struct platform_device fritz4020_spi_device = {
++	.name		= "spi_gpio",
++	.id		= 1,
++	.dev = {
++		.platform_data = &fritz4020_spi_data,
++	},
++};
++
++static struct spi_board_info fritz4020_spi_info[] = {
++	{
++		.bus_num		= 1,
++		.chip_select		= 0,
++		.max_speed_hz		= 10000000,
++		.modalias		= "74x164",
++		.platform_data		= &fritz4020_ssr_data,
++		.controller_data	= (void *) 0x0,
++	},
++};
++
++static struct mtd_partition fritz4020_flash_partitions[] = {
++	{
++		.name		= "urlader",
++		.offset		= 0,
++		.size		= 0x0020000,
++		.mask_flags	= MTD_WRITEABLE,
++	}, {
++		.name		= "firmware",
++		.offset		= 0x0020000,
++		.size		= 0x0EE0000,
++	}, {
++		.name		= "tffs (1)",
++		.offset		= 0x0f00000,
++		.size		= 0x0080000,
++		.mask_flags	= MTD_WRITEABLE,
++	}, {
++		.name		= "tffs (2)",
++		.offset		= 0x0f80000,
++		.size		= 0x0080000,
++		.mask_flags	= MTD_WRITEABLE,
++	}
++};
++
++static struct flash_platform_data fritz4020_flash_data = {
++	.parts		= fritz4020_flash_partitions,
++	.nr_parts	= ARRAY_SIZE(fritz4020_flash_partitions),
++};
++
++static struct gpio_led fritz4020_leds_gpio[] __initdata = {
++	{
++		.name		= "fritz4020:green:lan",
++		.gpio		= FRITZ4020_74HC_GPIO_LED_LAN,
++		.active_low	= 1,
++	}, {
++		.name		= "fritz4020:green:info",
++		.gpio		= FRITZ4020_74HC_GPIO_LED_INFO,
++		.active_low	= 1,
++	}, {
++		.name		= "fritz4020:red:info",
++		.gpio		= FRITZ4020_74HC_GPIO_LED_INFO_RED,
++		.active_low	= 1,
++	}, {
++		.name		= "fritz4020:green:power",
++		.gpio		= FRITZ4020_74HC_GPIO_LED_POWER,
++		.active_low	= 1,
++	}, {
++		.name		= "fritz4020:green:wlan",
++		.gpio		= FRITZ4020_74HC_GPIO_LED_WLAN,
++		.active_low	= 1,
++	}, {
++		.name		= "fritz4020:green:wan",
++		.gpio		= FRITZ4020_74HC_GPIO_LED_WAN,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button fritz4020_gpio_keys[] __initdata = {
++	{
++		.desc			= "RFKILL button",
++		.type			= EV_KEY,
++		.code			= KEY_RFKILL,
++		.debounce_interval	= FRITZ4020_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= FRITZ4020_GPIO_BTN_WLAN,
++		.active_low		= 0,
++	},
++	{
++		.desc			= "WPS button",
++		.type			= EV_KEY,
++		.code			= KEY_WPS_BUTTON,
++		.debounce_interval	= FRITZ4020_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= FRITZ4020_GPIO_BTN_WPS,
++		.active_low		= 0,
++	},
++};
++
++static void __init fritz4020_setup(void) {
++	u8 *urlader = (u8 *) KSEG1ADDR(0x1f000000);
++	u8 wifi_mac[ETH_ALEN];
++
++	ath79_register_m25p80(&fritz4020_flash_data);
++
++	/* Initialize ethernet */
++	ath79_extract_mac_reverse(urlader + FRTIZ4020_OFFSET_URLADER_WIFI_MAC_REVERSE, wifi_mac);
++	ath79_setup_qca956x_eth_cfg(QCA956X_ETH_CFG_SW_PHY_SWAP |
++				    QCA956X_ETH_CFG_SW_PHY_ADDR_SWAP);
++
++	ath79_register_mdio(0, 0x0);
++	ath79_register_mdio(1, 0x0);
++	ath79_init_mac(ath79_eth0_data.mac_addr, wifi_mac, -1);
++	ath79_init_mac(ath79_eth1_data.mac_addr, wifi_mac, -2);
++
++	/* WAN port */
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_mask = BIT(0);
++	ath79_register_eth(0);
++
++	/* LAN ports */
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_switch_data.phy_poll_mask |= BIT(0);
++	ath79_switch_data.phy4_mii_en = 1;
++	ath79_register_eth(1);
++
++	/* Initialize 2.4GHz WiFi */
++	ath79_register_wmac_simple();
++
++	/* Activate USB Power */
++	gpio_request_one(FRITZ4020_74HC_GPIO_USB_RST,
++			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++			 "USB power");
++
++	/* Initialize USB port */
++	ath79_register_usb();
++
++	/* Register LED shift-register */
++	spi_register_board_info(fritz4020_spi_info,
++				ARRAY_SIZE(fritz4020_spi_info));
++	platform_device_register(&fritz4020_spi_device);
++
++	/* Register GPIO buttons */
++	ath79_register_gpio_keys_polled(-1, FRITZ4020_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(fritz4020_gpio_keys),
++					fritz4020_gpio_keys);
++
++	/* Register LEDs */
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(fritz4020_leds_gpio),
++				 fritz4020_leds_gpio);
++}
++
++MIPS_MACHINE(ATH79_MACH_FRITZ4020, "FRITZ4020",
++	     "AVM FRITZ!Box 4020", fritz4020_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 72c1e38c74707aba8fbd3aebc36f35becabd4987..07f1877180e27ff189387c5f34a61702d0fa9bd2 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -102,6 +102,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_EW_DORIN,			/* embedded wireless Dorin Platform */
+ 	ATH79_MACH_EW_DORIN_ROUTER,		/* embedded wireless Dorin Router Platform */
+ 	ATH79_MACH_F9K1115V2,			/* Belkin AC1750DB */
++	ATH79_MACH_FRITZ4020,			/* AVM FRITZ!Box 4020 */
+ 	ATH79_MACH_GL_AR150,			/* GL-AR150 support */
+ 	ATH79_MACH_GL_AR300,			/* GL-AR300 */
+ 	ATH79_MACH_GL_AR300M,			/* GL-AR300M */
+diff --git a/target/linux/ar71xx/image/generic.mk b/target/linux/ar71xx/image/generic.mk
+index e11a8992f9c2f950079fddf121eb30c34926e33d..d113c5ad621bb2f15d4cbc4fd50e60904313a7da 100644
+--- a/target/linux/ar71xx/image/generic.mk
++++ b/target/linux/ar71xx/image/generic.mk
+@@ -738,3 +738,22 @@ define Device/bhr-4grv2
+   IMAGE/factory.bin = append-kernel | pad-to $$$$(KERNEL_SIZE) | append-rootfs | pad-rootfs | mkbuffaloimg
+ endef
+ TARGET_DEVICES += bhr-4grv2
++
++define Device/AVM
++  DEVICE_PACKAGES := fritz-tffs -uboot-envtools
++  KERNEL := kernel-bin | patch-cmdline | lzma | eva-image
++  KERNEL_INITRAMFS := $$(KERNEL)
++  IMAGE/sysupgrade.bin := append-kernel | pad-to 64k | \
++	append-squashfs-fakeroot-be | pad-to 256 | \
++	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
++endef
++
++define Device/fritz4020
++  $(call Device/AVM)
++  DEVICE_TITLE := AVM FRITZ!Box 4020
++  DEVICE_PACKAGES := kmod-usb-core kmod-usb2 kmod-usb-storage
++  BOARDNAME := FRITZ4020
++  SUPPORTED_DEVICES := fritz4020
++  IMAGE_SIZE := 15232k
++endef
++TARGET_DEVICES += fritz4020
+diff --git a/target/linux/ar71xx/mikrotik/config-default b/target/linux/ar71xx/mikrotik/config-default
+index 23e862762600f0724a37fe1a390d4d09639c472c..e0401102229c00985e8000331dce43375903e1aa 100644
+--- a/target/linux/ar71xx/mikrotik/config-default
++++ b/target/linux/ar71xx/mikrotik/config-default
+@@ -71,6 +71,7 @@
+ # CONFIG_ATH79_MACH_ESR900 is not set
+ # CONFIG_ATH79_MACH_EW_DORIN is not set
+ # CONFIG_ATH79_MACH_F9K1115V2 is not set
++# CONFIG_ATH79_MACH_FRITZ4020 is not set
+ # CONFIG_ATH79_MACH_GL_AR150 is not set
+ # CONFIG_ATH79_MACH_GL_AR300 is not set
+ # CONFIG_ATH79_MACH_GL_AR300M is not set
+@@ -217,6 +218,7 @@ CONFIG_MTD_NAND_ECC=y
+ CONFIG_MTD_NAND_RB4XX=y
+ CONFIG_MTD_NAND_RB750=y
+ CONFIG_MTD_NAND_RB91X=y
++# CONFIG_MTD_SPLIT_EVA_FW is not set
+ # CONFIG_MTD_REDBOOT_PARTS is not set
+ # CONFIG_MTD_TPLINK_PARTS is not set
+ CONFIG_MTD_UBI=y
+diff --git a/target/linux/ar71xx/nand/config-default b/target/linux/ar71xx/nand/config-default
+index c11ccfe29795d013776870cf21fb6ca8d907af1b..790fa8f9bd42aba8521b960c2a49a742285e6157 100644
+--- a/target/linux/ar71xx/nand/config-default
++++ b/target/linux/ar71xx/nand/config-default
+@@ -29,6 +29,7 @@
+ # CONFIG_ATH79_MACH_DIR_869_A1 is not set
+ # CONFIG_ATH79_MACH_EAP7660D is not set
+ # CONFIG_ATH79_MACH_EW_DORIN is not set
++# CONFIG_ATH79_MACH_FRITZ4020 is not set
+ # CONFIG_ATH79_MACH_HORNET_UB is not set
+ # CONFIG_ATH79_MACH_JA76PF is not set
+ # CONFIG_ATH79_MACH_JWAP003 is not set
+@@ -104,6 +105,7 @@ CONFIG_MTD_NAND_ECC=y
+ CONFIG_MTD_NAND_ECC_BCH=y
+ # CONFIG_MTD_REDBOOT_PARTS is not set
+ # CONFIG_MTD_SM_COMMON is not set
++# CONFIG_MTD_SPLIT_EVA_FW is not set
+ # CONFIG_MTD_SPLIT_SEAMA_FW is not set
+ # CONFIG_MTD_TPLINK_PARTS is not set
+ CONFIG_MTD_UBI=y

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -30,6 +30,10 @@ device allnet-all0315n all0315n ALL0315N
 factory
 
 
+# AVM
+device avm-fritz-box-4020 fritz4020 fritz4020
+factory
+
 # Buffalo
 
 device buffalo-wzr-hp-g300nh wzr-hp-g300nh WZRHPG300NH


### PR DESCRIPTION
This commit adds support for the AVM Fritz!Box 4020 WiFi-router.

Hardware specs can be taken from the OpenWRT commit message.

IMHO this device is a great addition to Gluon. In comparison with the TP-Link TL-WR1043v5 it lacks the gigabit ports but ships with double the RAM (128MB instead of 64MB). It is also very available, being the top-listed WiFi-Router on [Geizhals.de](https://geizhals.de/?cat=wlanrout). 

In addition to this, it is very stable in terms of pricing and ships since nearly 3 years in the same OpenWRT supportable revision.

It lacks a comfy way of flashing via a Web-GUI, but the flash process via EVA is safe and possible without any hardware modifications (UART).

We have currently [one running](https://meshviewer.darmstadt.freifunk.net/#/en/map/5c49793001b4) based on this pull-request in the network of Freifunk Darmstadt.

Autoupdater image-name:
```
root@64367-fritz-junior:~# lua -e 'print(require("platform_info").get_image_name())'
avm-fritz-box-4020
```
