### PR TITLE
ar71xx-generic: Add support for GL.iNet GL-AR750

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -142,6 +142,7 @@ ar71xx-generic
 
   - GL-AR150
   - GL-AR300M
+  - GL-AR750 [#ath10k]_
   - GL-iNet 6408A (v1)
   - GL-iNet 6416A (v1)
 

--- a/patches/lede/0086-ar71xx-set-status-led-for-the-gl-boards.patch
+++ b/patches/lede/0086-ar71xx-set-status-led-for-the-gl-boards.patch
@@ -1,0 +1,348 @@
+From: Wojciech Jowsa <w.jowsa@radytek.com>
+Date: Wed, 15 Feb 2017 12:38:07 +0100
+Subject: ar71xx: set status led for the gl-* boards
+
+Signed-off-by: Wojciech Jowsa <w.jowsa@radytek.com>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index e8b13af7c24dea86519c962fa6381fd75971e8b9..5ab407ab0f46d4927dd5c2af545814bf265b84ba 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -311,19 +311,18 @@ fritz4020)
+ 	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
+ 	;;
+-gl-ar150|\
+-gl-ar300|\
+-gl-ar300m|\
++gl-ar300m)
++	ucidef_set_led_wlan "wlan" "WLAN" "$board:red:wlan" "phy0tpt"
++	;;
+ gl-mifi)
++	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
++	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
++	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth1"
++	ucidef_set_led_netdev "3gnet" "3GNET" "$board:green:net" "3g-wan"
++	;;
++gl-ar150|\
++gl-ar300)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:wlan" "phy0tpt"
+-
+-	case "$board" in
+-	gl-mifi)
+-		ucidef_set_led_netdev "wan" "WAN" "$board:wan" "eth0"
+-		ucidef_set_led_netdev "lan" "LAN" "$board:lan" "eth1"
+-		ucidef_set_led_netdev "3gnet" "3GNET" "$board:net" "3g-wan"
+-		;;
+-	esac
+ 	;;
+ gl-domino|\
+ wrt160nl)
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 382500b75ee6dc1fe1126fb3121f4ae205c901d4..a5ad6ea24cf51e7fb5e49e82856851851c7fdcdb 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -64,7 +64,9 @@ get_status_led() {
+ 	ap90q|\
+ 	cpe830|\
+ 	cpe870|\
+-	gl-inet)
++	gl-inet|\
++	gl-mifi|\
++	gl-ar300m)
+ 		status_led="$board:green:lan"
+ 		;;
+ 	ap96)
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar300m.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar300m.c
+index 62906a1922f890eb36ad212e9542dc52dc56006c..ca44b364c51559350fedc5551a023b2772bb69a1 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar300m.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar300m.c
+@@ -6,9 +6,9 @@
+  *  Copyright (C) 2013 alzhao <alzhao@gmail.com>
+  *  Copyright (C) 2014 Michel Stempin <michel.stempin@wanadoo.fr>
+  *
+- *  This program is free software; you can redistribute it and/or modify it
+- *  under the terms of the GNU General Public License version 2 as published
+- *  by the Free Software Foundation.
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 as published
++ * by the Free Software Foundation.
+  */
+ 
+ #include <linux/gpio.h>
+@@ -37,130 +37,130 @@
+ #define GL_AR300M_GPIO_BTN_LEFT		0
+ #define GL_AR300M_GPIO_BTN_RIGHT	1
+ 
+-#define GL_AR300M_KEYS_POLL_INTERVAL        20  /* msecs */
+-#define GL_AR300M_KEYS_DEBOUNCE_INTERVAL    (3 * GL_AR300M_KEYS_POLL_INTERVAL)
++#define GL_AR300M_KEYS_POLL_INTERVAL		20	/* msecs */
++#define GL_AR300M_KEYS_DEBOUNCE_INTERVAL	(3 * GL_AR300M_KEYS_POLL_INTERVAL)
+ 
+-#define GL_AR300M_MAC0_OFFSET   0
+-#define GL_AR300M_MAC1_OFFSET   6
+-#define GL_AR300M_WMAC_CALDATA_OFFSET   0x1000
+-#define GL_AR300M_PCIE_CALDATA_OFFSET   0x5000
++#define GL_AR300M_MAC0_OFFSET	0
++#define GL_AR300M_MAC1_OFFSET	6
++#define GL_AR300M_WMAC_CALDATA_OFFSET	0x1000
++#define GL_AR300M_PCIE_CALDATA_OFFSET	0x5000
+ 
+ static struct gpio_led gl_ar300m_leds_gpio[] __initdata = {
+-    {
+-        .name = "gl-ar300m:usb",
+-        .gpio = GL_AR300M_GPIO_LED_USB,
+-        .active_low = 0,
+-        .default_state = 1,
+-    },
+-    {
+-        .name = "gl-ar300m:wlan",
+-        .gpio = GL_AR300M_GPIO_LED_WLAN,
+-        .active_low = 1,
+-    },
+-    {
+-        .name = "gl-ar300m:lan",
+-        .gpio = GL_AR300M_GPIO_LED_LAN,
+-        .active_low = 1,
+-    },
+-    {
+-        .name = "gl-ar300m:system",
+-        .gpio = GL_AR300M_GPIO_LED_SYSTEM,
+-        .active_low = 1,
+-        .default_state = 1,
+-    },
++	{
++		.name = "gl-ar300m:green:usb",
++		.gpio = GL_AR300M_GPIO_LED_USB,
++		.active_low = 0,
++		.default_state = 1,
++	},
++	{
++		.name = "gl-ar300m:green:wlan",
++		.gpio = GL_AR300M_GPIO_LED_WLAN,
++		.active_low = 1,
++	},
++	{
++		.name = "gl-ar300m::green:lan",
++		.gpio = GL_AR300M_GPIO_LED_LAN,
++		.active_low = 1,
++	},
++	{
++		.name = "gl-ar300m:green:system",
++		.gpio = GL_AR300M_GPIO_LED_SYSTEM,
++		.active_low = 1,
++		.default_state = 1,
++	},
+ };
+ 
+ static struct gpio_keys_button gl_ar300m_gpio_keys[] __initdata = {
+-    {
+-        .desc = "reset",
+-        .type = EV_KEY,
+-        .code = KEY_RESTART,
+-        .debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
+-        .gpio = GL_AR300M_GPIO_BTN_RESET,
+-        .active_low = 1,
+-    },
+-    {
+-        .desc = "button right",
+-        .type = EV_KEY,
+-        .code = BTN_0,
+-        .debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
+-        .gpio = GL_AR300M_GPIO_BTN_LEFT,
+-        .active_low = 0,
+-    },
+-    {
+-        .desc = "button left",
+-        .type = EV_KEY,
+-        .code = BTN_1,
+-        .debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
+-        .gpio = GL_AR300M_GPIO_BTN_RIGHT,
+-        .active_low = 0,
+-    },
++	{
++		.desc = "reset",
++		.type = EV_KEY,
++		.code = KEY_RESTART,
++		.debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
++		.gpio = GL_AR300M_GPIO_BTN_RESET,
++		.active_low = 1,
++	},
++	{
++		.desc = "button right",
++		.type = EV_KEY,
++		.code = BTN_0,
++		.debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
++		.gpio = GL_AR300M_GPIO_BTN_LEFT,
++		.active_low = 0,
++	},
++	{
++		.desc = "button left",
++		.type = EV_KEY,
++		.code = BTN_1,
++		.debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
++		.gpio = GL_AR300M_GPIO_BTN_RIGHT,
++		.active_low = 0,
++	},
+ };
+ 
+ static struct spi_board_info gl_ar300m_spi_info[] = {
+-    {
+-        .bus_num    = 0,
+-        .chip_select    = 0,
+-        .max_speed_hz   = 25000000,
+-        .modalias   = "m25p80",
+-        .platform_data  = NULL,
+-    },
+-    {
+-        .bus_num    = 0,
+-        .chip_select    = 1,
+-        .max_speed_hz   = 25000000,
+-        .modalias   = "ath79-spinand",
+-        .platform_data  = NULL,
+-    }
++	{
++		.bus_num	= 0,
++		.chip_select	= 0,
++		.max_speed_hz	= 25000000,
++		.modalias	= "m25p80",
++		.platform_data	= NULL,
++	},
++	{
++		.bus_num	= 0,
++		.chip_select	= 1,
++		.max_speed_hz	= 25000000,
++		.modalias	= "ath79-spinand",
++		.platform_data	= NULL,
++	}
+ };
+ 
+ static struct ath79_spi_platform_data gl_ar300m_spi_data = {
+-    .bus_num        = 0,
+-    .num_chipselect     = 2,
++	.bus_num		= 0,
++	.num_chipselect		= 2,
+ };
+ 
+ static void __init gl_ar300m_setup(void)
+ {
+-    u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
+-    u8 tmpmac[ETH_ALEN];
+-
+-    ath79_gpio_function_enable(AR934X_GPIO_FUNC_JTAG_DISABLE);
+-    ath79_register_spi(&gl_ar300m_spi_data, gl_ar300m_spi_info, 2);
+-
+-    /* register gpio LEDs and keys */
+-    ath79_register_leds_gpio(-1, ARRAY_SIZE(gl_ar300m_leds_gpio),
+-                 gl_ar300m_leds_gpio);
+-    ath79_register_gpio_keys_polled(-1, GL_AR300M_KEYS_POLL_INTERVAL,
+-                    ARRAY_SIZE(gl_ar300m_gpio_keys),
+-                    gl_ar300m_gpio_keys);
+-
+-    ath79_register_mdio(0, 0x0);
+-
+-    /* WAN */
+-    ath79_init_mac(ath79_eth0_data.mac_addr, art + GL_AR300M_MAC0_OFFSET, 0);
+-    ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
+-    ath79_eth0_data.speed = SPEED_100;
+-    ath79_eth0_data.duplex = DUPLEX_FULL;
+-    ath79_eth0_data.phy_mask = BIT(4);
+-    ath79_register_eth(0);
+-
+-    /* LAN */
+-    ath79_init_mac(ath79_eth1_data.mac_addr, art + GL_AR300M_MAC1_OFFSET, 0);
+-    ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
+-    ath79_eth1_data.speed = SPEED_1000;
+-    ath79_eth1_data.duplex = DUPLEX_FULL;
+-    ath79_switch_data.phy_poll_mask |= BIT(4);
+-    ath79_switch_data.phy4_mii_en = 1;
+-    ath79_register_eth(1);
+-
+-    ath79_init_mac(tmpmac, art + GL_AR300M_WMAC_CALDATA_OFFSET + 2, 0);
+-    ath79_register_wmac(art + GL_AR300M_WMAC_CALDATA_OFFSET, tmpmac);
+-
+-    /* enable usb */
+-    ath79_register_usb();
+-    /* enable pci */
+-    ath79_register_pci();
++	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
++	u8 tmpmac[ETH_ALEN];
++
++	ath79_gpio_function_enable(AR934X_GPIO_FUNC_JTAG_DISABLE);
++	ath79_register_spi(&gl_ar300m_spi_data, gl_ar300m_spi_info, 2);
++
++	/* register gpio LEDs and keys */
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(gl_ar300m_leds_gpio),
++				 gl_ar300m_leds_gpio);
++	ath79_register_gpio_keys_polled(-1, GL_AR300M_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(gl_ar300m_gpio_keys),
++					gl_ar300m_gpio_keys);
++
++	ath79_register_mdio(0, 0x0);
++
++	/* WAN */
++	ath79_init_mac(ath79_eth0_data.mac_addr, art + GL_AR300M_MAC0_OFFSET, 0);
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_mask = BIT(4);
++	ath79_register_eth(0);
++
++	/* LAN */
++	ath79_init_mac(ath79_eth1_data.mac_addr, art + GL_AR300M_MAC1_OFFSET, 0);
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_switch_data.phy_poll_mask |= BIT(4);
++	ath79_switch_data.phy4_mii_en = 1;
++	ath79_register_eth(1);
++
++	ath79_init_mac(tmpmac, art + GL_AR300M_WMAC_CALDATA_OFFSET + 2, 0);
++	ath79_register_wmac(art + GL_AR300M_WMAC_CALDATA_OFFSET, tmpmac);
++
++	/* enable usb */
++	ath79_register_usb();
++	/* enable pci */
++	ath79_register_pci();
+ }
+ 
+ MIPS_MACHINE(ATH79_MACH_GL_AR300M, "GL-AR300M", "GL-AR300M",
+-         gl_ar300m_setup);
++		 gl_ar300m_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c
+index 42f4415d7fe0252aadf39e2ca50f96566c023728..412c562fa042e7abb0ccb35208bb55821efc8660 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c
+@@ -41,27 +41,27 @@
+ 
+ static struct gpio_led gl_mifi_leds_gpio[] __initdata = {
+ 	{
+-		.name = "gl-mifi:wan",
++		.name = "gl-mifi:greeen:wan",
+ 		.gpio = GL_MIFI_GPIO_LED_WAN,
+ 		.active_low = 0,
+ 	},
+ 	{
+-		.name = "gl-mifi:lan",
++		.name = "gl-mifi:green:lan",
+ 		.gpio = GL_MIFI_GPIO_LED_LAN,
+ 		.active_low = 0,
+ 	},
+ 	{
+-		.name = "gl-mifi:wlan",
++		.name = "gl-mifi:green:wlan",
+ 		.gpio = GL_MIFI_GPIO_LED_WLAN,
+ 		.active_low = 0,
+ 	},
+ 	{
+-		.name = "gl-mifi:net",
++		.name = "gl-mifi:green:net",
+ 		.gpio = GL_MIFI_GPIO_LED_NET,
+ 		.active_low = 0,
+ 	},
+ 	{
+-		.name = "gl-mifi:3gcontrol",
++		.name = "gl-mifi:green:3gcontrol",
+ 		.gpio = GL_MIFI_GPIO_LED_3GCONTROL,
+ 		.active_low = 0,
+ 	}

--- a/patches/lede/0087-ar71xx-add-support-for-GL.iNet-GL-AR750.patch
+++ b/patches/lede/0087-ar71xx-add-support-for-GL.iNet-GL-AR750.patch
@@ -1,0 +1,364 @@
+From: Piotr Dymacz <pepe2k@gmail.com>
+Date: Tue, 17 Oct 2017 23:30:01 +0200
+Subject: ar71xx: add support for GL.iNet GL-AR750
+
+GL.iNet GL-AR750 is a small size, dual-band (AC750) router, based on
+Qualcomm/Atheros QCA9531 v2 + QCA9887. FCC ID: 2AFIW-AR750.
+
+Specification:
+
+- 650/597/216 MHz (CPU/DDR/AHB)
+- 128 MB of RAM (DDR2)
+- 16 MB of FLASH (SPI NOR)
+- 3x 10/100 Mbps Ethernet
+- 2T2R 2.4 GHz (QCA9531)
+- 1T1R 5 GHz (QCA9887)
+- 1x USB 2.0 (power controlled by GPIO)
+- 1x microSD (GL857L)
+- 3x LED (all driven by GPIO)
+- 1x button (reset)
+- 1x 2-pos switch
+- header for optional PoE module
+- 1x micro USB for main power input
+- UART + I2C header on PCB
+
+Flash instruction:
+
+Vendor firmware is based on OpenWrt/LEDE. GUI or sysupgrade can be used
+to flash OpenWrt/LEDE firmware.
+
+Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 5ab407ab0f46d4927dd5c2af545814bf265b84ba..fae773b65c2a5e604a61b845406340f88ec59637 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -314,6 +314,10 @@ fritz4020)
+ gl-ar300m)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:red:wlan" "phy0tpt"
+ 	;;
++gl-ar750)
++	ucidef_set_led_wlan "wlan2g" "WLAN2G" "$board:white:wlan2g" "phy1tpt"
++	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:white:wlan5g" "phy0tpt"
++	;;
+ gl-mifi)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
+ 	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 1018ab4449f896d565b57ecbdc73b7e3d7fbe486..2f42862b8607fab814ed550b5d1841a572492923 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -368,6 +368,7 @@ ar71xx_setup_interfaces()
+ 	onion-omega)
+ 		ucidef_set_interface_lan "wlan0"
+ 		;;
++	gl-ar750|\
+ 	rb-435g)
+ 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+ 		ucidef_add_switch "switch0" \
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index a5ad6ea24cf51e7fb5e49e82856851851c7fdcdb..bfb11c105b1c6be16729145fce5f93e834c6ea8d 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -249,6 +249,7 @@ get_status_led() {
+ 	nbg460n_550n_550nh)
+ 		status_led="nbg460n:green:power"
+ 		;;
++	gl-ar750|\
+ 	nbg6716)
+ 		status_led="$board:white:power"
+ 		;;
+@@ -486,7 +487,8 @@ set_state() {
+ 	done)
+ 		status_led_on
+ 		case $(ar71xx_board_name) in
+-		gl-ar300m)
++		gl-ar300m|\
++		gl-ar750)
+ 			fw_printenv lc >/dev/null 2>&1 && fw_setenv "bootcount" 0
+ 			;;
+ 		qihoo-c301)
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 91bdf0d3c591516f58030b165052b3dd2751314f..1626622a8e46484bbf2719f19843e61d9cc92506 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -103,6 +103,7 @@ case "$FIRMWARE" in
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
+ 		;;
++	gl-ar750|\
+ 	tl-wpa8630)
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index a815ffe07322c20cddaa3c4f97e3bf62a3cf15ec..6071f95fa7a9d74270cc1f07c0729884defced81 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -650,6 +650,9 @@ ar71xx_board_detect() {
+ 	*"GL-AR300M")
+ 		name="gl-ar300m"
+ 		;;
++	*"GL-AR750")
++		name="gl-ar750"
++		;;
+ 	*"GL-MIFI")
+ 		name="gl-mifi"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx b/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
+index d677599d8c6380d9920e95abc9fb4b92cc0cec29..ba6e08b00d979bc73f7199756e22ca3941fad97d 100644
+--- a/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
++++ b/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
+@@ -17,6 +17,7 @@ set_preinit_iface() {
+ 	archer-c7 |\
+ 	bhr-4grv2 |\
+ 	dir-505-a1 |\
++	gl-ar750|\
+ 	gl-inet |\
+ 	jwap003 |\
+ 	pb42 |\
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index 491b5d5a98b44844f14441d4024f2ad9667186e0..113af2f1f87e9e8b7cb10ef3c8aa3513d06a7e89 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -253,6 +253,7 @@ platform_check_image() {
+ 	gl-ar150|\
+ 	gl-ar300m|\
+ 	gl-ar300|\
++	gl-ar750|\
+ 	gl-domino|\
+ 	gl-mifi|\
+ 	hiwifi-hc6361|\
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index 45bf500643837a7270b45e32b22225c06c5fb841..d96642b97c36187febb1f3843e7dd9acfab0e40d 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -110,6 +110,7 @@ CONFIG_ATH79_MACH_FRITZ4020=y
+ CONFIG_ATH79_MACH_GL_AR150=y
+ CONFIG_ATH79_MACH_GL_AR300=y
+ CONFIG_ATH79_MACH_GL_AR300M=y
++CONFIG_ATH79_MACH_GL_AR750=y
+ CONFIG_ATH79_MACH_GL_DOMINO=y
+ CONFIG_ATH79_MACH_GL_INET=y
+ CONFIG_ATH79_MACH_GL_MIFI=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+index 46366e0d922808e5e14fed0f2b5409cda11afd26..2449a8d6bce17f0a703d8fc4f82dd38e1f861ae3 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+@@ -691,6 +691,17 @@ config ATH79_MACH_GL_AR300M
+ 	select ATH79_DEV_USB
+ 	select ATH79_DEV_WMAC
+ 
++config ATH79_MACH_GL_AR750
++	bool "GL.iNet GL-AR750 support"
++	select SOC_QCA953X
++	select ATH79_DEV_AP9X_PCI if PCI
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_USB
++	select ATH79_DEV_WMAC
++
+ config ATH79_MACH_GL_DOMINO
+ 	bool "DOMINO support"
+ 	select SOC_AR933X
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Makefile b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+index 29c9c65bc122c0d02839adf1abb61dcda0795fb6..98281db31a05713168713f3e0fd62f736a2e7614 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+@@ -115,6 +115,7 @@ obj-$(CONFIG_ATH79_MACH_FRITZ4020)		+= mach-fritz4020.o
+ obj-$(CONFIG_ATH79_MACH_GL_AR150)		+= mach-gl-ar150.o
+ obj-$(CONFIG_ATH79_MACH_GL_AR300)		+= mach-gl-ar300.o
+ obj-$(CONFIG_ATH79_MACH_GL_AR300M)		+= mach-gl-ar300m.o
++obj-$(CONFIG_ATH79_MACH_GL_AR750)		+= mach-gl-ar750.o
+ obj-$(CONFIG_ATH79_MACH_GL_DOMINO)		+= mach-gl-domino.o
+ obj-$(CONFIG_ATH79_MACH_GL_INET)		+= mach-gl-inet.o
+ obj-$(CONFIG_ATH79_MACH_GL_MIFI)		+= mach-gl-mifi.o
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar750.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar750.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..9ee6e29c02139b972a83a555fcd693765bf8194f
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar750.c
+@@ -0,0 +1,146 @@
++/*
++ * GL.iNet GL-AR750 board support
++ *
++ * Copyright (C) 2018 Piotr Dymacz <pepe2k@gmail.com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 as published
++ * by the Free Software Foundation.
++ */
++
++#include <linux/gpio.h>
++#include <linux/i2c.h>
++#include <linux/i2c-gpio.h>
++#include <linux/platform_device.h>
++
++#include <asm/mach-ath79/ath79.h>
++#include <asm/mach-ath79/ar71xx_regs.h>
++
++#include "common.h"
++#include "dev-ap9x-pci.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-m25p80.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++#include "machtypes.h"
++
++#define GL_AR750_GPIO_LED_POWER		12
++#define GL_AR750_GPIO_LED_WLAN2G	14
++#define GL_AR750_GPIO_LED_WLAN5G	13
++
++#define GL_AR750_GPIO_BTN_RESET		3
++#define GL_AR750_GPIO_BTN_SW1		0
++
++#define GL_AR750_GPIO_I2C_SCL		16
++#define GL_AR750_GPIO_I2C_SDA		17
++
++#define GL_AR750_GPIO_USB_POWER		2
++
++#define GL_AR750_KEYS_POLL_INTERVAL	20
++#define GL_AR750_KEYS_DEBOUNCE_INTERVAL	(3 * GL_AR750_KEYS_POLL_INTERVAL)
++
++#define GL_AR750_MAC0_OFFSET		0
++#define GL_AR750_WMAC2G_CALDATA_OFFSET	0x1000
++#define GL_AR750_WMAC5G_CALDATA_OFFSET	0x5000
++
++static struct gpio_led gl_ar750_leds_gpio[] __initdata = {
++	{
++		.name		= "gl-ar750:white:power",
++		.gpio		= GL_AR750_GPIO_LED_POWER,
++		.default_state	= LEDS_GPIO_DEFSTATE_KEEP,
++		.active_low	= 1,
++	}, {
++		.name		= "gl-ar750:white:wlan2g",
++		.gpio		= GL_AR750_GPIO_LED_WLAN2G,
++		.active_low	= 1,
++	}, {
++		.name		= "gl-ar750:white:wlan5g",
++		.gpio		= GL_AR750_GPIO_LED_WLAN5G,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button gl_ar750_gpio_keys[] __initdata = {
++	{
++		.desc			= "reset",
++		.type			= EV_KEY,
++		.code			= KEY_RESTART,
++		.debounce_interval	= GL_AR750_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= GL_AR750_GPIO_BTN_RESET,
++		.active_low		= 1,
++	}, {
++		.desc			= "sw1",
++		.type			= EV_KEY,
++		.code			= BTN_0,
++		.debounce_interval	= GL_AR750_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= GL_AR750_GPIO_BTN_SW1,
++		.active_low		= 1,
++	},
++};
++
++static struct i2c_gpio_platform_data gl_ar750_i2c_gpio_data = {
++	.sda_pin = GL_AR750_GPIO_I2C_SDA,
++	.scl_pin = GL_AR750_GPIO_I2C_SCL,
++};
++
++static struct platform_device gl_ar750_i2c_gpio = {
++	.name	= "i2c-gpio",
++	.id	= 0,
++	.dev	= {
++		.platform_data = &gl_ar750_i2c_gpio_data,
++	},
++};
++
++static void __init gl_ar750_setup(void)
++{
++	u8 *art = (u8 *) KSEG1ADDR(0x1f050000);
++
++	ath79_register_m25p80(NULL);
++
++	ath79_setup_ar933x_phy4_switch(false, false);
++	ath79_register_mdio(0, 0x0);
++
++	ath79_switch_data.phy4_mii_en = 1;
++	ath79_switch_data.phy_poll_mask = 0xfc;
++
++	/* WAN */
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.phy_mask = BIT(4);
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_init_mac(ath79_eth0_data.mac_addr, art + GL_AR750_MAC0_OFFSET, 0);
++	ath79_register_eth(0);
++
++	/* LAN */
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_init_mac(ath79_eth1_data.mac_addr, art + GL_AR750_MAC0_OFFSET, 1);
++	ath79_register_eth(1);
++
++	/* Disable JTAG (enables GPIO0-3) */
++	ath79_gpio_function_enable(AR934X_GPIO_FUNC_JTAG_DISABLE);
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(gl_ar750_leds_gpio),
++				 gl_ar750_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, GL_AR750_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(gl_ar750_gpio_keys),
++					gl_ar750_gpio_keys);
++
++	gpio_request_one(GL_AR750_GPIO_USB_POWER,
++			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++			 "USB power");
++
++	platform_device_register(&gl_ar750_i2c_gpio);
++
++	ath79_register_usb();
++
++	ath79_register_wmac(art + GL_AR750_WMAC2G_CALDATA_OFFSET, NULL);
++
++	ap91_pci_init(art + GL_AR750_WMAC5G_CALDATA_OFFSET, NULL);
++}
++
++MIPS_MACHINE(ATH79_MACH_GL_AR750, "GL-AR750", "GL.iNet GL-AR750",
++	     gl_ar750_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 07f1877180e27ff189387c5f34a61702d0fa9bd2..a8a8df5e54473ecb827dda2f2c2154b1c056c426 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -106,6 +106,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_GL_AR150,			/* GL-AR150 support */
+ 	ATH79_MACH_GL_AR300,			/* GL-AR300 */
+ 	ATH79_MACH_GL_AR300M,			/* GL-AR300M */
++	ATH79_MACH_GL_AR750,			/* GL.iNet GL-AR750 */
+ 	ATH79_MACH_GL_DOMINO,			/* Domino */
+ 	ATH79_MACH_GL_INET,			/* GL-CONNECT GL-INET */
+ 	ATH79_MACH_GL_MIFI,			/* GL-MIFI support */
+diff --git a/target/linux/ar71xx/image/generic.mk b/target/linux/ar71xx/image/generic.mk
+index d113c5ad621bb2f15d4cbc4fd50e60904313a7da..d1375c8742d8aea6224f7aca3d9e9522d8056a94 100644
+--- a/target/linux/ar71xx/image/generic.mk
++++ b/target/linux/ar71xx/image/generic.mk
+@@ -161,6 +161,19 @@ define Device/gl-ar300m
+ endef
+ TARGET_DEVICES += gl-ar300m
+ 
++define Device/gl-ar750
++  DEVICE_TITLE := GL.iNet GL-AR750
++  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887 kmod-usb-core \
++	kmod-usb2 kmod-usb-storage
++  BOARDNAME := GL-AR750
++  SUPPORTED_DEVICES := gl-ar750
++  IMAGE_SIZE := 16000k
++  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(art)ro,-(firmware)
++  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
++	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
++endef
++TARGET_DEVICES += gl-ar750
++
+ define Device/gl-domino
+   DEVICE_TITLE := GL Domino Pi
+   DEVICE_PACKAGES := kmod-usb-core kmod-usb2

--- a/patches/lede/0088-uboot-envtools-add-support-for-GL.iNet-GL-AR750.patch
+++ b/patches/lede/0088-uboot-envtools-add-support-for-GL.iNet-GL-AR750.patch
@@ -1,0 +1,18 @@
+From: Piotr Dymacz <pepe2k@gmail.com>
+Date: Tue, 17 Oct 2017 23:32:11 +0200
+Subject: uboot-envtools: add support for GL.iNet GL-AR750
+
+Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+
+diff --git a/package/boot/uboot-envtools/files/ar71xx b/package/boot/uboot-envtools/files/ar71xx
+index 25bec7eb33fd691bae417512c4c03e133d93213d..26f1ff938b8191e84315cf308f78e0907264c671 100644
+--- a/package/boot/uboot-envtools/files/ar71xx
++++ b/package/boot/uboot-envtools/files/ar71xx
+@@ -29,6 +29,7 @@ cr3000|\
+ cr5000|\
+ eap300v2|\
+ gl-ar300m|\
++gl-ar750|\
+ hornet-ub|\
+ hornet-ub-x2|\
+ jwap230|\

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -67,6 +67,9 @@ factory
 device gl-ar300m gl-ar300m
 factory
 
+device gl-ar750 gl-ar750
+packages $ATH10K_PACKAGES
+factory
 
 # Linksys by Cisco
 


### PR DESCRIPTION
This PR backports hw support for GL.iNet GL-AR750.
The backport against 2017.1.x got already tested by @Commifreak and he will test this patchset asap. As of now, this is should be seen as untested until he reports back.

Fixes #1378