### PR TITLE
2017.1.x: ar71xx-generic: Add support for GL.iNet GL-AR750

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,7 @@ ar71xx-generic
 
   - GL-AR150
   - GL-AR300M
+  - GL-AR750 [#ath10k]_
   - GL-iNet 6408A (v1)
   - GL-iNet 6416A (v1)
 

--- a/patches/lede/0048-ar71xx-set-status-led-for-the-gl-boards.patch
+++ b/patches/lede/0048-ar71xx-set-status-led-for-the-gl-boards.patch
@@ -1,0 +1,348 @@
+From: Wojciech Jowsa <w.jowsa@radytek.com>
+Date: Wed, 15 Feb 2017 12:38:07 +0100
+Subject: ar71xx: set status led for the gl-* boards
+
+Signed-off-by: Wojciech Jowsa <w.jowsa@radytek.com>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index e67b5e38561e841b88e486341950c52e1d454322..49f27e9db40888ba8691014f2e70075114856978 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -291,19 +291,18 @@ dlan-pro-1200-ac)
+ 	ucidef_set_led_gpio "plcw" "dLAN" "devolo:status:dlan" "17" "0"
+ 	ucidef_set_led_gpio "plcr" "dLAN" "devolo:error:dlan" "16" "0"
+ 	;;
+-gl-ar150|\
+-gl-ar300|\
+-gl-ar300m|\
++gl-ar300m)
++	ucidef_set_led_wlan "wlan" "WLAN" "$board:red:wlan" "phy0tpt"
++	;;
+ gl-mifi)
++	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
++	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
++	ucidef_set_led_netdev "lan" "LAN" "$board:green:lan" "eth1"
++	ucidef_set_led_netdev "3gnet" "3GNET" "$board:green:net" "3g-wan"
++	;;
++gl-ar150|\
++gl-ar300)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:wlan" "phy0tpt"
+-
+-	case "$board" in
+-	gl-mifi)
+-		ucidef_set_led_netdev "wan" "WAN" "$board:wan" "eth0"
+-		ucidef_set_led_netdev "lan" "LAN" "$board:lan" "eth1"
+-		ucidef_set_led_netdev "3gnet" "3GNET" "$board:net" "3g-wan"
+-		;;
+-	esac
+ 	;;
+ gl-domino|\
+ wrt160nl)
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 61db387c9ecefd7090c25a5f5d75fdbf65a44d65..01dc7753ebce7079b789572393db7d4a87e4b98e 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -60,7 +60,9 @@ get_status_led() {
+ 	ap90q|\
+ 	cpe830|\
+ 	cpe870|\
+-	gl-inet)
++	gl-inet|\
++	gl-mifi|\
++	gl-ar300m)
+ 		status_led="$board:green:lan"
+ 		;;
+ 	ap96)
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar300m.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar300m.c
+index 62906a1922f890eb36ad212e9542dc52dc56006c..ca44b364c51559350fedc5551a023b2772bb69a1 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar300m.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar300m.c
+@@ -6,9 +6,9 @@
+  *  Copyright (C) 2013 alzhao <alzhao@gmail.com>
+  *  Copyright (C) 2014 Michel Stempin <michel.stempin@wanadoo.fr>
+  *
+- *  This program is free software; you can redistribute it and/or modify it
+- *  under the terms of the GNU General Public License version 2 as published
+- *  by the Free Software Foundation.
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 as published
++ * by the Free Software Foundation.
+  */
+ 
+ #include <linux/gpio.h>
+@@ -37,130 +37,130 @@
+ #define GL_AR300M_GPIO_BTN_LEFT		0
+ #define GL_AR300M_GPIO_BTN_RIGHT	1
+ 
+-#define GL_AR300M_KEYS_POLL_INTERVAL        20  /* msecs */
+-#define GL_AR300M_KEYS_DEBOUNCE_INTERVAL    (3 * GL_AR300M_KEYS_POLL_INTERVAL)
++#define GL_AR300M_KEYS_POLL_INTERVAL		20	/* msecs */
++#define GL_AR300M_KEYS_DEBOUNCE_INTERVAL	(3 * GL_AR300M_KEYS_POLL_INTERVAL)
+ 
+-#define GL_AR300M_MAC0_OFFSET   0
+-#define GL_AR300M_MAC1_OFFSET   6
+-#define GL_AR300M_WMAC_CALDATA_OFFSET   0x1000
+-#define GL_AR300M_PCIE_CALDATA_OFFSET   0x5000
++#define GL_AR300M_MAC0_OFFSET	0
++#define GL_AR300M_MAC1_OFFSET	6
++#define GL_AR300M_WMAC_CALDATA_OFFSET	0x1000
++#define GL_AR300M_PCIE_CALDATA_OFFSET	0x5000
+ 
+ static struct gpio_led gl_ar300m_leds_gpio[] __initdata = {
+-    {
+-        .name = "gl-ar300m:usb",
+-        .gpio = GL_AR300M_GPIO_LED_USB,
+-        .active_low = 0,
+-        .default_state = 1,
+-    },
+-    {
+-        .name = "gl-ar300m:wlan",
+-        .gpio = GL_AR300M_GPIO_LED_WLAN,
+-        .active_low = 1,
+-    },
+-    {
+-        .name = "gl-ar300m:lan",
+-        .gpio = GL_AR300M_GPIO_LED_LAN,
+-        .active_low = 1,
+-    },
+-    {
+-        .name = "gl-ar300m:system",
+-        .gpio = GL_AR300M_GPIO_LED_SYSTEM,
+-        .active_low = 1,
+-        .default_state = 1,
+-    },
++	{
++		.name = "gl-ar300m:green:usb",
++		.gpio = GL_AR300M_GPIO_LED_USB,
++		.active_low = 0,
++		.default_state = 1,
++	},
++	{
++		.name = "gl-ar300m:green:wlan",
++		.gpio = GL_AR300M_GPIO_LED_WLAN,
++		.active_low = 1,
++	},
++	{
++		.name = "gl-ar300m::green:lan",
++		.gpio = GL_AR300M_GPIO_LED_LAN,
++		.active_low = 1,
++	},
++	{
++		.name = "gl-ar300m:green:system",
++		.gpio = GL_AR300M_GPIO_LED_SYSTEM,
++		.active_low = 1,
++		.default_state = 1,
++	},
+ };
+ 
+ static struct gpio_keys_button gl_ar300m_gpio_keys[] __initdata = {
+-    {
+-        .desc = "reset",
+-        .type = EV_KEY,
+-        .code = KEY_RESTART,
+-        .debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
+-        .gpio = GL_AR300M_GPIO_BTN_RESET,
+-        .active_low = 1,
+-    },
+-    {
+-        .desc = "button right",
+-        .type = EV_KEY,
+-        .code = BTN_0,
+-        .debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
+-        .gpio = GL_AR300M_GPIO_BTN_LEFT,
+-        .active_low = 0,
+-    },
+-    {
+-        .desc = "button left",
+-        .type = EV_KEY,
+-        .code = BTN_1,
+-        .debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
+-        .gpio = GL_AR300M_GPIO_BTN_RIGHT,
+-        .active_low = 0,
+-    },
++	{
++		.desc = "reset",
++		.type = EV_KEY,
++		.code = KEY_RESTART,
++		.debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
++		.gpio = GL_AR300M_GPIO_BTN_RESET,
++		.active_low = 1,
++	},
++	{
++		.desc = "button right",
++		.type = EV_KEY,
++		.code = BTN_0,
++		.debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
++		.gpio = GL_AR300M_GPIO_BTN_LEFT,
++		.active_low = 0,
++	},
++	{
++		.desc = "button left",
++		.type = EV_KEY,
++		.code = BTN_1,
++		.debounce_interval = GL_AR300M_KEYS_DEBOUNCE_INTERVAL,
++		.gpio = GL_AR300M_GPIO_BTN_RIGHT,
++		.active_low = 0,
++	},
+ };
+ 
+ static struct spi_board_info gl_ar300m_spi_info[] = {
+-    {
+-        .bus_num    = 0,
+-        .chip_select    = 0,
+-        .max_speed_hz   = 25000000,
+-        .modalias   = "m25p80",
+-        .platform_data  = NULL,
+-    },
+-    {
+-        .bus_num    = 0,
+-        .chip_select    = 1,
+-        .max_speed_hz   = 25000000,
+-        .modalias   = "ath79-spinand",
+-        .platform_data  = NULL,
+-    }
++	{
++		.bus_num	= 0,
++		.chip_select	= 0,
++		.max_speed_hz	= 25000000,
++		.modalias	= "m25p80",
++		.platform_data	= NULL,
++	},
++	{
++		.bus_num	= 0,
++		.chip_select	= 1,
++		.max_speed_hz	= 25000000,
++		.modalias	= "ath79-spinand",
++		.platform_data	= NULL,
++	}
+ };
+ 
+ static struct ath79_spi_platform_data gl_ar300m_spi_data = {
+-    .bus_num        = 0,
+-    .num_chipselect     = 2,
++	.bus_num		= 0,
++	.num_chipselect		= 2,
+ };
+ 
+ static void __init gl_ar300m_setup(void)
+ {
+-    u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
+-    u8 tmpmac[ETH_ALEN];
+-
+-    ath79_gpio_function_enable(AR934X_GPIO_FUNC_JTAG_DISABLE);
+-    ath79_register_spi(&gl_ar300m_spi_data, gl_ar300m_spi_info, 2);
+-
+-    /* register gpio LEDs and keys */
+-    ath79_register_leds_gpio(-1, ARRAY_SIZE(gl_ar300m_leds_gpio),
+-                 gl_ar300m_leds_gpio);
+-    ath79_register_gpio_keys_polled(-1, GL_AR300M_KEYS_POLL_INTERVAL,
+-                    ARRAY_SIZE(gl_ar300m_gpio_keys),
+-                    gl_ar300m_gpio_keys);
+-
+-    ath79_register_mdio(0, 0x0);
+-
+-    /* WAN */
+-    ath79_init_mac(ath79_eth0_data.mac_addr, art + GL_AR300M_MAC0_OFFSET, 0);
+-    ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
+-    ath79_eth0_data.speed = SPEED_100;
+-    ath79_eth0_data.duplex = DUPLEX_FULL;
+-    ath79_eth0_data.phy_mask = BIT(4);
+-    ath79_register_eth(0);
+-
+-    /* LAN */
+-    ath79_init_mac(ath79_eth1_data.mac_addr, art + GL_AR300M_MAC1_OFFSET, 0);
+-    ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
+-    ath79_eth1_data.speed = SPEED_1000;
+-    ath79_eth1_data.duplex = DUPLEX_FULL;
+-    ath79_switch_data.phy_poll_mask |= BIT(4);
+-    ath79_switch_data.phy4_mii_en = 1;
+-    ath79_register_eth(1);
+-
+-    ath79_init_mac(tmpmac, art + GL_AR300M_WMAC_CALDATA_OFFSET + 2, 0);
+-    ath79_register_wmac(art + GL_AR300M_WMAC_CALDATA_OFFSET, tmpmac);
+-
+-    /* enable usb */
+-    ath79_register_usb();
+-    /* enable pci */
+-    ath79_register_pci();
++	u8 *art = (u8 *) KSEG1ADDR(0x1fff0000);
++	u8 tmpmac[ETH_ALEN];
++
++	ath79_gpio_function_enable(AR934X_GPIO_FUNC_JTAG_DISABLE);
++	ath79_register_spi(&gl_ar300m_spi_data, gl_ar300m_spi_info, 2);
++
++	/* register gpio LEDs and keys */
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(gl_ar300m_leds_gpio),
++				 gl_ar300m_leds_gpio);
++	ath79_register_gpio_keys_polled(-1, GL_AR300M_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(gl_ar300m_gpio_keys),
++					gl_ar300m_gpio_keys);
++
++	ath79_register_mdio(0, 0x0);
++
++	/* WAN */
++	ath79_init_mac(ath79_eth0_data.mac_addr, art + GL_AR300M_MAC0_OFFSET, 0);
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_mask = BIT(4);
++	ath79_register_eth(0);
++
++	/* LAN */
++	ath79_init_mac(ath79_eth1_data.mac_addr, art + GL_AR300M_MAC1_OFFSET, 0);
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_eth1_data.speed = SPEED_1000;
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_switch_data.phy_poll_mask |= BIT(4);
++	ath79_switch_data.phy4_mii_en = 1;
++	ath79_register_eth(1);
++
++	ath79_init_mac(tmpmac, art + GL_AR300M_WMAC_CALDATA_OFFSET + 2, 0);
++	ath79_register_wmac(art + GL_AR300M_WMAC_CALDATA_OFFSET, tmpmac);
++
++	/* enable usb */
++	ath79_register_usb();
++	/* enable pci */
++	ath79_register_pci();
+ }
+ 
+ MIPS_MACHINE(ATH79_MACH_GL_AR300M, "GL-AR300M", "GL-AR300M",
+-         gl_ar300m_setup);
++		 gl_ar300m_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c
+index 42f4415d7fe0252aadf39e2ca50f96566c023728..412c562fa042e7abb0ccb35208bb55821efc8660 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-mifi.c
+@@ -41,27 +41,27 @@
+ 
+ static struct gpio_led gl_mifi_leds_gpio[] __initdata = {
+ 	{
+-		.name = "gl-mifi:wan",
++		.name = "gl-mifi:greeen:wan",
+ 		.gpio = GL_MIFI_GPIO_LED_WAN,
+ 		.active_low = 0,
+ 	},
+ 	{
+-		.name = "gl-mifi:lan",
++		.name = "gl-mifi:green:lan",
+ 		.gpio = GL_MIFI_GPIO_LED_LAN,
+ 		.active_low = 0,
+ 	},
+ 	{
+-		.name = "gl-mifi:wlan",
++		.name = "gl-mifi:green:wlan",
+ 		.gpio = GL_MIFI_GPIO_LED_WLAN,
+ 		.active_low = 0,
+ 	},
+ 	{
+-		.name = "gl-mifi:net",
++		.name = "gl-mifi:green:net",
+ 		.gpio = GL_MIFI_GPIO_LED_NET,
+ 		.active_low = 0,
+ 	},
+ 	{
+-		.name = "gl-mifi:3gcontrol",
++		.name = "gl-mifi:green:3gcontrol",
+ 		.gpio = GL_MIFI_GPIO_LED_3GCONTROL,
+ 		.active_low = 0,
+ 	}

--- a/patches/lede/0049-ar71xx-add-support-for-GL.iNet-GL-AR750.patch
+++ b/patches/lede/0049-ar71xx-add-support-for-GL.iNet-GL-AR750.patch
@@ -1,0 +1,364 @@
+From: Piotr Dymacz <pepe2k@gmail.com>
+Date: Tue, 17 Oct 2017 23:30:01 +0200
+Subject: ar71xx: add support for GL.iNet GL-AR750
+
+GL.iNet GL-AR750 is a small size, dual-band (AC750) router, based on
+Qualcomm/Atheros QCA9531 v2 + QCA9887. FCC ID: 2AFIW-AR750.
+
+Specification:
+
+- 650/597/216 MHz (CPU/DDR/AHB)
+- 128 MB of RAM (DDR2)
+- 16 MB of FLASH (SPI NOR)
+- 3x 10/100 Mbps Ethernet
+- 2T2R 2.4 GHz (QCA9531)
+- 1T1R 5 GHz (QCA9887)
+- 1x USB 2.0 (power controlled by GPIO)
+- 1x microSD (GL857L)
+- 3x LED (all driven by GPIO)
+- 1x button (reset)
+- 1x 2-pos switch
+- header for optional PoE module
+- 1x micro USB for main power input
+- UART + I2C header on PCB
+
+Flash instruction:
+
+Vendor firmware is based on OpenWrt/LEDE. GUI or sysupgrade can be used
+to flash OpenWrt/LEDE firmware.
+
+Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 49f27e9db40888ba8691014f2e70075114856978..54c4f009c2d722301cba7e8a3282c2102f4e5ad7 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -294,6 +294,10 @@ dlan-pro-1200-ac)
+ gl-ar300m)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:red:wlan" "phy0tpt"
+ 	;;
++gl-ar750)
++	ucidef_set_led_wlan "wlan2g" "WLAN2G" "$board:white:wlan2g" "phy1tpt"
++	ucidef_set_led_wlan "wlan5g" "WLAN5G" "$board:white:wlan5g" "phy0tpt"
++	;;
+ gl-mifi)
+ 	ucidef_set_led_wlan "wlan" "WLAN" "$board:green:wlan" "phy0tpt"
+ 	ucidef_set_led_netdev "wan" "WAN" "$board:green:wan" "eth0"
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index 454abe6a5005621967dd96e0282e7bce2a0b127e..e29c7049a02a2890ac4bbcfb3fa39110ae47cdf4 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -355,6 +355,7 @@ ar71xx_setup_interfaces()
+ 	onion-omega)
+ 		ucidef_set_interface_lan "wlan0"
+ 		;;
++	gl-ar750|\
+ 	rb-435g)
+ 		ucidef_set_interfaces_lan_wan "eth1" "eth0"
+ 		ucidef_add_switch "switch0" \
+diff --git a/target/linux/ar71xx/base-files/etc/diag.sh b/target/linux/ar71xx/base-files/etc/diag.sh
+index 01dc7753ebce7079b789572393db7d4a87e4b98e..a7c87096dc9836298bde2bc8b812c58f947f3c85 100644
+--- a/target/linux/ar71xx/base-files/etc/diag.sh
++++ b/target/linux/ar71xx/base-files/etc/diag.sh
+@@ -245,6 +245,7 @@ get_status_led() {
+ 	nbg460n_550n_550nh)
+ 		status_led="nbg460n:green:power"
+ 		;;
++	gl-ar750|\
+ 	nbg6716)
+ 		status_led="$board:white:power"
+ 		;;
+@@ -482,7 +483,8 @@ set_state() {
+ 	done)
+ 		status_led_on
+ 		case $(ar71xx_board_name) in
+-		gl-ar300m)
++		gl-ar300m|\
++		gl-ar750)
+ 			fw_printenv lc >/dev/null 2>&1 && fw_setenv "bootcount" 0
+ 			;;
+ 		qihoo-c301)
+diff --git a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 68f90de802ddd18e09a1da39c0d56292eea9489c..88d0a9dfddb0a0073db98838bdfc9fcc29883439 100644
+--- a/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ar71xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -97,6 +97,7 @@ case "$FIRMWARE" in
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth1/address) -2)
+ 		;;
++	gl-ar750|\
+ 	tl-wpa8630)
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 6282420da534542b26e375d4db7c4a9f4b515a1e..6145b73d066a6fe909dca66f034b1dc23dd29379 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -656,6 +656,9 @@ ar71xx_board_detect() {
+ 	*"GL-AR300M")
+ 		name="gl-ar300m"
+ 		;;
++	*"GL-AR750")
++		name="gl-ar750"
++		;;
+ 	*"GL-MIFI")
+ 		name="gl-mifi"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx b/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
+index d677599d8c6380d9920e95abc9fb4b92cc0cec29..ba6e08b00d979bc73f7199756e22ca3941fad97d 100644
+--- a/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
++++ b/target/linux/ar71xx/base-files/lib/preinit/05_set_preinit_iface_ar71xx
+@@ -17,6 +17,7 @@ set_preinit_iface() {
+ 	archer-c7 |\
+ 	bhr-4grv2 |\
+ 	dir-505-a1 |\
++	gl-ar750|\
+ 	gl-inet |\
+ 	jwap003 |\
+ 	pb42 |\
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index 774e3c8964ef724d1efbae56434aeaa9f1c298a4..9d31efd8724ee52d6871438a1ca7fd2e35fa8b78 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -249,6 +249,7 @@ platform_check_image() {
+ 	gl-ar150|\
+ 	gl-ar300m|\
+ 	gl-ar300|\
++	gl-ar750|\
+ 	gl-domino|\
+ 	gl-mifi|\
+ 	hiwifi-hc6361|\
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index 57b6d2e541d7ef9dea8570ba8de72164d97b9775..9f3e9c4438d0df318d89d1057e98695e5c3ee048 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -106,6 +106,7 @@ CONFIG_ATH79_MACH_F9K1115V2=y
+ CONFIG_ATH79_MACH_GL_AR150=y
+ CONFIG_ATH79_MACH_GL_AR300=y
+ CONFIG_ATH79_MACH_GL_AR300M=y
++CONFIG_ATH79_MACH_GL_AR750=y
+ CONFIG_ATH79_MACH_GL_DOMINO=y
+ CONFIG_ATH79_MACH_GL_INET=y
+ CONFIG_ATH79_MACH_GL_MIFI=y
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+index 7ad5419f51ec9909d8b59f33178221a7d81ec184..6d5e24ce54cb7ea1c01116a99ef10bed23bddd70 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Kconfig.openwrt
+@@ -691,6 +691,17 @@ config ATH79_MACH_GL_AR300M
+ 	select ATH79_DEV_USB
+ 	select ATH79_DEV_WMAC
+ 
++config ATH79_MACH_GL_AR750
++	bool "GL.iNet GL-AR750 support"
++	select SOC_QCA953X
++	select ATH79_DEV_AP9X_PCI if PCI
++	select ATH79_DEV_ETH
++	select ATH79_DEV_GPIO_BUTTONS
++	select ATH79_DEV_LEDS_GPIO
++	select ATH79_DEV_M25P80
++	select ATH79_DEV_USB
++	select ATH79_DEV_WMAC
++
+ config ATH79_MACH_GL_DOMINO
+ 	bool "DOMINO support"
+ 	select SOC_AR933X
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/Makefile b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+index 3365a43ce16fc77b3212b39b92081efe678e8803..d092b937f6a2e2548c578ea49b00c26a33c02adf 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/Makefile
++++ b/target/linux/ar71xx/files/arch/mips/ath79/Makefile
+@@ -110,6 +110,7 @@ obj-$(CONFIG_ATH79_MACH_F9K1115V2)		+= mach-f9k1115v2.o
+ obj-$(CONFIG_ATH79_MACH_GL_AR150)		+= mach-gl-ar150.o
+ obj-$(CONFIG_ATH79_MACH_GL_AR300)		+= mach-gl-ar300.o
+ obj-$(CONFIG_ATH79_MACH_GL_AR300M)		+= mach-gl-ar300m.o
++obj-$(CONFIG_ATH79_MACH_GL_AR750)		+= mach-gl-ar750.o
+ obj-$(CONFIG_ATH79_MACH_GL_DOMINO)		+= mach-gl-domino.o
+ obj-$(CONFIG_ATH79_MACH_GL_INET)		+= mach-gl-inet.o
+ obj-$(CONFIG_ATH79_MACH_GL_MIFI)		+= mach-gl-mifi.o
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar750.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar750.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..9ee6e29c02139b972a83a555fcd693765bf8194f
+--- /dev/null
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-gl-ar750.c
+@@ -0,0 +1,146 @@
++/*
++ * GL.iNet GL-AR750 board support
++ *
++ * Copyright (C) 2018 Piotr Dymacz <pepe2k@gmail.com>
++ *
++ * This program is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 as published
++ * by the Free Software Foundation.
++ */
++
++#include <linux/gpio.h>
++#include <linux/i2c.h>
++#include <linux/i2c-gpio.h>
++#include <linux/platform_device.h>
++
++#include <asm/mach-ath79/ath79.h>
++#include <asm/mach-ath79/ar71xx_regs.h>
++
++#include "common.h"
++#include "dev-ap9x-pci.h"
++#include "dev-eth.h"
++#include "dev-gpio-buttons.h"
++#include "dev-leds-gpio.h"
++#include "dev-m25p80.h"
++#include "dev-usb.h"
++#include "dev-wmac.h"
++#include "machtypes.h"
++
++#define GL_AR750_GPIO_LED_POWER		12
++#define GL_AR750_GPIO_LED_WLAN2G	14
++#define GL_AR750_GPIO_LED_WLAN5G	13
++
++#define GL_AR750_GPIO_BTN_RESET		3
++#define GL_AR750_GPIO_BTN_SW1		0
++
++#define GL_AR750_GPIO_I2C_SCL		16
++#define GL_AR750_GPIO_I2C_SDA		17
++
++#define GL_AR750_GPIO_USB_POWER		2
++
++#define GL_AR750_KEYS_POLL_INTERVAL	20
++#define GL_AR750_KEYS_DEBOUNCE_INTERVAL	(3 * GL_AR750_KEYS_POLL_INTERVAL)
++
++#define GL_AR750_MAC0_OFFSET		0
++#define GL_AR750_WMAC2G_CALDATA_OFFSET	0x1000
++#define GL_AR750_WMAC5G_CALDATA_OFFSET	0x5000
++
++static struct gpio_led gl_ar750_leds_gpio[] __initdata = {
++	{
++		.name		= "gl-ar750:white:power",
++		.gpio		= GL_AR750_GPIO_LED_POWER,
++		.default_state	= LEDS_GPIO_DEFSTATE_KEEP,
++		.active_low	= 1,
++	}, {
++		.name		= "gl-ar750:white:wlan2g",
++		.gpio		= GL_AR750_GPIO_LED_WLAN2G,
++		.active_low	= 1,
++	}, {
++		.name		= "gl-ar750:white:wlan5g",
++		.gpio		= GL_AR750_GPIO_LED_WLAN5G,
++		.active_low	= 1,
++	},
++};
++
++static struct gpio_keys_button gl_ar750_gpio_keys[] __initdata = {
++	{
++		.desc			= "reset",
++		.type			= EV_KEY,
++		.code			= KEY_RESTART,
++		.debounce_interval	= GL_AR750_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= GL_AR750_GPIO_BTN_RESET,
++		.active_low		= 1,
++	}, {
++		.desc			= "sw1",
++		.type			= EV_KEY,
++		.code			= BTN_0,
++		.debounce_interval	= GL_AR750_KEYS_DEBOUNCE_INTERVAL,
++		.gpio			= GL_AR750_GPIO_BTN_SW1,
++		.active_low		= 1,
++	},
++};
++
++static struct i2c_gpio_platform_data gl_ar750_i2c_gpio_data = {
++	.sda_pin = GL_AR750_GPIO_I2C_SDA,
++	.scl_pin = GL_AR750_GPIO_I2C_SCL,
++};
++
++static struct platform_device gl_ar750_i2c_gpio = {
++	.name	= "i2c-gpio",
++	.id	= 0,
++	.dev	= {
++		.platform_data = &gl_ar750_i2c_gpio_data,
++	},
++};
++
++static void __init gl_ar750_setup(void)
++{
++	u8 *art = (u8 *) KSEG1ADDR(0x1f050000);
++
++	ath79_register_m25p80(NULL);
++
++	ath79_setup_ar933x_phy4_switch(false, false);
++	ath79_register_mdio(0, 0x0);
++
++	ath79_switch_data.phy4_mii_en = 1;
++	ath79_switch_data.phy_poll_mask = 0xfc;
++
++	/* WAN */
++	ath79_eth0_data.duplex = DUPLEX_FULL;
++	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_MII;
++	ath79_eth0_data.phy_mask = BIT(4);
++	ath79_eth0_data.speed = SPEED_100;
++	ath79_init_mac(ath79_eth0_data.mac_addr, art + GL_AR750_MAC0_OFFSET, 0);
++	ath79_register_eth(0);
++
++	/* LAN */
++	ath79_eth1_data.duplex = DUPLEX_FULL;
++	ath79_eth1_data.phy_if_mode = PHY_INTERFACE_MODE_GMII;
++	ath79_init_mac(ath79_eth1_data.mac_addr, art + GL_AR750_MAC0_OFFSET, 1);
++	ath79_register_eth(1);
++
++	/* Disable JTAG (enables GPIO0-3) */
++	ath79_gpio_function_enable(AR934X_GPIO_FUNC_JTAG_DISABLE);
++
++	ath79_register_leds_gpio(-1, ARRAY_SIZE(gl_ar750_leds_gpio),
++				 gl_ar750_leds_gpio);
++
++	ath79_register_gpio_keys_polled(-1, GL_AR750_KEYS_POLL_INTERVAL,
++					ARRAY_SIZE(gl_ar750_gpio_keys),
++					gl_ar750_gpio_keys);
++
++	gpio_request_one(GL_AR750_GPIO_USB_POWER,
++			 GPIOF_OUT_INIT_HIGH | GPIOF_EXPORT_DIR_FIXED,
++			 "USB power");
++
++	platform_device_register(&gl_ar750_i2c_gpio);
++
++	ath79_register_usb();
++
++	ath79_register_wmac(art + GL_AR750_WMAC2G_CALDATA_OFFSET, NULL);
++
++	ap91_pci_init(art + GL_AR750_WMAC5G_CALDATA_OFFSET, NULL);
++}
++
++MIPS_MACHINE(ATH79_MACH_GL_AR750, "GL-AR750", "GL.iNet GL-AR750",
++	     gl_ar750_setup);
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 9cb4a7f2e1df641232289721b676a9b0149c76e5..af4f5784f041fb1ca4f885b075a9d1e2ec4ee9a2 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -101,6 +101,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_GL_AR150,			/* GL-AR150 support */
+ 	ATH79_MACH_GL_AR300,			/* GL-AR300 */
+ 	ATH79_MACH_GL_AR300M,			/* GL-AR300M */
++	ATH79_MACH_GL_AR750,			/* GL.iNet GL-AR750 */
+ 	ATH79_MACH_GL_DOMINO,			/* Domino */
+ 	ATH79_MACH_GL_INET,			/* GL-CONNECT GL-INET */
+ 	ATH79_MACH_GL_MIFI,			/* GL-MIFI support */
+diff --git a/target/linux/ar71xx/image/generic.mk b/target/linux/ar71xx/image/generic.mk
+index e11a8992f9c2f950079fddf121eb30c34926e33d..1db27321053d607544c2141ac85f426ade7789dd 100644
+--- a/target/linux/ar71xx/image/generic.mk
++++ b/target/linux/ar71xx/image/generic.mk
+@@ -161,6 +161,19 @@ define Device/gl-ar300m
+ endef
+ TARGET_DEVICES += gl-ar300m
+ 
++define Device/gl-ar750
++  DEVICE_TITLE := GL.iNet GL-AR750
++  DEVICE_PACKAGES := kmod-ath10k ath10k-firmware-qca9887 kmod-usb-core \
++	kmod-usb2 kmod-usb-storage
++  BOARDNAME := GL-AR750
++  SUPPORTED_DEVICES := gl-ar750
++  IMAGE_SIZE := 16000k
++  MTDPARTS := spi0.0:256k(u-boot)ro,64k(u-boot-env),64k(art)ro,-(firmware)
++  IMAGE/sysupgrade.bin := append-kernel | pad-to $$$$(BLOCKSIZE) | \
++	append-rootfs | pad-rootfs | append-metadata | check-size $$$$(IMAGE_SIZE)
++endef
++TARGET_DEVICES += gl-ar750
++
+ define Device/gl-domino
+   DEVICE_TITLE := GL Domino Pi
+   DEVICE_PACKAGES := kmod-usb-core kmod-usb2

--- a/patches/lede/0050-uboot-envtools-add-support-for-GL.iNet-GL-AR750.patch
+++ b/patches/lede/0050-uboot-envtools-add-support-for-GL.iNet-GL-AR750.patch
@@ -1,0 +1,18 @@
+From: Piotr Dymacz <pepe2k@gmail.com>
+Date: Tue, 17 Oct 2017 23:32:11 +0200
+Subject: uboot-envtools: add support for GL.iNet GL-AR750
+
+Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+
+diff --git a/package/boot/uboot-envtools/files/ar71xx b/package/boot/uboot-envtools/files/ar71xx
+index 25bec7eb33fd691bae417512c4c03e133d93213d..26f1ff938b8191e84315cf308f78e0907264c671 100644
+--- a/package/boot/uboot-envtools/files/ar71xx
++++ b/package/boot/uboot-envtools/files/ar71xx
+@@ -29,6 +29,7 @@ cr3000|\
+ cr5000|\
+ eap300v2|\
+ gl-ar300m|\
++gl-ar750|\
+ hornet-ub|\
+ hornet-ub-x2|\
+ jwap230|\

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -65,6 +65,12 @@ factory
 device gl-ar300m gl-ar300m
 factory
 
+if [ "$ATH10K_PACKAGES" ]; then
+device gl-ar750 gl-ar750
+packages $ATH10K_PACKAGES
+factory
+fi
+
 
 # Linksys by Cisco
 


### PR DESCRIPTION
This PR backports hw support for GL.iNet GL-AR750 to v2017.1.x.

This PR got already tested by @Commifreak as can be seen in ticket #1378. The master backport still awaits his testing.