### PR TITLE
ar71xx: add model detection for UBNT AC-Mesh

### DIFF
--- a/patches/lede/0089-ar71xx-add-model-detection-for-UBNT-AC-Mesh.patch
+++ b/patches/lede/0089-ar71xx-add-model-detection-for-UBNT-AC-Mesh.patch
@@ -1,0 +1,54 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sun, 25 Feb 2018 12:09:38 +0100
+Subject: ar71xx: add model detection for UBNT AC-Mesh
+
+This commit adds correct model detection for UniFi
+AC-Mesh. Previously said device was incorrectly detected
+as UniFi AC-Lite.
+
+The Information about the device is stored at 0xC in the EEPROM
+partition. It corresponds to the sysid in /etc/board.info of the
+Ubiquiti stock firmware.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 35b742a5f1fee0bc24ab2d88e32f118c1df4e2b3..59c1899a588007d6a6a1860fcf95064b0ec35561 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -98,6 +98,27 @@ ubnt_xm_board_detect() {
+ 	[ -z "$model" ] || AR71XX_MODEL="${model}${magic:3:1}"
+ }
+ 
++ubnt_ac_lite_get_mtd_part_magic() {
++	ar71xx_get_mtd_offset_size_format EEPROM 12 2 %02x
++}
++
++ubnt_ac_lite_board_detect() {
++	local model
++	local magic
++
++	magic="$(ubnt_ac_lite_get_mtd_part_magic)"
++	case ${magic:0:4} in
++	"e517")
++		model="Ubiquiti UniFi-AC-LITE"
++		;;
++	"e557")
++		model="Ubiquiti UniFi-AC-MESH"
++		;;
++	esac
++
++	[ -z "$model" ] || AR71XX_MODEL="${model}"
++}
++
+ cybertan_get_hw_magic() {
+ 	local part
+ 
+@@ -1129,6 +1150,7 @@ ar71xx_board_detect() {
+ 		;;
+ 	*"UniFi-AC-LITE")
+ 		name="unifiac-lite"
++		ubnt_ac_lite_board_detect
+ 		;;
+ 	*"UniFi-AC-PRO")
+ 		name="unifiac-pro"


### PR DESCRIPTION
This PR adds board detection for Ubiquiti AC Mesh devices.
This patch got applied to v2017.1.x already and I forgot to submit it to master as well.