### PR TITLE
gluon-status-page: show site_code & role in node details

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -116,6 +116,8 @@
 								string.format(' (%s)', nodeinfo.software.autoupdater.branch)
 						%></dd>
 					<%- end %>
+					<dt><%:Role%></dt><dd><%| nodeinfo.system.role %></dd>
+					<dt><%:Site%></dt><dd><%| nodeinfo.system.site_code %></dd>
 				</dl>
 			</div>
 			<div class="frame">

--- a/package/gluon-status-page/i18n/de.po
+++ b/package/gluon-status-page/i18n/de.po
@@ -91,8 +91,14 @@ msgstr "RAM"
 msgid "Received"
 msgstr "Empfangen"
 
+msgid "Role"
+msgstr "Rolle"
+
 msgid "Status"
 msgstr "Status"
+
+msgid "Site"
+msgstr ""
 
 msgid "Traffic"
 msgstr ""

--- a/package/gluon-status-page/i18n/gluon-status-page.pot
+++ b/package/gluon-status-page/i18n/gluon-status-page.pot
@@ -82,7 +82,13 @@ msgstr ""
 msgid "Received"
 msgstr ""
 
+msgid "Role"
+msgstr ""
+
 msgid "Status"
+msgstr ""
+
+msgid "Site"
 msgstr ""
 
 msgid "Traffic"


### PR DESCRIPTION
As suggested by @ambassador86 on irc, this PR adds _site_code_ and _node role_ information to status page.