### PR TITLE
ar71xx: add support for Alfa AP121F

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -112,6 +112,7 @@ ar71xx-generic
 * ALFA Network
 
   - AP121
+  - AP121F
   - AP121U
   - Hornet-UB
   - Tube2H

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -16,6 +16,9 @@ factory
 
 # ALFA NETWORK
 
+device alfa-network-ap121f ap121f ap121f
+factory
+
 device alfa-network-hornet-ub hornet-ub HORNETUB
 alias alfa-network-ap121
 alias alfa-network-ap121u


### PR DESCRIPTION
Adds support for Alfa AP121F USB powered travel router (looks like an USB ethernet adapter).
It has 16 MB flash and 64 MB memory and low power consumption. There is only a sysupgrade file for it. The description of the flashing procedure is in the commit message.
Everything seems to work and the primary MAC is correct, but maximum TX power is 17 dBm and wireless has 1x1 chains (max. 150 MBit/s).
The case be opened easily to access the UART interface.