### PR TITLE
ar71xx: generic: enable CONFIG_MTD_SPLIT_TPLINK_FW

### DIFF
--- a/patches/lede/0090-ar71xx-generic-enable-CONFIG_MTD_SPLIT_TPLINK_FW.patch
+++ b/patches/lede/0090-ar71xx-generic-enable-CONFIG_MTD_SPLIT_TPLINK_FW.patch
@@ -1,0 +1,46 @@
+From: Piotr Dymacz <pepe2k@gmail.com>
+Date: Mon, 3 Jul 2017 18:57:36 +0200
+Subject: ar71xx: generic: enable CONFIG_MTD_SPLIT_TPLINK_FW
+
+We can use "tplink-fw" mtd splitter for TP-Link devices which use kernel
+with TP-Link header embedded inside "safeloader" image type and thus get
+rid of statically defined "kernel" and "rootfs" partitions in cmdline.
+
+Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+
+diff --git a/target/linux/ar71xx/config-4.4 b/target/linux/ar71xx/config-4.4
+index d96642b97c36187febb1f3843e7dd9acfab0e40d..6c29cd7748b3ce7e53adf359cd5002ba01066fbd 100644
+--- a/target/linux/ar71xx/config-4.4
++++ b/target/linux/ar71xx/config-4.4
+@@ -379,6 +379,7 @@ CONFIG_MTD_SPLIT_EVA_FW=y
+ CONFIG_MTD_SPLIT_FIRMWARE=y
+ CONFIG_MTD_SPLIT_LZMA_FW=y
+ CONFIG_MTD_SPLIT_SEAMA_FW=y
++CONFIG_MTD_SPLIT_TPLINK_FW=y
+ CONFIG_MTD_SPLIT_UIMAGE_FW=y
+ CONFIG_MTD_SPLIT_WRGG_FW=y
+ CONFIG_MTD_TPLINK_PARTS=y
+diff --git a/target/linux/ar71xx/mikrotik/config-default b/target/linux/ar71xx/mikrotik/config-default
+index e0401102229c00985e8000331dce43375903e1aa..f5d48ae0f674883371f8d549594f695913c3d216 100644
+--- a/target/linux/ar71xx/mikrotik/config-default
++++ b/target/linux/ar71xx/mikrotik/config-default
+@@ -219,6 +219,7 @@ CONFIG_MTD_NAND_RB4XX=y
+ CONFIG_MTD_NAND_RB750=y
+ CONFIG_MTD_NAND_RB91X=y
+ # CONFIG_MTD_SPLIT_EVA_FW is not set
++# CONFIG_MTD_SPLIT_TPLINK_FW is not set
+ # CONFIG_MTD_REDBOOT_PARTS is not set
+ # CONFIG_MTD_TPLINK_PARTS is not set
+ CONFIG_MTD_UBI=y
+diff --git a/target/linux/ar71xx/nand/config-default b/target/linux/ar71xx/nand/config-default
+index 790fa8f9bd42aba8521b960c2a49a742285e6157..0eee52d3ee69990fadf77de9f03f03c9c9b59190 100644
+--- a/target/linux/ar71xx/nand/config-default
++++ b/target/linux/ar71xx/nand/config-default
+@@ -107,6 +107,7 @@ CONFIG_MTD_NAND_ECC_BCH=y
+ # CONFIG_MTD_SM_COMMON is not set
+ # CONFIG_MTD_SPLIT_EVA_FW is not set
+ # CONFIG_MTD_SPLIT_SEAMA_FW is not set
++# CONFIG_MTD_SPLIT_TPLINK_FW is not set
+ # CONFIG_MTD_TPLINK_PARTS is not set
+ CONFIG_MTD_UBI=y
+ CONFIG_MTD_UBI_BEB_LIMIT=20


### PR DESCRIPTION
This patch enables "mtd split tplink fw" in kernel config.
If this patch is not applied devices like TP-Link RE450 will get stuck in a bootloop because the kernel cant find its root partition. This is caused by the backport in commit d139a13563efdf274f918115b345678962e3455d as it depends on this kernel feature.

I got this error while backporting the code for RE355, which is almost a clone of the RE450. Without this patch i got stuck in a bootloop requiring a serial connection to recover it. With the patch everything works as expected.