### PR TITLE
batman-adv: Fix best gw refcnt after netlink dump

### DIFF
--- a/patches/packages/routing/0002-batman-adv-Fix-best-gw-refcnt-after-netlink-dump.patch
+++ b/patches/packages/routing/0002-batman-adv-Fix-best-gw-refcnt-after-netlink-dump.patch
@@ -1,0 +1,115 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Sat, 2 Jun 2018 16:25:16 +0200
+Subject: batman-adv: Fix best gw refcnt after netlink dump
+
+A reference to the best gateway is taken when the list of gateways in the
+mesh is sent via netlink. This is necessary to check whether the currently
+dumped entry is the currently selected gateway or not. This information is
+then transferred as flag BATADV_ATTR_FLAG_BEST.
+
+After the comparison of the current entry is done,
+batadv_*_gw_dump_entry() has to decrease the reference counter again.
+Otherwise the reference will be held and thus prevents a proper shutdown of
+the batman-adv interfaces (and some of the interfaces enslaved in it).
+
+Fixes: 215d6b834fd1 ("batman-adv: upgrade package to latest release 2016.4")
+Reported-by: Andreas Ziegler <dev@andreas-ziegler.de>
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+diff --git a/batman-adv/patches/0002-batman-adv-Fix-bat_ogm_iv-best-gw-refcnt-after-netli.patch b/batman-adv/patches/0002-batman-adv-Fix-bat_ogm_iv-best-gw-refcnt-after-netli.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..86fbb0672c52e0158ab6a762591f12d2fc377ba5
+--- /dev/null
++++ b/batman-adv/patches/0002-batman-adv-Fix-bat_ogm_iv-best-gw-refcnt-after-netli.patch
+@@ -0,0 +1,43 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Sat, 2 Jun 2018 16:08:22 +0200
++Subject: [PATCH] batman-adv: Fix bat_ogm_iv best gw refcnt after netlink dump
++
++A reference to the best gateway is taken when the list of gateways in the
++mesh is sent via netlink. This is necessary to check whether the currently
++dumped entry is the currently selected gateway or not. This information is
++then transferred as flag BATADV_ATTR_FLAG_BEST.
++
++After the comparison of the current entry is done,
++batadv_iv_gw_dump_entry() has to decrease the reference counter again.
++Otherwise the reference will be held and thus prevents a proper shutdown of
++the batman-adv interfaces (and some of the interfaces enslaved in it).
++
++Fixes: fa3228924152 ("batman-adv: add B.A.T.M.A.N. IV bat_gw_dump implementations")
++Reported-by: Andreas Ziegler <dev@andreas-ziegler.de>
++Signed-off-by: Sven Eckelmann <sven@narfation.org>
++---
++ net/batman-adv/bat_iv_ogm.c | 4 +++-
++ 1 file changed, 3 insertions(+), 1 deletion(-)
++
++diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
++index be09a98838252f4f0c23cec0625930cf896cd0ff..73bf6a93a3cf1141a34657bf1284893199e04db9 100644
++--- a/net/batman-adv/bat_iv_ogm.c
+++++ b/net/batman-adv/bat_iv_ogm.c
++@@ -2732,7 +2732,7 @@ static int batadv_iv_gw_dump_entry(struct sk_buff *msg, u32 portid, u32 seq,
++ {
++ 	struct batadv_neigh_ifinfo *router_ifinfo = NULL;
++ 	struct batadv_neigh_node *router;
++-	struct batadv_gw_node *curr_gw;
+++	struct batadv_gw_node *curr_gw = NULL;
++ 	int ret = 0;
++ 	void *hdr;
++ 
++@@ -2780,6 +2780,8 @@ static int batadv_iv_gw_dump_entry(struct sk_buff *msg, u32 portid, u32 seq,
++ 	ret = 0;
++ 
++ out:
+++	if (curr_gw)
+++		batadv_gw_node_put(curr_gw);
++ 	if (router_ifinfo)
++ 		batadv_neigh_ifinfo_put(router_ifinfo);
++ 	if (router)
+diff --git a/batman-adv/patches/0003-batman-adv-Fix-bat_v-best-gw-refcnt-after-netlink-du.patch b/batman-adv/patches/0003-batman-adv-Fix-bat_v-best-gw-refcnt-after-netlink-du.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..f859d04affd07abd8abf2691cd1018b2725eb984
+--- /dev/null
++++ b/batman-adv/patches/0003-batman-adv-Fix-bat_v-best-gw-refcnt-after-netlink-du.patch
+@@ -0,0 +1,42 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Sat, 2 Jun 2018 16:08:22 +0200
++Subject: [PATCH] batman-adv: Fix bat_v best gw refcnt after netlink dump
++
++A reference to the best gateway is taken when the list of gateways in the
++mesh is sent via netlink. This is necessary to check whether the currently
++dumped entry is the currently selected gateway or not. This information is
++then transferred as flag BATADV_ATTR_FLAG_BEST.
++
++After the comparison of the current entry is done,
++batadv_v_gw_dump_entry() has to decrease the reference counter again.
++Otherwise the reference will be held and thus prevents a proper shutdown of
++the batman-adv interfaces (and some of the interfaces enslaved in it).
++
++Fixes: 15315a94ad98 ("batman-adv: add B.A.T.M.A.N. V bat_gw_dump implementations")
++Signed-off-by: Sven Eckelmann <sven@narfation.org>
++---
++ net/batman-adv/bat_v.c | 4 +++-
++ 1 file changed, 3 insertions(+), 1 deletion(-)
++
++diff --git a/net/batman-adv/bat_v.c b/net/batman-adv/bat_v.c
++index ec93337ee2597738e46b87dd72724d5becf3f48e..6baec4e68898c6e992e7522d2ee8c78ce62a1b08 100644
++--- a/net/batman-adv/bat_v.c
+++++ b/net/batman-adv/bat_v.c
++@@ -927,7 +927,7 @@ static int batadv_v_gw_dump_entry(struct sk_buff *msg, u32 portid, u32 seq,
++ {
++ 	struct batadv_neigh_ifinfo *router_ifinfo = NULL;
++ 	struct batadv_neigh_node *router;
++-	struct batadv_gw_node *curr_gw;
+++	struct batadv_gw_node *curr_gw = NULL;
++ 	int ret = 0;
++ 	void *hdr;
++ 
++@@ -995,6 +995,8 @@ static int batadv_v_gw_dump_entry(struct sk_buff *msg, u32 portid, u32 seq,
++ 	ret = 0;
++ 
++ out:
+++	if (curr_gw)
+++		batadv_gw_node_put(curr_gw);
++ 	if (router_ifinfo)
++ 		batadv_neigh_ifinfo_put(router_ifinfo);
++ 	if (router)


### PR DESCRIPTION
This fixes a problem similar to the one described in #1258.

This patch will not apply on 2017.1.x. An adjusted version can be found in https://github.com/FreifunkVogtland/gluon/tree/batadv/gw_refcnt_fix-2017.1.x

----

A reference for the best gateway is taken when the list of gateways in the mesh is sent via netlink. This is necessary to check whether the currently dumped entry is the currently selected gateway or not. This information is then transferred as flag BATADV_ATTR_FLAG_BEST.

After the comparison of the current entry is done, batadv_*_gw_dump_entry() has to decrease the reference counter again. Otherwise the reference will be held and thus prevents a proper shutdown of
the batman-adv interfaces (and some of the interfaces enslaved in it).