### PR TITLE
RFC: gluon-mesh-batman-adv: unconditionally rate limit ARP

### DIFF
--- a/package/gluon-ebtables-limit-arp/Makefile
+++ b/package/gluon-ebtables-limit-arp/Makefile
@@ -8,7 +8,7 @@ include ../gluon.mk
 
 define Package/gluon-ebtables-limit-arp
   TITLE:=Ebtables limiter for ARP packets
-  DEPENDS:=+gluon-core +gluon-ebtables gluon-mesh-batman-adv \
+  DEPENDS:=+gluon-core +gluon-ebtables \
 	+@GLUON_SPECIALIZE_KERNEL:KERNEL_BRIDGE_EBT_LIMIT \
 	+@GLUON_SPECIALIZE_KERNEL:KERNEL_BRIDGE_EBT_MARK \
 	+@GLUON_SPECIALIZE_KERNEL:KERNEL_BRIDGE_EBT_MARK_T

--- a/package/gluon-mesh-batman-adv/Makefile
+++ b/package/gluon-mesh-batman-adv/Makefile
@@ -7,7 +7,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-batman-adv/common
   PROVIDES:=gluon-mesh-batman-adv
-  DEPENDS:=+gluon-core +libgluonutil +gluon-client-bridge +gluon-ebtables +firewall +libiwinfo +kmod-dummy +libnl-tiny +libbatadv +@GLUON_SPECIALIZE_KERNEL:KERNEL_DUMMY +@GLUON_SPECIALIZE_KERNEL:KERNEL_CRC16 +@GLUON_SPECIALIZE_KERNEL:KERNEL_LIBCRC32C
+  DEPENDS:=+gluon-core +libgluonutil +gluon-client-bridge +gluon-ebtables +gluon-ebtables-limit-arp +firewall +libiwinfo +kmod-dummy +libnl-tiny +libbatadv +@GLUON_SPECIALIZE_KERNEL:KERNEL_DUMMY +@GLUON_SPECIALIZE_KERNEL:KERNEL_CRC16 +@GLUON_SPECIALIZE_KERNEL:KERNEL_LIBCRC32C
 endef
 
 define Package/gluon-mesh-batman-adv-14


### PR DESCRIPTION
With a reasoning similar to "gluon-ebtables: unconditionally segment
IGMP/MLD" also make the ARP rate limiting mandatory.

It turned out to be very common that there is a client device with
an application scanning the IP subnet, causing congestion and high
load for any community which did not add the gluon-ebtables-limit-arp
package yet.

Therefore just always add gluon-ebtables-limit-arp via a dependency.

Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>