### PR TITLE
v2017.1.x: mac80211: initialize sinfo in cfg80211_get_station

### DIFF
--- a/patches/lede/0051-mac80211-initialize-sinfo-in-cfg80211_get_station.patch
+++ b/patches/lede/0051-mac80211-initialize-sinfo-in-cfg80211_get_station.patch
@@ -1,0 +1,71 @@
+From: Sven Eckelmann <sven.eckelmann@openmesh.com>
+Date: Wed, 6 Jun 2018 11:21:53 +0200
+Subject: mac80211: initialize sinfo in cfg80211_get_station
+
+Most of the implementations behind cfg80211_get_station will not initialize
+sinfo to zero before manipulating it. For example, the member "filled",
+which indicates the filled in parts of this struct, is often only modified
+by enabling certain bits in the bitfield while keeping the remaining bits
+in their original state. A caller without a preinitialized sinfo.filled can
+then no longer decide which parts of sinfo were filled in by
+cfg80211_get_station (or actually the underlying implementations).
+
+cfg80211_get_station must therefore take care that sinfo is initialized to
+zero. Otherwise, the caller may tries to read information which was not
+filled in and which must therefore also be considered uninitialized. In
+batadv_v_elp_get_throughput's case, an invalid "random" expected throughput
+may be stored for this neighbor and thus the B.A.T.M.A.N V algorithm may
+switch to non-optimal neighbors for certain destinations.
+
+Signed-off-by: Sven Eckelmann <sven.eckelmann@openmesh.com>
+
+Forwarded: https://github.com/openwrt/openwrt/pull/1015
+
+diff --git a/package/kernel/mac80211/patches/379-cfg80211-initialize-sinfo-in-cfg80211_get_station.patch b/package/kernel/mac80211/patches/379-cfg80211-initialize-sinfo-in-cfg80211_get_station.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..37323c1f7defee830b3f876a46f255acf21fce42
+--- /dev/null
++++ b/package/kernel/mac80211/patches/379-cfg80211-initialize-sinfo-in-cfg80211_get_station.patch
+@@ -0,0 +1,42 @@
++From 4f717a2589be649afddbbd3ac58b67ebfa7426f7 Mon Sep 17 00:00:00 2001
++From: Sven Eckelmann <sven@narfation.org>
++Date: Wed, 6 Jun 2018 10:18:31 +0200
++Subject: [PATCH v2] cfg80211: initialize sinfo in cfg80211_get_station
++
++Most of the implementations behind cfg80211_get_station will not initialize
++sinfo to zero before manipulating it. For example, the member "filled",
++which indicates the filled in parts of this struct, is often only modified
++by enabling certain bits in the bitfield while keeping the remaining bits
++in their original state. A caller without a preinitialized sinfo.filled can
++then no longer decide which parts of sinfo were filled in by
++cfg80211_get_station (or actually the underlying implementations).
++
++cfg80211_get_station must therefore take care that sinfo is initialized to
++zero. Otherwise, the caller may tries to read information which was not
++filled in and which must therefore also be considered uninitialized. In
++batadv_v_elp_get_throughput's case, an invalid "random" expected throughput
++may be stored for this neighbor and thus the B.A.T.M.A.N V algorithm may
++switch to non-optimal neighbors for certain destinations.
++
++Fixes: 7406353d43c8 ("cfg80211: implement cfg80211_get_station cfg80211 API")
++Reported-by: Thomas Lauer <holminateur@gmail.com>
++Reported-by: Marcel Schmidt <ff.z-casparistrasse@mailbox.org>
++Cc: b.a.t.m.a.n@lists.open-mesh.org
++Signed-off-by: Sven Eckelmann <sven@narfation.org>
++
++Forwarded: https://patchwork.kernel.org/patch/10449857/
++---
++ net/wireless/util.c | 2 ++
++ 1 file changed, 2 insertions(+)
++
++--- a/net/wireless/util.c
+++++ b/net/wireless/util.c
++@@ -1749,6 +1749,8 @@ int cfg80211_get_station(struct net_devi
++ 	if (!rdev->ops->get_station)
++ 		return -EOPNOTSUPP;
++ 
+++	memset(sinfo, 0, sizeof(*sinfo));
+++
++ 	return rdev_get_station(rdev, dev, mac_addr, sinfo);
++ }
++ EXPORT_SYMBOL(cfg80211_get_station);


### PR DESCRIPTION
Most of the implementations behind cfg80211_get_station will not initialize sinfo to zero before manipulating it. For example, the member "filled", which indicates the filled in parts of this struct, is often only modified by enabling certain bits in the bitfield while keeping the remaining bits in their original state. A caller without a preinitialized sinfo.filled can then no longer decide which parts of sinfo were filled in by cfg80211_get_station (or actually the underlying implementations).

cfg80211_get_station must therefore take care that sinfo is initialized to zero. Otherwise, the caller may tries to read information which was not filled in and which must therefore also be considered uninitialized. In batadv_v_elp_get_throughput's case, an invalid "random" expected throughput may be stored for this neighbor and thus the B.A.T.M.A.N V algorithm may switch to non-optimal neighbors for certain destinations.

----

The patch was already forwarded to OpenWrt - https://github.com/openwrt/openwrt/pull/1015