### PR TITLE
v2017.1.x: batman-adv: add patches from 2018.1-maint 2018-06-12

### DIFF
--- a/patches/packages/routing/0006-batman-adv-add-patches-from-2018.1-maint-2018-06-12.patch
+++ b/patches/packages/routing/0006-batman-adv-add-patches-from-2018.1-maint-2018-06-12.patch
@@ -1,0 +1,106 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Tue, 12 Jun 2018 22:10:57 +0200
+Subject: batman-adv: add patches from 2018.1-maint 2018-06-12
+
+* Avoid storing non-TT-sync flags on singular entries too
+* Fix multicast TT issues with bogus ROAM flags
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Origin: backport, https://github.com/openwrt-routing/packages/commit/79f1094690f18b24b49023c966172ca8f49d27da
+
+diff --git a/batman-adv/patches/0027-batman-adv-Avoid-storing-non-TT-sync-flags-on-singul.patch b/batman-adv/patches/0027-batman-adv-Avoid-storing-non-TT-sync-flags-on-singul.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..ec6abed0db75b589976afb7472721f2bbb6d8f8c
+--- /dev/null
++++ b/batman-adv/patches/0027-batman-adv-Avoid-storing-non-TT-sync-flags-on-singul.patch
+@@ -0,0 +1,37 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Thu, 7 Jun 2018 00:46:23 +0200
++Subject: [PATCH] batman-adv: Avoid storing non-TT-sync flags on singular entries too
++
++Since commit 382d020fe3fa ("batman-adv: fix TT sync flag inconsistencies")
++TT sync flags and TT non-sync'd flags are supposed to be stored
++separately.
++
++The previous patch missed to apply this separation on a TT entry with
++only a single TT orig entry.
++
++This is a minor fix because with only a single TT orig entry the DDoS
++issue the former patch solves does not apply.
++
++Fixes: 382d020fe3fa ("batman-adv: fix TT sync flag inconsistencies")
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++Signed-off-by: Sven Eckelmann <sven@narfation.org>
++
++Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/beb6246b2339852b6a429ae9259a8eb30a685041
++---
++ net/batman-adv/translation-table.c | 3 ++-
++ 1 file changed, 2 insertions(+), 1 deletion(-)
++
++diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
++index dc6a8912e0b0521f1510c5fd6f2579a39201f370..41f5c85616c69213b9464b77efda8bd3d847c38d 100644
++--- a/net/batman-adv/translation-table.c
+++++ b/net/batman-adv/translation-table.c
++@@ -1695,7 +1695,8 @@ static bool batadv_tt_global_add(struct batadv_priv *bat_priv,
++ 		ether_addr_copy(common->addr, tt_addr);
++ 		common->vid = vid;
++ 
++-		common->flags = flags;
+++		common->flags = flags & (~BATADV_TT_SYNC_MASK);
+++
++ 		tt_global_entry->roam_at = 0;
++ 		/* node must store current time in case of roaming. This is
++ 		 * needed to purge this entry out on timeout (if nobody claims
+diff --git a/batman-adv/patches/0028-batman-adv-Fix-multicast-TT-issues-with-bogus-ROAM-f.patch b/batman-adv/patches/0028-batman-adv-Fix-multicast-TT-issues-with-bogus-ROAM-f.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..f542ded75b98ca050f6e67d79af4a713fba79018
+--- /dev/null
++++ b/batman-adv/patches/0028-batman-adv-Fix-multicast-TT-issues-with-bogus-ROAM-f.patch
+@@ -0,0 +1,46 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Thu, 7 Jun 2018 00:46:24 +0200
++Subject: [PATCH] batman-adv: Fix multicast TT issues with bogus ROAM flags
++
++When a (broken) node wrongly sends multicast TT entries with a ROAM
++flag then this causes any receiving node to drop all entries for the
++same multicast MAC address announced by other nodes, leading to
++packet loss.
++
++Fix this DoS vector by only storing TT sync flags. For multicast TT
++non-sync'ing flag bits like ROAM are unused so far anyway.
++
++Fixes: 405cc1e5a81e ("batman-adv: Modified forwarding behaviour for multicast packets")
++Reported-by: Leonardo Mörlein <me@irrelefant.net>
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++Signed-off-by: Sven Eckelmann <sven@narfation.org>
++
++Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/c7054ffae0c3b08bb4bef3cffee1e0a543e14096
++---
++ net/batman-adv/translation-table.c | 6 ++++--
++ 1 file changed, 4 insertions(+), 2 deletions(-)
++
++diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
++index 41f5c85616c69213b9464b77efda8bd3d847c38d..e28eca810f16b58ba6c03550f91f7b6686564812 100644
++--- a/net/batman-adv/translation-table.c
+++++ b/net/batman-adv/translation-table.c
++@@ -1695,7 +1695,8 @@ static bool batadv_tt_global_add(struct batadv_priv *bat_priv,
++ 		ether_addr_copy(common->addr, tt_addr);
++ 		common->vid = vid;
++ 
++-		common->flags = flags & (~BATADV_TT_SYNC_MASK);
+++		if (!is_multicast_ether_addr(common->addr))
+++			common->flags = flags & (~BATADV_TT_SYNC_MASK);
++ 
++ 		tt_global_entry->roam_at = 0;
++ 		/* node must store current time in case of roaming. This is
++@@ -1759,7 +1760,8 @@ static bool batadv_tt_global_add(struct batadv_priv *bat_priv,
++ 		 * TT_CLIENT_TEMP, therefore they have to be copied in the
++ 		 * client entry
++ 		 */
++-		common->flags |= flags & (~BATADV_TT_SYNC_MASK);
+++		if (!is_multicast_ether_addr(common->addr))
+++			common->flags |= flags & (~BATADV_TT_SYNC_MASK);
++ 
++ 		/* If there is the BATADV_TT_CLIENT_ROAM flag set, there is only
++ 		 * one originator left in the list and we previously received a


### PR DESCRIPTION
* Avoid storing non-TT-sync flags on singular entries too
* Fix multicast TT issues with bogus ROAM flags

----

The cfg80211_get_station workaround was removed from this backport because gluon already contains the proper fix (#1421) in the mac80211 package. There are already two PRs in openwrt-routing for the next/master branch in gluon.:

* openwrt-routing master: https://github.com/openwrt-routing/packages/pull/385
* openwrt-routing openwrt-18.06: https://github.com/openwrt-routing/packages/pull/385

According to T_X, this PR is related to #1419