### PR TITLE
Show sha256sum to verify upgrade checksum

### DIFF
--- a/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/upgrade_confirm.html
+++ b/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/upgrade_confirm.html
@@ -12,7 +12,7 @@ You may obtain a copy of the License at
 <h2><%:Upgrade firmware%></h2>
 
 <p>
-  <%:The firmware image has been transmitted. Please ensure the MD5 checksum and image size are correct and click "continue".%>
+  <%:The firmware image has been transmitted. Please ensure the SHA-256 checksum and image size are correct and click "continue".%>
 </p>
 
 <% if flashsize > 0 and filesize > flashsize then %>
@@ -21,7 +21,7 @@ You may obtain a copy of the License at
 
 <p>
   <ul>
-    <li>md5sum: <code><%=checksum%></code></li>
+    <li>sha256sum: <code><%=checksum%></code></li>
     <li><%:Size%>: <%
       function byte_format(byte)
         local suff = {"B", "KB", "MB", "GB", "TB"}

--- a/package/gluon-web-admin/i18n/de.po
+++ b/package/gluon-web-admin/i18n/de.po
@@ -90,10 +90,10 @@ msgid "Size"
 msgstr "Größe"
 
 msgid ""
-"The firmware image has been transmitted. Please ensure the MD5 checksum and "
+"The firmware image has been transmitted. Please ensure the SHA-256 checksum and "
 "image size are correct and click \"continue\"."
 msgstr ""
-"Die Firmwaredatei wurde übermittelt. Bitte vergleiche MD5-Checksumme und "
+"Die Firmwaredatei wurde übermittelt. Bitte vergleiche SHA-256-Checksumme und "
 "Dateigröße und klicke anschließend auf \"fortfahren\"."
 
 msgid "The firmware is currently being upgraded."

--- a/package/gluon-web-admin/i18n/fr.po
+++ b/package/gluon-web-admin/i18n/fr.po
@@ -91,10 +91,10 @@ msgid "Size"
 msgstr "Taille"
 
 msgid ""
-"The firmware image has been transmitted. Please ensure the MD5 checksum and "
+"The firmware image has been transmitted. Please ensure the SHA-256 checksum and "
 "image size are correct and click \"continue\"."
 msgstr ""
-"L'image de firmware a été transmise. Vérifiez que la somme MD5 et la taille "
+"L'image de firmware a été transmise. Vérifiez que la somme SHA-256 et la taille "
 "de l'image correspondent, et appuiez ensuite sur \"continuer\"."
 
 msgid "The firmware is currently being upgraded."

--- a/package/gluon-web-admin/i18n/gluon-web-admin.pot
+++ b/package/gluon-web-admin/i18n/gluon-web-admin.pot
@@ -77,7 +77,7 @@ msgid "Size"
 msgstr ""
 
 msgid ""
-"The firmware image has been transmitted. Please ensure the MD5 checksum and "
+"The firmware image has been transmitted. Please ensure the SHA-256 checksum and "
 "image size are correct and click \"continue\"."
 msgstr ""
 

--- a/package/gluon-web-admin/luasrc/lib/gluon/config-mode/controller/admin/upgrade.lua
+++ b/package/gluon-web-admin/luasrc/lib/gluon/config-mode/controller/admin/upgrade.lua
@@ -88,7 +88,7 @@ local function action_upgrade(http, renderer)
 	end
 
 	local function image_checksum(tmpfile)
-		return (util.exec(string.format("exec md5sum %q", tmpfile)):match("^([^%s]+)"))
+		return (util.exec(string.format("exec sha256sum %q", tmpfile)):match("^([^%s]+)"))
 	end
 
 


### PR DESCRIPTION
This changes the checksum shown in the upgrade page from MD5 to SHA-256. Upstream OpenWRT/LEDE is already doing this.