### PR TITLE
ar71xx: add support for ZyXEL NBG6716

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -235,6 +235,10 @@ ar71xx-nand
   - WNDR3700 (v4)
   - WNDR4300 (v1)
 
+* ZyXEL
+
+  - NBG6716 [#ath10k]_
+
 ar71xx-tiny
 ^^^^^^^^^^^
 

--- a/targets/ar71xx-nand
+++ b/targets/ar71xx-nand
@@ -7,3 +7,8 @@ sysupgrade -squashfs-sysupgrade .tar
 
 device netgear-wndr3700v4 wndr3700v4 WNDR3700V4
 device netgear-wndr4300 wndr4300 WNDR4300V1
+
+# ZyXEL
+device zyxel-nbg6716 nbg6716 NBG6716
+packages $ATH10K_PACKAGES
+factory -squashfs-factory .bin


### PR DESCRIPTION
As promised no backport this time ;)
This device comes with OpenWrt by default, is supported for ages and has still [decent internals](https://openwrt.org/toh/hwdata/zyxel/zyxel_nbg6716_a01).
I've tested everything thats on the [proposed checklist](https://github.com/freifunk-gluon/gluon/issues/1434#issuecomment-399168117) except autoupdate. Filename looks good tho.
Test node can be found here: https://meshviewer.chemnitz.freifunk.net/#!v:m;n:5cf4aba7d9fd