### PR TITLE
ar71xx: add ath10k packages for OpenMesh A40/A60

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -125,6 +125,7 @@ device onion-omega onion-omega
 
 device openmesh-a60 a60 A60
 alias openmesh-a40
+packages $ATH10K_PACKAGES
 
 device openmesh-mr1750 mr1750 MR1750
 alias openmesh-mr1750v2


### PR DESCRIPTION
The dependency line was lost during the rebase of the current master version.

Fixes: 9d719a2e572c ("ar71xx: add support for OpenMesh A40/A60 (#1424)")