### PR TITLE
gluon-config-mode-geo-location: allow overriding geo location description text

### DIFF
--- a/docs/site-example/i18n/de.po
+++ b/docs/site-example/i18n/de.po
@@ -80,3 +80,8 @@ msgstr ""
 
 msgid "gluon-config-mode:contact-note"
 msgstr "z.B. E-Mail oder Telefonnummer"
+
+msgid "gluon-config-mode:geo-location-help"
+msgstr ""
+"Um deinen Knoten auf der Karte anzeigen zu können, benötigen wir seine "
+"Koordinaten. Hier hast du die Möglichkeit, diese zu hinterlegen."

--- a/docs/site-example/i18n/en.po
+++ b/docs/site-example/i18n/en.po
@@ -74,3 +74,8 @@ msgstr ""
 
 msgid "gluon-config-mode:contact-note"
 msgstr "e.g. E-mail or phone number"
+
+msgid "gluon-config-mode:geo-location-help"
+msgstr ""
+"If you want the location of your node to be displayed on the map, you can "
+"enter its coordinates here."

--- a/docs/site-example/i18n/fr.po
+++ b/docs/site-example/i18n/fr.po
@@ -75,3 +75,7 @@ msgstr ""
 
 msgid "gluon-config-mode:contact-note"
 msgstr "Ex : E-mail ou numéro de téléphone"
+
+msgid "gluon-config-mode:geo-location-help"
+msgstr ""
+"Pour Afficher votre nœud sur la Carte nous avons besoin de ses coordonnées. "

--- a/docs/site-example/i18n/gluon-site.pot
+++ b/docs/site-example/i18n/gluon-site.pot
@@ -30,3 +30,6 @@ msgstr ""
 
 msgid "gluon-config-mode:contact-note"
 msgstr ""
+
+msgid "gluon-config-mode:geo-location-help"
+msgstr ""

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -520,6 +520,9 @@ gluon-config-mode:contact-help
 gluon-config-mode:contact-note
     Note shown (in small font) below the ``contact`` field
 
+gluon-config-mode:geo-location-help
+    Description for the usage of the coordinates fields
+
 gluon-config-mode:reboot
     General information shown on the reboot page.
 

--- a/package/gluon-config-mode-geo-location/luasrc/lib/gluon/config-mode/wizard/0400-geo-location.lua
+++ b/package/gluon-config-mode-geo-location/luasrc/lib/gluon/config-mode/wizard/0400-geo-location.lua
@@ -14,7 +14,7 @@ return function(form, uci)
 		return uci:get_bool("gluon-node-info", location, "altitude")
 	end
 
-	local text = pkg_i18n.translate(
+	local text = site_i18n._translate("gluon-config-mode:geo-location-help") or pkg_i18n.translate(
 		'If you want the location of your node to ' ..
 		'be displayed on the map, you can enter its coordinates here.'
 	)


### PR DESCRIPTION
allow overriding geo location description text

build and run tested on an TL-WR1043ND v2

inspired by #1409 and @RalfJung 