### PR TITLE
gluon-config-mode-hostname: allow overriding hostname description text

### DIFF
--- a/docs/site-example/i18n/de.po
+++ b/docs/site-example/i18n/de.po
@@ -80,3 +80,7 @@ msgstr ""
 
 msgid "gluon-config-mode:contact-note"
 msgstr "z.B. E-Mail oder Telefonnummer"
+
+# please find the default translation for this text in package/gluon-config-mode-hostname/i18n/
+msgid "gluon-config-mode:hostname-help"
+msgstr ""

--- a/docs/site-example/i18n/en.po
+++ b/docs/site-example/i18n/en.po
@@ -74,3 +74,7 @@ msgstr ""
 
 msgid "gluon-config-mode:contact-note"
 msgstr "e.g. E-mail or phone number"
+
+# please find the default translation for this text in package/gluon-config-mode-hostname/i18n/
+msgid "gluon-config-mode:hostname-help"
+msgstr ""

--- a/docs/site-example/i18n/fr.po
+++ b/docs/site-example/i18n/fr.po
@@ -75,3 +75,7 @@ msgstr ""
 
 msgid "gluon-config-mode:contact-note"
 msgstr "Ex : E-mail ou numéro de téléphone"
+
+# please find the default translation for this text in package/gluon-config-mode-hostname/i18n/
+msgid "gluon-config-mode:hostname-help"
+msgstr ""

--- a/docs/site-example/i18n/gluon-site.pot
+++ b/docs/site-example/i18n/gluon-site.pot
@@ -30,3 +30,6 @@ msgstr ""
 
 msgid "gluon-config-mode:contact-note"
 msgstr ""
+
+msgid "gluon-config-mode:hostname-help"
+msgstr ""

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -520,6 +520,9 @@ gluon-config-mode:contact-help
 gluon-config-mode:contact-note
     Note shown (in small font) below the ``contact`` field
 
+gluon-config-mode:hostname-help
+    Description for the usage of the ``hostname`` field
+
 gluon-config-mode:reboot
     General information shown on the reboot page.
 

--- a/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
+++ b/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
@@ -1,14 +1,16 @@
 return function(form, uci)
 	local pkg_i18n = i18n 'gluon-config-mode-hostname'
+	local site_i18n = i18n 'gluon-site'
 
 	local pretty_hostname = require 'pretty_hostname'
 	local site = require 'gluon.site'
 	local util = require 'gluon.util'
 
-	form:section(Section, nil, pkg_i18n.translate(
-		"The node name is used solely for identification of your node, e.g. on a "
-		.. "node map. It does not affect the name (SSID) of the broadcasted WLAN."
-	))
+	local help = site_i18n._translate("gluon-config-mode:hostname-help") or pkg_i18n.translate(
+		'The node name is used solely for identification of your node, e.g. on a '
+		.. 'node map. It does not affect the name (SSID) of the broadcasted WLAN.'
+	)
+	form:section(Section, nil, help)
 
 	local current_hostname = pretty_hostname.get(uci)
 	local default_hostname = util.default_hostname()


### PR DESCRIPTION
allow overriding hostname description text

build and run tested on an TL-WR1043ND v2

inspired by #1409 and @RalfJung