### PR TITLE
docs: increase recommended disk space

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -90,7 +90,7 @@ In case of errors read the messages carefully and try to fix the stated issues (
 ``ar71xx-generic`` is the most common target and will generate images for most of the supported hardware.
 To see a complete list of supported targets, call ``make`` without setting ``GLUON_TARGET``.
 
-You should reserve about 10GB of disk space for each `GLUON_TARGET`.
+You should generally reserve 5GB of disk space and additionally about 10GB for each `GLUON_TARGET`.
 
 The built images can be found in the directory `output/images`. Of these, the `factory`
 images are to be used when flashing from the original firmware a device came with,


### PR DESCRIPTION
With all the packages being built it seems that 10GB are not enough anymore.
This commit increases the recommendation for reserved disk space
for each target to a generally required free disk space size of 5GB
with additionally required 10GB per target.