### PR TITLE
docs: private-wlan: add uci command to set MAC

### DIFF
--- a/docs/features/private-wlan.rst
+++ b/docs/features/private-wlan.rst
@@ -7,14 +7,19 @@ Please note that you should not enable ``mesh_on_wan`` simultaneously.
 The private WLAN can be enabled through the config mode if the package ``gluon-web-private-wifi`` is installed.
 You may also enable a private WLAN using the command line::
 
-  uci set wireless.wan_radio0=wifi-iface
-  uci set wireless.wan_radio0.device=radio0
-  uci set wireless.wan_radio0.network=wan
-  uci set wireless.wan_radio0.mode=ap
-  uci set wireless.wan_radio0.encryption=psk2
-  uci set wireless.wan_radio0.ssid="$SSID"
-  uci set wireless.wan_radio0.key="$KEY"
-  uci set wireless.wan_radio0.disabled=0
+  RID=0
+  SSID="privateWLANname"
+  KEY="yoursecret1337password"
+
+  uci set wireless.wan_radio$RID=wifi-iface
+  uci set wireless.wan_radio$RID.device=radio$RID
+  uci set wireless.wan_radio$RID.network=wan
+  uci set wireless.wan_radio$RID.mode=ap
+  uci set wireless.wan_radio$RID.encryption=psk2
+  uci set wireless.wan_radio$RID.ssid="$SSID"
+  uci set wireless.wan_radio$RID.key="$KEY"
+  uci set wireless.wan_radio$RID.disabled=0
+  uci set wireless.wan_radio$RID.macaddr="$($(echo "lua -e print(require('gluon.util').generate_mac(3+4*$RID))"))"
   uci commit
   wifi
 


### PR DESCRIPTION
@rotanid noticed that a command  is missing in the docs to set the MAC address of the private WLAN when it is being configured manually. 

This commit adds the missing command to set the special Gluon MAC address of the private WLAN interface to the documentation.