### PR TITLE
docs: fix wrong Banana Pi model in v2018.1 release notes

### DIFF
--- a/docs/releases/v2018.1.rst
+++ b/docs/releases/v2018.1.rst
@@ -92,9 +92,9 @@ ramips-rt305x [#newtarget]_ [#noibss]_
 sunxi [#newtarget]_
 ===================
 
-* LeMaker
+* LeMaker/SinoVoip
 
-  - Lamobo r1
+  - Banana Pi (M1)
 
 
 .. [#newtarget]


### PR DESCRIPTION
The release notes for v2018.1 state that the _Lambo R1_ is now a stable/supported model but it should be the _Banana Pi (M1)_. I also set the brand to _LeMaker/SinoVoip_ as it is sold by two different companies.