### PR TITLE
ipq40xx: add target

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -285,6 +285,27 @@ brcm2708-bcm2709
 
 * RaspberryPi 2
 
+
+ipq40xx
+^^^^^^^
+
+* AVM
+
+  - FRITZ!Box 4040 [#80211s]_
+
+* GL.iNet
+
+  - GL-B1300 [#80211s]_
+
+* NETGEAR
+
+  - EX6100v2 [#80211s]_
+  - EX6150v2 [#80211s]_
+
+* ZyXEL
+
+  - WRE6606 [#80211s]_
+
 ipq806x
 ^^^^^^^
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -46,6 +46,8 @@ elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1',
                                             'archer-c59-v1', 'archer-c60-v1',
                                             'archer-c7'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')
+elseif platform.match('ipq40xx', nil, {'avm,fritzbox-4040'}) then
+  table.insert(try_files, 1, '/sys/class/net/eth0/address')
 end
 
 

--- a/scripts/update-patches.sh
+++ b/scripts/update-patches.sh
@@ -19,6 +19,6 @@ for module in $GLUON_MODULES; do
 	for commit in $(git rev-list --reverse --no-merges base..patched); do
 		let n=n+1
 		mkdir -p "$GLUONDIR"/patches/"$module"
-		git -c core.abbrev=40 show --pretty=format:'From: %an <%ae>%nDate: %aD%nSubject: %B' --no-renames "$commit" > "$GLUONDIR/patches/$module/$(printf '%04u' $n)-$(git show -s --pretty=format:%f "$commit").patch"
+		git -c core.abbrev=40 show --pretty=format:'From: %an <%ae>%nDate: %aD%nSubject: %B' --no-renames --binary "$commit" > "$GLUONDIR/patches/$module/$(printf '%04u' $n)-$(git show -s --pretty=format:%f "$commit").patch"
 	done
 done

--- a/targets/ipq40xx
+++ b/targets/ipq40xx
@@ -1,26 +1,37 @@
+ATH10K_PACKAGES_IPQ40XX=
+if [ "$GLUON_WLAN_MESH" = 'ibss' ]; then
+	ATH10K_PACKAGES_IPQ40XX='-kmod-ath10k kmod-ath10k-ct -ath10k-firmware-qca4019 ath10k-firmware-qca4019-ct'
+fi
+
+
 # AVM
 
 device avm-fritz-box-4040 avm_fritzbox-4040
 factory
 extra_image -squashfs-eva -bootloader .bin
+packages $ATH10K_PACKAGES_IPQ40XX
 
 
 # GL.iNet
 
 device gl.inet-gl-b1300 glinet_gl-b1300
 factory
+packages $ATH10K_PACKAGES_IPQ40XX
 
 
 # NETGEAR
 
 device netgear-ex6100v2 netgear_ex6100v2
 factory .img
+packages $ATH10K_PACKAGES_IPQ40XX
 
 device netgear-ex6150v2 netgear_ex6150v2
 factory .img
+packages $ATH10K_PACKAGES_IPQ40XX
 
 
 # ZyXEL
 
 device zyxel-wre6606 zyxel_wre6606
 factory
+packages $ATH10K_PACKAGES_IPQ40XX

--- a/targets/ipq40xx
+++ b/targets/ipq40xx
@@ -1,0 +1,26 @@
+# AVM
+
+device avm-fritz-box-4040 avm_fritzbox-4040
+factory
+extra_image -squashfs-eva -bootloader .bin
+
+
+# GL.iNet
+
+device gl.inet-gl-b1300 glinet_gl-b1300
+factory
+
+
+# NETGEAR
+
+device netgear-ex6100v2 netgear_ex6100v2
+factory .img
+
+device netgear-ex6150v2 netgear_ex6150v2
+factory .img
+
+
+# ZyXEL
+
+device zyxel-wre6606 zyxel_wre6606
+factory

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -13,6 +13,7 @@ $(eval $(call GluonTarget,x86,geode))
 $(eval $(call GluonTarget,x86,64))
 
 ifneq ($(GLUON_WLAN_MESH_11s)$(BROKEN),)
+$(eval $(call GluonTarget,ipq40xx))
 $(eval $(call GluonTarget,ipq806x))
 $(eval $(call GluonTarget,ramips,mt7620))
 $(eval $(call GluonTarget,ramips,mt76x8))


### PR DESCRIPTION
This PR adds support for the new IPQ40xx series of internet processors from Qualcomm.

Note that this PR is not ready for merging. Following things need to be done to fully support Gluon features:

- [x] Obtain status-led from device-tree instead of using diag.sh
- [x] Add support for "other" image-type for Fritz!Box 4040 EVA-Image (see #1474)

Fritz!Box 4040
- [x] Verify correct MAC (part of CWMP account on label)
- [X] Verify correct autoupdater-filename
```
root@64367-fritzbox:~# lua -e 'print(require("platform_info").get_image_name())'
avm-fritz-box-4040
```

GL-iNet B1300
- [x] Verify correct MAC (calling @skorpy2009)
- [X] Verify correct autoupdater-filename (calling @skorpy2009)
```
root@64367-ranzbox:~# lua -e 'print(require("platform_info").get_image_name())'
gl.inet-gl-b1300
```

NETGEAR EX61xxV2
- [X] Verify correct MAC (2.4GHz on case)
- [X] Verify correct autoupdater-filename
```
root@64367-brick:~# lua -e 'print(require("platform_info").get_image_name())'
netgear-ex6150v2
```

ZyXEL NBG6617
- [X] Verify correct MAC (2.4GHz on case)
- [X] Verify correct autoupdater-filename
```
root@64xxx-b8eca3d6884c:~# lua -e 'print(require("platform_info").get_image_name())'
zyxel-nbg6617
```

ZyXEL WRE6606
- [X] Verify correct MAC (2.4GHz on case)
- [X] Verify correct autoupdater-filename
```
root@61381-wireless-ranz-extender:~# lua -e 'print(require("platform_info").get_image_name())'
zyxel-wre6606
```
