### PR TITLE
ramips: add TP-Link TL-WR841N v13

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -343,6 +343,7 @@ ramips-mt7628
 * TP-Link
 
   - Archer C50 v3 [#80211s]_
+  - TL-WR841N v13 [#80211s]_
 
 * VoCore
 

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -4,6 +4,10 @@ device tp-link-archer-c50-v3 tplink_c50-v3
 factory
 extra_image -squashfs-tftp-recovery -bootloader .bin
 
+device tp-link-tl-wr-841n-v13 tl-wr841n-v13
+factory
+extra_image -squashfs-tftp-recovery -bootloader .bin
+
 
 # VoCore 2
 


### PR DESCRIPTION
This PR adds support for TP-Link TL-WR841N v13.

Note that this PR is not ready for merging. Following things need to be done to fully support Gluon features:

TP-Link TL-WR841N v13 #1392 (calling everyone!)
- [x] Verify correct MAC
- [x] Verify correct autoupdater-filename