### PR TITLE
ar71xx: add support for OCEDO Koala

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -30,7 +30,7 @@ if platform.match('ar71xx', 'generic', {'tl-wdr3600', 'tl-wdr4300'}) then
 elseif platform.match('ramips', 'mt7621', {'dir-860l-b1'}) then
   table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')
 elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2',
-                                            'a40', 'a60',
+                                            'a40', 'a60', 'koala',
                                             'mr600', 'mr600v2',
                                             'mr900', 'mr900v2',
                                             'mr1750', 'mr1750v2',

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -116,6 +116,12 @@ factory .img
 fi
 
 
+# OCEDO
+
+device ocedo-koala koala
+factory
+
+
 # Onion
 
 device onion-omega onion-omega


### PR DESCRIPTION
This adds support for the OCEDO Koala, a Wireless-AC Access Point with PoE support, spec wise comparable to an Archer C7 v2.

While this device most likely can't be bought (even on eBay), some Communities have gotten hold of a fairly large quantity of those devices. Therefore it would be great to add this device.

Checklist from here (https://github.com/freifunk-gluon/gluon/issues/1434#issuecomment-399168117) is completely tested, however flashing is possible only from a tftpboot image, but can be done without attaching UART.