### PR TITLE
ar71xx: add support for TP-Link RE355

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -225,6 +225,10 @@ if [ "$BROKEN" ]; then
 device tp-link-archer-c60-v1 archer-c60-v1 # BROKEN: OOM with 5GHz enabled in most environments
 fi
 
+if [ "$BROKEN" ]; then
+device tp-link-re355 re355-v1 # BROKEN: OOM with 5GHz enabled in most environments if device is 64M RAM variant
+fi
+
 device tp-link-re450 re450-v1
 packages $ATH10K_PACKAGES
 


### PR DESCRIPTION
Support is marked as broken because this device is sold in two variants,
one with 64M RAM and another with 128M. As of now 64M is not enough
for ath10k with 5GHz enabled.
As there is no indication known which variant one will get better mark
it as broken.