### PR TITLE
 gluon-web-admin: add site-commit to info page 

### DIFF
--- a/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/info.html
+++ b/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/info.html
@@ -23,7 +23,8 @@
 		{ _('Hostname'), pretty_hostname.get(uci) },
 		{ _('MAC address'), sysconfig.primary_mac },
 		{ _('Hardware model'), platform.get_model() },
-		{ _('Gluon version'), util.trim(util.readfile('/lib/gluon/gluon-version')) },
+		{ _('Gluon version') .. " / " .. _('Site version'), util.trim(util.readfile('/lib/gluon/gluon-version')) 
+			.. " / " .. util.trim(util.readfile('/lib/gluon/site-version')) },
 		{ _('Firmware release'), util.trim(util.readfile('/lib/gluon/release')) },
 		{ _('Site'), site.site_name() },
 		{ _('Public VPN key'), pubkey },

--- a/package/gluon-web-admin/i18n/de.po
+++ b/package/gluon-web-admin/i18n/de.po
@@ -50,6 +50,9 @@ msgstr "Firmware-Release"
 msgid "Gluon version"
 msgstr "Gluon-Version"
 
+msgid "Site version"
+msgstr "Site-Version"
+
 msgid "Hardware model"
 msgstr "Hardware-Modell"
 

--- a/package/gluon-web-admin/i18n/fr.po
+++ b/package/gluon-web-admin/i18n/fr.po
@@ -51,6 +51,9 @@ msgstr "Version de la firmware"
 msgid "Gluon version"
 msgstr "Version de Gluon"
 
+msgid "Site version"
+msgstr "Version de Site"
+
 msgid "Hardware model"
 msgstr "Modèle du Matériel"
 

--- a/package/gluon-web-admin/i18n/gluon-web-admin.pot
+++ b/package/gluon-web-admin/i18n/gluon-web-admin.pot
@@ -37,6 +37,9 @@ msgstr ""
 msgid "Gluon version"
 msgstr ""
 
+msgid "Site version"
+msgstr ""
+
 msgid "Hardware model"
 msgstr ""
 


### PR DESCRIPTION
This will enable the communities to add links to their build structure and repositories to the info page.

(Tested on a build on tag 2018.1.x)

## screenshot

![auswahl_004](https://user-images.githubusercontent.com/1591563/42863463-95d8cb98-8a63-11e8-8237-4c685c8ffc7b.png)

