### PR TITLE
ramips: add support for TP-Link Archer C50 v3

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -319,6 +319,10 @@ ramips-mt7621
 ramips-mt7628
 ^^^^^^^^^^^^^
 
+* TP-Link
+
+  - Archer C50 v3 [#80211s]_
+
 * VoCore
 
   - VoCore2 [#80211s]_

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -1,3 +1,10 @@
+# TP-Link
+
+device tp-link-archer-c50-v3 tplink_c50-v3
+factory
+extra_image -squashfs-tftp-recovery -bootloader .bin
+
+
 # VoCore 2
 
 device vocore2 vocore2


### PR DESCRIPTION
This PR adds support for TP-Link Archer C50 v3.

- [x] Add support for "other" image-type (Both devices need special TFTP images) (see #1474)

TP-Link Archer C50 v3
- [X] Verify correct MAC
- [x] Verify correct autoupdater-filename
```
root@64367-mediadreck:~# lua -e 'print(require("platform_info").get_image_name())'
tp-link-archer-c50-v3
```
