### PR TITLE
ar71xx: add AVM FRITZ!WLAN Reapeater 450E

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -130,6 +130,7 @@ ar71xx-generic
 * AVM
 
   - Fritz!Box 4020
+  - Fritz!WLAN Repeater 450E
 
 * Buffalo
 

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -34,8 +34,13 @@ factory
 
 
 # AVM
+
 device avm-fritz-box-4020 fritz4020 fritz4020
 factory
+
+device avm-fritz-wlan-repeater-450e fritz450e
+factory
+
 
 # Buffalo
 


### PR DESCRIPTION
This adds the AVM FRITZ!WLAN Repeater 450E. (QCA9556/16M/64M)

The two patches are needed to circumvent the SOCs hardware bug described [here](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=f4f99ec9737c653815268f2efad0210caaa32e2d).

In case @NeoRaider sees a success chance in backporting these two needed patches to 18.06, we can also try to go that route to not add kernel patches.

Personally i think these devices are perfectly fine (although i wouldn't pick them as "recommended") as people tend to have these kind of devices lying around.

Hardware wise, except for the RSSI LEDs everything is working fine (WPS button, other LEDs, ethernet, wifi).

- [x] Verify correct MAC (no mac printed on the case so yay?)
- [X] Verify correct autoupdater-filename
```
root@64293-switchboard2:~# lua -e 'print(require("platform_info").get_image_name())'
avm-fritz-wlan-repeater-450e
root@64293-switchboard2:~# 
```