### PR TITLE
ramips-mt7620: add support for TP-Link Archer C20 v1

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -340,6 +340,10 @@ ramips-mt7620
   - GL-MT300N [#80211s]_
   - GL-MT750 [#80211s]_
 
+* TP-Link
+
+  - Archer C20 (v1) [#80211s]_
+
 ramips-mt7621
 ^^^^^^^^^^^^^
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -47,6 +47,8 @@ elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1',
 elseif platform.match('ipq40xx', nil, {'avm,fritzbox-4040',
                                        'openmesh,a42', 'openmesh,a62'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
+elseif platform.match('ramips', 'mt7620', {'tplink,c20-v1'}) then
+  table.insert(try_files, 1, '/sys/class/net/eth0/address')
 end
 
 

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -7,3 +7,9 @@ factory
 
 device gl-mt750 gl-mt750
 factory
+
+# TP-Link
+if [ "$BROKEN" ]; then
+device tp-link-archer-c20-v1 tplink_c20-v1 # BROKEN: only 2.4GHz wifi working
+fi
+


### PR DESCRIPTION
  - [X] must be flashable from vendor firmware
I used the TFTP method as advised by openwrt wiki.

- [x]  must support upgrade mechanism
  - [x]  must have working sysupgrade
  - [ ]  must have working autoupdate
maybe there is an upstream problem as the image (gluon and openwrt) fail the image check because of an additional dash in the name
`Device tplink,c20-v1 not supported by this image
Supported devices: c20v1
`

- [x] wired network
   - [x] should support all network ports on the device
   - [x] must have correct port assignment (WAN/LAN)
- [ ] wifi (if applicable)
  - [x] association with AP must be possible on all radios
only on 2,4 GHZ as 5GHz is not supported at the moment
  - [x] association with 802.11s mesh must be working on all radios
only on 2,4 GHZ as 5GHz is not supported at the moment
  - [ ] ap/mesh mode must work in parallel on all usable radios

- [x] led mapping
  - [x] power/sys led
  - [x] lit while the device is on
  - [x] should display config mode blink sequence

- [ ] radio leds
they are both turned off
  - [ ] should map to their respective radio
  - [ ] should show activity
 - [x] switchport leds
  - [x] should map to their respective port (or switch, if only one led present)
  - [x] should show link state and activity

- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) 
issues resolved