### PR TITLE
docs: add OCEDO Koala to supported devices

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -161,6 +161,10 @@ ar71xx-generic
   - WNDR3800
   - WNDRMAC (v2)
 
+* OCEDO
+
+  - Koala [#ath10k]_
+
 * Onion
 
   - Omega


### PR DESCRIPTION
Addition of the OCEDO Koala to the supported devices in the docs was
forgotten in 52bc028.