### PR TITLE
package/features: add gluon-ebtables-limit-arp on batman packages as Opt out

### DIFF
--- a/package/features
+++ b/package/features
@@ -23,4 +23,5 @@ packages 'web-advanced & autoupdater' \
 	'gluon-web-autoupdater'
 
 packages 'status-page & (mesh-batman-adv-14 | mesh-batman-adv-15)' \
-        'gluon-status-page-mesh-batman-adv'
+        'gluon-status-page-mesh-batman-adv' \
+        'gluon-ebtables-limit-arp'

--- a/package/features
+++ b/package/features
@@ -25,5 +25,5 @@ packages 'web-advanced & autoupdater' \
 packages 'status-page & (mesh-batman-adv-14 | mesh-batman-adv-15)' \
         'gluon-status-page-mesh-batman-adv'
 
-packages '(mesh-batman-adv-14 | mesh-batman-adv-15)' \
+packages 'mesh-batman-adv-14 | mesh-batman-adv-15' \
         'gluon-ebtables-limit-arp'

--- a/package/features
+++ b/package/features
@@ -23,5 +23,7 @@ packages 'web-advanced & autoupdater' \
 	'gluon-web-autoupdater'
 
 packages 'status-page & (mesh-batman-adv-14 | mesh-batman-adv-15)' \
-        'gluon-status-page-mesh-batman-adv' \
+        'gluon-status-page-mesh-batman-adv'
+
+packages '(mesh-batman-adv-14 | mesh-batman-adv-15)' \
         'gluon-ebtables-limit-arp'


### PR DESCRIPTION
This MR is an alternative idea for #1418

The gluon-ebtables-limit-arp is selected as default when the batman package is selected.
For communities who don't want this package, the can deselect it as described below:
```
GLUON_SITE_PACKAGES := \
        -gluon-ebtables-limit-arp
```