### PR TITLE
[RFC] gluon-status-page: update memory usage estimation

### DIFF
--- a/package/gluon-respondd/src/respondd.c
+++ b/package/gluon-respondd/src/respondd.c
@@ -197,6 +197,8 @@ static struct json_object * get_memory(void) {
 			json_object_object_add(ret, "total", json_object_new_int(value));
 		else if (!strcmp(label, "MemFree"))
 			json_object_object_add(ret, "free", json_object_new_int(value));
+		else if (!strcmp(label, "MemAvailable"))
+			json_object_object_add(ret, "available", json_object_new_int(value));
 		else if (!strcmp(label, "Buffers"))
 			json_object_object_add(ret, "buffers", json_object_new_int(value));
 		else if (!strcmp(label, "Cached"))

--- a/package/gluon-status-page/javascript/status-page.js
+++ b/package/gluon-status-page/javascript/status-page.js
@@ -74,7 +74,7 @@
 			return _['%s used'].sprintf(formatNumber(100 * value, 3) + '%');
 		},
 		'memory': function(memory) {
-			var usage = 1 - (memory.free + memory.buffers + memory.cached) / memory.total
+			var usage = 1 - memory.available / memory.total
 			return formats.percent(usage);
 		},
 		'time': function(seconds) {


### PR DESCRIPTION
This commit changes the way gluon estimates memory-usage on the status-page. Currently memory consumption in percent gets calculated using

> MEM = 1-(free+cached+buffers)/total

This commit (https://github.com/torvalds/linux/commit/34e431b0ae398fc54ea69ff85ec700722c9da773) suggests that this might not the best way to calculate such an estimation.

**TL-MR3020 v1**
```
MemTotal:          27368 kB
MemFree:            4508 kB
MemAvailable:       8368 kB
Buffers:            1940 kB
Cached:             4108 kB
```
Old: `1-((4508+1940+4108)/27368) = 61.42%`
New: `1-(8368/27368) = 69.42%`


**TL-WR1043 v3**
```
MemTotal:          60000 kB
MemFree:           29280 kB
MemAvailable:      23388 kB
Buffers:            2672 kB
Cached:             4108 kB
```
Old: `1-((29280+2672+4108)/60000) = 39.90%`
New: `1-(23388/60000) = 61.02%`

As those results are not all small differences but somewhat drastic differences (and I'm lacking in-depth knowledge about memory-management) I'm not sure which way better reflects true memory availability. 