### PR TITLE
gluon-mesh-vpn-core: add abstraction layer for vpn interface return

### DIFF
--- a/package/gluon-mesh-vpn-core/luasrc/usr/lib/lua/gluon/vpn-util.lua
+++ b/package/gluon-mesh-vpn-core/luasrc/usr/lib/lua/gluon/vpn-util.lua
@@ -1,0 +1,24 @@
+local uci = require('simple-uci').cursor()
+local unistd = require 'posix.unistd'
+
+local M = {}
+
+function M.get_mesh_vpn_interface()
+  local ret = {}
+  if unistd.access('/lib/gluon/mesh-vpn/fastd') then
+    local vpnifac = uci:get('fastd', 'mesh_vpn_backbone', 'net')
+    if vpnifac  ~= nil then
+      vpnifac = vpnifac:gsub("%_",'-')
+      table.insert(ret,vpnifac)
+    end
+  end
+  if unistd.access('/lib/gluon/mesh-vpn/tunneldigger') then
+    local vpnifac = uci:get('tunneldigger', 'mesh_vpn', 'interface')
+    if vpnifac  ~= nil then
+      table.insert(ret,vpnifac)
+    end
+  end
+  return ret
+end
+
+return M


### PR DESCRIPTION
This PR should intergrade a missing abstraction that give developers the option to get the mesh VPN interface name, with hasn't to be aware of every vpn-tunneling-solution.