### PR TITLE
docs: enhance  example values for gluon-config-mode-geo-location-osm

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -428,11 +428,11 @@ config_mode \: optional
             show_altitude = true,
             osm = {
               center = {
-                lon = 52.951947558,
-                lat = 7.844238281,
+                lat = 52.951947558,
+                lon = 8.744238281,
               },
               zoom = 13,
-              openlayers_url = 'http://ffac/ol',
+              -- openlayers_url = 'http://ffac.example.org/openlayer',
             },
           },
           remote_login = {


### PR DESCRIPTION
Latitude and longitude was swapped and the example Layer URL is not reacheable so it should be set in comments.