### PR TITLE
gluon-config-mode-hostname: add option to use default hostname

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -403,6 +403,9 @@ config_mode \: optional
     and the node's primary MAC address is assigned. Manually setting a hostname
     can be enforced by setting *hostname.optional* to *false*.
 
+    To not prefill the hostname-field in config-mode with the default hostname,
+    set *hostname.prefill* to *false*.
+
     By default, no altitude field is shown by the *gluon-config-mode-geo-location*
     package. Set *geo_location.show_altitude* to *true* if you want the altitude
     field to be visible.
@@ -423,6 +426,7 @@ config_mode \: optional
         config_mode = {
           hostname = {
             optional = false,
+            prefill = true,
           },
           geo_location = {
             show_altitude = true,

--- a/package/gluon-config-mode-hostname/check_site.lua
+++ b/package/gluon-config-mode-hostname/check_site.lua
@@ -1,1 +1,2 @@
 need_boolean(in_site({'config_mode', 'hostname', 'optional'}), false)
+need_boolean(in_site({'config_mode', 'hostname', 'prefill'}), true)

--- a/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
+++ b/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
@@ -23,7 +23,7 @@ return function(form, uci)
 		o.optional = true
 		o.placeholder = default_hostname
 	end
-	if configured then
+	if configured or site.config_mode.hostname.prefill(true) then
 		o.default = current_hostname
 	end
 


### PR DESCRIPTION
Before 7827f89, mandatory hostname field in config mode was pre-filled with the default hostname.

This commit adds the config_mode.hostname.prefill option for controlling the default value.