### PR TITLE
mt76x8: flag target as broken

### DIFF
--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -15,7 +15,6 @@ $(eval $(call GluonTarget,x86,64))
 ifneq ($(GLUON_WLAN_MESH_11s)$(BROKEN),)
 $(eval $(call GluonTarget,ipq40xx))
 $(eval $(call GluonTarget,ramips,mt7620))
-$(eval $(call GluonTarget,ramips,mt76x8))
 $(eval $(call GluonTarget,ramips,rt305x))
 endif
 
@@ -24,4 +23,5 @@ $(eval $(call GluonTarget,ar71xx,mikrotik)) # BROKEN: no sysupgrade support
 $(eval $(call GluonTarget,brcm2708,bcm2710)) # BROKEN: Untested
 $(eval $(call GluonTarget,ipq806x)) # BROKEN: unstable wifi drivers
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No AP+IBSS or 11s support
+$(eval $(call GluonTarget,ramips,mt76x8)) # BROKEN: unstable WiFi
 endif


### PR DESCRIPTION
The MT76x8 is currently not stable enough for worry-free use with Gluon.
It suffers from reboots in intervals as little as 12 hours or WiFi
freezes for several hours.

It may be unflagged as soon the situation with mt76 got better.