### PR TITLE
ath10k-ct: reduce memory consumption

### DIFF
--- a/patches/openwrt/0008-ath10k-ct-reduce-memory-consumption.patch
+++ b/patches/openwrt/0008-ath10k-ct-reduce-memory-consumption.patch
@@ -1,0 +1,78 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Mon, 18 Jun 2018 21:03:37 +0200
+Subject: ath10k-ct: reduce memory consumption
+
+ath10k uses a rather high number of buffers to communicate with the QCA
+firmware. Especially the HTC (host-target-communication) and HTT
+(host-target-transport) can take up a lot of memory when data is
+transferred over a ath10k wifi link.
+
+This problem was already worked around in commit cc189c0b7fa0 ("mac80211:
+enable ath10k AHB support for QCA4019") for the ath10k driver from
+mac80211. But this change was forgotton for the ath10k-ct driver.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+Forwarded: https://github.com/openwrt/openwrt/pull/1077
+
+diff --git a/package/kernel/ath10k-ct/patches/960-0010-ath10k-limit-htt-rx-ring-size.patch b/package/kernel/ath10k-ct/patches/960-0010-ath10k-limit-htt-rx-ring-size.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..7ee89be9cc4c7602db10dc6c118b803e3b130192
+--- /dev/null
++++ b/package/kernel/ath10k-ct/patches/960-0010-ath10k-limit-htt-rx-ring-size.patch
+@@ -0,0 +1,11 @@
++--- a/ath10k-4.13/htt.h
+++++ b/ath10k-4.13/htt.h
++@@ -199,7 +199,7 @@ enum htt_rx_ring_flags {
++ };
++ 
++ #define HTT_RX_RING_SIZE_MIN 128
++-#define HTT_RX_RING_SIZE_MAX 2048
+++#define HTT_RX_RING_SIZE_MAX 512
++ 
++ struct htt_rx_ring_setup_ring {
++ 	__le32 fw_idx_shadow_reg_paddr;
+diff --git a/package/kernel/ath10k-ct/patches/960-0011-ath10k-limit-pci-buffer-size.patch b/package/kernel/ath10k-ct/patches/960-0011-ath10k-limit-pci-buffer-size.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..82ccb88ccbf341ab63da8fd12aeb13ff468cc98a
+--- /dev/null
++++ b/package/kernel/ath10k-ct/patches/960-0011-ath10k-limit-pci-buffer-size.patch
+@@ -0,0 +1,38 @@
++--- a/ath10k-4.13/pci.c
+++++ b/ath10k-4.13/pci.c
++@@ -128,7 +128,7 @@ static struct ce_attr host_ce_config_wla
++ 		.flags = CE_ATTR_FLAGS,
++ 		.src_nentries = 0,
++ 		.src_sz_max = 2048,
++-		.dest_nentries = 512,
+++		.dest_nentries = 128,
++ 		.recv_cb = ath10k_pci_htt_htc_rx_cb,
++ 	},
++ 
++@@ -137,7 +137,7 @@ static struct ce_attr host_ce_config_wla
++ 		.flags = CE_ATTR_FLAGS,
++ 		.src_nentries = 0,
++ 		.src_sz_max = 2048,
++-		.dest_nentries = 128,
+++		.dest_nentries = 64,
++ 		.recv_cb = ath10k_pci_htc_rx_cb,
++ 	},
++ 
++@@ -164,7 +164,7 @@ static struct ce_attr host_ce_config_wla
++ 		.flags = CE_ATTR_FLAGS,
++ 		.src_nentries = 0,
++ 		.src_sz_max = 512,
++-		.dest_nentries = 512,
+++		.dest_nentries = 128,
++ 		.recv_cb = ath10k_pci_htt_rx_cb,
++ 	},
++ 
++@@ -189,7 +189,7 @@ static struct ce_attr host_ce_config_wla
++ 		.flags = CE_ATTR_FLAGS,
++ 		.src_nentries = 0,
++ 		.src_sz_max = 2048,
++-		.dest_nentries = 128,
+++		.dest_nentries = 96,
++ 		.recv_cb = ath10k_pci_pktlog_rx_cb,
++ 	},
++ 


### PR DESCRIPTION
ath10k-ct uses a rather high number of buffers to communicate with the QCA/Candelatech firmware. Especially the HTC (host-target-communication) and HTT (host-target-transport) can take up a lot of memory when data is transferred over a ath10k wifi link.

Even a 256MB device with three radios can go OOM (while sending to three devices using UDP unicast/multicast packets) with the default buffer limits. Unfortunately, this also reduced the maximum 5GHz throughput on an IPQ40xx device from 494/432 Mbit/s for TCP transfers (download/upload) to
438/343 Mbit/s. These throughput values should still be good enough for a Freifunk installation. And these changes are already used by ath10k in OpenWrt 18.06.

----

There was already a pull request for LEDE 17.01 (gluon 2018.1.x)  in #1440. This one was not accepted before the release of 2018.1 and later rejected for 2018.1.x. See also the failed PR for OpenWrt 18.06 https://github.com/openwrt/openwrt/pull/1077 . The original ath10k (no -ct) driver was patched in https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=cc189c0b7fa015978b04bb663a75b1da726376b5

This change will affect QCA 802.11 11ac based hardware:

* every target  when using GLUON_WLAN_MESH = 'ibss'
* target ipq806x
* target x86