### PR TITLE
Bugfix: package/gluon-config-mode-geo-location: delet nodes Position after disable location option by reenterd config-mode. Also set location independend from sharing

### DIFF
--- a/package/gluon-config-mode-geo-location/i18n/de.po
+++ b/package/gluon-config-mode-geo-location/i18n/de.po
@@ -26,6 +26,9 @@ msgstr "Breitengrad"
 msgid "Longitude"
 msgstr "Längengrad"
 
+msgid "Set node position"
+msgstr "Knotenposition setzen"
+
 msgid "Advertise node position"
 msgstr "Knotenposition veröffentlichen"
 

--- a/package/gluon-config-mode-geo-location/i18n/fr.po
+++ b/package/gluon-config-mode-geo-location/i18n/fr.po
@@ -24,6 +24,9 @@ msgstr "Latitude"
 msgid "Longitude"
 msgstr "Longitude"
 
+msgid "Set node position"
+msgstr ""
+
 msgid "Advertise node position"
 msgstr ""
 

--- a/package/gluon-config-mode-geo-location/i18n/gluon-config-mode-geo-location.pot
+++ b/package/gluon-config-mode-geo-location/i18n/gluon-config-mode-geo-location.pot
@@ -15,6 +15,9 @@ msgstr ""
 msgid "Longitude"
 msgstr ""
 
+msgid "Set node position"
+msgstr ""
+
 msgid "Advertise node position"
 msgstr ""
 


### PR DESCRIPTION
Fix an issue after reentering the config-mode. In case a user has enterd the config-mode again and is disabling the location option the previously stored coordinates will be not deleted. Furthermore, this MR makes able to set a position independent from the option to share the nodes location.