### PR TITLE
ar71xx: flag FritzBox 4020 buttons as active low

### DIFF
--- a/patches/lede/0102-ar71xx-flag-FritzBox-4020-buttons-as-active-low.patch
+++ b/patches/lede/0102-ar71xx-flag-FritzBox-4020-buttons-as-active-low.patch
@@ -1,0 +1,33 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 11 Sep 2018 17:04:16 +0200
+Subject: ar71xx: flag FritzBox 4020 buttons as active low
+
+Buttons of AVM FritzBox 4020 are incorrectly flagged as active high.
+
+This was an oversight as RFKill button was working as expected even
+with incorrectly flagged GPIO.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-fritz4020.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-fritz4020.c
+index ed7f9a8b3ead80dbbe7f8d27c7dd5ecf0543d733..c00cf681b2da3ff4989fbf4c3de7b44075bb395a 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-fritz4020.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-fritz4020.c
+@@ -169,7 +169,7 @@ static struct gpio_keys_button fritz4020_gpio_keys[] __initdata = {
+ 		.code			= KEY_RFKILL,
+ 		.debounce_interval	= FRITZ4020_KEYS_DEBOUNCE_INTERVAL,
+ 		.gpio			= FRITZ4020_GPIO_BTN_WLAN,
+-		.active_low		= 0,
++		.active_low		= 1,
+ 	},
+ 	{
+ 		.desc			= "WPS button",
+@@ -177,7 +177,7 @@ static struct gpio_keys_button fritz4020_gpio_keys[] __initdata = {
+ 		.code			= KEY_WPS_BUTTON,
+ 		.debounce_interval	= FRITZ4020_KEYS_DEBOUNCE_INTERVAL,
+ 		.gpio			= FRITZ4020_GPIO_BTN_WPS,
+-		.active_low		= 0,
++		.active_low		= 1,
+ 	},
+ };
+ 


### PR DESCRIPTION
This is a pull request for the current Gluon stable branch. It is not against Gluon master as @NeoRaider might want to consider cherry-picking this commit for the openwrt-18.06 branch, making a downstream patch obsolete.

---

Buttons of AVM FritzBox 4020 are incorrectly flagged as active high.

This was an oversight as RFKill button was working as expected even
with incorrectly flagged GPIO.

Config mode is still accessable but will start on any button press, not
only for the ones >= 10 seconds.

This commit corrects this behavior to the expected one (10 second long
press necessary to enter config mode).