### PR TITLE
mt76x8: add support for GL.iNet GL-MT300N-V2

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -349,8 +349,11 @@ ramips-mt7621
   - EdgeRouter X
   - EdgeRouter X-SFP
 
-ramips-mt7628
+ramips-mt76x8
 ^^^^^^^^^^^^^
+
+* GL.iNet
+  - MT300N v2 [#80211s]_
 
 * TP-Link
 

--- a/patches/openwrt/0012-ramips-fix-leds-on-GL.iNet-GL-MT300N-V2.patch
+++ b/patches/openwrt/0012-ramips-fix-leds-on-GL.iNet-GL-MT300N-V2.patch
@@ -1,0 +1,34 @@
+From: Martin Weinelt <hexa@darmstadt.ccc.de>
+Date: Fri, 2 Nov 2018 20:52:01 +0100
+Subject: ramips: fix leds on GL.iNet GL-MT300N-V2
+
+The WAN LED now shows the link state. It's color is green,
+not blue.
+
+Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>
+
+diff --git a/target/linux/ramips/base-files/etc/board.d/01_leds b/target/linux/ramips/base-files/etc/board.d/01_leds
+index 54504c6ee8bb45db0ffa371ec68c3a8fd7e4d673..6057275978591192e3b7799a8e6d97761c3e23a5 100755
+--- a/target/linux/ramips/base-files/etc/board.d/01_leds
++++ b/target/linux/ramips/base-files/etc/board.d/01_leds
+@@ -210,6 +210,7 @@ gl-mt750)
+ 	;;
+ gl-mt300n-v2)
+ 	set_wifi_led "$boardname:red:wlan"
++	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x1"
+ 	;;
+ hc5661|\
+ hc5661a)
+diff --git a/target/linux/ramips/dts/GL-MT300N-V2.dts b/target/linux/ramips/dts/GL-MT300N-V2.dts
+index e99d5578f05bbaf82917878b87eb973a8323198c..98c9a796330068b36df5946f4a428e1b324594f8 100644
+--- a/target/linux/ramips/dts/GL-MT300N-V2.dts
++++ b/target/linux/ramips/dts/GL-MT300N-V2.dts
+@@ -28,7 +28,7 @@
+ 		};
+ 
+ 		wan {
+-			label = "gl-mt300n-v2:blue:wan";
++			label = "gl-mt300n-v2:green:wan";
+ 			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
+ 		};
+ 

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -1,3 +1,8 @@
+# GL.iNet
+
+device gl-mt300n-v2 gl-mt300n-v2
+factory
+
 # TP-Link
 
 device tp-link-archer-c50-v3 tplink_c50-v3


### PR DESCRIPTION
I'm currently evaluating this device with a colleague and will update the checklist when I hear back from him.

https://meshviewer.darmstadt.freifunk.net/#/de/map/e4956e442864

---

### Checklist
- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp *not tested*
  - [x] other: sysupgrade
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state ~and activity~
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)