### PR TITLE
modules: update OpenWrt

### DIFF
--- a/modules
+++ b/modules
@@ -2,7 +2,7 @@ GLUON_FEEDS='packages routing luci gluon'
 
 OPENWRT_REPO=https://git.openwrt.org/openwrt/openwrt.git
 OPENWRT_BRANCH=openwrt-18.06
-OPENWRT_COMMIT=8baadecb1647a125f5d8f9eaf521c1468543133a
+OPENWRT_COMMIT=4fb73b61c0838ca6bbffb6b563f7cd0fdb074ac5
 
 PACKAGES_PACKAGES_REPO=https://github.com/openwrt/packages.git
 PACKAGES_PACKAGES_BRANCH=openwrt-18.06


### PR DESCRIPTION
- [x] compile test ar71xx-generic

```
4fb73b61c0 bcm53xx: use upstream SPI controller fix
2db4015285 bcm53xx: replace SPI revert with a fix sent upstream
1e2164aeb4 kernel: add missing symbol for target bcm53xx
3a9aed24d1 dnsmasq: bump to v2.80
270b9d30f6 kernel: bump 4.14 to 4.14.78
4dc42ef40e kernel: bump 4.9 to 4.9.135
47f68ca586 kernel: bump 4.14 to 4.14.77
dbd067013d kernel: bump 4.9 to 4.9.134
486dc7583d ar71xx: fix mtd corruption
9ac7eb4a86 kernel: bump 4.14 to 4.14.76
235148b077 kernel: bump 4.9 to 4.9.133
4fa4b5edaf mac80211: fix A-MSDU packet handling with TCP retransmission
70cb2d20c9 netfilter: add missing dependency for kernel 4.14
bba743458e kernel: bump 4.14 to 4.14.75
86a3d2604f kernel: bump 4.9 to 4.9.132
ae2a3a1d80 kernel: enable memory compaction
46a700e118 e2fsprogs: fix glibc compile issue (FS#1749,FS#1796)
0dbe3d28f7 iperf: fix --daemon option
95e2da8366 ar71xx: Fix installation of fw_setenv in sysupgrade ramdisk
234b893a18 base-files: Reintroduce sysupgrade_pre_upgrade hook
f3753a9ae0 netifd: fix segfault (FS#1875)
b3c64797db build: use CMAKE_SOURCE_SUBDIR variable to cmake.mk
149dcc26d1 kernel: bump 4.14 to 4.14.74
d837c93623 kernel: bump 4.9 to 4.9.131
```