### PR TITLE
ar71xx: remove BROKEN flag for TL-WR810N v1

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -183,9 +183,7 @@ device tp-link-wbs510-v1.20 wbs510-v1
 device tp-link-tl-wr710n-v1 tl-wr710n-v1
 device tp-link-tl-wr710n-v2.1 tl-wr710n-v2.1
 
-if [ "$BROKEN" ]; then
-device tp-link-tl-wr810n-v1 tl-wr810n-v1 # BROKEN: Untested
-fi
+device tp-link-tl-wr810n-v1 tl-wr810n-v1
 
 device tp-link-tl-wr842n-nd-v1 tl-wr842n-v1
 device tp-link-tl-wr842n-nd-v2 tl-wr842n-v2


### PR DESCRIPTION
This removes the BROKEN flag for the TP-Link TL-WR810N v1 as it is verified to be working by @Marssl78

Fixes #856