### PR TITLE
[RFC] gluon-setup-mode: add wifi interfaces

### DIFF
--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S20network
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S20network
@@ -13,6 +13,21 @@ delete_interface() {
         [ "$1" = 'loopback' ] || uci_remove network "$1"
 }
 
+delete_wifi_iface() {
+	uci_remove wireless "$1"
+}
+
+add_wifi_iface() {
+	uci_add wireless wifi-iface "setup_$1"
+	uci_set wireless "setup_$1" ifname "setup${1#radio}"
+	uci_set wireless "setup_$1" network "setup"
+	uci_set wireless "setup_$1" device "$1"
+	uci_set wireless "setup_$1" mode 'ap'
+	uci_set wireless "setup_$1" ssid 'Gluon Setup'
+	uci_set wireless "setup_$1" encryption 'psk2'
+	uci_set wireless "setup_$1" key "$(lua -e 'print(require("gluon.sysconfig").primary_mac:gsub(":",""):lower())')"
+}
+
 prepare_config() {
 (
 	export UCI_CONFIG_DIR=/var/gluon/setup-mode/config
@@ -33,6 +48,14 @@ prepare_config() {
 	uci_set network setup netmask "$SETUP_MODE_NETMASK"
 
 	uci_commit network
+
+	cp /etc/config/wireless "$UCI_CONFIG_DIR"
+
+	config_load wireless
+	config_foreach delete_wifi_iface wifi-iface
+	config_foreach add_wifi_iface wifi-device
+
+	uci_commit wireless
 )
 }
 


### PR DESCRIPTION
Since more and more manufactures drop LAN interfaces on their notebooks and don't include a wired NIC in form of an adapter we should provide a way to configure a node via WiFi. This PR is just a rough idea to start the discussion on how to implement it. We were already discussing the existing code on the Freifunk Hessen Meetup and came to the conclusion that using the primary_mac as PSK doesn't work for all devices. Other ideas are to reduce the txpower to the minimum and set maximum connections to 1.