### PR TITLE
Local node routing table separation

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/310-gluon-client-bridge-local-node
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/310-gluon-client-bridge-local-node
@@ -23,8 +23,7 @@ uci:section('network', 'device', 'local_node_dev', {
 local ip4, ip6
 
 if next_node.ip4 then
-	local plen = site.prefix4():match('/%d+$')
-	ip4 = next_node.ip4 .. plen
+	ip4 = next_node.ip4 .. '/32'
 end
 
 if next_node.ip6 then

--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
@@ -25,7 +25,18 @@ uci:section('network', 'interface', 'client', {
 
 uci:delete('network', 'client_lan')
 
+uci:section('network', 'rule', 'local_node_rule', {
+	src = next_node.ip4 .. '/32',
+	lookup = 2,
+})
+uci:set('network', 'local_node_rule', 'in', 'loopback')
+
 uci:delete('network', 'local_node_route')
+uci:section('network', 'route', 'local_node_route', {
+	interface = 'local_node',
+	target = site.prefix4(),
+	table = 2,
+})
 
 uci:section('network', 'rule6', 'local_node_rule6', {
 	src = next_node.ip6 .. '/128',

--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
@@ -8,6 +8,7 @@ local site = require 'gluon.site'
 local sysconfig = require 'gluon.sysconfig'
 local util = require 'gluon.util'
 local uci = require('simple-uci').cursor()
+local next_node = site.next_node({})
 
 
 uci:section('network', 'interface', 'client', {
@@ -26,11 +27,17 @@ uci:delete('network', 'client_lan')
 
 uci:delete('network', 'local_node_route')
 
+uci:section('network', 'rule6', 'local_node_rule6', {
+	src = next_node.ip6 .. '/128',
+	lookup = 2,
+})
+uci:set('network', 'local_node_rule6', 'in', 'loopback')
+
 uci:delete('network', 'local_node_route6')
 uci:section('network', 'route6', 'local_node_route6', {
-	interface = 'client',
+	interface = 'local_node',
 	target = site.prefix6(),
-	gateway = '::',
+	table = 2,
 })
 
 uci:save('network')

--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
@@ -25,6 +25,11 @@ uci:section('network', 'interface', 'client', {
 
 uci:delete('network', 'client_lan')
 
+uci:section('network', 'route', 'br_client_route', {
+	interface = 'client',
+	target = site.prefix4(),
+})
+
 uci:section('network', 'rule', 'local_node_rule', {
 	src = next_node.ip4 .. '/32',
 	lookup = 2,


### PR DESCRIPTION
This pull request includes one minor fix for the source MAC for IPv6 packets from the local-node ULA. And two changes similar to the previous attempt from commit b3762fc61cca ("gluon-client-bridge: move IPv4 local subnet route to br-client (#1312)"). But without the drawbacks @ecsv had discovered with it (3ef28a4684).

Conceptually, the new approach is to use a separate routing table for the local-node interface. Which we will only jump into if a node tries to use its IPv4 or IPv6 local-node address. This should ensure, that we never use the local-node interface's MAC address for any purpose other than direct client-to-node communication (for instance, routed packets will always use the unique MAC address from br-client).

This is also in preparation for the gluon-alt-esc packages (#1094).