### PR TITLE
gluon-mesh-babel: fix several issues reported by cppcheck

### DIFF
--- a/package/gluon-mesh-babel/src/respondd.c
+++ b/package/gluon-mesh-babel/src/respondd.c
@@ -591,7 +591,7 @@ static struct json_object * get_clients(void) {
 
 	count_stations(&wifi24, &wifi5);
 
-	size_t total = ask_l3roamd_for_client_count();
+	int total = ask_l3roamd_for_client_count();
 
 	size_t wifi = wifi24 + wifi5;
 	struct json_object *ret = json_object_new_object();

--- a/package/gluon-mesh-babel/src/respondd.c
+++ b/package/gluon-mesh-babel/src/respondd.c
@@ -559,11 +559,12 @@ static int ask_l3roamd_for_client_count() {
 
 	int rc = 0;
 	do {
-		buf = realloc(buf, already_read + SOCKET_INPUT_BUFFER_SIZE + 1);
-		if (buf == NULL) {
+		char *buf_tmp = realloc(buf, already_read + SOCKET_INPUT_BUFFER_SIZE + 1);
+		if (buf_tmp == NULL) {
 			fprintf(stderr, "could not allocate memory for buffer\n");
 			goto end;
 		}
+		buf = buf_tmp;
 
 		rc = read(fd, &buf[already_read], SOCKET_INPUT_BUFFER_SIZE);
 		already_read+=rc;

--- a/package/gluon-mesh-babel/src/respondd.c
+++ b/package/gluon-mesh-babel/src/respondd.c
@@ -352,10 +352,9 @@ static struct json_object * get_mesh_ifs() {
 		goto end;
 	}
 
-	int uret = -2;
 	blob_buf_init(&b, 0);
 	ubus_lookup_id(ubus_ctx, "network.interface", &id);
-	uret = ubus_invoke(ubus_ctx, id, "dump", b.head, receive_call_result_data, &ret, UBUS_TIMEOUT * 1000);
+	int uret = ubus_invoke(ubus_ctx, id, "dump", b.head, receive_call_result_data, &ret, UBUS_TIMEOUT * 1000);
 
 	if (uret > 0)
 		fprintf(stderr, "ubus command failed: %s\n", ubus_strerror(uret));


### PR DESCRIPTION
Noticed the following issues with the help of cppcheck, not sure if these are 'real' issues or changing the code will break other things.

```
$ cppcheck --enable=all package/gluon-mesh-babel/src/respondd.c 
Checking package/gluon-mesh-babel/src/respondd.c ...
[package/gluon-mesh-babel/src/respondd.c:355] -> [package/gluon-mesh-babel/src/respondd.c:358]: (style) Variable 'uret' is reassigned a value before the old one has been used.
[package/gluon-mesh-babel/src/respondd.c:598]: (style) Unsigned variable 'total' can't be negative so it is unnecessary to test it.
[package/gluon-mesh-babel/src/respondd.c:562]: (error) Common realloc mistake: 'buf' nulled but not freed upon failure
(information) Cppcheck cannot find all the include files (use --check-config for details)
```