### PR TITLE
ar71xx-generic: Add support for CPE210 V3

### DIFF
--- a/patches/openwrt/0012-firmware-utils-tplink-safeloader-Add-CPE210-v3.patch
+++ b/patches/openwrt/0012-firmware-utils-tplink-safeloader-Add-CPE210-v3.patch
@@ -1,0 +1,34 @@
+From: Robert Marko <robimarko@gmail.com>
+Date: Sat, 11 Aug 2018 17:12:01 +0200
+Subject: firmware-utils: tplink-safeloader: Add CPE210 v3
+
+Add TP-Link CPE210 v3 to the support list.
+Its identical to the v2.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index b2cc96bc3ce765df62bee837bdf0e3cf2d53be1b..8164c1ce314c5c658f2fe071c648059e7b4e1caf 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -155,7 +155,7 @@ static struct device_info boards[] = {
+ 		.last_sysupgrade_partition = "support-list",
+ 	},
+ 
+-	/** Firmware layout for the CPE210 V2 */
++	/** Firmware layout for the CPE210 V2 and V3 */
+ 	{
+ 		.id     = "CPE210V2",
+ 		.vendor = "CPE210(TP-LINK|UN|N300-2|00000000):2.0\r\n",
+@@ -170,7 +170,11 @@ static struct device_info boards[] = {
+ 			"CPE210(TP-LINK|US|N300-2|55530000):2.0\r\n"
+ 			"CPE210(TP-LINK|UN|N300-2):2.0\r\n"
+ 			"CPE210(TP-LINK|EU|N300-2):2.0\r\n"
+-			"CPE210(TP-LINK|US|N300-2):2.0\r\n",
++			"CPE210(TP-LINK|US|N300-2):2.0\r\n"
++			"CPE210(TP-LINK|EU|N300-2|45550000):3.0\r\n"
++			"CPE210(TP-LINK|UN|N300-2|00000000):3.0\r\n"
++			"CPE210(TP-LINK|UN|N300-2):3.0\r\n"
++			"CPE210(TP-LINK|EU|N300-2):3.0\r\n",
+ 		.support_trail = '\xff',
+ 		.soft_ver = NULL,
+ 

--- a/patches/openwrt/0013-ar71xx-Add-support-for-TP-Link-CPE210-v3.patch
+++ b/patches/openwrt/0013-ar71xx-Add-support-for-TP-Link-CPE210-v3.patch
@@ -1,0 +1,133 @@
+From: Robert Marko <robimarko@gmail.com>
+Date: Sat, 11 Aug 2018 17:32:48 +0200
+Subject:  ar71xx: Add support for TP-Link CPE210 v3
+
+ ar71xx: Add support for TP-Link CPE210 v3.
+Looks identical to the v2.
+
+This PR adds support for a popular low-cost 2.4GHz N based AP
+
+Specifications:
+ - SoC: Qualcomm Atheros QCA9533 (650MHz)
+ - RAM: 64MB
+ - Storage: 8 MB SPI NOR
+ - Wireless: 2.4GHz N based built into SoC 2x2
+ - Ethernet: 1x 100/10 Mbps, integrated into SoC, 24V POE IN
+
+Installation:
+Flash factory image through stock firmware WEB UI
+or through TFTP
+To get to TFTP recovery just hold reset button while powering on for
+around 4-5 seconds and release.
+Rename factory image to recovery.bin
+Stock TFTP server IP:192.168.0.100
+Stock device TFTP adress:192.168.0.254
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 592133ac286b5bd5d1a82bce7e5d2cd8486a363b..89cc0cbff7822026a78240d115226311dfe6cd40 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -249,6 +249,7 @@ cf-e530n)
+ 	;;
+ cpe210|\
+ cpe210-v2|\
++cpe210-v3|\
+ cpe510|\
+ wbs210|\
+ wbs510)
+@@ -259,7 +260,8 @@ wbs510)
+ 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "76" "100" "-75" "13"
+ 
+ 	case "$board" in
+-	cpe210-v2)
++	cpe210-v2|\
++	cpe210-v3)
+ 		ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan0" "eth0"
+ 		;;
+ 	*)
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index b0076366bc505d578f2daa7b83987f788dbda2f4..f04ef27a840b47cf2d6215c593574d7d62fcff3c 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -75,6 +75,7 @@ ar71xx_setup_interfaces()
+ 	cf-e380ac-v1|\
+ 	cf-e380ac-v2|\
+ 	cpe210-v2|\
++	cpe210-v3|\
+ 	dr342|\
+ 	eap120|\
+ 	eap300v2|\
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index 3af2eee2bd5f28dd1b1ffd2f212f79ff392b811a..c943e5cfd73b2fb0f3484b22e9794539f282cebf 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -577,6 +577,10 @@ ar71xx_board_detect() {
+ 		name="cpe210-v2"
+ 		tplink_pharos_board_detect "$(tplink_pharos_v2_get_model_string)"
+ 		;;
++	*"CPE210 v3")
++		name="cpe210-v3"
++		tplink_pharos_board_detect "$(tplink_pharos_v2_get_model_string)"
++		;;
+ 	*"CPE505N")
+ 		name="cpe505n"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index ca1270b7fdc84c53f8417c226f18ca4fff1f27d8..a04dd7441d28e9db4dc7c744707bb5f35936da00 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -587,7 +587,8 @@ platform_check_image() {
+ 		tplink_pharos_check_image "$1" "7f454c46" "$(tplink_pharos_get_model_string)" '' && return 0
+ 		return 1
+ 		;;
+-	cpe210-v2)
++	cpe210-v2|\
++	cpe210-v3)
+ 		tplink_pharos_check_image "$1" "01000000" "$(tplink_pharos_v2_get_model_string)" '\0\xff\r' && return 0
+ 		return 1
+ 		;;
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c
+index ceb1769ddd522d51014228fe65e2662f2f3e627c..16efbc8802ab96a10aab474721902344664c7f8f 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c
+@@ -236,6 +236,9 @@ MIPS_MACHINE(ATH79_MACH_CPE210, "CPE210", "TP-LINK CPE210/220",
+ MIPS_MACHINE(ATH79_MACH_CPE210_V2, "CPE210V2", "TP-LINK CPE210 v2",
+ 	     cpe210_v2_setup);
+ 
++MIPS_MACHINE(ATH79_MACH_CPE210_V3, "CPE210V3", "TP-LINK CPE210 v3",
++	     cpe210_v2_setup);
++
+ MIPS_MACHINE(ATH79_MACH_CPE510, "CPE510", "TP-LINK CPE510/520",
+ 	     cpe510_setup);
+ 
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 390ec0b2c38d9af99e215f75009eed9b2e4c0b01..f7621c421dd8a8bdc68c43458e5de86d749407de 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -75,6 +75,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_CF_E530N,			/* COMFAST CF-E530N */
+ 	ATH79_MACH_CPE210,			/* TP-LINK CPE210 v1 */
+ 	ATH79_MACH_CPE210_V2,			/* TP-LINK CPE210 v2 */
++	ATH79_MACH_CPE210_V3,			/* TP-LINK CPE210 v3 */
+ 	ATH79_MACH_CPE505N,			/* P&W CPE505N */
+ 	ATH79_MACH_CPE510,			/* TP-LINK CPE510 */
+ 	ATH79_MACH_CPE830,			/* YunCore CPE830 */
+diff --git a/target/linux/ar71xx/image/generic-tp-link.mk b/target/linux/ar71xx/image/generic-tp-link.mk
+index 502c88b1bae970e0242ce6fb934911b38f4e2c7a..e5aca30e349d69cf37076a101b9cb6dd7108650b 100644
+--- a/target/linux/ar71xx/image/generic-tp-link.mk
++++ b/target/linux/ar71xx/image/generic-tp-link.mk
+@@ -195,6 +195,13 @@ define Device/cpe210-v2
+ endef
+ TARGET_DEVICES += cpe210-v2
+ 
++define Device/cpe210-v3
++  $(Device/cpe210-v2)
++  DEVICE_TITLE := TP-LINK CPE210 v3
++  BOARDNAME := CPE210V3
++endef
++TARGET_DEVICES += cpe210-v3
++
+ define Device/wbs210-v1
+   $(Device/cpe510-520-v1)
+   DEVICE_TITLE := TP-LINK WBS210 v1

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -172,6 +172,9 @@ alias tp-link-cpe210-v1.1
 alias tp-link-cpe220-v1.1
 
 device tp-link-cpe210-v2.0 cpe210-v2
+if [ "$BROKEN" ]; then
+device tp-link-cpe210-v3.0 cpe210-v3
+fi
 
 device tp-link-cpe510-v1.0 cpe510-520-v1
 alias tp-link-cpe510-v1.1


### PR DESCRIPTION
Since upstream support seems to be "problematic", why don't we just add support via a patch until the device is finally supported upstream? 

~I've tested everything but upgrading.~

- [X] must be flashable from vendor firmware
  - [X] webinterface
  - [X] tftp
  - [ ] other: <specify>
- [X] must support upgrade mechanism
  - [X] must have working sysupgrade
    - [X] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [X] must have working autoupdate
    *usually means: gluon profile name must match image name*
- wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [X] association with AP must be possible on all radios
  - [X] association with 802.11s mesh must be working on all radios 
  - [X] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [X] lit while the device is on
    - [X] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [X] should map to their respective radio
    - [X] should show activity
  - switchport leds
    - [X] should map to their respective port (or switch, if only one led present) 
    - [X] should show link state and activity
- [X] reset/wps button must return device into config mode
- [X] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)