### PR TITLE
gluon-status-page: show site_code, domain_code & role

### DIFF
--- a/package/gluon-respondd/src/respondd.c
+++ b/package/gluon-respondd/src/respondd.c
@@ -68,6 +68,18 @@ static struct json_object * get_site_code(void) {
 	return ret;
 }
 
+static struct json_object * get_site_name(void) {
+	struct json_object *site = gluonutil_load_site_config();
+	if (!site)
+		return NULL;
+ 	struct json_object *ret = NULL;
+	json_object_object_get_ex(site, "site_name", &ret);
+	if (ret)
+		json_object_get(ret);
+ 	json_object_put(site);
+	return ret;
+}
+
 static struct json_object * get_domain_code(void) {
 	return gluonutil_wrap_and_free_string(gluonutil_get_domain());
 }
@@ -130,6 +142,7 @@ static struct json_object * respondd_provider_nodeinfo(void) {
 	json_object_object_add(system, "site_code", get_site_code());
 	if (gluonutil_has_domains())
 		json_object_object_add(system, "domain_code", get_domain_code());
+	json_object_object_add(system, "site_name", get_site_name());
 	json_object_object_add(ret, "system", system);
 
 	return ret;

--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -122,6 +122,15 @@
 								string.format(' (%s)', nodeinfo.software.autoupdater.branch)
 						%></dd>
 					<%- end %>
+					<% if nodeinfo.system.role then -%>
+						<dt><%:Role%></dt><dd><%| nodeinfo.system.role %></dd>
+					<%- end %>
+					<% if nodeinfo.system.site_code then -%>
+						<dt><%:Site%></dt><dd><%| nodeinfo.system.site_code %></dd>
+					<%- end %>
+					<% if nodeinfo.system.domain_code then -%>
+						<dt><%:Domain%></dt><dd><%| nodeinfo.system.domain_code %></dd>
+					<%- end %>
 				</dl>
 			</div>
 			<div class="frame">

--- a/package/gluon-status-page/i18n/de.po
+++ b/package/gluon-status-page/i18n/de.po
@@ -40,6 +40,9 @@ msgstr "Position"
 msgid "Distance"
 msgstr "Entfernung"
 
+msgid "Domain"
+msgstr "Domäne"
+
 msgid "Error"
 msgstr "Fehler"
 
@@ -94,8 +97,14 @@ msgstr "RAM"
 msgid "Received"
 msgstr "Empfangen"
 
+msgid "Role"
+msgstr "Rolle"
+
 msgid "Status"
 msgstr "Status"
+
+msgid "Site"
+msgstr ""
 
 msgid "Traffic"
 msgstr ""

--- a/package/gluon-status-page/i18n/gluon-status-page.pot
+++ b/package/gluon-status-page/i18n/gluon-status-page.pot
@@ -31,6 +31,9 @@ msgstr ""
 msgid "Distance"
 msgstr ""
 
+msgid "Domain"
+msgstr ""
+
 msgid "Error"
 msgstr ""
 
@@ -85,7 +88,13 @@ msgstr ""
 msgid "Received"
 msgstr ""
 
+msgid "Role"
+msgstr ""
+
 msgid "Status"
+msgstr ""
+
+msgid "Site"
 msgstr ""
 
 msgid "Traffic"


### PR DESCRIPTION
The data should be displayed if it is availiable. In addition to that the node should also provide this information via respondd. The pretty domain name is very expensive to figure out on the status page. 
This PR should be the requested patch for https://github.com/freifunk-gluon/gluon/issues/1415