### PR TITLE
docs: fix some old urls or 'upgrade' to https

### DIFF
--- a/docs/features/monitoring.rst
+++ b/docs/features/monitoring.rst
@@ -33,7 +33,7 @@ There are two packages responsible for distribution of the information. For
 one, information is distributed across the mesh using alfred_. Information
 between neighbouring nodes is exchanged using `gluon-respondd`.
 
-.. _alfred: http://www.open-mesh.org/projects/alfred
+.. _alfred: https://www.open-mesh.org/projects/alfred
 
 alfred (mesh bound)
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/releases/v2016.2.6.rst
+++ b/docs/releases/v2016.2.6.rst
@@ -13,7 +13,7 @@ Bugfixes
 ~~~~~~~~
 
 * Fix `CVE-2016-10229 <https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-10229>`_
-  (`#1097 <https://github.com/freifunk-gluon/gluon/issues/1097>`_)
+  (`#1097 <https://github.com/freifunk-gluon/gluon/pull/1097>`_)
 
   Fortunately, the standard Gluon setup is not vulnerable, as the issue only affects
   applications that use MSG_PEEK on UDP sockets. dnsmasq does use MSG_PEEK, but

--- a/docs/releases/v2016.2.rst
+++ b/docs/releases/v2016.2.rst
@@ -64,13 +64,13 @@ New features
 * batman-adv: mesh_no_rebroadcast is now enabled for Mesh-on-WAN/LAN (`#652 <https://github.com/freifunk-gluon/gluon/issues/652>`_)
 
 * The new UCI option ``gluon-core.@wireless[0].preserve_channels`` can be used to
-  prevent a changed WLAN channel from being reset on firmware upgrades (`#640 <https://github.com/freifunk-gluon/gluon/issues/640>`_)
+  prevent a changed WLAN channel from being reset on firmware upgrades (`#640 <https://github.com/freifunk-gluon/gluon/pull/640>`_)
 
 * PoE passthrough can now be configured from site.conf and the Advanced Settings
   on TP-Link CPE 210/510 and Ubiquiti NanoStations (`#328 <https://github.com/freifunk-gluon/gluon/issues/328>`_)
 
 * The config mode *altitude* field can now be hidden using the ``config_mode.geo_location.show_altitude``
-  site.conf setting (`#693 <https://github.com/freifunk-gluon/gluon/issues/693>`_)
+  site.conf setting (`#693 <https://github.com/freifunk-gluon/gluon/pull/693>`_)
 
 * The contact information field in the config mode can be made obligatory using
   the ``config_mode.owner.obligatory`` site.conf option
@@ -93,7 +93,7 @@ New features
   802.11b rates (`#810 <https://github.com/freifunk-gluon/gluon/pull/810>`_)
 
 * ath10k-based devices are now supported officially; it's possible to choose between
-  IBSS- and 11s-capable firmwares in site.mk (`#864 <https://github.com/freifunk-gluon/gluon/pull/864>`_)
+  IBSS- and 11s-capable firmwares in site.mk (`#864 <https://github.com/freifunk-gluon/gluon/issues/864>`_)
 
 * The ``prefix4`` and ``next_node.ip4`` site.conf options are optional now.
 
@@ -106,7 +106,7 @@ Bugfixes
   mac80211, hostapd and other related drivers and services have been backported from LEDE ``42f559e``.
 
 * Extremely slow downloads could lead to multiple instances of the autoupdater
-  running concurrently (`#582 <https://github.com/freifunk-gluon/gluon/pull/582>`_)
+  running concurrently (`#582 <https://github.com/freifunk-gluon/gluon/issues/582>`_)
 
   A lockfile is used to prevent this and timeouts have been added to download processes.
 

--- a/docs/releases/v2017.1.2.rst
+++ b/docs/releases/v2017.1.2.rst
@@ -12,7 +12,7 @@ New features
   preserved on upgrades.
 
 * Allow configuring the batman-adv routing algorithm (*BATMAN IV* or *BATMAN V*)
-  in *site.conf* (`#1185 <https://github.com/freifunk-gluon/gluon/issues/1185>`_)
+  in *site.conf* (`#1185 <https://github.com/freifunk-gluon/gluon/pull/1185>`_)
 
   *BATMAN V* still hasn't received extensive testing (and is incompatible with *BATMAN IV*).
   This new option allows to set up *BATMAN V*-based test meshes. If unset, the routing
@@ -55,7 +55,7 @@ Bugfixes
   fixed, triggering a reboot instead.
 
 * Also display *gluon-config-mode:novpn* message when Tunneldigger is installed, but disabled
-  (`#1172 <https://github.com/freifunk-gluon/gluon/issues/1172>`_)
+  (`#1172 <https://github.com/freifunk-gluon/gluon/pull/1172>`_)
 
   It was only displayed on nodes with fastd before.
 

--- a/docs/releases/v2017.1.3.rst
+++ b/docs/releases/v2017.1.3.rst
@@ -26,7 +26,7 @@ Bugfixes
   of the Gluon build, including tcpdump, curl and mbedtls
 
   Please refer to the
-  `LEDE commit log <https://git.lede-project.org/?p=source.git;a=shortlog;h=refs/heads/lede-17.01>`_
+  `LEDE commit log <https://git.openwrt.org/?p=source.git;a=shortlog;h=refs/heads/lede-17.01>`_
   for details.
 
 * Filtering of multicast packets between the mesh and the *local-node* interface

--- a/docs/releases/v2017.1.rst
+++ b/docs/releases/v2017.1.rst
@@ -83,13 +83,13 @@ New features
 ~~~~~~~~~~~~
 
 * Localization support has been added to the status page. In addition to German,
-  there are English and Russian translations now (`#1044 <https://github.com/freifunk-gluon/gluon/issues/1044>`_)
+  there are English and Russian translations now (`#1044 <https://github.com/freifunk-gluon/gluon/pull/1044>`_)
 
 * Add support for making nodes a DNS cache for clients
-  (`#1000 <https://github.com/freifunk-gluon/gluon/issues/1000>`_)
+  (`#1000 <https://github.com/freifunk-gluon/gluon/pull/1000>`_)
 
 * Add L2TP via tunneldigger as an alternative VPN system
-  (`#978 <https://github.com/freifunk-gluon/gluon/issues/978>`_)
+  (`#978 <https://github.com/freifunk-gluon/gluon/pull/978>`_)
 
   L2TP will usually give better performance than fastd as it runs in kernel
   space, but it does not provide encryption. Also, tunneling over IPv6 is
@@ -98,7 +98,7 @@ New features
   It is not possible to include both fastd and tunneldigger in the same
   firmware.
 
-* Add source filter package (`#1015 <https://github.com/freifunk-gluon/gluon/issues/1015>`_)
+* Add source filter package (`#1015 <https://github.com/freifunk-gluon/gluon/pull/1015>`_)
 
   The new package *gluon-ebtables-source-filter* can be used to prevent traffic
   using unexpected IP addresses or packet types from entering the mesh.
@@ -184,7 +184,7 @@ Internals
 ~~~~~~~~~
 
 * The LuCI base libraries have been replaced by a stripped-down
-  version called "gluon-web" (`#1007 <https://github.com/freifunk-gluon/gluon/issues/1007>`_)
+  version called "gluon-web" (`#1007 <https://github.com/freifunk-gluon/gluon/pull/1007>`_)
 
   Custom packages will need to be adjusted; in particular, all uses of *luci.model.uci*
   need to be replaced with *simple-uci*. The Gluon documentation explains the most important

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -1,7 +1,7 @@
 -- This is an example site configuration for Gluon v2018.1+
 --
 -- Take a look at the documentation located at
--- http://gluon.readthedocs.org/ for details.
+-- https://gluon.readthedocs.io/ for details.
 --
 -- This configuration will not work as is. You're required to make
 -- community specific changes to it!
@@ -27,7 +27,7 @@
   prefix6 = 'fdxx:xxxx:xxxx::/64',
 
   -- Timezone of your community.
-  -- See http://wiki.openwrt.org/doc/uci/system#time_zones
+  -- See https://openwrt.org/docs/guide-user/base-system/system_configuration#time_zones
   timezone = 'CET-1CEST,M3.5.0,M10.5.0/3',
 
   -- List of NTP servers in your community.
@@ -108,7 +108,7 @@
     mtu = 1312,
 
     fastd = {
-      -- Refer to http://fastd.readthedocs.org/en/latest/ to better understand
+      -- Refer to https://fastd.readthedocs.io/en/latest/ to better understand
       -- what these options do.
 
       -- List of crypto-methods to use.

--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -32,7 +32,7 @@ Consider these key values:
   - and configure `MSS clamping`_ accordingly,
   - and announce your link MTU via Router Advertisments and DHCP
 
-  .. _MSS clamping: http://www.tldp.org/HOWTO/Adv-Routing-HOWTO/lartc.cookbook.mtu-mss.html
+  .. _MSS clamping: https://www.tldp.org/HOWTO/Adv-Routing-HOWTO/lartc.cookbook.mtu-mss.html
 
 - Encapsulation: Account for the overhead created by the configured mesh protocol
   encapsulating the payload, which is

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -19,7 +19,7 @@ an old site configuration to a newer release of Gluon.
 
 An example configuration can be found in the Gluon repository at *docs/site-example/*.
 
-.. _Git tags: http://git-scm.com/book/en/Git-Basics-Tagging
+.. _Git tags: https://git-scm.com/book/en/v2/Git-Basics-Tagging
 .. _list of gluon releases: https://github.com/freifunk-gluon/gluon/releases
 
 Dependencies


### PR DESCRIPTION
* `wiki.openwrt.org` seems to redirecting to `https://oldwiki.archive.openwrt.org/` which is not usable, lately

* `https://git-scm.com/book/en/Git-Basics-Tagging` redirects to `https://git-scm.com/book/en/v2/Git-Basics-Tagging`
Q: not sure if we should keep the link or use version 2?

* Some links where upgraded to https
Q; Is that useful at all?

* Also noted some of the issues are linked as pull requests in the release notes or the other way round, e.g.
`https://github.com/freifunk-gluon/gluon/issues/1097` -> `https://github.com/freifunk-gluon/gluon/pull/1097` or
`https://github.com/freifunk-gluon/gluon/pull/864` -> `https://github.com/freifunk-gluon/gluon/issues/864`
Q: Should that be fixed?