### PR TITLE
gluon-core: fix pattern %v in opkg URLs

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/500-opkg
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/500-opkg
@@ -16,7 +16,7 @@ local subst = {}
 
 local f = io.popen('. /etc/os-release; echo "$ID"; echo "$VERSION_ID"; echo "$LEDE_BOARD"; echo "$LEDE_ARCH"')
 subst['%%d'] = f:read()
-subst['%%v'] = f:read():gsub('-SNAPSHOT', '')
+subst['%%v'] = f:read():gsub('-snapshot', '')
 subst['%%S'] = f:read()
 subst['%%A'] = f:read()
 f:close()


### PR DESCRIPTION
$VERSION_ID is a lowercase value