### PR TITLE
gluon-mesh-babel: remove broken log-file option from config

### DIFF
--- a/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
+++ b/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
@@ -7,7 +7,6 @@ file = io.open(babelconf, "w")
 file:write("ipv6-subtrees true\n")
 file:write("reflect-kernel-metric true\n")
 file:write("export-table 254\n")
-file:write("log-file /dev/stderr\n")
 file:write("import-table 254\n")
 
 file:write("out ip " .. site.next_node.ip6() .. "/128 deny\n")


### PR DESCRIPTION
log-file /dev/stderr is broken for babeld as it eats log messages for debug log.
This commit gets rid of the option. This allows -d N to be used as babeld command
line option.