### PR TITLE
gluon-client-bridge: set ra_holdoff interval to 30 seconds

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
@@ -35,6 +35,7 @@ uci:section('network', 'interface', 'client', {
 	macaddr = sysconfig.primary_mac,
 	igmp_snooping = true,
 	multicast_querier = true,
+	ra_holdoff = 30,
 })
 
 uci:save('network')


### PR DESCRIPTION
Allow odhcp6c to fork the script to handle router
advertisments in 30 seconds intervals. This is the value
that was previously used in Gluon v2018.1 / LEDE 17.06.

The default value is 3 seconds and while it is RFC compliant
it can put alot of pressure on even moderately sized devices.

Signed-off-by: Martin Weinelt <martin@darmstadt.freifunk.net>

---

The following was observed on a CPE210 device. The load penalty occured when updating from v2018.1.x to master, the load fell when this changed was introduced.

![ra_holdoff load compared between v2018.1.x and master](https://forum.darmstadt.freifunk.net/uploads/default/original/1X/acfea54d57d6794e909d1af89899375e9077eade.png)

