### PR TITLE
docs: update some old urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ triggered and what you did to fix it. If in question, have a glance at the
 existing commit messages to get the idea.
 
 
-[packages]: http://gluon.readthedocs.org/en/latest/user/site.html#packages
+[packages]: https://gluon.readthedocs.io/en/latest/user/site.html#packages
 [#gluon]: https://webirc.hackint.org/#gluon
 [mailing list]: mailto:gluon@luebeck.freifunk.net
 [list of rejected features]: https://github.com/freifunk-gluon/gluon/issues?q=label%3Arejected

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Documentation (incomplete at this time, contribute if you can!) may be found at
-https://gluon.readthedocs.org/.
+https://gluon.readthedocs.io/.
 
 If you're new to Gluon and ready to get your feet wet, have a look at the
-[Getting Started Guide](https://gluon.readthedocs.org/en/latest/user/getting_started.html).
+[Getting Started Guide](https://gluon.readthedocs.io/en/latest/user/getting_started.html).
 
 **Gluon IRC channel: `#gluon` in [hackint](https://hackint.org/)**
 

--- a/docs/features/monitoring.rst
+++ b/docs/features/monitoring.rst
@@ -97,7 +97,7 @@ In order to retrieve statistics data you could run:
 
 You can find more information about alfred in its README_.
 
-.. _README: https://git.open-mesh.org/alfred.git/blob_plain/refs/heads/master:/README
+.. _README: https://git.open-mesh.org/alfred.git/blob_plain/refs/heads/master:/README.rst
 
 gluon-respondd
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
Update the readthedocs links to `https://gluon.readthedocs.io` and fix a broken alfred readme link