### PR TITLE
ar71xx: add support for ZyXEL NBG6616

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -238,6 +238,10 @@ ar71xx-generic
   - My Net N600
   - My Net N750
 
+* ZyXEL
+
+  - NBG6616 [#ath10k]_
+
 ar71xx-nand
 ^^^^^^^^^^^
 

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -320,3 +320,7 @@ factory
 
 device wd-my-net-n600 mynet-n600
 device wd-my-net-n750 mynet-n750
+
+# ZyXEL
+device zyxel-nbg6616 NBG6616
+packages $ATH10K_PACKAGES


### PR DESCRIPTION
### Device checklist
- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] tftp
  - [x] other: ssh into device, mtd onto /dev/mtd6
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
  - [x] must have working autoupdate [1]
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging)

[1] `root@nbg6616-test:~# lua -e 'print(require("platform_info").get_image_name())' 
zyxel-nbg6616`

Test device can be found here: http://[2001:bc8:3f13:ffc2:92ef:68ff:fe7e:ac3d]/cgi-bin/status

Signed-off-by: Christoph Krapp <achterin@googlemail.com>