### PR TITLE
docs: getting_started: Update to Debian Stretch

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -25,7 +25,7 @@ An example configuration can be found in the Gluon repository at *docs/site-exam
 Dependencies
 ------------
 To build Gluon, several packages need to be installed on the system. On a
-freshly installed Debian Wheezy system the following packages are required:
+freshly installed Debian Stretch system the following packages are required:
 
 * `git` (to get Gluon and other dependencies)
 * `subversion`


### PR DESCRIPTION
I just followed this document on a Debian Stretch, and it worked out of
the box. So let's use Debian's current stable release here.