### PR TITLE
ramips-mt7621: remove BROKEN flag for ZBT WG3526-16M & WG3526-32M

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -361,6 +361,11 @@ ramips-mt7621
   - EdgeRouter X
   - EdgeRouter X-SFP
 
+* ZBT
+
+  - WG3526-16M [#80211s]_
+  - WG3526-32M [#80211s]_
+
 ramips-rt305x
 ^^^^^^^^^^^^^
 

--- a/patches/openwrt/0012-ramips-mt7621-fix-5GHz-WiFi-LED-on-ZBT-WG3526.patch
+++ b/patches/openwrt/0012-ramips-mt7621-fix-5GHz-WiFi-LED-on-ZBT-WG3526.patch
@@ -1,0 +1,23 @@
+From: Andreas Ziegler <dev@andreas-ziegler.de>
+Date: Thu, 27 Dec 2018 15:02:41 +0100
+Subject: ramips: mt7621: fix 5GHz WiFi LED on ZBT WG3526
+
+This fixes the 5GHz WiFi LED which was previously not working.
+
+Signed-off-by: Andreas Ziegler <dev@andreas-ziegler.de>
+
+diff --git a/target/linux/ramips/dts/ZBT-WG3526.dtsi b/target/linux/ramips/dts/ZBT-WG3526.dtsi
+index 104a51f8de7110c0f65f760af70033853f3da745..e42ec5e33de7fb69a9c668406f876f6443d2912b 100644
+--- a/target/linux/ramips/dts/ZBT-WG3526.dtsi
++++ b/target/linux/ramips/dts/ZBT-WG3526.dtsi
+@@ -101,6 +101,10 @@
+ 			mediatek,mtd-eeprom = <&factory 0x8000>;
+ 			ieee80211-freq-limit = <5000000 6000000>;
+ 		};
++
++		led {
++			led-sources = <2>;
++		};
+ 	};
+ };
+ 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -4,22 +4,25 @@ if [ "$BROKEN" ] || [ "$GLUON_WLAN_MESH" = '11s' ]; then
 device d-link-dir-860l-b1 dir-860l-b1 # BROKEN: IBSS untested
 fi
 
-# BROKEN: No AP+IBSS support (plus individual issues)
-if [ "$BROKEN" ]; then
 
 ## Netgear
 
+if [ "$BROKEN" ]; then
 device netgear-wndr3700v5 wndr3700v5 # BROKEN: Untested
 factory
+fi
 
+
+# BROKEN: IBSS untested
+if [ "$BROKEN" ] || [ "$GLUON_WLAN_MESH" = '11s' ]; then
 
 ## ZBT
 
-device zbt-wg3526-16m zbt-wg3526-16M # BROKEN: Untested
+device zbt-wg3526-16m zbt-wg3526-16M
 factory
 manifest_alias zbt-wg3526
 
-device zbt-wg3526-32m zbt-wg3526-32M # BROKEN: Untested
+device zbt-wg3526-32m zbt-wg3526-32M
 factory
 
 fi


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] tftp
  - [ ] other (not tested)
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- [x] reset/wps button must return device into config mode
- [ ] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes) (device has no printed MAC)

to fix the devices 5GHz radio LED it needs three additional lines in the file `target/linux/ramips/dts/ZBT-WG3526.dtsi`
which i submitted as a patch upstream ( https://patchwork.ozlabs.org/patch/1018892/ )