### PR TITLE
ar71xx: add support for FRITZ!Repeater 300E

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -135,6 +135,7 @@ ar71xx-generic
 * AVM
 
   - Fritz!Box 4020 [#avmflash]_
+  - Fritz!WLAN Repeater 300E [#avmflash]_
   - Fritz!WLAN Repeater 450E [#avmflash]_
 
 * Buffalo

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -39,6 +39,9 @@ factory
 device avm-fritz-box-4020 fritz4020 fritz4020
 factory
 
+device avm-fritz-wlan-repeater-300e fritz300e
+factory
+
 device avm-fritz-wlan-repeater-450e fritz450e
 factory
 


### PR DESCRIPTION
Signed-off-by: Martin Weinelt <martin@darmstadt.freifunk.net>

Slight issue: The radio is dualband and is currently autoconfigured for 5 GHz. We are lacking a sane default and/or a toggle.

```
root@64283-fritz300e:~# uci show wireless
wireless.radio0=wifi-device
wireless.radio0.type='mac80211'
wireless.radio0.hwmode='11a'
wireless.radio0.path='pci0000:00/0000:00:00.0'
wireless.radio0.htmode='HT20'
wireless.radio0.country='DE'
wireless.radio0.channel='48'
wireless.mesh_radio0=wifi-iface
wireless.mesh_radio0.ifname='mesh0'
wireless.mesh_radio0.network='mesh_radio0'
wireless.mesh_radio0.device='radio0'
wireless.mesh_radio0.mesh_fwding='0'
wireless.mesh_radio0.mesh_id='ffda-mesh-dom1'
wireless.mesh_radio0.mcast_rate='12000'
wireless.mesh_radio0.mode='mesh'
wireless.mesh_radio0.disabled='0'
wireless.mesh_radio0.macaddr='3e:34:64:7b:0c:09'
wireless.client_radio0=wifi-iface
wireless.client_radio0.ifname='client0'
wireless.client_radio0.network='client'
wireless.client_radio0.disabled='0'
wireless.client_radio0.device='radio0'
wireless.client_radio0.mode='ap'
wireless.client_radio0.macaddr='3e:34:64:7b:0c:08'
wireless.client_radio0.ssid='darmstadt.freifunk.net'
```

```
root@64283-fritz300e:~# iw phy
Wiphy phy0
	max # scan SSIDs: 4
	max scan IEs length: 2257 bytes
	max # sched scan SSIDs: 0
	max # match sets: 0
	max # scan plans: 1
	max scan plan interval: -1
	max scan plan iterations: 0
	Retry short limit: 7
	Retry long limit: 4
	Coverage class: 0 (up to 0m)
	Device supports AP-side u-APSD.
	Device supports T-DLS.
	Available Antennas: TX 0x3 RX 0x3
	Configured Antennas: TX 0x3 RX 0x3
	Supported interface modes:
		 * IBSS
		 * managed
		 * AP
		 * AP/VLAN
		 * monitor
		 * mesh point
		 * P2P-client
		 * P2P-GO
		 * outside context of a BSS
	Band 1:
		Capabilities: 0x11ef
			RX LDPC
			HT20/HT40
			SM Power Save disabled
			RX HT20 SGI
			RX HT40 SGI
			TX STBC
			RX STBC 1-stream
			Max AMSDU length: 3839 bytes
			DSSS/CCK HT40
		Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
		Minimum RX AMPDU time spacing: 8 usec (0x06)
		HT TX/RX MCS rate indexes supported: 0-15
		Frequencies:
			* 2412 MHz [1] (20.0 dBm)
			* 2417 MHz [2] (20.0 dBm)
			* 2422 MHz [3] (20.0 dBm)
			* 2427 MHz [4] (20.0 dBm)
			* 2432 MHz [5] (20.0 dBm)
			* 2437 MHz [6] (20.0 dBm)
			* 2442 MHz [7] (20.0 dBm)
			* 2447 MHz [8] (20.0 dBm)
			* 2452 MHz [9] (20.0 dBm)
			* 2457 MHz [10] (20.0 dBm)
			* 2462 MHz [11] (20.0 dBm)
			* 2467 MHz [12] (20.0 dBm)
			* 2472 MHz [13] (20.0 dBm)
			* 2484 MHz [14] (disabled)
	Band 2:
		Capabilities: 0x11ef
			RX LDPC
			HT20/HT40
			SM Power Save disabled
			RX HT20 SGI
			RX HT40 SGI
			TX STBC
			RX STBC 1-stream
			Max AMSDU length: 3839 bytes
			DSSS/CCK HT40
		Maximum RX AMPDU length 65535 bytes (exponent: 0x003)
		Minimum RX AMPDU time spacing: 8 usec (0x06)
		HT TX/RX MCS rate indexes supported: 0-15
		Frequencies:
			* 5180 MHz [36] (20.0 dBm)
			* 5200 MHz [40] (20.0 dBm)
			* 5220 MHz [44] (20.0 dBm)
			* 5240 MHz [48] (20.0 dBm)
			* 5260 MHz [52] (20.0 dBm) (radar detection)
			* 5280 MHz [56] (20.0 dBm) (radar detection)
			* 5300 MHz [60] (20.0 dBm) (radar detection)
			* 5320 MHz [64] (20.0 dBm) (radar detection)
			* 5500 MHz [100] (24.0 dBm) (radar detection)
			* 5520 MHz [104] (24.0 dBm) (radar detection)
			* 5540 MHz [108] (24.0 dBm) (radar detection)
			* 5560 MHz [112] (24.0 dBm) (radar detection)
			* 5580 MHz [116] (24.0 dBm) (radar detection)
			* 5600 MHz [120] (24.0 dBm) (radar detection)
			* 5620 MHz [124] (24.0 dBm) (radar detection)
			* 5640 MHz [128] (24.0 dBm) (radar detection)
			* 5660 MHz [132] (24.0 dBm) (radar detection)
			* 5680 MHz [136] (24.0 dBm) (radar detection)
			* 5700 MHz [140] (24.0 dBm) (radar detection)
			* 5745 MHz [149] (13.0 dBm)
			* 5765 MHz [153] (13.0 dBm)
			* 5785 MHz [157] (13.0 dBm)
			* 5805 MHz [161] (13.0 dBm)
			* 5825 MHz [165] (13.0 dBm)
	valid interface combinations:
		 * #{ managed } <= 2048, #{ AP, mesh point } <= 8, #{ P2P-client, P2P-GO } <= 1, #{ IBSS } <= 1,
		   total <= 2048, #channels <= 1, STA/AP BI must match, radar detect widths: { 20 MHz (no HT), 20 MHz, 40 MHz }

	HT Capability overrides:
		 * MCS: ff ff ff ff ff ff ff ff ff ff
		 * maximum A-MSDU length
		 * supported channel width
		 * short GI for 40 MHz
		 * max A-MPDU length exponent
		 * min MPDU start spacing
```

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: FTP (fritzflash: https://github.com/freifunk-darmstadt/fritz-tools)
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
    ```shell
    # lua -e 'print(require("platform_info").get_image_name())'
    avm-fritz-wlan-repeater-300e
    ```
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)

Live at https://meshviewer.darmstadt.freifunk.net/#/en/map/c025066336b1