### PR TITLE
ramips-mt76x8: remove broken flag

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -372,6 +372,15 @@ ramips-mt7621
 ramips-mt76x8
 ^^^^^^^^^^^^^
 
+* GL.iNet
+
+  - GL-MT300N v2 [#80211s]_
+
+* TP-Link
+
+  - TL-WR841N v13 [#80211s]_
+  - Archer C50 v3 [#80211s]_
+
 * VoCore
 
   - VoCore2 [#80211s]_

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -1,9 +1,8 @@
-if [ "$BROKEN" ]; then
-
 # GL.iNet
 
 device gl-mt300n-v2 gl-mt300n-v2
 factory
+
 
 # TP-Link
 
@@ -14,8 +13,6 @@ extra_image -squashfs-tftp-recovery -bootloader .bin
 device tp-link-tl-wr-841n-v13 tl-wr841n-v13
 factory
 extra_image -squashfs-tftp-recovery -bootloader .bin
-
-fi
 
 
 # VoCore 2


### PR DESCRIPTION
This commit removes the broken flag from all devices in the mt76x8
subtarget.

The stability of the mt76 driver for the mt7628 and mt7612 has greatly
improved in the last half-year. It might be still behind ath9k and
ath10k but it is suitable for daily use.

This affects the following devices:

 - GL.iNet MT300N v2
 - TP-Link Archer C50 v3
 - TP-Link TL-WR841 v13