### PR TITLE
add renamed target information to changelog

### DIFF
--- a/docs/releases/v2018.2.rst
+++ b/docs/releases/v2018.2.rst
@@ -117,6 +117,13 @@ The :doc:`../package/gluon-ebtables-limit-arp` package, introduced in Gluon
 2018.1, is now included by default. In case of issues, it can be removed by
 adding ``-gluon-ebtables-limit-arp`` to *GLUON_SITE_PACKAGES*.
 
+Renamed targets
+***************
+
+The `ramips-mt7628` target got renamed to `ramips-mt76x8`, and the `sunxi`
+target got renamed to `sunxi-cortexa7`. You might have to update your build
+scripts accordingly.
+
 Site changes
 ************
 


### PR DESCRIPTION
I think target name changes should be mentioned in the changelog.  We had two new firmware CI builds fail because the build script still used the old target names.