### PR TITLE
Removed BROKEN because sysupgrade works now

### DIFF
--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -3,6 +3,7 @@ GLUON_WLAN_MESH_11s := $(filter 11s,$(GLUON_WLAN_MESH))
 $(eval $(call GluonTarget,ar71xx,generic))
 $(eval $(call GluonTarget,ar71xx,tiny))
 $(eval $(call GluonTarget,ar71xx,nand))
+$(eval $(call GluonTarget,ar71xx,mikrotik))
 $(eval $(call GluonTarget,brcm2708,bcm2708))
 $(eval $(call GluonTarget,brcm2708,bcm2709))
 $(eval $(call GluonTarget,mpc85xx,generic))
@@ -20,7 +21,6 @@ $(eval $(call GluonTarget,ramips,rt305x))
 endif
 
 ifneq ($(BROKEN),)
-$(eval $(call GluonTarget,ar71xx,mikrotik)) # BROKEN: no sysupgrade support
 $(eval $(call GluonTarget,brcm2708,bcm2710)) # BROKEN: Untested
 $(eval $(call GluonTarget,ipq806x)) # BROKEN: unstable wifi drivers
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No AP+IBSS or 11s support


### PR DESCRIPTION
OpenWRT on Mikrotik supports sysupgrade now. Tested on mANTBox 15s (RB921GS-5HPacD-15S). I suggest removing BROKEN.