### PR TITLE
mikrotik-mantbox-15s-r2: add support for mANTBox 15s

### DIFF
--- a/targets/ar71xx-mikrotik
+++ b/targets/ar71xx-mikrotik
@@ -1,8 +1,15 @@
 config 'CONFIG_GLUON_SPECIALIZE_KERNEL=y'
 
+ATH10K_PACKAGES='kmod-ath10k-ct ath10k-firmware-qca9887 ath10k-firmware-qca988x'
+if [ "$GLUON_WLAN_MESH" = 'ibss' ]; then
+	ATH10K_PACKAGES='kmod-ath10k-ct ath10k-firmware-qca9887-ct ath10k-firmware-qca988x-ct'
+fi
+
 # Enable ath5k in addition to ath9k
 # ath5k cards are commonly used with Mikrotik hardware
 packages 'kmod-ath5k'
+
+packages $ATH10K_PACKAGES
 
 device mikrotik-nand-64m nand-64m
 factory

--- a/targets/ar71xx-mikrotik
+++ b/targets/ar71xx-mikrotik
@@ -1,18 +1,19 @@
 config 'CONFIG_GLUON_SPECIALIZE_KERNEL=y'
 
-ATH10K_PACKAGES='kmod-ath10k-ct ath10k-firmware-qca9887 ath10k-firmware-qca988x'
-if [ "$GLUON_WLAN_MESH" = 'ibss' ]; then
-	ATH10K_PACKAGES='kmod-ath10k-ct ath10k-firmware-qca9887-ct ath10k-firmware-qca988x-ct'
-fi
-
 # Enable ath5k in addition to ath9k
 # ath5k cards are commonly used with Mikrotik hardware
 packages 'kmod-ath5k'
 
-packages $ATH10K_PACKAGES
+if [ "$GLUON_WLAN_MESH" = '11s' ]; then
+device mikrotik-mantbox-15s-r2 nand-large
+packages kmod-ath10k-ct ath10k-firmware-qca988x
+factory
+fi
 
+if [ "$BROKEN" ]; then
 device mikrotik-nand-64m nand-64m
 factory
 
 device mikrotik-nand-large nand-large
 factory
+fi


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] tftp
  - [ ] other: <specify>
- [ ] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [ ] must have working autoupdate
    *usually means: gluon profile name must match image name*
- wired network
  - [ ] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [ ] association with 802.11s mesh must be working on all radios 
  - [ ] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [ ] lit while the device is on
    - [ ] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- [ ] reset/wps button must return device into config mode
- [ ] primary mac should match address on device label (or packaging) 