### PR TITLE
[WIP] target ar71xx-mikrotik: add missing OpenWrt image types

### DIFF
--- a/targets/ar71xx-mikrotik
+++ b/targets/ar71xx-mikrotik
@@ -1,9 +1,5 @@
 config 'CONFIG_GLUON_SPECIALIZE_KERNEL=y'
 
-# Enable ath5k in addition to ath9k
-# ath5k cards are commonly used with Mikrotik hardware
-packages 'kmod-ath5k'
-
 device mikrotik-rb-nor-flash-16M rb-nor-flash-16M
 factory
 

--- a/targets/ar71xx-mikrotik
+++ b/targets/ar71xx-mikrotik
@@ -4,8 +4,17 @@ config 'CONFIG_GLUON_SPECIALIZE_KERNEL=y'
 # ath5k cards are commonly used with Mikrotik hardware
 packages 'kmod-ath5k'
 
+device mikrotik-rb-nor-flash-16M rb-nor-flash-16M
+factory
+
+device mikrotik-rb-nor-flash-16M-ac rb-nor-flash-16M-ac
+factory
+
 device mikrotik-nand-64m nand-64m
 factory
 
 device mikrotik-nand-large nand-large
+factory
+
+device mikrotik-nand-large-ac nand-large-ac
 factory


### PR DESCRIPTION
Add the missing OpenWrt image types according to https://openwrt.org/toh/mikrotik/common#downloading_openwrt_images

sorted alphanumeric, compile tested