### PR TITLE
mt7620: add support for Nexx WT3020 (8M)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -352,6 +352,10 @@ ramips-mt7620
   - GL-MT300N [#80211s]_
   - GL-MT750 [#80211s]_
 
+* Nexx
+
+  - WT3020AD/F/H (8M)
+
 ramips-mt7621
 ^^^^^^^^^^^^^
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -354,7 +354,7 @@ ramips-mt7620
 
 * Nexx
 
-  - WT3020AD/F/H (8M)
+  - WT3020AD/F/H
 
 ramips-mt7621
 ^^^^^^^^^^^^^

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -1,4 +1,5 @@
 # GL Innovations
+
 device gl-mt300a gl-mt300a
 factory
 
@@ -7,5 +8,7 @@ factory
 
 device gl-mt750 gl-mt750
 factory
+
+# Nexx
 
 device nexx-wt3020-8m wt3020-8M

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -12,3 +12,6 @@ factory
 # Nexx
 
 device nexx-wt3020-8m wt3020-8M
+alias nexx-wt3020ad
+alias nexx-wt3020f
+alias nexx-wt3020h

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -8,4 +8,4 @@ factory
 device gl-mt750 gl-mt750
 factory
 
-device wt3020-8M wt3020-8M
+device nexx-wt3020-8m wt3020-8M

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -7,3 +7,5 @@ factory
 
 device gl-mt750 gl-mt750
 factory
+
+device wt3020-8M wt3020-8M


### PR DESCRIPTION
* [x]  must be flashable from vendor firmware
  
 * Works easy with the default Firmware

* [x]  must support upgrade mechanism

  * [x]  must have working sysupgrade
    
    * [x]  must keep/forget configuration (if applicable)
      _think `sysupgrade [-n]` or `firstboot`_
  * [x]  must have working autoupdate
    _usually means: gluon profile name must match image name_

* wired network
  
  * [x]  should support all network ports on the device
  * [x]  must have correct port assignment (WAN/LAN)

* wifi (if applicable)
  
  * [x]  association with AP must be possible on all radios
  * [x]  association with 802.11s mesh must be working on all radios
  * [x]  ap/mesh mode must work in parallel on all radios

* led mapping
 
  * power/sys led
    
    * [x]  lit while the device is on
    * [x]  should display config mode blink sequence
      (https://gluon.readthedocs.io/en/latest/features/configmode.html)

  * radio leds
    
    * [ ]  should map to their respective radio
    * [ ]  should show activity

      * device has only one LED for power status

  * switchport leds
    
    * [ ]  should map to their respective port (or switch, if only one led present)

    * [ ]  should show link state and activity

      * device has only one LED for power status

* [x]  reset/wps button must return device into config mode

* it just have an reset button and it works fine

* [ ]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)

* it doesn't have a mac adress on the case or sticker printed and the packaging is long gone, so i can't confirm, neither deny this.