### PR TITLE
 ar71xx: fix incorrect gl-ar750 image name

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -79,7 +79,7 @@ factory
 device gl-ar300m gl-ar300m
 factory
 
-device gl-ar750 gl-ar750
+device gl.inet-gl-ar750 gl-ar750
 packages $ATH10K_PACKAGES
 factory
 


### PR DESCRIPTION
```
root@ffac-Bergdriesch-GL-AR750:~# lua -e 'print(require("platform_info").get_image_name())'
gl.inet-gl-ar750
```

Not sure if this is the way it should be fixed, but this way the manifest file is accepted by the autoupdater.