### PR TITLE
gluon-core: assert WiFi driver provides 4 MAC-addresses

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -212,14 +212,21 @@ end
 local function get_wlan_mac_from_driver(uci, radio, vif)
 	local primary = sysconfig.primary_mac:lower()
 
-	local i = 1
-	for addr in get_addresses(uci, radio) do
-		if addr:lower() ~= primary then
-			if i == vif then
-				return addr
-			end
+	local addresses = {}
+	for address in get_addresses(uci, radio) do
+		if address:lower() ~= primary then
+			table.insert(addresses, address)
+		end
+	end
 
-			i = i + 1
+	-- Make sure we have at least 4 addresses
+	if #addresses < 4 then
+		return nil
+	end
+
+	for i, addr in ipairs(addresses) do
+		if i == vif then
+			return addr
 		end
 	end
 end


### PR DESCRIPTION
Disclaimer
----
We should not be affected by this bug yet as there are (on first sight) no affected MediaTek devices with the affected driver in Gluon. I ran into the Bug using an Archer C2 v2 on next.

Commit-message
----
Gluon has multiple ways to obtain unique MAC-addresses. They are either
provided by the WiFi driver or derived from the primary MAC-address.

Quoting the same file:

> It's necessary that the first 45 bits of the MAC address don't
> vary on a single hardware interface, since some chips are using
> a hardware MAC filter. (e.g 'rt305x')

This currently fails in case the rt35xx based chips mac address differs
from the primary MAC. In this case, the MAC address for the client0 radio
(vif 1) comes from the WiFi driver. As there is only a single
MAC-address provided by '/sys/class/ieee80211/phyX/addresses' but the
MAC-address for mesh 0 (vif 2) is derived from the Node-ID, resulting in
different first 45 bits. The WiFi won't come up altogether in this case.

This commit verifies at least 4 MAC-Addresses are provided by the WiFi
driver. If this is not the case, all MAC-addresses are derived from the
primary MAC. This way, affected radios are working correctly.