### PR TITLE
gluon-core: fix primary mac selection on unifiac devices

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -26,10 +26,10 @@ end
 if platform.match('ar71xx', 'generic', {'tl-wdr3600', 'tl-wdr4300',
                                         'tl-wr902ac-v1'}) then
   table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')
-elseif platform.match('ramips', 'mt7621', {'dir-860l-b1'}) then
-  table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')
-elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2',
-                                            'a40', 'a60', 'koala',
+elseif platform.match('ar71xx', 'generic', {'a40', 'a60',
+                                            'archer-c7-v4', 'archer-c7-v5',
+                                            'carambola2',
+                                            'koala',
                                             'mr600', 'mr600v2',
                                             'mr900', 'mr900v2',
                                             'mr1750', 'mr1750v2',
@@ -39,7 +39,7 @@ elseif platform.match('ar71xx', 'generic', {'unifi-outdoor-plus', 'carambola2',
                                             'om2p-lc',
                                             'om5p', 'om5p-an',
                                             'om5p-ac', 'om5p-acv2',
-                                            'archer-c7-v4', 'archer-c7-v5'}) then
+                                            'unifi-outdoor-plus'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1',
                                             'archer-c59-v1', 'archer-c60-v1',
@@ -48,6 +48,8 @@ elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1',
 elseif platform.match('ipq40xx', nil, {'avm,fritzbox-4040',
                                        'openmesh,a42', 'openmesh,a62'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
+elseif platform.match('ramips', 'mt7621', {'dir-860l-b1'}) then
+  table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')
 end
 
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -39,7 +39,8 @@ elseif platform.match('ar71xx', 'generic', {'a40', 'a60',
                                             'om2p-lc',
                                             'om5p', 'om5p-an',
                                             'om5p-ac', 'om5p-acv2',
-                                            'unifi-outdoor-plus'}) then
+                                            'unifi-outdoor-plus',
+                                            'unifiac-lite', 'unifiac-pro'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1',
                                             'archer-c59-v1', 'archer-c60-v1',


### PR DESCRIPTION
also sort by target and board_name

Tested on
- [x] Unifi AP AC Lite/Mesh
- [x] Unifi AP AC Pro/Mesh Pro

```sh
root@64283-cccda-w:~# cd /lib/gluon/core/sysconfig
root@64283-cccda-w:/lib/gluon/core/sysconfi# cat primary_mac
f0:9f:c2:de:c4:c5
root@64283-cccda-w:/lib/gluon/core/sysconfig# cp primary_mac primary_mac.bak
root@64283-cccda-w:/lib/gluon/core/sysconfig# rm primary_mac
root@64283-cccda-w:/lib/gluon/core/sysconfig# /lib/gluon/upgrade/010-primary-mac 
root@64283-cccda-w:/lib/gluon/core/sysconfig# cat primary_mac
f0:9f:c2:dc:c4:c5
root@64283-cccda-w:/lib/gluon/core/sysconfig# mv primary_mac.bak primary_mac
```

This change only affects newly flashed devices.

fixes #1629 