### PR TITLE
ramips-mt76x8: add support for Wavlink WL-WN570HA1

### DIFF
--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -19,3 +19,5 @@ extra_image -squashfs-tftp-recovery -bootloader .bin
 
 device vocore2 vocore2
 factory
+
+device wavlink_wl-wn570ha1 wavlink_wl-wn570ha1


### PR DESCRIPTION
I'd like to add support for the Wavlink WL-WN570HA1 (https://wikidevi.com/wiki/Wavlink_WL-WN570HA1), a 64 MB RAM/8 MB Flash dual band outdoor-access-point based on the MT7688AN. The device wasn't in the last OpenWRT release so it would require a backport. I do think it would be worth it though, since the access-point costs only around 40 Euros making it the cheapest dual band outdoor-access-point on the market. It uses the same 24V PoE Pins as Ubnt, TP-Link and so on.

What do you think?

I have compiled a Freifunk Hannover image for the device and it seems to run fine on the two WN570 that I bought. The LEDs aren't mapped correctly though (no radio activity, no blinking in config mode). I have never contributed to Gluon before and I can't find any documentation on how to map the LEDs correctly. Is that done by simply changing the GPIO definitions of the LEDs?

Update: Mesh doesn't work on 5 GHz.

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] tftp
  - [ ] other: <specify>
- [ ] must support upgrade mechanism
  - [ ] must have working sysupgrade
    - [ ] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [ ] must have working autoupdate
    *usually means: gluon profile name must match image name*
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [ ] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [ ] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)