### PR TITLE
target x86-*: change from ext4 to squashfs

### DIFF
--- a/targets/x86-64
+++ b/targets/x86-64
@@ -1,6 +1,6 @@
 . targets/x86.inc
 
-factory_image x86-64 combined-ext4 .img.gz
-factory_image x86-64 combined-ext4 .vdi
-factory_image x86-64 combined-ext4 .vmdk
-sysupgrade_image x86-64 combined-ext4 .img.gz
+factory_image x86-64 combined-squashfs .img.gz
+factory_image x86-64 combined-squashfs .vdi
+factory_image x86-64 combined-squashfs .vmdk
+sysupgrade_image x86-64 combined-squashfs .img.gz

--- a/targets/x86-generic
+++ b/targets/x86-generic
@@ -1,8 +1,8 @@
 . targets/x86.inc
 
-factory_image x86-generic combined-ext4 .img.gz
-factory_image x86-generic combined-ext4 .vdi
-factory_image x86-generic combined-ext4 .vmdk
-sysupgrade_image x86-generic combined-ext4 .img.gz
+factory_image x86-generic combined-squashfs .img.gz
+factory_image x86-generic combined-squashfs .vdi
+factory_image x86-generic combined-squashfs .vmdk
+sysupgrade_image x86-generic combined-squashfs .img.gz
 manifest_alias x86-kvm
 manifest_alias x86-xen_domu

--- a/targets/x86-geode
+++ b/targets/x86-geode
@@ -1,5 +1,5 @@
 packages 'kmod-3c59x' 'kmod-8139cp' 'kmod-8139too' 'kmod-e100' 'kmod-e1000' 'kmod-forcedeth' 'kmod-igb' 'kmod-natsemi' 'kmod-ne2k-pci'
 packages 'kmod-pcnet32' 'kmod-r8169' 'kmod-sis900' 'kmod-sky2' 'kmod-tg3' 'kmod-tulip' 'kmod-via-rhine' 'kmod-via-velocity'
 
-factory_image x86-geode combined-ext4 .img.gz
-sysupgrade_image x86-geode combined-ext4 .img.gz
+factory_image x86-geode combined-squashfs .img.gz
+sysupgrade_image x86-geode combined-squashfs .img.gz


### PR DESCRIPTION
This allows for smaller firmware images and makes it possible to reset a
device via firstboot command.

closes #1596 