### PR TITLE
ramips-mt7620: add support for Xiaomi MiWifi Mini

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -51,6 +51,8 @@ elseif platform.match('ipq40xx', nil, {'avm,fritzbox-4040',
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ipq806x', nil, {'netgear,r7800'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')
+elseif platform.match('ramips', 'mt7620', {'miwifi-mini'}) then
+  table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ramips', 'mt7621', {'dir-860l-b1'}) then
   table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')
 end

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -21,3 +21,10 @@ device nexx-wt3020-8m wt3020-8M
 alias nexx-wt3020ad
 alias nexx-wt3020f
 alias nexx-wt3020h
+
+# Xiaomi
+
+if [ "$BROKEN" ]; then
+device xiaomi-miwifi-mini miwifi-mini # BROKEN: 2.4GHz WiFi is Unstable 
+factory
+fi


### PR DESCRIPTION
Mesh is working but it depends on PR #1626 to get it working on both radios, without it only mesh on radio0 (the extra wifi chip) is working.

This is the cleaned up PR of #1627 

* [x]  must be flashable from vendor firmware
  
 * There are two ways to flash. Both are written in the OpenWRT Wiki. One via an Code Injection Bug and one via an Account on miwifi.com
* https://openwrt.org/toh/xiaomi/mini#quick_openwrt_installation

* [x]  must support upgrade mechanism

  * [x]  must have working sysupgrade
    
    * [x]  must keep/forget configuration (if applicable)
      _think `sysupgrade [-n]` or `firstboot`_
  * [x]  must have working autoupdate
    _usually means: gluon profile name must match image name_

* wired network
  
  * [x]  should support all network ports on the device
  * [x]  must have correct port assignment (WAN/LAN)

* wifi (if applicable)
  
  * [x]  association with AP must be possible on all radios
  * [x]  association with 802.11s mesh must be working on all radios
  * [x]  ap/mesh mode must work in parallel on all radios
* WiFi on 2.4GHz is Unstable most of the time for now.

* led mapping
 
  * power/sys led
    
    * [x]  lit while the device is on
    * [x]  should display config mode blink sequence
      (https://gluon.readthedocs.io/en/latest/features/configmode.html)

  * radio leds
    
    * [ ]  should map to their respective radio
    * [ ]  should show activity

      * device has only one LED for power status

  * switchport leds
    
    * [ ]  should map to their respective port (or switch, if only one led present)

    * [ ]  should show link state and activity

      * device has only one LED for power status

* [x]  reset/wps button must return device into config mode

* it just have an reset button and it works fine

* [x]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)

* fixed