### PR TITLE
ar71xx: fix incorrect GL.iNet image names

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -72,14 +72,19 @@ factory
 # GL Innovations
 
 device gl-inet-6408a-v1 gl-inet-6408A-v1
+
 device gl-inet-6416a-v1 gl-inet-6416A-v1
 
-device gl-ar150 gl-ar150
+device gl.inet-gl-ar150 gl-ar150
+manifest_alias gl-ar150
 factory
-device gl-ar300m gl-ar300m
+
+device gl.inet-gl-ar300m gl-ar300m
+manifest_alias gl-ar300m
 factory
 
 device gl.inet-gl-ar750 gl-ar750
+manifest_alias gl-ar750
 packages $ATH10K_PACKAGES
 factory
 


### PR DESCRIPTION
In current Gluon versions the content of the manifest file does not match with the device identifier of a GL.iNet GL-AR150. To solve this issue the manifest content and device identifier must be correspond.

Solution:
This commit adjusted the GL-AR150 Gluon profile name which is used to refer to the device and image name.