### PR TITLE
ramips-mt76x8: add support for TP-Link Archer C50 v4

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -384,6 +384,7 @@ ramips-mt76x8
 
   - TL-WR841N v13 [#80211s]_
   - Archer C50 v3 [#80211s]_
+  - Archer C50 v4 [#80211s]_
 
 * VoCore
 

--- a/patches/openwrt/0012-tools-mktplinkfw2-add-split-uboot-layout.patch
+++ b/patches/openwrt/0012-tools-mktplinkfw2-add-split-uboot-layout.patch
@@ -1,0 +1,26 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Wed, 28 Nov 2018 23:56:31 +0100
+Subject: tools: mktplinkfw2: add split-uboot layout
+
+This commit adds the split-uboot partition layout used by the
+Archer C50 v4 to mktplinkfw2.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/tools/firmware-utils/src/mktplinkfw2.c b/tools/firmware-utils/src/mktplinkfw2.c
+index dead49e7af8839bac5d1dee7445cf8921208c970..35db848bbab9f8315526dfa24ed351ad58878dde 100644
+--- a/tools/firmware-utils/src/mktplinkfw2.c
++++ b/tools/firmware-utils/src/mktplinkfw2.c
+@@ -146,6 +146,12 @@ static struct flash_layout layouts[] = {
+ 		.kernel_la	= 0x80000000,
+ 		.kernel_ep	= 0x80000000,
+ 		.rootfs_ofs	= 0x140000,
++	}, {
++		.id		= "8MSUmtk", /* Split U-Boot OS */
++		.fw_max_len	= 0x770000,
++		.kernel_la	= 0x80000000,
++		.kernel_ep	= 0x80000000,
++		.rootfs_ofs	= 0x140000,
+ 	}, {
+ 		.id		= "8MLmtk",
+ 		.fw_max_len	= 0x7b0000,

--- a/patches/openwrt/0013-ramips-add-support-for-Archer-C50-v4.patch
+++ b/patches/openwrt/0013-ramips-add-support-for-Archer-C50-v4.patch
@@ -1,0 +1,370 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sun, 3 Feb 2019 00:23:18 +0100
+Subject: ramips: add support for Archer C50 v4
+
+This adds support for the TP-Link Archer C50 v4.
+It uses the same hardware as the v3 variant, sharing the same FCC-ID.
+
+CPU:   MediaTek MT7628 (580MHz)
+RAM:   64M DDR2
+FLASH: 8M SPI
+WiFi:  2.4GHz 2x2 MT7628 b/g/n integrated
+WiFI:  5GHz 2x2 MT7612 a/n/ac
+ETH:   1x WAN 4x LAN
+LED:   Power, WiFi2, WiFi5, LAN, WAN, WPS
+BTN:   WPS/WiFi, RESET
+UART:  Near ETH ports, 115200 8n1, TP-Link pinout
+
+Create Factory image
+--------------------
+As all installation methods require a U-Boot to be integrated into the
+Image (and we do not ship one with the image) we are not able to create
+an image in the OpenWRT build-process.
+
+Download a TP-Link image from their Wesite and a OpenWRT sysupgrade
+image for the device and build yourself a factory image like following:
+
+TP-Link image:             tpl.bin
+OpenWRT sysupgrade image:  owrt.bin
+
+ > dd if=tpl.bin of=boot.bin bs=131584 count=1
+ > cat owrt.bin >> boot.bin
+
+Installing via Web-UI
+---------------------
+Upload the boot.bin via TP-Links firmware upgrade tool in the
+web-interface.
+
+Installing via Recovery
+-----------------------
+Activate Web-Recovery by beginning the upgrade Process with a
+Firmware-Image from TP-Link. After starting the Firmware Upgrade,
+wait ~3 seconds (When update status is switching to 0%), then
+disconnect the power supply from the device. Upgrade flag (which
+activates Web-Recovery) is written before the OS-image is touched and
+removed after write is succesfull, so this procedure should be safe.
+
+Plug the power back in. It will come up in Recovery-Mode on 192.168.0.1.
+When active, all LEDs but the WPS LED are off.
+Remeber to assign yourself a static IP-address as DHCP is not active in
+this mode.
+
+The boot.bin can now be uploaded and flashed using the web-recovery.
+
+Installing via TFTP
+-------------------
+Prepare an image like following (Filenames from factory image steps
+apply here)
+
+ > dd if=/dev/zero of=tp_recovery.bin bs=196608 count=1
+ > dd if=tpl.bin of=tmp.bin bs=131584 count=1
+ > dd if=tmp.bin of=boot.bin bs=512 skip=1
+ > cat boot.bin >> tp_recovery.bin
+ > cat owrt.bin >> tp_recovery.bin
+
+Place tp_recovery.bin in root directory of TFTP server and listen on
+192.168.0.66/24.
+
+Connect router LAN ports with your computer and power up the router
+while pressing the reset button. The router will download the image via
+tftp and after ~1 Minute reboot into OpenWRT.
+
+U-Boot CLI
+----------
+U-Boot CLI can be activated by holding down '4' on bootup.
+
+Dual U-Boot
+-----------
+This is the first TP-Link MediaTek device to feature a split-uboot
+design. The first (factory-uboot) provides recovery via TFTP and HTTP,
+jumping straight into the second (firmware-uboot) if no recovery needs
+to be performed. The firmware-uboot unpacks and executed the kernel.
+
+Web-Recovery
+------------
+TP-Link integrated a new Web-Recovery like the one on the Archer C7v4 /
+TL-WR1043v5. Stock-firmware sets a flag in the "romfile" partition
+before beginning to write and removes it afterwards. If the router boots
+with this flag set, bootloader will automatically start Web-recovery and
+listens on 192.168.0.1. This way, the vendor-firmware or an OpenWRT
+factory image can be written.
+
+It is important to note that Web-Recovery is only based on this flag. It
+can't detect e.g. a crashing kernel or other means. Once activated it
+won't boot the OS before a recovery action (either via TFTP or HTTP) is
+performed. This recovery-mode is indicated by an illuminated WPS-LED on
+boot.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ramips/base-files/etc/board.d/01_leds b/target/linux/ramips/base-files/etc/board.d/01_leds
+index 6057275978591192e3b7799a8e6d97761c3e23a5..19386b9e139a25fd1ac29cd9a66b738b5b092cdf 100755
+--- a/target/linux/ramips/base-files/etc/board.d/01_leds
++++ b/target/linux/ramips/base-files/etc/board.d/01_leds
+@@ -410,7 +410,8 @@ tplink,c20-v4)
+ 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
+ 	ucidef_set_led_netdev "wlan2g" "wlan2g" "$boardname:green:wlan2g" "wlan0"
+ 	;;
+-tplink,c50-v3)
++tplink,c50-v3|\
++tplink,c50-v4)
+ 	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x1e"
+ 	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x01"
+ 	ucidef_set_led_wlan "wlan2g" "wlan2g" "$boardname:green:wlan2g" "phy0tpt"
+diff --git a/target/linux/ramips/base-files/etc/board.d/02_network b/target/linux/ramips/base-files/etc/board.d/02_network
+index ebf40ad1fa874d324b43c8f0613bca53a19ab2d0..1c6cc6b0af745b43b81bbfffc9b5462c1b88defc 100755
+--- a/target/linux/ramips/base-files/etc/board.d/02_network
++++ b/target/linux/ramips/base-files/etc/board.d/02_network
+@@ -205,6 +205,7 @@ ramips_setup_interfaces()
+ 	rt-n14u|\
+ 	tplink,c20-v4|\
+ 	tplink,c50-v3|\
++	tplink,c50-v4|\
+ 	tplink,tl-mr3420-v5|\
+ 	tplink,tl-wr842n-v5|\
+ 	tl-wr840n-v4|\
+diff --git a/target/linux/ramips/base-files/etc/diag.sh b/target/linux/ramips/base-files/etc/diag.sh
+index 2f51add331fef4693e997433a4ab0e665da80e02..6d021b6def2f1fe7b71a67f36749c440f3bad1d4 100644
+--- a/target/linux/ramips/base-files/etc/diag.sh
++++ b/target/linux/ramips/base-files/etc/diag.sh
+@@ -42,6 +42,7 @@ get_status_led() {
+ 	r6220|\
+ 	tplink,c20-v4|\
+ 	tplink,c50-v3|\
++	tplink,c50-v4|\
+ 	tplink,tl-mr3420-v5|\
+ 	tplink,tl-wr842n-v5|\
+ 	tplink,tl-wr902ac-v3|\
+diff --git a/target/linux/ramips/base-files/lib/upgrade/platform.sh b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+index ffdc5e73e0ede286c10396810954a230c8ea32fc..8055853508fc850a1826166c7e0cbdf443df27cb 100755
+--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+@@ -256,6 +256,7 @@ platform_check_image() {
+ 	tplink,c20-v1|\
+ 	tplink,c20-v4|\
+ 	tplink,c50-v3|\
++	tplink,c50-v4|\
+ 	tplink,tl-mr3420-v5|\
+ 	tplink,tl-wr842n-v5|\
+ 	tplink,tl-wr902ac-v3|\
+diff --git a/target/linux/ramips/dts/ArcherC50V4.dts b/target/linux/ramips/dts/ArcherC50V4.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..bb4a65436fa435e5636aca3bf326b5a3ca61f7e3
+--- /dev/null
++++ b/target/linux/ramips/dts/ArcherC50V4.dts
+@@ -0,0 +1,93 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/dts-v1/;
++
++#include "TPLINK-8M-SPLIT-UBOOT.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	compatible = "tplink,c50-v4", "mediatek,mt7628an-soc";
++	model = "TP-Link Archer C50 v4";
++
++	keys {
++		compatible = "gpio-keys-polled";
++		poll-interval = <20>;
++
++		reset {
++			label = "reset";
++			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++		};
++
++		rfkill {
++			label = "rfkill";
++			gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RFKILL>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led_power: power {
++			label = "c50-v4:green:power";
++			gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
++		};
++
++		wlan2 {
++			label = "c50-v4:green:wlan2g";
++			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
++		};
++
++		wlan5 {
++			label = "c50-v4:green:wlan5g";
++			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
++		};
++
++		lan {
++			label = "c50-v4:green:lan";
++			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
++		};
++
++		wan {
++			label = "c50-v4:green:wan";
++			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
++		};
++
++		wan_orange {
++			label = "c50-v4:orange:wan";
++			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
++		};
++
++		wps {
++			label = "c50-v4:green:wps";
++			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&pinctrl {
++	state_default: pinctrl0 {
++		gpio {
++			ralink,group = "i2c", "p0led_an", "p1led_an", "p2led_an",
++				       "p3led_an", "p4led_an", "wdt", "wled_an";
++			ralink,function = "gpio";
++		};
++	};
++};
++
++&pcie {
++	status = "okay";
++
++	pcie-bridge {
++		mt76@0,0 {
++			reg = <0x0000 0 0 0 0>;
++			device_type = "pci";
++			mediatek,mtd-eeprom = <&radio 0x8000>;
++			ieee80211-freq-limit = <5000000 6000000>;
++			mtd-mac-address = <&rom 0xf100>;
++			mtd-mac-address-increment = <(-1)>;
++		};
++	};
++};
+\ No newline at end of file
+diff --git a/target/linux/ramips/dts/TPLINK-8M-SPLIT-UBOOT.dtsi b/target/linux/ramips/dts/TPLINK-8M-SPLIT-UBOOT.dtsi
+new file mode 100644
+index 0000000000000000000000000000000000000000..539f476dce6e1fe43769f3ed41ae94d5f6fbc2cc
+--- /dev/null
++++ b/target/linux/ramips/dts/TPLINK-8M-SPLIT-UBOOT.dtsi
+@@ -0,0 +1,90 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++#include "mt7628an.dtsi"
++
++/ {
++	chosen {
++		bootargs = "console=ttyS0,115200";
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x4000000>;
++	};
++};
++
++&spi0 {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++		m25p,chunked-io = <32>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "factory-uboot";
++				reg = <0x0 0x30000>;
++				read-only;
++			};
++
++			partition@30000 {
++				label = "boot";
++				reg = <0x30000 0x20000>;
++				read-only;
++			};
++
++			partition@50000 {
++				compatible = "tplink,firmware";
++				label = "firmware";
++				reg = <0x50000 0x770000>;
++			};
++
++			partition@7c0000 {
++				label = "config";
++				reg = <0x7c0000 0x10000>;
++				read-only;
++			};
++
++			rom: partition@7d0000 {
++				label = "rom";
++				reg = <0x7d0000 0x10000>;
++				read-only;
++			};
++
++			partition@7e0000 {
++				label = "romfile";
++				reg = <0x7e0000 0x10000>;
++			};
++
++			radio: partition@7f0000 {
++				label = "radio";
++				reg = <0x7f0000 0x10000>;
++				read-only;
++			};
++		};
++	};
++};
++
++&ehci {
++	status = "disabled";
++};
++
++&ohci {
++	status = "disabled";
++};
++
++&wmac {
++	status = "okay";
++	mtd-mac-address = <&rom 0xf100>;
++	mediatek,mtd-eeprom = <&radio 0x0>;
++};
++
++&ethernet {
++	mtd-mac-address = <&rom 0xf100>;
++	mediatek,portmap = "llllw";
++};
+diff --git a/target/linux/ramips/image/mt76x8.mk b/target/linux/ramips/image/mt76x8.mk
+index 21c5357a089fdd0675afa6f131ff5b34a9a8f54d..34bd662f3a9490bdb0fd125af5ffa8a0f77c5f16 100644
+--- a/target/linux/ramips/image/mt76x8.mk
++++ b/target/linux/ramips/image/mt76x8.mk
+@@ -182,6 +182,20 @@ define Device/tplink_c50-v3
+ endef
+ TARGET_DEVICES += tplink_c50-v3
+ 
++define Device/tplink_c50-v4
++  $(Device/tplink)
++  DTS := ArcherC50V4
++  IMAGE_SIZE := 7616k
++  DEVICE_TITLE := TP-Link ArcherC50 v4
++  TPLINK_FLASHLAYOUT := 8MSUmtk
++  TPLINK_HWID := 0x001D589B
++  TPLINK_HWREV := 0x93
++  TPLINK_HWREVADD := 0x2
++  TPLINK_HVERSION := 3
++  IMAGES := sysupgrade.bin
++endef
++TARGET_DEVICES += tplink_c50-v4
++
+ define Device/tplink_tl-mr3420-v5
+   $(Device/tplink)
+   DTS := TL-MR3420V5

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -10,6 +10,9 @@ device tp-link-archer-c50-v3 tplink_c50-v3
 factory
 extra_image -squashfs-tftp-recovery -bootloader .bin
 
+device tp-link-archer-c50-v4 tplink_c50-v4
+factory
+
 device tp-link-tl-wr-841n-v13 tl-wr841n-v13
 factory
 extra_image -squashfs-tftp-recovery -bootloader .bin


### PR DESCRIPTION
This backports the TP-Link Archer C50 v4.

We are dropping the following upstream commits. They add support for the
TP-Link recovery-flag which enabled the web-recovery. As they are not
needed for the router to work, we drop them for now.

28cd2ca base-files: sysupgrade: support additional mtd options
1e06482 mtd: add logic for TP-Link ramips recovery magic

----

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
    ```
    root@64xxx-0c80637f6a04:~# lua -e 'print(require("platform_info").get_image_name())'
    tp-link-archer-c50-v4
    ```
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)