### PR TITLE
ramips-mt7620: add support for ASUS RT-AC51U as broken

### DIFF
--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -1,3 +1,9 @@
+# ASUS
+if [ "$BROKEN" ]; then
+device asus-rt-ac51u rt-ac51u # BROKEN: no 5GHz usable, LEDs not fully supported
+factory
+fi
+
 # GL Innovations
 
 device gl-mt300a gl-mt300a


### PR DESCRIPTION
This device is based on the MediaTek MT7620A with 580MHz, 16MB Flash and 64MB RAM. The radios are MediaTek MT7620A and MediaTek MT7610E. 
For now this device should remain as broken. The LED config is not correct and the 5GHz is not working. Test device: http://map.chemnitz.freifunk.net/#!v:m;n:708bcdea0a38


* [x]  must be flashable from vendor firmware
  * [x]  tftp
* [x]  must support upgrade mechanism
  * [x]  must have working sysupgrade 
    * [x]  must keep/forget configuration (if applicable)
  * [x]  must have working autoupdate
* wired network  
  * [x]  should support all network ports on the device
  * [x]  must have correct port assignment (WAN/LAN)
* wifi (if applicable)
  * [x]  association with AP must be possible on  2.4GHZ only
  * [x]  association with 802.11s mesh must be working on  2.4GHZ only
  * [x]  ap/mesh mode must work in parallel on 2.4GHZ only
* led mapping
  * power/sys led
    * [x]  lit while the device is on
    * [x]  should display config mode blink sequence
  * radio leds
    * [ ]  should map to their respective radio
    * [ ]  should show activity
  * switchport leds
    * [ ]  should map to their respective port (or switch, if only one led present)
    * [ ]  should show link state and activity
* [x]  reset/wps button must return device into config mode
* [x]  primary mac should match address on device label (or packaging) 
