### PR TITLE
docs: improve references to the IRC chatroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ https://gluon.readthedocs.io/.
 If you're new to Gluon and ready to get your feet wet, have a look at the
 [Getting Started Guide](https://gluon.readthedocs.io/en/latest/user/getting_started.html).
 
-**Gluon IRC channel: `#gluon` in [hackint](https://hackint.org/)**
+Gluon's developers frequent an IRC chatroom at [#gluon](ircs://irc.hackint.org/#gluon)
+on [hackint](https://hackint.org/). There is also a [webchat](https://webirc.hackint.org/#irc://irc.hackint.org/#gluon)
+that allows for access from within your browser.
 
 ## Issues & Feature requests
 

--- a/docs/dev/basics.rst
+++ b/docs/dev/basics.rst
@@ -15,9 +15,13 @@ The `main repo`_ does have issues enabled.
 IRC
 ---
 
-Gluon's developers frequent `#gluon on hackint`_. You're welcome to join us!
+Gluon's developers frequent the IRC chatroom `#gluon`_ on `hackint`_.
+There is a `webchat`_ that allows for easy access from within your
+webbrowser. You're welcome to join us!
 
-.. _#gluon on hackint: irc://irc.hackint.org/#gluon
+.. _#gluon: ircs://irc.hackint.org/#gluon
+.. _hackint: https://hackint.org/
+.. _webchat: https://webirc.hackint.org/#irc://irc.hackint.org/#gluon
 
 
 Working with repositories


### PR DESCRIPTION
I saw T_X referencing our chatroom in https://github.com/freifunk-gluon/gluon/pull/1201#issuecomment-460985739 and the documentation for it could benefit from some improvement to allow for easier onboarding.

- [x] Link to webchat, so users can join from within their browsers
- [x] Link to hackint.org, as it provides much more information on how to access the network
- [x] Update chatroom link to `ircs://` URI scheme