### PR TITLE
docs: missing uci commit in gluon-reconfigure example

### DIFF
--- a/docs/features/multidomain.rst
+++ b/docs/features/multidomain.rst
@@ -93,6 +93,7 @@ Switching the domain
 ::
 
     uci set gluon.core.domain="newdomaincode"
+    uci commit gluon.core.domain
     gluon-reconfigure
     reboot
 


### PR DESCRIPTION
The example to switch the domain via commandline doesn't commit the uci changes and a node would fall back to its previous domain after a reboot.