### PR TITLE
ramips-mt76x8: add support for Netgear R6120

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -380,6 +380,10 @@ ramips-mt76x8
 
   - GL-MT300N v2 [#80211s]_
 
+* NETGEAR
+
+  - R6120 [#80211s]_
+
 * TP-Link
 
   - TL-WR841N v13 [#80211s]_

--- a/patches/openwrt/0016-ramips-add-support-for-Netgear-R6120.patch
+++ b/patches/openwrt/0016-ramips-add-support-for-Netgear-R6120.patch
@@ -1,0 +1,271 @@
+From: Ludwig Thomeczek <ledesrc@wxorx.net>
+Date: Tue, 12 Jun 2018 21:17:23 +0200
+Subject: ramips: add support for Netgear R6120
+
+This patch adds support for the Netgear R6120, aka Netgear AC1200.
+
+Specification:
+- SoC: MediaTek MT7628 (580 MHz)
+- Flash: 16 MiB
+- RAM: 64 MiB
+- Wireless: 2.4Ghz(builtin) and 5Ghz (MT7612E)
+- LAN speed: 10/100
+- LAN ports: 4
+- WAN speed: 10/100
+- WAN ports: 1
+- Serial baud rate of Bootloader and factory firmware: 57600
+
+To flash use nmrpflash with the provided factory.img.
+Flashing via webinterface will not work, for now.
+
+Signed-off-by: Ludwig Thomeczek <ledesrc@wxorx.net>
+
+diff --git a/target/linux/ramips/base-files/etc/board.d/01_leds b/target/linux/ramips/base-files/etc/board.d/01_leds
+index 19386b9e139a25fd1ac29cd9a66b738b5b092cdf..4203773b4fa3ec771f07b7a8c414a416a0da0f20 100755
+--- a/target/linux/ramips/base-files/etc/board.d/01_leds
++++ b/target/linux/ramips/base-files/etc/board.d/01_leds
+@@ -301,6 +301,11 @@ mzk-ex750np)
+ na930)
+ 	set_usb_led "$boardname:blue:status"
+ 	;;
++netgear,r6120)
++	ucidef_set_led_switch "lan" "lan" "$boardname:green:lan" "switch0" "0x0f"
++	ucidef_set_led_switch "wan" "wan" "$boardname:green:wan" "switch0" "0x10"
++	ucidef_set_led_wlan "wlan2g" "WiFi 2.4GHz" "$boardname:green:wlan2g" "phy0tpt"
++	;;
+ newifi-d1)
+ 	set_usb_led "$boardname:red:status"
+ 	;;
+diff --git a/target/linux/ramips/base-files/etc/board.d/02_network b/target/linux/ramips/base-files/etc/board.d/02_network
+index 1c6cc6b0af745b43b81bbfffc9b5462c1b88defc..9424c7ddfd64f9149a24ff91e63b71990265d211 100755
+--- a/target/linux/ramips/base-files/etc/board.d/02_network
++++ b/target/linux/ramips/base-files/etc/board.d/02_network
+@@ -301,6 +301,10 @@ ramips_setup_interfaces()
+ 			"0:lan" "1:lan" "2:lan" "3:lan" "6t@eth0"
+ 		ucidef_set_interface_wan "usb0"
+ 		;;
++	netgear,r6120)
++		ucidef_add_switch "switch0" \
++			"0:lan:4" "1:lan:3" "2:lan:2" "3:lan:1" "4:wan" "6@eth0"
++		;;
+ 	mzk-dp150n|\
+ 	vocore-8M|\
+ 	vocore-16M)
+diff --git a/target/linux/ramips/base-files/etc/diag.sh b/target/linux/ramips/base-files/etc/diag.sh
+index 6d021b6def2f1fe7b71a67f36749c440f3bad1d4..097cc6df569518f64dbfd641eeccc1a4b1b37a2b 100644
+--- a/target/linux/ramips/base-files/etc/diag.sh
++++ b/target/linux/ramips/base-files/etc/diag.sh
+@@ -38,6 +38,7 @@ get_status_led() {
+ 	mzk-w300nh2|\
+ 	nbg-419n|\
+ 	nbg-419n2|\
++	netgear,r6120|\
+ 	pwh2004|\
+ 	r6220|\
+ 	tplink,c20-v4|\
+diff --git a/target/linux/ramips/base-files/lib/upgrade/platform.sh b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+index 8055853508fc850a1826166c7e0cbdf443df27cb..7213b22d0c2734488bd96bc34e921f08649b8c2f 100755
+--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+@@ -129,6 +129,7 @@ platform_check_image() {
+ 	psr-680w|\
+ 	px-4885-4M|\
+ 	px-4885-8M|\
++	netgear,r6120|\
+ 	rb750gr3|\
+ 	re6500|\
+ 	rp-n53|\
+diff --git a/target/linux/ramips/dts/R6120.dts b/target/linux/ramips/dts/R6120.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..a0df0072379a7d8f974ec8025483410d5f9f1da1
+--- /dev/null
++++ b/target/linux/ramips/dts/R6120.dts
+@@ -0,0 +1,142 @@
++/dts-v1/;
++
++#include "mt7628an.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	compatible = "netgear,r6120", "mediatek,mt7628an-soc";
++	model = "Netgear R6120";
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x4000000>;
++	};
++
++	gpio-keys-polled {
++		compatible = "gpio-keys-polled";
++		poll-interval = <20>;
++
++		reset {
++			label = "reset";
++			gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++		};
++	};
++
++	gpio-leds {
++		compatible = "gpio-leds";
++
++		lan {
++			label = "r6120:green:lan";
++			gpios = <&gpio1 12 GPIO_ACTIVE_LOW>;
++		};
++
++		led_power: power {
++			label = "r6120:green:power";
++			gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
++		};
++
++		wlan {
++			label = "r6120:green:wlan2g";
++			gpios = <&gpio1 10 GPIO_ACTIVE_LOW>;
++		};
++
++		wlan_orange {
++			label = "r6120:orange:wlan2g";
++			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
++		};
++
++		wan {
++			label = "r6120:green:wan";
++			gpios = <&gpio1 8 GPIO_ACTIVE_LOW>;
++		};
++
++		wan_orange {
++			label = "r6120:orange:wan";
++			gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&pinctrl {
++	state_default: pinctrl0 {
++		gpio {
++			ralink,group = "p0led_an", "p1led_an", "p2led_an",
++				       "p3led_an", "p4led_an", "wdt", "wled_an";
++			ralink,function = "gpio";
++		};
++	};
++};
++
++&spi0 {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++		m25p,chunked-io = <32>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "u-boot";
++				reg = <0x0 0x40000>;
++				read-only;
++			};
++
++			factory: partition@40000 {
++				label = "factory";
++				reg = <0x40000 0x20000>;
++				read-only;
++			};
++
++			partition@60000 {
++				label = "nvram";
++				reg = <0x60000 0x30000>;
++				read-only;
++			};
++
++			partition@90000 {
++				label = "firmware";
++				reg = <0x90000 0xf60000>;
++			};
++
++			partition@ff0000 {
++				label = "reserved";
++				reg = <0xff0000 0x10000>;
++				read-only;
++			};
++		};
++	};
++};
++
++&wmac {
++	status = "okay";
++	mtd-mac-address = <&factory 0x4>;
++	mediatek,mtd-eeprom = <&factory 0x0>;
++};
++
++&ethernet {
++	mtd-mac-address = <&factory 0x4>;
++};
++
++&pcie {
++	status = "okay";
++
++	pcie-bridge {
++		mt76@0,0 {
++			reg = <0x0000 0 0 0 0>;
++			device_type = "pci";
++			mediatek,mtd-eeprom = <&factory 0x8000>;
++			ieee80211-freq-limit = <5000000 6000000>;
++			mtd-mac-address = <&factory 0x4>;
++			mtd-mac-address-increment = <(2)>;
++		};
++	};
++};
+diff --git a/target/linux/ramips/image/mt76x8.mk b/target/linux/ramips/image/mt76x8.mk
+index 34bd662f3a9490bdb0fd125af5ffa8a0f77c5f16..bc282666d8c1a4b6ce5beabe2b492331fb48a23a 100644
+--- a/target/linux/ramips/image/mt76x8.mk
++++ b/target/linux/ramips/image/mt76x8.mk
+@@ -2,6 +2,17 @@
+ # MT76x8 Profiles
+ #
+ 
++DEVICE_VARS += SERCOMM_KERNEL_OFFSET SERCOMM_HWID SERCOMM_HWVER SERCOMM_SWVER
++
++define Build/mksercommfw
++	$(STAGING_DIR_HOST)/bin/mksercommfw \
++		$@ \
++		$(SERCOMM_KERNEL_OFFSET) \
++		$(SERCOMM_HWID) \
++		$(SERCOMM_HWVER) \
++		$(SERCOMM_SWVER)
++endef
++
+ define Device/tplink
+   TPLINK_FLASHLAYOUT :=
+   TPLINK_HWID :=
+@@ -90,6 +101,23 @@ define Device/mt7628
+ endef
+ TARGET_DEVICES += mt7628
+ 
++define Device/netgear_r6120
++  DTS := R6120
++  BLOCKSIZE := 64k
++  IMAGE_SIZE := $(ralink_default_fw_size_16M)
++  DEVICE_TITLE := Netgear R6120
++  DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
++  SERCOMM_KERNEL_OFFSET := 90000
++  SERCOMM_HWID := CGQ
++  SERCOMM_HWVER := A001
++  SERCOMM_SWVER := 0040
++  IMAGES += factory.img
++  IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE)| append-rootfs | pad-rootfs
++  IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
++  IMAGE/factory.img := $$(IMAGE/default) | mksercommfw
++endef
++TARGET_DEVICES += netgear_r6120
++
+ define Device/omega2
+   DTS := OMEGA2
+   IMAGE_SIZE := $(ralink_default_fw_size_16M)

--- a/patches/openwrt/0017-tools-add-zip-utility.patch
+++ b/patches/openwrt/0017-tools-add-zip-utility.patch
@@ -1,0 +1,465 @@
+From: Mathias Kresin <dev@kresin.me>
+Date: Sat, 5 Jan 2019 20:51:00 +0100
+Subject: tools: add zip utility
+
+One image requires a zip compressed image, so add the zip util found in
+the packages feed, and extend it with some useful debian patches.
+
+Signed-off-by: Mathias Kresin <dev@kresin.me>
+
+tools: zip: add option for reproducible archives
+
+Add the option -mt/--mtime to pass a timestamp which is used as filedate
+for the containing files.
+
+So far, it isn't used for anything written to the extra fields,
+therefore requires the -X (eXclude eXtra file attributes) parameter to
+be effective.
+
+Signed-off-by: Mathias Kresin <dev@kresin.me>
+
+diff --git a/tools/Makefile b/tools/Makefile
+index d2b5daf18c233c8e94657fd61922c75770a3b35b..3ac3b226d35311c606e6dcc562fb8a2d31cec584 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -32,7 +32,7 @@ tools-$(CONFIG_TARGET_x86) += qemu
+ tools-$(CONFIG_TARGET_mxs) += elftosb sdimage
+ tools-$(CONFIG_TARGET_ar71xx) += lzma-old squashfs
+ tools-$(CONFIG_USES_MINOR) += kernel2minor
+-tools-y += lzma squashfs4
++tools-y += lzma squashfs4 zip
+ tools-$(BUILD_B43_TOOLS) += b43-tools
+ tools-$(BUILD_ISL) += isl
+ tools-$(CONFIG_USE_SPARSE) += sparse
+diff --git a/tools/zip/Makefile b/tools/zip/Makefile
+new file mode 100644
+index 0000000000000000000000000000000000000000..7dd81a1b8bc3bfeb5773d0770cb57c164f6db157
+--- /dev/null
++++ b/tools/zip/Makefile
+@@ -0,0 +1,36 @@
++#
++# Copyright (C) 2007-2016 OpenWrt.org
++#
++# This is free software, licensed under the GNU General Public License v2.
++# See /LICENSE for more information.
++#
++
++include $(TOPDIR)/rules.mk
++
++PKG_NAME:=zip
++PKG_REV:=30
++PKG_VERSION:=3.0
++
++PKG_SOURCE:=$(PKG_NAME)$(PKG_REV).tar.gz
++PKG_SOURCE_URL:=@SF/infozip
++PKG_HASH:=f0e8bb1f9b7eb0b01285495a2699df3a4b766784c1765a8f1aeedf63c0806369
++
++PKG_LICENSE:=BSD-4-Clause
++PKG_LICENSE_FILES:=LICENSE
++
++HOST_BUILD_DIR:=$(BUILD_DIR_HOST)/$(PKG_NAME)-$(PKG_VERSION)/zip$(PKG_REV)
++HOST_BUILD_PARALLEL:=1
++
++include $(INCLUDE_DIR)/host-build.mk
++
++define Host/Compile
++	+$(HOST_MAKE_VARS) $(MAKE) $(HOST_JOBS) -C $(HOST_BUILD_DIR) -I. -f unix/Makefile zip
++endef
++
++define Host/Install
++	$(INSTALL_DIR) $(STAGING_DIR_HOST)/bin/
++	$(INSTALL_BIN) $(HOST_BUILD_DIR)/zip $(STAGING_DIR_HOST)/bin/
++endef
++
++$(eval $(call HostBuild))
++#$(eval $(call BuildPackage,zip))
+diff --git a/tools/zip/patches/001-unix-configure-borrow-the-LFS-test-from-autotools.patch b/tools/zip/patches/001-unix-configure-borrow-the-LFS-test-from-autotools.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..ef0de6fd9b9bb1f2ee29a9609ce0dbd7799f3410
+--- /dev/null
++++ b/tools/zip/patches/001-unix-configure-borrow-the-LFS-test-from-autotools.patch
+@@ -0,0 +1,89 @@
++From fc392c939b9a18959482f588aff0afc29dd6d30a Mon Sep 17 00:00:00 2001
++From: Romain Naour <romain.naour at openwide.fr>
++Date: Fri, 23 Jan 2015 22:20:18 +0100
++Subject: [PATCH 6/6] unix/configure: borrow the LFS test from autotools.
++
++Infozip's LFS check can't work for cross-compilation
++since it try to run a target's binary on the host system.
++
++Instead, use to LFS test used by autotools which is a
++compilation test.
++(see autotools/lib/autoconf/specific.m4)
++
++Reported-by: Richard Genoud <richard.genoud at gmail.com>
++Signed-off-by: Romain Naour <romain.naour at openwide.fr>
++---
++ configure |   46 +++++++++++++++-------------------------------
++ 1 file changed, 15 insertions(+), 31 deletions(-)
++
++--- a/unix/configure
+++++ b/unix/configure
++@@ -399,9 +399,8 @@ else
++ fi
++ 
++ 
++-# Now we set the 64-bit file environment and check the size of off_t
++-# Added 11/4/2003 EG
++-# Revised 8/12/2004 EG
+++# LFS check borrowed from autotools sources
+++# lib/autoconf/specific.m4
++ 
++ echo Check for Large File Support
++ cat > conftest.c << _EOF_
++@@ -410,23 +409,19 @@ cat > conftest.c << _EOF_
++ # define _FILE_OFFSET_BITS 64       /* select default interface as 64 bit */
++ # define _LARGE_FILES        /* some OSes need this for 64-bit off_t */
++ #include <sys/types.h>
++-#include <sys/stat.h>
++-#include <unistd.h>
++-#include <stdio.h>
+++
+++ /* Check that off_t can represent 2**63 - 1 correctly.
+++    We can't simply define LARGE_OFF_T to be 9223372036854775807,
+++    since some C++ compilers masquerading as C compilers
+++    incorrectly reject 9223372036854775807.  */
+++#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
+++  int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
+++		       && LARGE_OFF_T % 2147483647 == 1)
+++		      ? 1 : -1];
+++
++ int main()
++ {
++-  off_t offset;
++-  struct stat s;
++-  /* see if have 64-bit off_t */
++-  if (sizeof(offset) < 8)
++-    return 1;
++-  printf("  off_t is %d bytes\n", sizeof(off_t));
++-  /* see if have 64-bit stat */
++-  if (sizeof(s.st_size) < 8) {
++-    printf("  s.st_size is %d bytes\n", sizeof(s.st_size));
++-    return 2;
++-  }
++-  return 3;
+++  return 0;
++ }
++ _EOF_
++ # compile it
++@@ -434,19 +429,8 @@ $CC -o conftest conftest.c >/dev/null 2>
++ if [ $? -ne 0 ]; then
++   echo -- no Large File Support
++ else
++-# run it
++-  ./conftest
++-  r=$?
++-  if [ $r -eq 1 ]; then
++-    echo -- no Large File Support - no 64-bit off_t
++-  elif [ $r -eq 2 ]; then
++-    echo -- no Large File Support - no 64-bit stat
++-  elif [ $r -eq 3 ]; then
++-    echo -- yes we have Large File Support!
++-    CFLAGS="${CFLAGS} -DLARGE_FILE_SUPPORT"
++-  else
++-    echo -- no Large File Support - conftest returned $r
++-  fi
+++  echo -- yes we have Large File Support!
+++  CFLAGS="${CFLAGS} -DLARGE_FILE_SUPPORT"
++ fi
++ 
++ 
+diff --git a/tools/zip/patches/004-do-not-set-unwanted-cflags.patch b/tools/zip/patches/004-do-not-set-unwanted-cflags.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..bfd226077a9742f87a1988747a81e9226e89dfaf
+--- /dev/null
++++ b/tools/zip/patches/004-do-not-set-unwanted-cflags.patch
+@@ -0,0 +1,15 @@
++From: Santiago Vila <sanvila@debian.org>
++Subject: Do not set unwanted CFLAGS, as it breaks DEB_BUILD_OPTIONS
++X-Debian-version: 2.32-1
++
++--- a/unix/configure
+++++ b/unix/configure
++@@ -98,7 +98,7 @@ int main()
++ _EOF_
++       $CC $CFLAGS -c conftest.c > /dev/null 2>/dev/null
++       if test $? -eq 0; then
++-        CFLAGS_OPT='-O3'
+++        # CFLAGS_OPT='-O3'
++         echo "  GNU C ($CFLAGS_OPT)"
++         # Special Mac OS X shared library "ld" option?
++         if test ` uname -s 2> /dev/null ` = 'Darwin'; then
+diff --git a/tools/zip/patches/006-stack-markings-to-avoid-executable-stack.patch b/tools/zip/patches/006-stack-markings-to-avoid-executable-stack.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..8b479faedaeedbe83d378306d386a0a88493b282
+--- /dev/null
++++ b/tools/zip/patches/006-stack-markings-to-avoid-executable-stack.patch
+@@ -0,0 +1,21 @@
++From: Kees Cook <kees@debian.org>
++Subject: put stack markings in i386 assembly to avoid executable stack
++Bug-Debian: http://bugs.debian.org/528280
++X-Debian-version: 3.0-2
++
++--- a/crc_i386.S
+++++ b/crc_i386.S
++@@ -302,3 +302,5 @@ _crc32:                         /* ulg c
++ #endif /* i386 || _i386 || _I386 || __i386 */
++ 
++ #endif /* !USE_ZLIB && !CRC_TABLE_ONLY */
+++.section .note.GNU-stack, "", @progbits
+++.previous
++--- a/match.S
+++++ b/match.S
++@@ -405,3 +405,5 @@ L__return:
++ #endif /* i386 || _I386 || _i386 || __i386  */
++ 
++ #endif /* !USE_ZLIB */
+++.section .note.GNU-stack, "", @progbits
+++.previous
+diff --git a/tools/zip/patches/007-fclose-in-file-not-fclose-x.patch b/tools/zip/patches/007-fclose-in-file-not-fclose-x.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..402f90a2d5ef3d08a7d71268fe4f5e2484a10664
+--- /dev/null
++++ b/tools/zip/patches/007-fclose-in-file-not-fclose-x.patch
+@@ -0,0 +1,16 @@
++From: Christian Spieler
++Subject: zipnote.c: Close in_file instead of undefined file x
++Bug-Debian: http://bugs.debian.org/628594
++X-Debian-version: 3.0-4
++
++--- a/zipnote.c
+++++ b/zipnote.c
++@@ -661,7 +661,7 @@ char **argv;            /* command line
++     if ((r = zipcopy(z)) != ZE_OK)
++       ziperr(r, "was copying an entry");
++   }
++-  fclose(x);
+++  fclose(in_file);
++ 
++   /* Write central directory and end of central directory with new comments */
++   if ((c = zftello(y)) == (zoff_t)-1)    /* get start of central */
+diff --git a/tools/zip/patches/008-hardening-build-fix-1.patch b/tools/zip/patches/008-hardening-build-fix-1.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..a0c3a91eeec064b2305c3873a8a95669c750ea9b
+--- /dev/null
++++ b/tools/zip/patches/008-hardening-build-fix-1.patch
+@@ -0,0 +1,25 @@
++From: Santiago Vila <sanvila@debian.org>
++Subject: Use format specifier %s to print strings, not the string itself
++Bug-Debian: http://bugs.debian.org/673476
++X-Debian-version: 3.0-5
++
++--- a/zip.c
+++++ b/zip.c
++@@ -1028,7 +1028,7 @@ local void help_extended()
++ 
++   for (i = 0; i < sizeof(text)/sizeof(char *); i++)
++   {
++-    printf(text[i]);
+++    printf("%s", text[i]);
++     putchar('\n');
++   }
++ #ifdef DOS
++@@ -1225,7 +1225,7 @@ local void version_info()
++             CR_MAJORVER, CR_MINORVER, CR_BETA_VER, CR_VERSION_DATE);
++   for (i = 0; i < sizeof(cryptnote)/sizeof(char *); i++)
++   {
++-    printf(cryptnote[i]);
+++    printf("%s", cryptnote[i]);
++     putchar('\n');
++   }
++   ++i;  /* crypt support means there IS at least one compilation option */
+diff --git a/tools/zip/patches/009-hardening-build-fix-2.patch b/tools/zip/patches/009-hardening-build-fix-2.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..e295ffbc641879768cc9257641fae85af327a338
+--- /dev/null
++++ b/tools/zip/patches/009-hardening-build-fix-2.patch
+@@ -0,0 +1,16 @@
++From: Santiago Vila <sanvila@debian.org>
++Subject: unix/configure: Take linking flags from the environment
++Bug-Debian: http://bugs.debian.org/673476
++X-Debian-version: 3.0-5
++
++--- a/unix/configure
+++++ b/unix/configure
++@@ -18,7 +18,7 @@ trap "rm -f conftest* core a.out; exit 1
++ 
++ CC=${1-cc}
++ CFLAGS=${2-"-I. -DUNIX"}
++-LFLAGS1=''
+++LFLAGS1=${LDFLAGS}
++ LFLAGS2=''
++ LN="ln -s"
++ 
+diff --git a/tools/zip/patches/010-remove-build-date.patch b/tools/zip/patches/010-remove-build-date.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..5fc385228a8f6bff01416748bb6c392f2e986322
+--- /dev/null
++++ b/tools/zip/patches/010-remove-build-date.patch
+@@ -0,0 +1,15 @@
++From: Santiago Vila <sanvila@debian.org>
++Subject: Remove (optional) build date to make the build reproducible
++Bug-Debian: http://bugs.debian.org/779042
++
++--- a/unix/unix.c
+++++ b/unix/unix.c
++@@ -1020,7 +1020,7 @@ void version_local()
++ 
++ 
++ /* Define the compile date string */
++-#ifdef __DATE__
+++#if 0
++ #  define COMPILE_DATE " on " __DATE__
++ #else
++ #  define COMPILE_DATE ""
+diff --git a/tools/zip/patches/011-add-option-for-reproducible-archives.patch b/tools/zip/patches/011-add-option-for-reproducible-archives.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..45b9d67e159327798535db55cd264ab9eeec6c38
+--- /dev/null
++++ b/tools/zip/patches/011-add-option-for-reproducible-archives.patch
+@@ -0,0 +1,145 @@
++From 6d659fc87451c02c8777dc33f750b16834e4c715 Mon Sep 17 00:00:00 2001
++From: Mathias Kresin <dev@kresin.me>
++Date: Sat, 12 Jan 2019 19:33:33 +0100
++Subject: [PATCH] add option for reproducible archives
++
++Add the option -mt/--mtime to pass a timestamp which is used as filedate
++for the containing files.
++
++So far, it isn't used for anything written to the extra fields,
++therefore requires the -X (eXclude eXtra file attributes) parameter to
++be effective.
++
++Signed-off-by: Mathias Kresin <dev@kresin.me>
++---
++ globals.c |  1 +
++ util.c    | 22 ++++++++++++++++++++++
++ zip.c     |  6 ++++++
++ zip.h     |  1 +
++ zipup.c   |  4 +++-
++ 5 files changed, 33 insertions(+), 1 deletion(-)
++
++--- a/globals.c
+++++ b/globals.c
++@@ -205,6 +205,7 @@ uzoff_t bytes_this_split = 0;     /* byt
++ int read_split_archive = 0;       /* 1=scanzipf_reg detected spanning signature */
++ int split_method = 0;             /* 0=no splits, 1=seekable, 2=data desc, -1=no */
++ uzoff_t split_size = 0;           /* how big each split should be */
+++time_t timestamp = -1;             /* fixed timestamp for archive content filedate */
++ int split_bell = 0;               /* when pause for next split ring bell */
++ uzoff_t bytes_prev_splits = 0;    /* total bytes written to all splits before this */
++ uzoff_t bytes_this_entry = 0;     /* bytes written for this entry across all splits */
++--- a/util.c
+++++ b/util.c
++@@ -1217,6 +1217,7 @@ int DisplayNumString(file, i)
++   return 0;
++ }
++ 
+++
++ /* Read numbers with trailing size multiplier (like 10M) and return number.
++    10/30/04 EG */
++ 
++@@ -1279,6 +1280,29 @@ uzoff_t ReadNumString( numstring )
++ }
++ 
++ 
+++uzoff_t ReadNumStringUL( numstring )
+++  char *numstring;
+++{
+++  zoff_t num = 0;
+++
+++  /* check if valid number (currently no negatives) */
+++  if (numstring == NULL) {
+++    zipwarn("Unable to read empty number in ReadNumString", "");
+++    return (uzoff_t)-1;
+++  }
+++  if (numstring[0] < '0' || numstring[0] > '9') {
+++    zipwarn("Unable to read number (must start with digit): ", numstring);
+++    return (uzoff_t)-1;
+++  }
+++  if (strlen(numstring) > 10) {
+++    zipwarn("Number too long to read (10 characters max): ", numstring);
+++    return (uzoff_t)-1;
+++  }
+++
+++  return (uzoff_t)atoll(numstring);
+++}
+++
+++
++ /* Write the number as a string with a multiplier (like 10M) to outstring.
++    Always writes no more than 3 digits followed maybe by a multiplier and
++    returns the characters written or -1 if error.
++--- a/zip.c
+++++ b/zip.c
++@@ -1942,6 +1942,7 @@ int set_filetype(out_path)
++ #ifdef UNICODE_TEST
++ #define o_sC            0x146
++ #endif
+++#define o_mt            0x255
++ 
++ 
++ /* the below is mainly from the old main command line
++@@ -2036,6 +2037,7 @@ struct option_struct far options[] = {
++     {"m",  "move",        o_NO_VALUE,       o_NOT_NEGATABLE, 'm',  "add files to archive then delete files"},
++     {"mm", "",            o_NO_VALUE,       o_NOT_NEGATABLE, o_mm, "not used"},
++     {"MM", "must-match",  o_NO_VALUE,       o_NOT_NEGATABLE, o_MM, "error if in file not matched/not readable"},
+++    {"mt", "mtime",       o_REQUIRED_VALUE, o_NOT_NEGATABLE, o_mt, "use fixed timestamp for archive content filedate"},
++     {"n",  "suffixes",    o_REQUIRED_VALUE, o_NOT_NEGATABLE, 'n',  "suffixes to not compress: .gz:.zip"},
++     {"nw", "no-wild",     o_NO_VALUE,       o_NOT_NEGATABLE, o_nw, "no wildcards during add or update"},
++ #if defined(AMIGA) || defined(MACOS)
++@@ -2440,6 +2442,7 @@ char **argv;            /* command line
++   split_method = 0;           /* 0=no splits, 1=update LHs, 2=data descriptors */
++   split_size = 0;             /* how big each split should be */
++   split_bell = 0;             /* when pause for next split ring bell */
+++  timestamp = -1;             /* fixed timestamp for archive content filedate */
++   bytes_prev_splits = 0;      /* total bytes written to all splits before this */
++   bytes_this_entry = 0;       /* bytes written for this entry across all splits */
++   noisy_splits = 0;           /* be verbose about creating splits */
++@@ -2897,6 +2900,9 @@ char **argv;            /* command line
++           dispose = 1;  break;
++         case o_MM:  /* Exit with error if input file can't be read */
++           bad_open_is_error = 1; break;
+++        case o_mt:  /* fixed timestamp for archive content filedate */
+++          timestamp = ReadNumStringUL(value);
+++          break;
++         case 'n':   /* Don't compress files with a special suffix */
++           special = value;
++           /* special = NULL; */ /* will be set at next argument */
++--- a/zip.h
+++++ b/zip.h
++@@ -502,6 +502,7 @@ extern uzoff_t bytes_this_split; /* byte
++ extern int read_split_archive;   /* 1=scanzipf_reg detected spanning signature */
++ extern int split_method;         /* 0=no splits, 1=seekable, 2=data descs, -1=no */
++ extern uzoff_t split_size;       /* how big each split should be */
+++extern time_t timestamp;         /* fixed timestamp for archive content filedate */
++ extern int split_bell;           /* when pause for next split ring bell */
++ extern uzoff_t bytes_prev_splits; /* total bytes written to all splits before this */
++ extern uzoff_t bytes_this_entry; /* bytes written for this entry across all splits */
++@@ -789,6 +790,7 @@ char *zip_fzofft       OF((zoff_t, char
++ int DisplayNumString OF ((FILE *file, uzoff_t i));
++ int WriteNumString OF((uzoff_t num, char *outstring));
++ uzoff_t ReadNumString OF((char *numstring));
+++uzoff_t ReadNumStringUL OF((char *numstring));
++ 
++ /* returns true if abbrev is abbreviation for string */
++ int abbrevmatch OF((char *, char *, int, int));
++--- a/zipup.c
+++++ b/zipup.c
++@@ -415,7 +415,6 @@ struct zlist far *z;    /* zip entry to
++   char *tempextra = NULL;
++   char *tempcextra = NULL;
++ 
++-
++ #ifdef WINDLL
++ # ifdef ZIP64_SUPPORT
++   extern _int64 filesize64;
++@@ -441,6 +440,9 @@ struct zlist far *z;    /* zip entry to
++   if (tim == 0 || q == (zoff_t) -3)
++     return ZE_OPEN;
++ 
+++  if (timestamp > 0)
+++    tim = unix2dostime(&timestamp);
+++
++   /* q is set to -1 if the input file is a device, -2 for a volume label */
++   if (q == (zoff_t) -2) {
++      isdir = 1;

--- a/patches/openwrt/0018-firmware-utils-add-sercomm-netgear-tool.patch
+++ b/patches/openwrt/0018-firmware-utils-add-sercomm-netgear-tool.patch
@@ -1,0 +1,469 @@
+From: Ludwig Thomeczek <ledesrc@wxorx.net>
+Date: Tue, 12 Jun 2018 21:16:40 +0200
+Subject: firmware-utils: add sercomm/netgear tool
+
+This adds a tool to generate a firmware file accepted
+by Netgear or sercomm devices.
+
+They use a zip-packed rootfs with header and a custom
+checksum. The generated Image can be flashed via the
+nmrpflash tool or the webinterface of the router.
+
+Signed-off-by: Ludwig Thomeczek <ledesrc@wxorx.net>
+
+firmware-utils/mksercommfw: fix musl build
+
+* add missing <sys/types.h> for musl
+
+Signed-off-by: Andy Walsh <andy.walsh44+github@gmail.com>
+
+firmware-utils/mksercommfw: fix build with clang/macOS
+
+fixes error: non-void function 'main' should return a value
+
+Fixes: FS#1770
+
+Signed-off-by: Ryan Mounce <ryan@mounce.com.au>
+
+ramips: fix image generation for mt76x8
+
+Buildbot fails to generate images for targets also generating a
+Sercomm binary with following error:
+
+Opening file: /mnt/ramdisk/koen/firmware/builds/owrt_mt76x8/build_dir/target-mipsel_24kc_musl/linux-ramips_mt76x8/tmp/openwrt-ramips-mt76x8-netgear_r6120-squashfs-factory.img.rootfs.zip
+Filesize: 3648606 .
+mksercommfw: malloc.c:2427: sysmalloc: Assertion `(old_top == initial_top (av) && old_size == 0) || ((unsigned long) (old_size) >= MINSIZE && prev_inuse (old_top) && ((unsigned long) old_end & (pagesize - 1)) == 0)' failed.
+Makefile:287: recipe for target '/mnt/ramdisk/koen/firmware/builds/owrt_mt76x8/build_dir/target-mipsel_24kc_musl/linux-ramips_mt76x8/tmp/openwrt-ramips-mt76x8-netgear_r6120-squashfs-factory.img' failed
+
+Debugging using valgrind shows stack corruption due to a buffer overflow.
+The author of the generator assumes the filename ends with "root",
+while it should be "rootfs".
+
+Fix this by accounting for the 2 missing characters which solves the build issues.
+
+More work is required to cleanup this source, which will be done later on.
+
+Reported-by: Hannu Nyman <hannu.nyman@iki.fi>
+Signed-off-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
+
+ramips: fix netgear r6120 factory image generation
+
+as indicated in commit c5bf408ed6bd "(ramips: fix image generation for mt76x8")
+more rework was needed to fix the other issues.
+
+Building on another machine, but using the same arch, showed
+the application failing again for different reasons.
+
+Fix this by completely rewriting the application, fixing following found issues:
+
+- buffer overflows, resulting in stack corruption
+- flaws in memory requirement calculations (too small, too large)
+- memory leaks
+- missing bounds checking on string handling
+- non-reproducable images, by using unitilized memory in checksum calculation
+- missing error handling, resulting in succes on specific image errors
+- endianness errors when building on BE machines
+- various minor build warnings
+- documentation did not match the code actions (header item locations)
+- allowing input to be decimal, hex or octal now
+
+Signed-off-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
+
+tools: firmware-utils: mksercommfw build on Darwin
+
+asm/byteorder.h & hence __cpu_to_be32() doesn't exist on Darwin
+
+Shamelessly copy some byte swap functions from oseama.c
+
+Acked-by: Koen Vandeputte <koen.vandeputte@ncentric.com>
+Signed-off-by: Kevin Darbyshire-Bryant <ldir@darbyshire-bryant.me.uk>
+
+firmware-utils: mksercommfw: overhaul image creation
+
+Move the zip compression into a build recipe. Pad the image using the
+existing build recipes as well to remove duplicate functionality
+
+Change the code to append header and footer in two steps. Allow to use a
+fixed filename as the netgear update image does.
+
+Use a fixed timestamp within the zip archive to make the images
+reproducible.
+
+Due to the changes we are now compatible to the gnu89 c standard used by
+default on the buildbots and we don't need to force a more recent
+standard anymore.
+
+Beside all changes, the footer still looks wrong in compare to the
+netgear update image.
+
+Signed-off-by: Mathias Kresin <dev@kresin.me>
+
+diff --git a/include/image-commands.mk b/include/image-commands.mk
+index 552d8db1cbacf533c12d0d8e2e5cffbe5591adb4..aec044294365bf5e964906e022d468d1a1c95fba 100644
+--- a/include/image-commands.mk
++++ b/include/image-commands.mk
+@@ -115,6 +115,16 @@ define Build/tplink-safeloader
+ 		$(if $(findstring sysupgrade,$(word 1,$(1))),-S) && mv $@.new $@ || rm -f $@
+ endef
+ 
++define Build/mksercommfw
++	-$(STAGING_DIR_HOST)/bin/mksercommfw \
++		$@ \
++		$(KERNEL_OFFSET) \
++		$(HWID) \
++		$(HWVER) \
++		$(SWVER)
++endef
++
++
+ define Build/append-dtb
+ 	cat $(KDIR)/image-$(firstword $(DEVICE_DTS)).dtb >> $@
+ endef
+@@ -152,6 +162,16 @@ define Build/gzip
+ 	@mv $@.new $@
+ endef
+ 
++define Build/zip
++	mkdir $@.tmp
++	mv $@ $@.tmp/$(1)
++
++	zip -j -X \
++		$(if $(SOURCE_DATE_EPOCH),--mtime="$(SOURCE_DATE_EPOCH)") \
++		$@ $@.tmp/$(if $(1),$(1),$@)
++	rm -rf $@.tmp
++endef
++
+ define Build/jffs2
+ 	rm -rf $(KDIR_TMP)/$(DEVICE_NAME)/jffs2 && \
+ 		mkdir -p $(KDIR_TMP)/$(DEVICE_NAME)/jffs2/$$(dirname $(1)) && \
+diff --git a/target/linux/ramips/image/mt76x8.mk b/target/linux/ramips/image/mt76x8.mk
+index bc282666d8c1a4b6ce5beabe2b492331fb48a23a..f1bf78e0713a1bc47d4ac384efdac1d08c1bd8bc 100644
+--- a/target/linux/ramips/image/mt76x8.mk
++++ b/target/linux/ramips/image/mt76x8.mk
+@@ -2,17 +2,22 @@
+ # MT76x8 Profiles
+ #
+ 
+-DEVICE_VARS += SERCOMM_KERNEL_OFFSET SERCOMM_HWID SERCOMM_HWVER SERCOMM_SWVER
++DEVICE_VARS += SERCOMM_HWID SERCOMM_HWVER SERCOMM_SWVER
+ 
+-define Build/mksercommfw
++define Build/sercom-seal
+ 	$(STAGING_DIR_HOST)/bin/mksercommfw \
+-		$@ \
+-		$(SERCOMM_KERNEL_OFFSET) \
+-		$(SERCOMM_HWID) \
+-		$(SERCOMM_HWVER) \
+-		$(SERCOMM_SWVER)
++		-i $@ \
++		-b $(SERCOMM_HWID) \
++		-r $(SERCOMM_HWVER) \
++		-v $(SERCOMM_SWVER) \
++		$(1)
+ endef
+ 
++define Build/sercom-footer
++	$(call Build/sercom-seal,-f)
++endef
++
++
+ define Device/tplink
+   TPLINK_FLASHLAYOUT :=
+   TPLINK_HWID :=
+@@ -107,14 +112,14 @@ define Device/netgear_r6120
+   IMAGE_SIZE := $(ralink_default_fw_size_16M)
+   DEVICE_TITLE := Netgear R6120
+   DEVICE_PACKAGES := kmod-usb2 kmod-usb-ohci
+-  SERCOMM_KERNEL_OFFSET := 90000
+   SERCOMM_HWID := CGQ
+   SERCOMM_HWVER := A001
+-  SERCOMM_SWVER := 0040
++  SERCOMM_SWVER := 0x0040
+   IMAGES += factory.img
+   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE)| append-rootfs | pad-rootfs
+   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+-  IMAGE/factory.img := $$(IMAGE/default) | mksercommfw
++  IMAGE/factory.img := pad-extra 576k | $$(IMAGE/default) | \
++	sercom-footer | pad-to 128 | zip R6120.bin | sercom-seal
+ endef
+ TARGET_DEVICES += netgear_r6120
+ 
+diff --git a/tools/firmware-utils/Makefile b/tools/firmware-utils/Makefile
+index a6379e35eb01f1cbbe2b1ece3fc9eb20bcd68d90..ca7722163d68d028b88e4cca2f0457875e633af6 100644
+--- a/tools/firmware-utils/Makefile
++++ b/tools/firmware-utils/Makefile
+@@ -85,6 +85,7 @@ define Host/Compile
+ 	$(call cc,mkdhpimg buffalo-lib, -Wall)
+ 	$(call cc,mkdlinkfw mkdlinkfw-lib, -lz -Wall --std=gnu99)
+ 	$(call cc,dns313-header, -Wall)
++	$(call cc,mksercommfw, -Wall)
+ endef
+ 
+ define Host/Install
+diff --git a/tools/firmware-utils/src/mksercommfw.c b/tools/firmware-utils/src/mksercommfw.c
+new file mode 100644
+index 0000000000000000000000000000000000000000..f6f1d93f37970be0cdf94e71a5e1093b3e92c040
+--- /dev/null
++++ b/tools/firmware-utils/src/mksercommfw.c
+@@ -0,0 +1,261 @@
++#include <stdio.h>
++#include <string.h>
++#include <stdlib.h>
++#include <sys/types.h>
++#include <unistd.h>
++#include <byteswap.h>
++#include <endian.h>
++#include <getopt.h>
++
++#if !defined(__BYTE_ORDER)
++#error "Unknown byte order"
++#endif
++
++#if __BYTE_ORDER == __BIG_ENDIAN
++#define cpu_to_be32(x)  (x)
++#elif __BYTE_ORDER == __LITTLE_ENDIAN
++#define cpu_to_be32(x)  bswap_32(x)
++#else
++#error "Unsupported endianness"
++#endif
++
++/* #define DEBUG 1 */
++
++#ifdef DEBUG
++#define DBG(...) {printf(__VA_ARGS__); }
++#else
++#define DBG(...) {}
++#endif
++
++#define ERR(...) {printf(__VA_ARGS__); }
++
++/*
++ * Fw Header Layout for Netgear / Sercomm devices (bytes)
++ *
++ * Size : 512 bytes + zipped image size
++ *
++ * Locations:
++ * magic  : 0-6    ASCII
++ * version: 7-11   fixed
++ * hwID   : 11-44  ASCII
++ * hwVer  : 45-54  ASCII
++ * swVer  : 55-62  uint32_t in BE
++ * magic  : 63-69  ASCII
++ * ChkSum : 511    Inverse value of the full image checksum while this location is 0x00
++ */
++static const char* magic = "sErCoMm"; /* 7 */
++static const unsigned char version[4] = { 0x00, 0x01, 0x00, 0x00 };
++static const int header_sz = 512;
++static const int footer_sz = 71;
++
++static int is_header = 1;
++
++struct file_info {
++	char* file_name; /* name of the file */
++	char* file_data; /* data of the file in memory */
++	u_int32_t file_size; /* length of the file */
++};
++
++static u_int8_t getCheckSum(char* data, int len) {
++	u_int8_t new = 0;
++	int i;
++
++	if (!data) {
++		ERR("Invalid pointer provided!\n");
++		return 0;
++	}
++
++	for (i = 0; i < len; i++) {
++		new += data[i];
++	}
++
++	return new;
++}
++
++/*
++ * read file into buffer
++ * add space for header/footer
++ */
++static int copyToOutputBuf(struct file_info* finfo) {
++	FILE* fp = NULL;
++
++	int file_sz = 0;
++	int extra_sz;
++	int hdr_pos;
++	int img_pos;
++
++	if (!finfo || !finfo->file_name) {
++		ERR("Invalid pointer provided!\n");
++		return -1;
++	}
++
++	DBG("Opening file: %s\n", finfo->file_name);
++
++	if (!(fp = fopen(finfo->file_name, "rb"))) {
++		ERR("Error opening file: %s\n", finfo->file_name);
++		return -1;
++	}
++
++	/* Get filesize */
++	rewind(fp);
++	fseek(fp, 0L, SEEK_END);
++	file_sz = ftell(fp);
++	rewind(fp);
++
++	if (file_sz < 1) {
++		ERR("Error getting filesize: %s\n", finfo->file_name);
++		fclose(fp);
++		return -1;
++	}
++
++	if (is_header) {
++		extra_sz = header_sz;
++		hdr_pos = 0;
++		img_pos = header_sz;
++	} else {
++		extra_sz = footer_sz;
++		hdr_pos = file_sz;
++		img_pos = 0;
++	}
++
++	DBG("Filesize: %i\n", file_sz);
++	finfo->file_size = file_sz + extra_sz;
++
++	if (!(finfo->file_data = malloc(finfo->file_size))) {
++		ERR("Out of memory!\n");
++		fclose(fp);
++		return -1;
++	}
++
++	/* init header/footer bytes */
++	memset(finfo->file_data + hdr_pos, 0, extra_sz);
++
++	/* read file and take care of leading header if exists */
++	if (fread(finfo->file_data + img_pos, 1, file_sz, fp) != file_sz) {
++		ERR("Error reading file %s\n", finfo->file_name);
++		fclose(fp);
++		return -1;
++	}
++
++	DBG("File: read successful\n");
++	fclose(fp);
++
++	return hdr_pos;
++}
++
++static int writeFile(struct file_info* finfo) {
++	FILE* fp;
++
++	if (!finfo || !finfo->file_name) {
++		ERR("Invalid pointer provided!\n");
++		return -1;
++	}
++
++	DBG("Opening file: %s\n", finfo->file_name);
++
++	if (!(fp = fopen(finfo->file_name, "w"))) {
++		ERR("Error opening file: %s\n", finfo->file_name);
++		return -1;
++	}
++
++	DBG("Writing file: %s\n", finfo->file_name);
++
++	if (fwrite(finfo->file_data, 1, finfo->file_size, fp) != finfo->file_size) {
++		ERR("Wanted to write, but something went wrong!\n");
++		fclose(fp);
++		return -1;
++	}
++
++	fclose(fp);
++	return 0;
++}
++
++static void usage(char* argv[]) {
++	printf("Usage: %s [OPTIONS...]\n"
++	       "\n"
++	       "Options:\n"
++	       "  -f            add sercom footer (if absent, header)\n"
++	       "  -b <hwid>     use hardware id specified with <hwid> (ASCII)\n"
++	       "  -r <hwrev>    use hardware revision specified with <hwrev> (ASCII)\n"
++	       "  -v <version>  set image version to <version> (decimal, hex or octal notation)\n"
++	       "  -i <file>     input file\n"
++	       , argv[0]);
++}
++
++int main(int argc, char* argv[]) {
++	struct file_info image = { 0 };
++
++	char* hwID = NULL;
++	char* hwVer = NULL;
++	u_int32_t swVer = 0;
++	u_int8_t chkSum;
++	int hdr_offset;
++
++	while ( 1 ) {
++		int c;
++
++		c = getopt(argc, argv, "b:i:r:v:f");
++		if (c == -1)
++			break;
++
++		switch (c) {
++		case 'b':
++			hwID = optarg;
++			break;
++		case 'f':
++			is_header = 0;
++			break;
++		case 'i':
++			image.file_name = optarg;
++			break;
++		case 'r':
++			hwVer = optarg;
++			break;
++		case 'v':
++			swVer = (u_int32_t) strtol(optarg, NULL, 0);
++			swVer = cpu_to_be32(swVer);
++			break;
++		default:
++			usage(argv);
++			return EXIT_FAILURE;
++		}
++	}
++
++	if (!hwID || !hwVer || !image.file_name) {
++			usage(argv);
++			return EXIT_FAILURE;
++	}
++
++	/*
++	 * copy input to buffer, add extra space for header/footer and return
++	 * header position
++	 */
++	hdr_offset = copyToOutputBuf(&image);
++	if (hdr_offset < 0)
++		return EXIT_FAILURE;
++
++	DBG("Filling header: %s %s %2X %s\n", hwID, hwVer, swVer, magic);
++
++	strncpy(image.file_data + hdr_offset + 0, magic, 7);
++	memcpy(image.file_data + hdr_offset + 7, version, sizeof(version));
++	strncpy(image.file_data + hdr_offset + 11, hwID, 34);
++	strncpy(image.file_data + hdr_offset + 45, hwVer, 10);
++	memcpy(image.file_data + hdr_offset + 55, &swVer, sizeof(swVer));
++	strncpy(image.file_data + hdr_offset + 63, magic, 7);
++
++	/* calculate checksum and invert checksum */
++	if (is_header) {
++		chkSum = getCheckSum(image.file_data, image.file_size);
++		chkSum = (chkSum ^ 0xFF) + 1;
++		DBG("Checksum for Image: %hhX\n", chkSum);
++
++		/* write checksum to header */
++		image.file_data[511] = (char) chkSum;
++	}
++
++	/* overwrite input file */
++	if (writeFile(&image))
++		return EXIT_FAILURE;
++
++	return EXIT_SUCCESS;
++}

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -4,6 +4,12 @@ device gl-mt300n-v2 gl-mt300n-v2
 factory
 
 
+# Netgear
+
+device netgear-r6120 netgear_r6120
+factory .img
+
+
 # TP-Link
 
 device tp-link-archer-c50-v3 tplink_c50-v3


### PR DESCRIPTION
MT7628/MT7612 based dualband-ac WiFi router. Very similar to the Archer C50 v3/v4 but with double the Flash (16MiB instead of 8 MiB).

This is also the first MT7628 based dualband device which can be flashed directly from the Vendor Web-Interface.

Price:
 - [New: ~40€ ](https://geizhals.de/netgear-r6120-r6120-100pes-a1624501.html)
 - [Refurbished (Amazon WHD): 30€](https://www.amazon.de/gp/offer-listing/B071HWVV5J/ref=dp_olp_used?ie=UTF8&condition=used)

-----

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp
  - [x] other: nmrp recovery tool
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
    ```
    root@64xxx-b039560bc5ab:~# lua -e 'print(require("platform_info").get_image_name())'
    netgear-r6120
    ```
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
        - Device has only one WiFi LED. Shows status of 2.4 GHz radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
        - Shows Link state. Activity is not shown as there is no netdev trigger tied to it. This is fairly common (maybe update this requirement)
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)