### PR TITLE
Minor changes of web references

### DIFF
--- a/contrib/sign.sh
+++ b/contrib/sign.sh
@@ -15,7 +15,7 @@ The script may be performed multiple times to the same document
 to indicate an approval by multiple developers.
 
 See also
- * ecdsautils on https://github.com/tcatm/ecdsautils
+ * ecdsautils on https://github.com/freifunk-gluon/ecdsautils
 
 EOHELP
 	exit 1

--- a/contrib/sigtest.sh
+++ b/contrib/sigtest.sh
@@ -8,8 +8,8 @@ sigtest.sh checks if a manifest is signed by the public key <public>. There is
 no output, success or failure is indicated via the return code.
 
 See also:
- * ecdsautils in https://github.com/tcatm/ecdsautils
- * http://gluon.readthedocs.org/en/latest/features/autoupdater.html
+ * ecdsautils in https://github.com/freifunk-gluon/ecdsautils
+ * https://gluon.readthedocs.io/en/latest/features/autoupdater.html
 
 EOHELP
     exit 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -447,7 +447,7 @@ Footnotes
   is explicitly set to something other than *11s*
 
 .. [#avmflash]
-  For instructions on how to flash AVM devices, visit https://www.fritzfla.sh
+  For instructions on how to flash AVM devices, visit https://fritzfla.sh
 
 License
 -------

--- a/docs/releases/v2017.1.3.rst
+++ b/docs/releases/v2017.1.3.rst
@@ -26,7 +26,7 @@ Bugfixes
   of the Gluon build, including tcpdump, curl and mbedtls
 
   Please refer to the
-  `LEDE commit log <https://git.openwrt.org/?p=source.git;a=shortlog;h=refs/heads/lede-17.01>`_
+  `LEDE commit log <https://git.openwrt.org/?p=openwrt/openwrt.git;a=shortlog;h=refs/heads/lede-17.01>`_
   for details.
 
 * Filtering of multicast packets between the mesh and the *local-node* interface

--- a/package/gluon-ebtables-limit-arp/src/lookup3.c
+++ b/package/gluon-ebtables-limit-arp/src/lookup3.c
@@ -95,7 +95,7 @@ satisfy this are
    14  9  3  7 17  3
 Well, "9 15 3 18 27 15" didn't quite get 32 bits diffing
 for "differ" defined as + with a one-bit base and a two-bit delta.  I
-used http://burtleburtle.net/bob/hash/avalanche.html to choose 
+used https://burtleburtle.net/bob/hash/avalanche.html to choose
 the operations, constants, and arrangements of the variables.
 
 This does not achieve avalanche.  There are input bits of (a,b,c)

--- a/package/gluon-radv-filterd/src/gluon-radv-filterd.c
+++ b/package/gluon-radv-filterd/src/gluon-radv-filterd.c
@@ -634,7 +634,7 @@ static int fork_execvp_timeout(struct timespec *timeout, const char *file, const
 	if (child == 0) {
 		sigprocmask(SIG_SETMASK, &oldsignals, NULL);
 		// casting discards const, but should be safe
-		// (see http://stackoverflow.com/q/36925388)
+		// (see https://stackoverflow.com/q/36925388)
 		execvp(file, (char**) argv);
 		fprintf(stderr, "can't execvp(\"%s\", ...): %s\n", file, strerror(errno));
 		_exit(1);


### PR DESCRIPTION
just some minor changes
* ecdsa utils new home (?) https://github.com/freifunk-gluon/ecdsautils
* update some urls by following 301 'moved permanently' redirects
* switch http to https