### PR TITLE
gluon-web-node-role: Fix i18n role translation

### DIFF
--- a/package/gluon-web-node-role/i18n/de.po
+++ b/package/gluon-web-node-role/i18n/de.po
@@ -10,18 +10,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Node role"
-msgstr "Verwendungszweck"
-
-msgid "Role"
-msgstr "Rolle"
-
 msgid ""
 "If this node has a special role within the mesh network you can specify this "
 "role here. Please find out about the available roles and their impact first. "
 "Only change the role if you know what you are doing."
 msgstr ""
-"Wenn dein Knoten eine besondere Rolle im Mesh-Netzwerk einnimmt, "
-"kannst du diese hier angeben. Bringe bitte zuvor in Erfahrung, welche "
-"Bedeutung die zur Verfügung stehenden Rollen haben. "
-"Setze die Rolle nur, wenn du weißt, was du tust."
+"Wenn dein Knoten eine besondere Rolle im Mesh-Netzwerk einnimmt, kannst du "
+"diese hier angeben. Bringe bitte zuvor in Erfahrung, welche Bedeutung die "
+"zur Verfügung stehenden Rollen haben. Setze die Rolle nur, wenn du weißt, "
+"was du tust."
+
+msgid "Node role"
+msgstr "Verwendungszweck"
+
+msgid "Role"
+msgstr "Rolle"

--- a/package/gluon-web-node-role/i18n/fr.po
+++ b/package/gluon-web-node-role/i18n/fr.po
@@ -10,18 +10,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgid "Node role"
-msgstr "Rôle du nœud"
-
-msgid "Role"
-msgstr "Rôle"
-
 msgid ""
 "If this node has a special role within the mesh network you can specify this "
 "role here. Please find out about the available roles and their impact first. "
 "Only change the role if you know what you are doing."
 msgstr ""
-"Si votre nœud a un rôle spécial dans le réseau MESH, vous pouvez "
-"spécifier ce rôle ici. Avant de changer, informez vous sur les rôles "
-"disponibles et sur leur impacts. Changez de rôle uniquement si vous "
-"comprenez ce que vous faites."
+"Si votre nœud a un rôle spécial dans le réseau MESH, vous pouvez spécifier "
+"ce rôle ici. Avant de changer, informez vous sur les rôles disponibles et "
+"sur leur impacts. Changez de rôle uniquement si vous comprenez ce que vous "
+"faites."
+
+msgid "Node role"
+msgstr "Rôle du nœud"
+
+msgid "Role"
+msgstr "Rôle"

--- a/package/gluon-web-node-role/i18n/gluon-web-node-role.pot
+++ b/package/gluon-web-node-role/i18n/gluon-web-node-role.pot
@@ -1,14 +1,14 @@
 msgid ""
 msgstr "Content-Type: text/plain; charset=UTF-8"
 
+msgid ""
+"If this node has a special role within the mesh network you can specify this "
+"role here. Please find out about the available roles and their impact first. "
+"Only change the role if you know what you are doing."
+msgstr ""
+
 msgid "Node role"
 msgstr ""
 
 msgid "Role"
-msgstr ""
-
-msgid ""
-"If this node has a special role within the mesh network you can specify this role here. "
-"Please find out about the available roles and their impact first. "
-"Only change the role if you know what you are doing."
 msgstr ""

--- a/package/gluon-web-node-role/luasrc/lib/gluon/config-mode/model/admin/noderole.lua
+++ b/package/gluon-web-node-role/luasrc/lib/gluon/config-mode/model/admin/noderole.lua
@@ -1,5 +1,6 @@
 local f, s, o
 local site = require 'gluon.site'
+local site_i18n = i18n 'gluon-site'
 local uci = require("simple-uci").cursor()
 local config = 'gluon-node-info'
 
@@ -9,7 +10,7 @@ local role = uci:get(config, uci:get_first(config, "system"), "role")
 f = Form(translate("Node role"))
 
 s = f:section(Section, nil, translate(
-	"If this node has a special role within the freifunk network you can specify this role here. "
+	"If this node has a special role within the mesh network you can specify this role here. "
 	.. "Please find out about the available roles and their impact first. "
 	.. "Only change the role if you know what you are doing."
 ))
@@ -17,7 +18,7 @@ s = f:section(Section, nil, translate(
 o = s:option(ListValue, "role", translate("Role"))
 o.default = role
 for _, role in ipairs(site.roles.list()) do
-	o:value(role, translate('gluon-web-node-role:role:' .. role))
+	o:value(role, site_i18n.translate('gluon-web-node-role:role:' .. role))
 end
 
 function o:write(data)


### PR DESCRIPTION
By commit 91ae553c93670dcd1dca2f73466be960580a0231 the translation of the package `gluon-web-node-role` was adjusted but the change missed the source file `noderole.lua`, i guess.

In addition i noticed that the role descriptions from a site translation where not used at the config page, instead the id e.g. `gluon-web-node-role:role:node`, `gluon-web-node-role:role:backbone`, .. where displayed, only. (added `site_i18n` to fix that)

Also executed the following commands (mentioned in the docs https://gluon.readthedocs.io/en/latest/dev/web/i18n.html) to update the translation files. Those commands updated the line and string order of the pot file and po files but the text is untouched (not sure if those changes should be undone).
```
../../../contrib/i18n-scan.pl ../files ../luasrc > gluon-web-node-role.pot
msgmerge -U de.po gluon-web-node-role.pot
msgmerge -U fr.po gluon-web-node-role.pot
```

Those commands also added 
```
msgid "gluon-web-node-role:role:"
msgstr ""
```
But i removed it as it is unused.