### PR TITLE
gluon-*batman-adv: Also list neighbors with non-best direct link

### DIFF
--- a/package/gluon-mesh-batman-adv/src/respondd.c
+++ b/package/gluon-mesh-batman-adv/src/respondd.c
@@ -667,9 +667,6 @@ static int parse_orig_list_netlink_cb(struct nl_msg *msg, void *arg)
 				      BATADV_ARRAY_SIZE(parse_orig_list_mandatory)))
 		return NL_OK;
 
-	if (!attrs[BATADV_ATTR_FLAG_BEST])
-		return NL_OK;
-
 	orig = nla_data(attrs[BATADV_ATTR_ORIG_ADDRESS]);
 	dest = nla_data(attrs[BATADV_ATTR_NEIGH_ADDRESS]);
 	tq = nla_get_u8(attrs[BATADV_ATTR_TQ]);

--- a/package/gluon-mesh-batman-adv/src/respondd.c
+++ b/package/gluon-mesh-batman-adv/src/respondd.c
@@ -695,6 +695,7 @@ static int parse_orig_list_netlink_cb(struct nl_msg *msg, void *arg)
 
 	json_object_object_add(obj, "tq", json_object_new_int(tq));
 	json_object_object_add(obj, "lastseen", json_object_new_double(lastseen / 1000.));
+	json_object_object_add(obj, "best", json_object_new_boolean(attrs[BATADV_ATTR_FLAG_BEST]));
 	json_object_object_add(interface, mac1, obj);
 
 	return NL_OK;

--- a/package/gluon-status-page-mesh-batman-adv/src/neighbours-batadv.c
+++ b/package/gluon-status-page-mesh-batman-adv/src/neighbours-batadv.c
@@ -75,6 +75,7 @@ static int parse_orig_list_netlink_cb(struct nl_msg *msg, void *arg)
 
   json_object_object_add(neigh, "tq", json_object_new_int(tq * 100 / 255));
   json_object_object_add(neigh, "ifname", json_object_new_string(ifname));
+  json_object_object_add(neigh, "best", json_object_new_boolean(attrs[BATADV_ATTR_FLAG_BEST]));
 
   json_object_object_add(opts->obj, mac1, neigh);
 

--- a/package/gluon-status-page-mesh-batman-adv/src/neighbours-batadv.c
+++ b/package/gluon-status-page-mesh-batman-adv/src/neighbours-batadv.c
@@ -54,9 +54,6 @@ static int parse_orig_list_netlink_cb(struct nl_msg *msg, void *arg)
 	                        BATADV_ARRAY_SIZE(parse_orig_list_mandatory)))
     return NL_OK;
 
-  if (!attrs[BATADV_ATTR_FLAG_BEST])
-    return NL_OK;
-
   orig = nla_data(attrs[BATADV_ATTR_ORIG_ADDRESS]);
   dest = nla_data(attrs[BATADV_ATTR_NEIGH_ADDRESS]);
   tq = nla_get_u8(attrs[BATADV_ATTR_TQ]);


### PR DESCRIPTION
Links between two direct neighbors are not always the best route between
these devices. The flag BATADV_ATTR_FLAG_BEST would not be set for these
originator entries and the respondd module would just ignore this entry.

This causes missing links in meshviewer and similar tools. And when the
link quality is nearly equal and but fluctuates slightly, these links will
from time to time appear and disappear on the map.

Or ff these neighbors are not accepted and returned to the status page then
some of the neighbor entries will show a name, (acceptable) signal strength
and mac address but no TQ value.