### PR TITLE
patches/openwrt: refresh 0006-generic-vxlan-backport-support-for-VXLA…

### DIFF
--- a/patches/openwrt/0006-generic-vxlan-backport-support-for-VXLAN-over-link-local-IPv6-to-4.9.patch
+++ b/patches/openwrt/0006-generic-vxlan-backport-support-for-VXLAN-over-link-local-IPv6-to-4.9.patch
@@ -182,10 +182,10 @@ index 0000000000000000000000000000000000000000..b38b9977bca192eafe9a0d9b8c36a120
 +
 diff --git a/target/linux/generic/backport-4.9/095-0003-vxlan-fix-snooping-for-link-local-IPv6-addresses.patch b/target/linux/generic/backport-4.9/095-0003-vxlan-fix-snooping-for-link-local-IPv6-addresses.patch
 new file mode 100644
-index 0000000000000000000000000000000000000000..dcfd1ce7c2f015354d21a65f12f6ebd00331b629
+index 0000000000000000000000000000000000000000..89523ac027b227a9f84b1130db06a7fc67ff68ce
 --- /dev/null
 +++ b/target/linux/generic/backport-4.9/095-0003-vxlan-fix-snooping-for-link-local-IPv6-addresses.patch
-@@ -0,0 +1,93 @@
+@@ -0,0 +1,88 @@
 +From 010b2b541d958e12d78ba1c79734c700f169610b Mon Sep 17 00:00:00 2001
 +Message-Id: <010b2b541d958e12d78ba1c79734c700f169610b.1515533863.git.mschiffer@universe-factory.net>
 +In-Reply-To: <f45ba82cd83d27b5d44d3dc417e0e480ba0d3703.1515533863.git.mschiffer@universe-factory.net>
@@ -209,11 +209,9 @@ index 0000000000000000000000000000000000000000..dcfd1ce7c2f015354d21a65f12f6ebd0
 + drivers/net/vxlan.c | 20 +++++++++++++++-----
 + 1 file changed, 15 insertions(+), 5 deletions(-)
 +
-+diff --git a/drivers/net/vxlan.c b/drivers/net/vxlan.c
-+index 863d9528b900..c28c6f34b3b3 100644
 +--- a/drivers/net/vxlan.c
 ++++ b/drivers/net/vxlan.c
-+@@ -917,16 +917,25 @@ static int vxlan_fdb_dump(struct sk_buff *skb, struct netlink_callback *cb,
++@@ -917,16 +917,25 @@ out:
 +  * Return true if packet is bogus and should be dropped.
 +  */
 + static bool vxlan_snoop(struct net_device *dev,
@@ -241,7 +239,7 @@ index 0000000000000000000000000000000000000000..dcfd1ce7c2f015354d21a65f12f6ebd0
 + 			return false;
 + 
 + 		/* Don't migrate static entries, drop packets */
-+@@ -952,7 +961,7 @@ static bool vxlan_snoop(struct net_device *dev,
++@@ -952,7 +961,7 @@ static bool vxlan_snoop(struct net_devic
 + 					 NLM_F_EXCL|NLM_F_CREATE,
 + 					 vxlan->cfg.dst_port,
 + 					 vxlan->default_dst.remote_vni,
@@ -250,7 +248,7 @@ index 0000000000000000000000000000000000000000..dcfd1ce7c2f015354d21a65f12f6ebd0
 + 		spin_unlock(&vxlan->hash_lock);
 + 	}
 + 
-+@@ -1223,6 +1232,7 @@ static bool vxlan_set_mac(struct vxlan_dev *vxlan,
++@@ -1223,6 +1232,7 @@ static bool vxlan_set_mac(struct vxlan_d
 + 			  struct sk_buff *skb)
 + {
 + 	union vxlan_addr saddr;
@@ -258,7 +256,7 @@ index 0000000000000000000000000000000000000000..dcfd1ce7c2f015354d21a65f12f6ebd0
 + 
 + 	skb_reset_mac_header(skb);
 + 	skb->protocol = eth_type_trans(skb, vxlan->dev);
-+@@ -1244,7 +1254,7 @@ static bool vxlan_set_mac(struct vxlan_dev *vxlan,
++@@ -1244,7 +1254,7 @@ static bool vxlan_set_mac(struct vxlan_d
 + 	}
 + 
 + 	if ((vxlan->flags & VXLAN_F_LEARN) &&
@@ -267,18 +265,15 @@ index 0000000000000000000000000000000000000000..dcfd1ce7c2f015354d21a65f12f6ebd0
 + 		return false;
 + 
 + 	return true;
-+@@ -1932,7 +1942,7 @@ static void vxlan_encap_bypass(struct sk_buff *skb, struct vxlan_dev *src_vxlan,
++@@ -1939,7 +1949,7 @@ static void vxlan_encap_bypass(struct sk
 + 	}
 + 
 + 	if (dst_vxlan->flags & VXLAN_F_LEARN)
-+-		vxlan_snoop(skb->dev, &loopback, eth_hdr(skb)->h_source);
-++		vxlan_snoop(skb->dev, &loopback, eth_hdr(skb)->h_source, 0);
++-		vxlan_snoop(dev, &loopback, eth_hdr(skb)->h_source);
+++		vxlan_snoop(dev, &loopback, eth_hdr(skb)->h_source, 0);
 + 
 + 	u64_stats_update_begin(&tx_stats->syncp);
 + 	tx_stats->tx_packets++;
-+-- 
-+2.15.1
-+
 diff --git a/target/linux/generic/backport-4.9/095-0004-vxlan-allow-multiple-VXLANs-with-same-VNI-for-IPv6-l.patch b/target/linux/generic/backport-4.9/095-0004-vxlan-allow-multiple-VXLANs-with-same-VNI-for-IPv6-l.patch
 new file mode 100644
 index 0000000000000000000000000000000000000000..18ae230a3b04d2b57184109fa14f9533f0fb7192


### PR DESCRIPTION
…N-over-link-local-IPv6-to-4.9.patch

The patchset clashed with this change in 4.9.160: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?h=linux-4.9.y&id=163b06a5fba4282812bea65e37e674dad4c27689.

I refreshed the patch using quilt and the format somewhat changed, is it still fine that way?

Compile-tested: ar71xx-generic, ramips-mt7621