### PR TITLE
docs: faq: add note for supported hardware

### DIFF
--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -1,10 +1,20 @@
 Frequently Asked Questions
 ==========================
 
+.. _faq-hardware:
+
+What hardware is supported?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+A table with hardware supported by Gluon can be found on the `OpenWrt Wiki`_.
+If you want to find out if your device can potentially be supported 
+have a look at :doc:`../dev/hardware` for detailed hardware requirements.
+
+.. _OpenWrt Wiki: https://openwrt.org/toh/views/toh_gluon_supported
+
 .. _faq-dns:
 
-DNS does not work on the nodes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Why does DNS not work on the nodes?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Gluon nodes will ignore the DNS server on the WAN port for everything except
 the mesh VPN, which can lead to confusion.
@@ -18,8 +28,8 @@ in this case, the *radvd* is only used to announce the DNS server.
 
 .. _faq-mtu:
 
-What is a good MTU on the mesh-vpn
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+What is a good MTU on the mesh-vpn?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Setting the MTU on the transport interface requires careful consideration, as
 setting it too low will cause excessive fragmentation and setting it too high


### PR DESCRIPTION
A table with hardware supported by Gluon can be found on the OpenWrt Wiki. This commit adds a corresponding FAQ entry.