### PR TITLE
[RFC] add support for dual 5GHz radio configurations

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
@@ -3,6 +3,8 @@
 local util = require 'gluon.util'
 
 local uci = require('simple-uci').cursor()
+local sysconfig = require 'gluon.sysconfig'
+local iwinfo = require 'iwinfo'
 
 
 local function is_disabled(config, name)
@@ -13,6 +15,8 @@ local function is_disabled(config, name)
 	return config.disabled(false)
 end
 
+local has_client_radio = false
+
 util.foreach_radio(uci, function(radio, index, config)
 	local radio_name = radio['.name']
 
@@ -21,6 +25,10 @@ util.foreach_radio(uci, function(radio, index, config)
 
 	local ap = config.ap
 	local disabled = is_disabled(ap, name)
+
+	if not util.supports_channel(radio, config.channel()) then
+		has_client_radio = true
+	end
 
 	uci:delete('wireless', name)
 
@@ -43,5 +51,17 @@ util.foreach_radio(uci, function(radio, index, config)
 		disabled = disabled or false,
 	})
 end)
+
+if not sysconfig.gluon_version and has_client_radio then
+	util.foreach_radio(uci, function(radio, index, config)
+		local radio_name = radio['.name']
+
+		local name = 'client_' .. radio_name
+
+		if util.supports_channel(radio, config.channel()) and (radio.hwmode == '11a' or radio.hwmode == '11na') then
+			uci:set('wireless', name, 'disabled', true)
+		end
+	end)
+end
 
 uci:save('wireless')

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -56,7 +56,8 @@ local function get_channel(radio, config)
 	if uci:get_first('gluon-core', 'wireless', 'preserve_channels') then
 		-- preserved channel always wins
 		channel = radio.channel
-	elseif  (radio.hwmode == '11a' or radio.hwmode == '11na') and is_outdoor() then
+
+	elseif  (radio.hwmode == '11a' or radio.hwmode == '11na') and (is_outdoor() or not util.supports_channel(radio, config.channel())) then
 		-- actual channel will be picked and probed from chanlist
 		channel = 'auto'
 	end
@@ -251,7 +252,7 @@ util.foreach_radio(uci, function(radio, index, config)
 		uci:set('wireless', radio_name, 'legacy_rates', false)
 		configure_mesh_wireless(radio, index, config)
 	elseif (hwmode == '11a' or hwmode == '11na') then
-		if is_outdoor() then
+		if is_outdoor() or not util.supports_channel(radio, config.channel()) then
 			uci:set('wireless', radio_name, 'channels', config.outdoor_chanlist())
 
 			-- enforce outdoor channels by filtering the regdom for outdoor channels
@@ -274,7 +275,6 @@ util.foreach_radio(uci, function(radio, index, config)
 
 	fixup_wan(radio, index)
 end)
-
 
 if uci:get('system', 'rssid_wlan0') then
 	if uci:get('wireless', 'mesh_radio0') then

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -157,6 +157,16 @@ function M.find_phy(config)
 	end
 end
 
+local function supports_channel(radio, channel)
+	local phy = M.find_phy(radio)
+	for i, chan in ipairs(iwinfo.nl80211.freqlist(phy)) do
+		if channel == chan.channel then
+			return true
+		end
+	end
+	return false
+end
+
 local function get_addresses(radio)
 	local phy = M.find_phy(radio)
 	if not phy then

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -178,13 +178,16 @@ end
 -- 5: mesh1
 -- 6: ibss1
 -- 7: wan_radio1 (private WLAN); mesh VPN
+-- 8: client2
+-- 9: mesh2
+-- A: ibss2
+-- B: wan_radio2
 function M.generate_mac(i)
-	if i > 7 or i < 0 then return nil end -- max allowed id (0b111)
-
 	local hashed = string.sub(hash.md5(sysconfig.primary_mac), 0, 12)
 	local m1, m2, m3, m4, m5, m6 = string.match(hashed, '(%x%x)(%x%x)(%x%x)(%x%x)(%x%x)(%x%x)')
 
 	m1 = tonumber(m1, 16)
+	m5 = tonumber(m5, 16)
 	m6 = tonumber(m6, 16)
 
 	m1 = bit.bor(m1, 0x02)  -- set locally administered bit
@@ -196,6 +199,9 @@ function M.generate_mac(i)
 
 	m6 = bit.band(m6, 0xF8) -- zero the last three bits (space needed for counting)
 	m6 = m6 + i                   -- add virtual interface id
+
+	local overflow = math.floor(i/8)
+	m5 = math.fmod(m5 + overflow, 256)
 
 	return string.format('%02x:%s:%s:%s:%s:%02x', m1, m2, m3, m4, m5, m6)
 end

--- a/targets/ipq40xx
+++ b/targets/ipq40xx
@@ -1,5 +1,6 @@
 local ATH10K_PACKAGES_IPQ40XX = {}
 local ATH10K_PACKAGES_IPQ40XX_QCA9888 = {'ath10k-firmware-qca9888'}
+local ATH10K_PACKAGES_IPQ40XX_QCA9984 = {'ath10k-firmware-qca9984'}
 if env.GLUON_WLAN_MESH == 'ibss' then
 	ATH10K_PACKAGES_IPQ40XX = {
 		'-kmod-ath10k',
@@ -14,6 +15,14 @@ if env.GLUON_WLAN_MESH == 'ibss' then
 		'ath10k-firmware-qca4019-ct',
 		'-ath10k-firmware-qca9888',
 		'ath10k-firmware-qca9888-ct',
+	}
+	ATH10K_PACKAGES_IPQ40XX_QCA9984 = {
+		'-kmod-ath10k',
+		'kmod-ath10k-ct',
+		'-ath10k-firmware-qca4019',
+		'ath10k-firmware-qca4019-ct',
+		'-ath10k-firmware-qca9984',
+		'ath10k-firmware-qca9984-ct',
 	}
 end
 
@@ -30,6 +39,11 @@ device('avm-fritz-box-4040', 'avm_fritzbox-4040', {
 	extra_images = {
 		{'-squashfs-eva', '-bootloader', '.bin'},
 	},
+})
+
+device('avm-fritz-repeater-3000', 'avm_fritzrepeater-3000', {
+	packages = ATH10K_PACKAGES_IPQ40XX_QCA9984,
+	factory = false,
 })
 
 


### PR DESCRIPTION

This commit adds support for devices with the following properties (#1661):
 - Features two 5GHz radios
 - Each of the two radios only supports channel 36-64 or 100-144

This is the case for most (if not all) triple-radio devices based on the IPQ40xx platform. Examples are the _OpenMesh A62_, _ASUS Lyra_, _AVM FRITZ!Repeater 3000_.

On first boot, the device will be configured like following:

 - One 5GHz radio on DFS channels
   - Mesh deactivated
 - One 5GHz radio on indoor (default) channel
   - Client disabled

The channel range for the 5GHz is obtained from the outdoor chanlist introduced by the outdoor mode. This site.conf parameter could therefore be renamed (currently not part of this PR).

Speaking of outdoor mode: In case of activated outdoor mode, the mesh radio will not work due to DFS channels marked as unusable by the driver.

This PR could be extended to support devices with two 5GHz radios which support the entire frequency spectrum (similar to how the radio distribution https://github.com/freifunk-gluon/gluon/commit/888cddb662847c3c082f150fb2c9ad8d95f62324 works).  
