### PR TITLE
docs: remove unavailable devices (Picostation M5 and TL-WR710N v1/v2.1)

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -223,7 +223,7 @@ ar71xx-generic
   - Loco M2/M5 XW
   - Nanostation M2/M5
   - Nanostation M2/M5 XW
-  - Picostation M2/M5
+  - Picostation M2
   - Rocket M2/M5
   - Rocket M2/M5 Ti
   - Rocket M2/M5 XW
@@ -284,7 +284,7 @@ ar71xx-tiny
   - TL-WA7210N (v2)
   - TL-WA7510N (v1)
   - TL-WR703N (v1)
-  - TL-WR710N (v1, v2, v2.1)
+  - TL-WR710N (v2)
   - TL-WR740N (v1, v3, v4, v5)
   - TL-WR741N/ND (v1, v2, v4, v5)
   - TL-WR743N/ND (v1, v2)


### PR DESCRIPTION
Can't find a device called Picostation M5. Only a Picostation M2 is available.

TL-WR710N v1, v2.1 are part of ar71xx-generic not ar71xx-tiny
```
$ grep wr710n targets/*
targets/ar71xx-generic:device tp-link-tl-wr710n-v1 tl-wr710n-v1
targets/ar71xx-generic:device tp-link-tl-wr710n-v2.1 tl-wr710n-v2.1
targets/ar71xx-tiny:device tp-link-tl-wr710n-v2 tl-wr710n-v2
```