### PR TITLE
ipq806x: add support for NETGEAR R7800

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -49,6 +49,8 @@ elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1',
 elseif platform.match('ipq40xx', nil, {'avm,fritzbox-4040',
                                        'openmesh,a42', 'openmesh,a62'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
+elseif platform.match('ipq806x', nil, {'netgear,r7800'}) then
+  table.insert(try_files, 1, '/sys/class/net/eth1/address')
 elseif platform.match('ramips', 'mt7621', {'dir-860l-b1'}) then
   table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')
 end

--- a/targets/ipq806x
+++ b/targets/ipq806x
@@ -1,7 +1,31 @@
-ATH10K_PACKAGES='-kmod-ath10k kmod-ath10k-ct -ath10k-firmware-qca99x0 ath10k-firmware-qca99x0-ct'
+# The QCA9980 was discontinued by Qualcomm. It didn't receive any firmware-update for over 4 years.
+# See https://github.com/kvalo/ath10k-firmware/tree/master/QCA99X0/hw2.0
+# 802.11s was never implemented for the chip's firmware. It will most likely be broken forever.
+# The QCA9984 on the other hand works fine for 11s meshes on both bands.
+
+QCA9980_PACKAGES='-kmod-ath10k kmod-ath10k-ct -ath10k-firmware-qca99x0 ath10k-firmware-qca99x0-ct'
+QCA9984_PACKAGES='kmod-ath10k -kmod-ath10k-ct ath10k-firmware-qca9984 -ath10k-firmware-qca9984-ct'
 
 
+#
+# QCA9980
+#
+
+if [ "$BROKEN" ]; then
 # TP-Link
-
 device tp-link-archer-c2600 tplink_c2600
-packages $ATH10K_PACKAGES
+packages $QCA9980_PACKAGES
+fi
+
+#
+# QCA9984
+#
+
+# -- ToDo --
+# The BROKEN flag for the target can be removed when switching to an OpenWrt base newer than 18.06,
+# as in 18.06 the LEDs are not yet functional. This is already fixed in the current OpenWrt master.
+
+# NETGEAR
+device netgear-nighthawk-x4s-r7800 netgear_r7800
+factory .img
+packages $QCA9984_PACKAGES

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -22,6 +22,6 @@ endif
 ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,ar71xx,mikrotik)) # BROKEN: no sysupgrade support
 $(eval $(call GluonTarget,brcm2708,bcm2710)) # BROKEN: Untested
-$(eval $(call GluonTarget,ipq806x)) # BROKEN: unstable wifi drivers
+$(eval $(call GluonTarget,ipq806x)) # BROKEN: See target file for details
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No AP+IBSS or 11s support
 endif


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] tftp
  - [x] other: <nmrpflash utility
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
    ```
    root@64367-nighthawk-x4s:~# lua -e 'print(require("platform_info").get_image_name())'
    netgear-nighthawk-x4s-r7800
    ```
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)