### PR TITLE
ar71xx: add support for D-Link DAP-1330

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -148,6 +148,7 @@ ar71xx-generic
 
 * D-Link
 
+  - DAP-1330 (A1)
   - DIR-505 (A1, A2)
   - DIR-825 (B1)
 

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -62,6 +62,9 @@ sysupgrade_image buffalo-wzr-hp-ag300h-wzr-600dhp wzr-hp-ag300h-squashfs-sysupgr
 
 # D-Link
 
+device d-link-dap-1330-rev-a1 dap-1330-a1
+factory .img
+
 device d-link-dir-505-rev-a1 dir-505-a1 DIR505A1
 alias d-link-dir-505-rev-a2
 


### PR DESCRIPTION
* [x]  must be flashable from vendor firmware
  
    * [x] Flash over Web Interface

* [x]  must support upgrade mechanism

  * [x]  must have working sysupgrade
    
    * [x]  must keep/forget configuration (if applicable)
      _think `sysupgrade [-n]` or `firstboot`_
  * [x]  must have working autoupdate
    _usually means: gluon profile name must match image name_

* wired network
  
  * [x]  should support all network ports on the device
  * [x]  must have correct port assignment (WAN/LAN)

* wifi (if applicable)
  
  * [x]  association with AP must be possible on all radios
  * [x]  association with 802.11s mesh must be working on all radios
  * [x]  ap/mesh mode must work in parallel on all radios

* led mapping
 
  * power/sys led
    
    * [x]  lit while the device is on
    * [x]  should display config mode blink sequence
      (https://gluon.readthedocs.io/en/latest/features/configmode.html)

  * radio leds
    
    * [x]  should map to their respective radio
    * [x]  should show activity


  * switchport leds
    
    * [x]  should map to their respective port (or switch, if only one led present)

    * [x]  should show link state and activity

* [x]  reset/wps button must return device into config mode

* [x]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)

Tested by Sebastian Schaper: (not running at the moment)
https://hannover.freifunk.net/karte/#/de/map/e46f132a097b