### PR TITLE
docs: update targets

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -403,8 +403,8 @@ ramips-rt305x
 
   - VoCore (8M, 16M) [#80211s]_
 
-sunxi
-^^^^^
+sunxi-cortexa7
+^^^^^^^^^^^^^^
 
 * LeMaker
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -332,13 +332,6 @@ ipq40xx
   - NBG6617 [#80211s]_
   - WRE6606 [#80211s]_
 
-ipq806x
-^^^^^^^
-
-* TP-Link
-
-  - Archer C2600 [#80211s]_
-
 mpc85xx-generic
 ^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
target ipq806x was marked as broken because of #1505 
target sunxi was renamed to sunxi-cortexa7 via 210d97c53eb147ad9519118634c71e28eace4694