### PR TITLE
ramips-mt76x8: add support for TP-Link TL-WR902AC v3

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -345,6 +345,7 @@ ramips-mt76x8
 
   - TL-MR3420 v5
   - TL-WR841N v13
+  - TL-WR902AC v3
   - Archer C50 v3
   - Archer C50 v4
 

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -43,6 +43,12 @@ device('tp-link-tl-wr841n-v13', 'tl-wr841n-v13', {
 	},
 })
 
+device('tp-link-tl-wr902ac-v3', 'tplink_tl-wr902ac-v3', {
+	factory = false,
+	extra_images = {
+		{'-squashfs-tftp-recovery', '-bootloader', '.bin'},
+	},
+})
 
 -- VoCore 2
 


### PR DESCRIPTION
* [x]  must be flashable from vendor firmware  
  * [x]  tftp - use gluon-...-tp-link-tl-wr902ac-v3-bootloader.bin file
* [x]  must support upgrade mechanism
  * [x]  must have working sysupgrade 
    * [x]  must keep/forget configuration (if applicable) _think `sysupgrade [-n]` or `firstboot`_
  * [x]  must have working autoupdate   _usually means: gluon profile name must match image name_
`root@ffc-d80d170318c4:~# lua -e 'print(require("platform_info").get_image_name())'
tp-link-tl-wr902ac-v3
root@ffc-d80d170318c4:~# 
`

* wired network  
  * [X]  should support all network ports on the device
  * [X]  must have correct port assignment (WAN/LAN) -- WAN only
* wifi
  * [X]  association with AP must be possible  
  * [X]  association with 802.11s mesh must be working  
  * [X]  ap/mesh mode must work in parallel 
* led mapping
  * power/sys led
    * [X]  lit while the device is on
    * [X]  should display config mode blink sequence
      (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  * radio leds
    * [x]  should map to their respective radio
    * [x]  should show activity
  * switchport leds
    * [x]  should map to their respective port (or switch, if only one led present) 
    * [?]  should show link state and activity -- the LED at the RJ45 connector shows the link state but no activity
* [X]  wps button must return device into config mode
* [X]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
