### PR TITLE
Bugfix: gluon-config-mode-mesh-vpn: 0300-mesh-vpn.lua limit_ingress 

### DIFF
--- a/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
+++ b/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
@@ -50,7 +50,7 @@ return function(form, uci)
 	o:depends(limit, true)
 	o.default = uci:get("simple-tc", "mesh_vpn", "limit_ingress")
 	if has_tunneldigger then
-		-- Check if limit_bw_down exsist if not take value vom limit_ingress
+		-- Check if limit_bw_down exsists. If not, take value from limit_ingress
 		local limit_bw_down = uci:get("tunneldigger", "mesh_vpn", "limit_bw_down")
 		if limit_bw_down ~= nil then
 			o.default = limit_bw_down

--- a/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
+++ b/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
@@ -50,7 +50,7 @@ return function(form, uci)
 	o:depends(limit, true)
 	o.default = uci:get("simple-tc", "mesh_vpn", "limit_ingress")
 	if has_tunneldigger then
-		-- Check if limit_bw_down exsists. If not, take value from limit_ingress
+		-- Check if limit_bw_down exists. If not, take the value from limit_ingress
 		local limit_bw_down = uci:get("tunneldigger", "mesh_vpn", "limit_bw_down")
 		if limit_bw_down ~= nil then
 			o.default = limit_bw_down

--- a/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
+++ b/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
@@ -48,10 +48,13 @@ return function(form, uci)
 
 	o = s:option(Value, "limit_ingress", pkg_i18n.translate("Downstream (kbit/s)"))
 	o:depends(limit, true)
+	o.default = uci:get("simple-tc", "mesh_vpn", "limit_ingress")
 	if has_tunneldigger then
-		o.default = uci:get("tunneldigger", "mesh_vpn", "limit_bw_down")
-	else
-		o.default = uci:get("simple-tc", "mesh_vpn", "limit_ingress")
+		-- Check if limit_bw_down exsist if not take value vom limit_ingress
+		local limit_bw_down = uci:get("tunneldigger", "mesh_vpn", "limit_bw_down")
+		if limit_bw_down ~= nil then
+			o.default = limit_bw_down
+		end
 	end
 	o.datatype = "uinteger"
 	function o:write(data)


### PR DESCRIPTION
fix limit_ingress default value in case of default disabled simple-tc for tunneldigger.

In case if 'limit_bw_down' set for tunneldigger should simple-tc still be enabled?

If simple-tc enabled by default via site.conf the script '500-mesh-vpn' from 'gluon-mesh-vpn-core' will set 'limit_ingress' to 0 and also enabled simple-tc. Does 0 have a special meaning in this situation like "ignore it"?

Bug appears here: #1460 
Related to #1447 

Thanks to @lrnzo 

Signed-off-by: Jan-Tarek Butt <tarek@ring0.de>