### PR TITLE
gluon-check-connection: extracted from gluon-scheduled-domain-switch

### DIFF
--- a/docs/package/gluon-scheduled-domain-switch.rst
+++ b/docs/package/gluon-scheduled-domain-switch.rst
@@ -24,8 +24,8 @@ domain_switch : optional (needed for domains to switch)
 
 check_connection :
     targets :
-        - array of IPv6 addresses which are probed to determine if the node is
-	  connected to the mesh
+        - array of IPv6 addresses which are probed to determine if the node can
+          reach any time-servers to acquire the correct time
 
 Example::
 
@@ -41,3 +41,6 @@ Example::
       '2001:4860:4860::8844',
     },
   },
+
+Note: the package ``gluon-check-connection`` is installed as dependency but it can
+also be used stand-alone, e.g. to detect if a connection to the internet is working.

--- a/docs/package/gluon-scheduled-domain-switch.rst
+++ b/docs/package/gluon-scheduled-domain-switch.rst
@@ -22,11 +22,6 @@ domain_switch : optional (needed for domains to switch)
     switch_time :
         - UNIX epoch after which domain will be switched
 
-check_connection :
-    targets :
-        - array of IPv6 addresses which are probed to determine if the node can
-          reach any time-servers to acquire the correct time
-
 Example::
 
   domain_switch = {
@@ -42,5 +37,6 @@ Example::
     },
   },
 
-Note: the package ``gluon-check-connection`` is installed as dependency but it can
-also be used stand-alone, e.g. to detect if a connection to the internet is working.
+Note: the package ``gluon-check-connection`` is installed as dependency so you
+have to define ``check_connection`` too. A node is considered online if any of
+the specified ip addresses can be reached via ping.

--- a/docs/package/gluon-scheduled-domain-switch.rst
+++ b/docs/package/gluon-scheduled-domain-switch.rst
@@ -21,7 +21,9 @@ domain_switch : optional (needed for domains to switch)
         - amount of time without reachable gateway to switch unconditionally
     switch_time :
         - UNIX epoch after which domain will be switched
-    connection_check_targets :
+
+check_connection :
+    targets :
         - array of IPv6 addresses which are probed to determine if the node is
 	  connected to the mesh
 
@@ -31,7 +33,10 @@ Example::
     target_domain = 'new_domain',
     switch_after_offline_mins = 120,
     switch_time = 1546344000, -- 01.01.2019 - 12:00 UTC
-    connection_check_targets = {
+  },
+
+  check_connection = {
+    targets = {
       '2001:4860:4860::8888',
       '2001:4860:4860::8844',
     },

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -419,6 +419,22 @@ autoupdater \: package
     All configured mirrors must be reachable from the nodes via IPv6. If you don't want to set an IPv6 address
     explicitly, but use a hostname (which is recommended), see also the :ref:`FAQ <faq-dns>`.
 
+.. _user-site-check_connection:
+
+check_connection \: optional
+    ``targets`` defines an array of IPv6 addresses which are probed for
+    connectivity, for example determine if the node can reach any time-servers
+    to acquire the correct time. This is e.g. used for the
+    *gluon-scheduled-domain-switch* package
+    ::
+
+      check_connection = {
+        targets = {
+          '2001:4860:4860::8888',
+          '2001:4860:4860::8844',
+        },
+      },
+
 .. _user-site-config_mode:
 
 config_mode \: optional

--- a/package/gluon-check-connection/Makefile
+++ b/package/gluon-check-connection/Makefile
@@ -1,0 +1,13 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-check-connection
+PKG_VERSION:=1
+
+include ../gluon.mk
+
+define Package/gluon-check-connection
+  TITLE:=Checks if a node can ping definable targets
+  DEPENDS:=+gluon-core
+endef
+
+$(eval $(call BuildPackageGluon,gluon-check-connection))

--- a/package/gluon-check-connection/check_site.lua
+++ b/package/gluon-check-connection/check_site.lua
@@ -1,0 +1,1 @@
+need_string_array_match({'check_connection', 'targets'}, '^[%x:]+$')

--- a/package/gluon-check-connection/luasrc/usr/bin/gluon-check-connection
+++ b/package/gluon-check-connection/luasrc/usr/bin/gluon-check-connection
@@ -4,17 +4,11 @@ local unistd = require 'posix.unistd'
 local util = require 'gluon.util'
 local site = require 'gluon.site'
 
-local offline_flag_file = "/tmp/gluon_offline"
+local offline_flag_file = "/var/gluon/check-connection/offline"
 local is_offline = true
 
--- Check if domain-switch is scheduled
-if site.domain_switch() == nil then
-	-- Switch not applicable for current domain
-	os.exit(0)
-end
-
 -- Check reachability of pre-defined targets
-for _, ip in ipairs(site.domain_switch.connection_check_targets()) do
+for _, ip in ipairs(site.check_connection.targets()) do
 	local exit_code = os.execute("ping -c 1 -w 10 " .. ip)
 	if exit_code == 0 then
 		is_offline = false

--- a/package/gluon-check-connection/luasrc/usr/bin/gluon-check-connection
+++ b/package/gluon-check-connection/luasrc/usr/bin/gluon-check-connection
@@ -4,7 +4,8 @@ local unistd = require 'posix.unistd'
 local util = require 'gluon.util'
 local site = require 'gluon.site'
 
-local offline_flag_file = "/var/gluon/check-connection/offline"
+local offline_flag_file_path = "/var/gluon/check-connection"
+local offline_flag_file = offline_flag_file_path + "/offline"
 local is_offline = true
 
 -- Check reachability of pre-defined targets
@@ -20,6 +21,10 @@ if is_offline then
 	-- Check if we were previously offline
 	if unistd.access(offline_flag_file) then
 		os.exit(0)
+	end
+	-- check if path exists
+	if !access(offline_flag_file_path, F_OK) then
+		stat.mkdir(offline_flag_file_path)
 	end
 	-- Create offline flag
 	local f = io.open(offline_flag_file, "w")

--- a/package/gluon-scheduled-domain-switch/Makefile
+++ b/package/gluon-scheduled-domain-switch/Makefile
@@ -7,7 +7,7 @@ include ../gluon.mk
 
 define Package/gluon-scheduled-domain-switch
   TITLE:=Allows scheduled migrations between domains
-  DEPENDS:=+gluon-core @GLUON_MULTIDOMAIN
+  DEPENDS:=+gluon-core +gluon-check-connection @GLUON_MULTIDOMAIN
 endef
 
 $(eval $(call BuildPackageGluon,gluon-scheduled-domain-switch))

--- a/package/gluon-scheduled-domain-switch/check_site.lua
+++ b/package/gluon-scheduled-domain-switch/check_site.lua
@@ -2,5 +2,4 @@ if need_table(in_domain({'domain_switch'}), nil, false) then
 	need_domain_name(in_domain({'domain_switch', 'target_domain'}))
 	need_number(in_domain({'domain_switch', 'switch_after_offline_mins'}))
 	need_number(in_domain({'domain_switch', 'switch_time'}))
-	need_string_array_match(in_domain({'domain_switch', 'connection_check_targets'}), '^[%x:]+$')
 end

--- a/package/gluon-scheduled-domain-switch/luasrc/usr/bin/gluon-switch-domain
+++ b/package/gluon-scheduled-domain-switch/luasrc/usr/bin/gluon-switch-domain
@@ -5,9 +5,10 @@ local unistd = require 'posix.unistd'
 local util = require 'gluon.util'
 local site = require 'gluon.site'
 
--- Returns true if node was offline long enough to perform domain switch
+-- Returns true if node was offline long enough to perform domain switch (set by gluon-check-connection)
 local function switch_after_min_reached()
-	if not unistd.access("/tmp/gluon_offline") then
+	local offline_flag_file = "/var/gluon/check-connection/offline"
+	if not unistd.access(offline_flag_file) then
 		return false
 	end
 
@@ -18,7 +19,7 @@ local function switch_after_min_reached()
 		return false
 	end
 
-	local f = util.readfile("/tmp/gluon_offline")
+	local f = util.readfile(offline_flag_file)
 	if f == nil then
 		return false
 	end


### PR DESCRIPTION
Extract the connection-check for example, to reuse it in gluon-offline-ssid package #1649 .

The check so far only pings some definable IP6 addresses. In the old ssid-changer, we only used a batctl check if a gateway is reachable instead. It seems like the ping solution is the better, but are there any other suggestions?

We could also add a TQ-check to the gateway as in the offline-ssid package, so it is treated as offline, if the TQ sinks below a threshold.