### PR TITLE
docs: add notice for opkg repo change

### DIFF
--- a/docs/releases/v2018.2.rst
+++ b/docs/releases/v2018.2.rst
@@ -127,8 +127,12 @@ adding ``-gluon-ebtables-limit-arp`` to *GLUON_SITE_PACKAGES*.
 Site changes
 ************
 
-No changes need to be made to *site.conf* or *site.mk* when upgrading from
-Gluon v2018.1.x.
+If an opkg repository for ``lede`` was configured the key needs to be migrated
+to ``openwrt``. ``lede`` is ignored and without an ``openwrt`` key the default
+OpenWrt repository is used.
+
+No other changes need to be made to *site.conf* or *site.mk* when upgrading
+from Gluon v2018.1.x.
 
 Internals
 *********


### PR DESCRIPTION
A diff might describe it better
https://github.com/freifunk-gluon/gluon/commit/210d97c53eb147ad9519118634c71e28eace4694#diff-0d44e6a3fa2aba2dc4a79afbfcc4ab1fR78

A cherrypick to v2018.2.x might be useful.