### PR TITLE
ar71xx-generic: Add support for TP-Link CPE210 V3

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -194,7 +194,7 @@ ar71xx-generic
   - Archer C5 (v1) [#ath10k]_
   - Archer C59 (v1) [#80211s]_
   - Archer C7 (v2, v4, v5) [#ath10k]_
-  - CPE210 (v1.0, v1.1, v2.0)
+  - CPE210 (v1.0, v1.1, v2.0, v3.0)
   - CPE220 (v1.1)
   - CPE510 (v1.0, v1.1)
   - CPE520 (v1.1)

--- a/patches/openwrt/0022-firmware-utils-tplink-safeloader-Add-CPE210-v3.patch
+++ b/patches/openwrt/0022-firmware-utils-tplink-safeloader-Add-CPE210-v3.patch
@@ -1,0 +1,58 @@
+From: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+Date: Wed, 10 Oct 2018 20:05:53 +0200
+Subject: firmware-utils: tplink-safeloader: Add CPE210 v3
+
+Add TP-Link CPE210 v3 to the support list.
+It's identical to the v2.
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+[Use separate definition to prevent cross-updates]
+Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index 4b227e1c97b6c5b236dba29dbdd5f0bcd68621cb..de15faf6796c993efc6c2a36b22bb1e978e3be90 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -197,6 +197,42 @@ static struct device_info boards[] = {
+ 		.last_sysupgrade_partition = "support-list",
+ 	},
+ 
++	/** Firmware layout for the CPE210 V3 */
++	{
++		.id     = "CPE210V3",
++		.vendor = "CPE210(TP-LINK|UN|N300-2|00000000):3.0\r\n",
++		.support_list =
++			"SupportList:\r\n"
++			"CPE210(TP-LINK|EU|N300-2|45550000):3.0\r\n"
++			"CPE210(TP-LINK|UN|N300-2|00000000):3.0\r\n"
++			"CPE210(TP-LINK|UN|N300-2):3.0\r\n"
++			"CPE210(TP-LINK|EU|N300-2):3.0\r\n",
++		.support_trail = '\xff',
++		.soft_ver = NULL,
++
++		.partitions = {
++			{"fs-uboot", 0x00000, 0x20000},
++			{"partition-table", 0x20000, 0x02000},
++			{"default-mac", 0x30000, 0x00020},
++			{"product-info", 0x31100, 0x00100},
++			{"device-info", 0x31400, 0x00400},
++			{"signature", 0x32000, 0x00400},
++			{"device-id", 0x33000, 0x00100},
++			{"os-image", 0x40000, 0x1c0000},
++			{"file-system", 0x200000, 0x5b0000},
++			{"soft-version", 0x7b0000, 0x00100},
++			{"support-list", 0x7b1000, 0x01000},
++			{"user-config", 0x7c0000, 0x10000},
++			{"default-config", 0x7d0000, 0x10000},
++			{"log", 0x7e0000, 0x10000},
++			{"radio", 0x7f0000, 0x10000},
++			{NULL, 0, 0}
++		},
++
++		.first_sysupgrade_partition = "os-image",
++		.last_sysupgrade_partition = "support-list",
++	},
++
+ 	/** Firmware layout for the CPE510/520 */
+ 	{
+ 		.id	= "CPE510",

--- a/patches/openwrt/0023-ar71xx-Add-support-for-TP-Link-CPE210-v3.patch
+++ b/patches/openwrt/0023-ar71xx-Add-support-for-TP-Link-CPE210-v3.patch
@@ -1,0 +1,141 @@
+From: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+Date: Wed, 10 Oct 2018 20:13:09 +0200
+Subject: ar71xx: Add support for TP-Link CPE210 v3
+
+Looks identical to the v2
+
+This PR adds support for a popular low-cost 2.4GHz N based AP
+
+Specifications:
+ - SoC: Qualcomm Atheros QCA9533 (650MHz)
+ - RAM: 64MB
+ - Storage: 8 MB SPI NOR
+ - Wireless: 2.4GHz N based built into SoC 2x2
+ - Ethernet: 1x 100/10 Mbps, integrated into SoC, 24V POE IN
+
+Installation:
+Flash factory image through stock firmware WEB UI or
+through TFTP
+To get to TFTP recovery just hold reset button while
+powering on for around 4-5 seconds and release.
+Rename factory image to recovery.bin
+Stock TFTP server IP:192.168.0.100
+Stock device TFTP address:192.168.0.254
+
+Signed-off-by: Robert Marko <robimarko@gmail.com>
+[Adjusted for separate safeloader entry, do not inherit device
+definition from cpe210-v2]
+Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/01_leds b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+index 23f3d23bf53883fb08944bc65b98cac06a16c0a5..e0222f3637b60b89a6ef6c0d10cfb20fbe73f075 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/01_leds
++++ b/target/linux/ar71xx/base-files/etc/board.d/01_leds
+@@ -249,6 +249,7 @@ cf-e530n)
+ 	;;
+ cpe210|\
+ cpe210-v2|\
++cpe210-v3|\
+ cpe510|\
+ wbs210|\
+ wbs510)
+@@ -259,7 +260,8 @@ wbs510)
+ 	ucidef_set_led_rssi "rssihigh" "RSSIHIGH" "tp-link:green:link4" "wlan0" "76" "100" "-75" "13"
+ 
+ 	case "$board" in
+-	cpe210-v2)
++	cpe210-v2|\
++	cpe210-v3)
+ 		ucidef_set_led_netdev "lan" "LAN" "tp-link:green:lan0" "eth0"
+ 		;;
+ 	*)
+diff --git a/target/linux/ar71xx/base-files/etc/board.d/02_network b/target/linux/ar71xx/base-files/etc/board.d/02_network
+index e9522252a2b8ba7de1c8ca7d070ff7f2897aade9..386d93e58451b953937320b1bfe8d71ed73c69fd 100755
+--- a/target/linux/ar71xx/base-files/etc/board.d/02_network
++++ b/target/linux/ar71xx/base-files/etc/board.d/02_network
+@@ -75,6 +75,7 @@ ar71xx_setup_interfaces()
+ 	cf-e380ac-v1|\
+ 	cf-e380ac-v2|\
+ 	cpe210-v2|\
++	cpe210-v3|\
+ 	dr342|\
+ 	eap120|\
+ 	eap300v2|\
+diff --git a/target/linux/ar71xx/base-files/lib/ar71xx.sh b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+index ccbd4e77c324a36e7fba6e6dccad59d8f94a3921..2200069c647b33220126e797b6a61928d1fb428e 100755
+--- a/target/linux/ar71xx/base-files/lib/ar71xx.sh
++++ b/target/linux/ar71xx/base-files/lib/ar71xx.sh
+@@ -583,6 +583,10 @@ ar71xx_board_detect() {
+ 		name="cpe210-v2"
+ 		tplink_pharos_board_detect "$(tplink_pharos_v2_get_model_string)"
+ 		;;
++	*"CPE210 v3")
++		name="cpe210-v3"
++		tplink_pharos_board_detect "$(tplink_pharos_v2_get_model_string)"
++		;;
+ 	*"CPE505N")
+ 		name="cpe505n"
+ 		;;
+diff --git a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+index ca1270b7fdc84c53f8417c226f18ca4fff1f27d8..a04dd7441d28e9db4dc7c744707bb5f35936da00 100755
+--- a/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ar71xx/base-files/lib/upgrade/platform.sh
+@@ -587,7 +587,8 @@ platform_check_image() {
+ 		tplink_pharos_check_image "$1" "7f454c46" "$(tplink_pharos_get_model_string)" '' && return 0
+ 		return 1
+ 		;;
+-	cpe210-v2)
++	cpe210-v2|\
++	cpe210-v3)
+ 		tplink_pharos_check_image "$1" "01000000" "$(tplink_pharos_v2_get_model_string)" '\0\xff\r' && return 0
+ 		return 1
+ 		;;
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c
+index ceb1769ddd522d51014228fe65e2662f2f3e627c..f25a69f08e8a69d9b6de0ca9d7d7d14f8dff5fa0 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-cpe510.c
+@@ -236,6 +236,9 @@ MIPS_MACHINE(ATH79_MACH_CPE210, "CPE210", "TP-LINK CPE210/220",
+ MIPS_MACHINE(ATH79_MACH_CPE210_V2, "CPE210V2", "TP-LINK CPE210 v2",
+ 	     cpe210_v2_setup);
+ 
++MIPS_MACHINE(ATH79_MACH_CPE210_V3, "CPE210V3", "TP-LINK CPE210 v3",
++             cpe210_v2_setup);
++
+ MIPS_MACHINE(ATH79_MACH_CPE510, "CPE510", "TP-LINK CPE510/520",
+ 	     cpe510_setup);
+ 
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+index 80f6e1d95b7a4e5559e7d5da041b32d962ad4e84..c82cb17cf613bdb3796a15e384215d4579767468 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
++++ b/target/linux/ar71xx/files/arch/mips/ath79/machtypes.h
+@@ -75,6 +75,7 @@ enum ath79_mach_type {
+ 	ATH79_MACH_CF_E530N,			/* COMFAST CF-E530N */
+ 	ATH79_MACH_CPE210,			/* TP-LINK CPE210 v1 */
+ 	ATH79_MACH_CPE210_V2,			/* TP-LINK CPE210 v2 */
++	ATH79_MACH_CPE210_V3,			/* TP-LINK CPE210 v3 */
+ 	ATH79_MACH_CPE505N,			/* P&W CPE505N */
+ 	ATH79_MACH_CPE510,			/* TP-LINK CPE510 */
+ 	ATH79_MACH_CPE830,			/* YunCore CPE830 */
+diff --git a/target/linux/ar71xx/image/generic-tp-link.mk b/target/linux/ar71xx/image/generic-tp-link.mk
+index daf6c35ae4610d844bd9e8f44ea5deab72143a48..8ad1f6e38228b639d1d127937ba875c030a6a632 100644
+--- a/target/linux/ar71xx/image/generic-tp-link.mk
++++ b/target/linux/ar71xx/image/generic-tp-link.mk
+@@ -195,6 +195,18 @@ define Device/cpe210-v2
+ endef
+ TARGET_DEVICES += cpe210-v2
+ 
++define Device/cpe210-v3
++  $(Device/cpexxx)
++  DEVICE_TITLE := TP-LINK CPE210 v3
++  BOARDNAME := CPE210V3
++  TPLINK_BOARD_ID := CPE210V3
++  KERNEL := kernel-bin | patch-cmdline | lzma | tplink-v1-header
++  TPLINK_HWID := 0x0
++  TPLINK_HWREV := 0
++  TPLINK_HEADER_VERSION := 1
++endef
++TARGET_DEVICES += cpe210-v3
++
+ define Device/wbs210-v1
+   $(Device/cpe510-520-v1)
+   DEVICE_TITLE := TP-LINK WBS210 v1

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -246,8 +246,8 @@ end
 device('tp-link-cpe210-v1.0', 'cpe210-220-v1', {
 	aliases = {'tp-link-cpe210-v1.1', 'tp-link-cpe220-v1.1'},
 })
-
 device('tp-link-cpe210-v2.0', 'cpe210-v2')
+device('tp-link-cpe210-v3.0', 'cpe210-v3')
 
 device('tp-link-cpe510-v1.0', 'cpe510-520-v1', {
 	aliases = {'tp-link-cpe510-v1.1', 'tp-link-cpe520-v1.1'},


### PR DESCRIPTION
Since the PR seemed to be blocked by git problems, I just re-did it.

This is not tested, and I did not check whether the patches are correctly rebased (currently they apply onto openwrt-18.06.2).

Follows up:
https://github.com/freifunk-gluon/gluon/pull/1695
https://github.com/freifunk-gluon/gluon/pull/1588
https://github.com/freifunk-gluon/gluon/pull/1445

Other changes compared to first v3 PR:
- Added entry in docs/index.rst
- Removed BROKEN in targets/ar71xx-generic
