### PR TITLE
ar71xx: add support for TP-Link TL-WR840N v2

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -290,6 +290,7 @@ ar71xx-tiny
   - TL-WR740N (v1, v3, v4, v5)
   - TL-WR741N/ND (v1, v2, v4, v5)
   - TL-WR743N/ND (v1, v2)
+  - TL-WR840N (v2)
   - TL-WR841N/ND (v3, v5, v7, v8, v9, v10, v11, v12)
   - TL-WR843N/ND (v1)
   - TL-WR940N (v1, v2, v3, v4, v5, v6)

--- a/targets/ar71xx-tiny
+++ b/targets/ar71xx-tiny
@@ -42,6 +42,8 @@ if [ "$BROKEN" ]; then
 device tp-link-tl-wr802n-v1 tl-wr802n-v1 # BROKEN: Untested
 fi
 
+device tp-link-tl-wr840n-v2 tl-wr840n-v2
+
 device tp-link-tl-wr841n-nd-v3 tl-wr841-v3
 device tp-link-tl-wr841n-nd-v5 tl-wr841-v5
 device tp-link-tl-wr841n-nd-v7 tl-wr841-v7


### PR DESCRIPTION
TP-Link TL-WR840N v2: https://openwrt.org/toh/hwdata/tp-link/tp-link_tl-wr840n_v2

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)