### PR TITLE
gluon.mk: fix reference to LuaSrcDiet binary

### DIFF
--- a/package/gluon.mk
+++ b/package/gluon.mk
@@ -58,7 +58,7 @@ define GluonSrcDiet
 	rm -rf $(2)
 	$(CP) $(1) $(2)
 	$(FIND) $(2) -type f | while read src; do \
-		if LuaSrcDiet --noopt-binequiv -o "$$$$src.o" "$$$$src"; then \
+		if luasrcdiet --noopt-binequiv -o "$$$$src.o" "$$$$src"; then \
 			chmod $$$$(stat -c%a "$$$$src") "$$$$src.o"; \
 			mv "$$$$src.o" "$$$$src"; \
 		fi; \


### PR DESCRIPTION
The luci modules where updated (c919f5fd29aeb37e6a7a50d6834fa338e7328dfd)
And there is a luasrcdiet update included `b5d5e5bf1 luci-base: update luasrcdiet` (https://github.com/openwrt/luci/commit/b5d5e5bf13e572af7f1589a01bfd338691d5f063)

I noticed some `bash: LuaSrcDiet: command not found` in the `make V=s` output and updated the luasrcdiet call

Could someone check a Gluon build if the result of the luasrcdiet output is as expected?