### PR TITLE
ramips-mt76x8: add support for GL.iNet VIXMINI

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -271,6 +271,7 @@ ramips-mt76x8 [#80211s]_
 * GL.iNet
 
   - GL-MT300N v2
+  - VIXMINI
 
 * NETGEAR
 

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -4,6 +4,10 @@ device('gl-mt300n-v2', 'gl-mt300n-v2', {
 	factory = false,
 })
 
+device('gl.inet-vixmini', 'glinet_vixmini', {
+	factory = false,
+})
+
 
 -- Netgear
 


### PR DESCRIPTION
GL.iNet VIXMINI is a 300M router based on MT7628 with 8M Flash and 64M RAM. Currently, it can only be bought from china for 20$ either on [AliExpress](https://de.aliexpress.com/wholesale?SearchText=Vixmini) or [GL.iNet shop](https://store.gl-inet.com/collections/all-wifi-devices/products/vixmini-mini-travel-router).

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] other: bootloader httpd
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
     > root@64367-vixmini:~# lua -e 'print(require("platform_info").get_image_name())'
     > gl.inet-vixmini
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)