### PR TITLE
targets/ipq40xx: add support for jalapeno from 8devices

### DIFF
--- a/targets/ipq40xx
+++ b/targets/ipq40xx
@@ -49,3 +49,10 @@ packages $ATH10K_PACKAGES_IPQ40XX
 device zyxel-wre6606 zyxel_wre6606
 factory
 packages $ATH10K_PACKAGES_IPQ40XX
+
+# 8devices
+
+device 8devices-jalapeno 8dev_jalapeno
+factory -squashfs-nand-factory .ubi
+sysupgrade -squashfs-nand-sysupgrade .bin
+packages $ATH10K_PACKAGES_IPQ40XX


### PR DESCRIPTION
product page: https://www.8devices.com/products/jalapeno
openwrt page: https://openwrt.org/toh/hwdata/8devices/8devices_jalapeno

  

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] other: sysupgrade (factory image is openwrt)

- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
      - [x] must keep/forget configuration (if applicable)
  - [x] must have working autoupdate
         usually means: gluon profile name must match image name
	   > root@testing-8devices-jalapeno:~# lua -e 'print(require("platform_info").get_image_name())'
	   > 	8devices-jalapeno
- [x] wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- [x] wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios
  - [x] ap/mesh mode must work in parallel on all radios
- [x] led mapping
  - [x] power/sys led (critical, because led definitions are setup on firstboot only)
      - [x] lit while the device is on
      - [x] should display config mode blink sequence
        (https://gluon.readthedocs.io/en/latest/features/configmode.html)
	      > device has no LEDs for that, only for ETH and serial interface
  - [x] radio leds
      - [x] should map to their respective radio
      - [x] should show activity
	    > device has no radio LEDs

- [ ] reset/wps button must return device into config mode
> Device have 2 Buttons one is a hard reset Butten and the other is user defined.

- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)

Signed-off-by: Jan-Tarek Butt <tarek@ring0.de>