### PR TITLE
gluon-core: disable legacy_rates by default, drop support for support…

### DIFF
--- a/docs/features/multidomain.rst
+++ b/docs/features/multidomain.rst
@@ -160,8 +160,6 @@ site.conf only variables
    in a domain specific way:
 
    -  mesh_vpn.fastd.syslog_level
-   -  wifi*.supported_rates
-   -  wifi*.basic_rate
    -  timezone
    -  regdom
 

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -42,14 +42,6 @@
     -- Wireless channel.
     channel = 1,
 
-    -- List of supported wifi rates (optional)
-    -- Example removes 802.11b compatibility for better performance
-    supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000},
-
-    -- List of basic wifi rates (optional, required if supported_rates is set)
-    -- Example removes 802.11b compatibility for better performance
-    basic_rate = {6000, 9000, 18000, 36000, 54000},
-
     -- ESSID used for client network.
     ap = {
       ssid = 'alpha-centauri.freifunk.net',

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -131,19 +131,6 @@ wifi24 \: optional
     This will only affect new installations.
     Upgrades will not change the disabled state.
 
-    Additionally it is possible to configure the ``supported_rates`` and ``basic_rate``
-    of each radio. Both are optional, by default hostapd/driver dictate the rates.
-    If ``supported_rates`` is set, ``basic_rate`` is required, because ``basic_rate``
-    has to be a subset of ``supported_rates``. Possible values are: 
-
-    - 6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000 (OFDM)
-    - 1000, 5500, 11000 (legacy 802.11b, DSSS)
-
-    The example below disables legacy 802.11b rates (DSSS) for performance reasons.  
-    For backwards compatibility in 802.11, this setting only effects 802.11a/b/g rates. 
-    I.e in 802.11n 6 MBit/s is announced  all time. In 802.11ac the field is used to 
-    derive the length of a packet.
-
     ``ap`` requires a single parameter, a string, named ``ssid`` which sets the
     interface's ESSID. This is the WiFi the clients connect to.
 
@@ -162,8 +149,6 @@ wifi24 \: optional
 
        wifi24 = {
          channel = 11,
-         supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000},
-         basic_rate = {6000, 9000, 18000, 36000, 54000},
          ap = {
            ssid = 'alpha-centauri.freifunk.net',
          },

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -27,28 +27,27 @@ need_string_array({'ntp_servers'}, false)
 
 need_string_match(in_domain({'prefix6'}), '^[%x:]+/64$')
 
-
+local supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000}
 for _, config in ipairs({'wifi24', 'wifi5'}) do
 	if need_table({config}, nil, false) then
 		need_string(in_site({'regdom'})) -- regdom is only required when wifi24 or wifi5 is configured
 
 		need_number({config, 'channel'})
 
-		local rates = {1000, 2000, 5500, 6000, 9000, 11000, 12000, 18000, 24000, 36000, 48000, 54000}
-		local supported_rates = need_array_of(in_site({config, 'supported_rates'}), rates, false)
-		need_array_of({config, 'basic_rate'}, supported_rates or rates, supported_rates ~= nil)
+		obsolete({config, 'supported_rates'}, '802.11b rates are disabled by default.')
+		obsolete({config, 'basic_rate'}, '802.11b rates are disabled by default.')
 
 		if need_table({config, 'ibss'}, nil, false) then
 			need_string_match(in_domain({config, 'ibss', 'ssid'}), '^' .. ('.?'):rep(32) .. '$')
 			need_string_match(in_domain({config, 'ibss', 'bssid'}), '^%x[02468aAcCeE]:%x%x:%x%x:%x%x:%x%x:%x%x$')
-			need_one_of({config, 'ibss', 'mcast_rate'}, supported_rates or rates, false)
+			need_one_of({config, 'ibss', 'mcast_rate'}, supported_rates, false)
 			need_number({config, 'ibss', 'vlan'}, false)
 			need_boolean({config, 'ibss', 'disabled'}, false)
 		end
 
 		if need_table({config, 'mesh'}, nil, false) then
 			need_string_match(in_domain({config, 'mesh', 'id'}), '^' .. ('.?'):rep(32) .. '$')
-			need_one_of({config, 'mesh', 'mcast_rate'}, supported_rates or rates, false)
+			need_one_of({config, 'mesh', 'mcast_rate'}, supported_rates, false)
 			need_boolean({config, 'mesh', 'disabled'}, false)
 		end
 	end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -207,9 +207,13 @@ util.foreach_radio(uci, function(radio, index, config)
 	uci:set('wireless', radio_name, 'htmode', htmode)
 	uci:set('wireless', radio_name, 'country', site.regdom())
 
-	uci:set_list('wireless', radio_name, 'supported_rates', config.supported_rates())
-	uci:set_list('wireless', radio_name, 'basic_rate', config.basic_rate())
+	local hwmode = radio.hwmode
+	if hwmode == '11g' or hwmode == '11ng' then
+		uci:set('wireless', radio_name, 'legacy_rates', false)
+	end
 
+	uci:delete('wireless', radio_name, 'supported_rates')
+	uci:delete('wireless', radio_name, 'basic_rate')
 
 	local ibss_disabled = is_disabled('ibss_' .. radio_name)
 	local mesh_disabled = is_disabled('mesh_' .. radio_name)


### PR DESCRIPTION
…ed and basic rates

All we ever wanted to achieve with supported and basic rates was disabling 802.11b. In the meantime OpenWrt provides¹ the `legacy_rates` option to accomplish exactly that. This obsoletes the need for configurable basic and supported rates, as neither 802.11a nor 802.11g are considered as harmful as 802.11b. Their "slowness" will instead be mitigated through airtime fairness in a future release.

This patchset makes use of the obsoletion check feature in #1702.

[1] https://github.com/openwrt/openwrt/commit/ed62d91f4b5296a4aa883ce975d76f590ef4e910