### PR TITLE
Added encryption support for mesh + managed networks

### DIFF
--- a/package/gluon-wlan-encryption-psk/Makefile
+++ b/package/gluon-wlan-encryption-psk/Makefile
@@ -1,0 +1,13 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-wlan-encryption-psk
+PKG_VERSION:=1
+
+include ../gluon.mk
+
+define Package/gluon-wlan-encryption-psk
+  TITLE:=Encrypt wlan using a pre-shared key (psk)
+  DEPENDS:=+gluon-core +wpad-mesh-wolfssl
+endef
+
+$(eval $(call BuildPackageGluon,gluon-wlan-encryption-psk))

--- a/package/gluon-wlan-encryption-psk/Readme.md
+++ b/package/gluon-wlan-encryption-psk/Readme.md
@@ -1,0 +1,15 @@
+# Gluon wlan encrypt
+Encrypt wireless networks in a non-Freifunk setup.
+
+This package allows to encrypt 802.11s and infrastructure networks using a pre shared key (psk).
+
+This setup results in passwords being stored in plain-text. Site-configuration, Firmware-downloads and
+Devices must be protected against unauthorized access
+
+*make sure to use exclude hostapd-mini site.mk*
+
+Example configuration:
+
+```lua
+wlan_encryption_psk = { mesh = '802.11s.passwd', ap = ' infrastructure.passwd', },
+```

--- a/package/gluon-wlan-encryption-psk/check_site.lua
+++ b/package/gluon-wlan-encryption-psk/check_site.lua
@@ -1,0 +1,1 @@
+need_table({'wlan_encryption_psk'})

--- a/package/gluon-wlan-encryption-psk/luasrc/lib/gluon/upgrade/390-gluon-wlan-encryption-psk
+++ b/package/gluon-wlan-encryption-psk/luasrc/lib/gluon/upgrade/390-gluon-wlan-encryption-psk
@@ -1,0 +1,21 @@
+#!/usr/bin/lua
+
+local site = require 'gluon.site'
+local uci = require('simple-uci').cursor()
+
+local ap_password = site.wlan_encryption_psk()["ap"]
+local mesh_password = site.wlan_encryption_psk()["mesh"]
+
+
+uci:foreach('wireless', 'wifi-iface', function(wifi_if)
+    local ifname = wifi_if['.name']
+    if wifi_if.mode == 'ap' and ap_password ~= nil and ap_password ~= '' then
+      uci:set('wireless', ifname, 'encryption', 'psk2')
+      uci:set('wireless', ifname, 'key', ap_password)
+    elseif wifi_if.mode == "mesh" and mesh_password ~= nil and mesh_password ~= '' then
+      uci:set('wireless', ifname, 'encryption', 'psk2/aes')
+      uci:set('wireless', ifname,  'key', mesh_password)
+    end
+end)
+
+uci:save('wireless')


### PR DESCRIPTION
* This package arose from fieldtracks.org and addresses non-Freifunk setups, in which all routers are under a single administrative control.
* Unlike https://github.com/freifunk-gluon/gluon/pull/1658 the code is implemented outside of gluon's core scripts, reducing complexity and dependencies. IMHO it doesn't feel right to make it a core functionality.
* The code requires passwords to be present in the site.conf.  This is generally a bad practicie and replacing the password during build is basically a one-liner (`envsubst < site.conf.template > site.conf)`, that is not supported by gluon's build system #1569.