### PR TITLE
Consenting Auto Updater - Initial version

### DIFF
--- a/package/gluon-config-mode-autoupdater-freifunk/Makefile
+++ b/package/gluon-config-mode-autoupdater-freifunk/Makefile
@@ -1,0 +1,14 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-config-mode-autoupdater-freifunk
+PKG_VERSION:=1
+
+include ../gluon.mk
+
+define Package/gluon-config-mode-autoupdater-freifunk
+  TITLE:=Config Mode: Ask the user for consent regarding automatic updates based on Freifunk's Memorandum of Understanding. This includes a view for the wizzard and for the admin section
+  DEPENDS:=+gluon-config-mode-core +gluon-autoupdater
+  CONFLICTS:=gluon-config-mode-autoupdater gluon-web-autoupdater
+endef
+
+$(eval $(call BuildPackageGluon,gluon-config-mode-autoupdater-freifunk))

--- a/package/gluon-config-mode-autoupdater-freifunk/Readme.md
+++ b/package/gluon-config-mode-autoupdater-freifunk/Readme.md
@@ -1,0 +1,35 @@
+# gluon-config-mode-autoupdater-freifunk
+
+The package gluon-config-mode-autoupdater-freifunk provides an
+ alternative to both gluon-config-mode-autoupdater and gluon-web-autoupdater.
+By replacing both packages, gluon-config-mode-autoupdater-freifunk it cannot be installed in combination: Both
+have to be missing from site.mk.
+ 
+Users are asked for consent before enabling automatic updates. This follows (Freifunk's 
+Memorandum of understanding)[https://github.com/freifunk/MoU]. The question is asked using radio-buttons without any defaults. It is neither opt-in nor opt-out.
+
+To maintain compatibility with existing setups and keep defaults, enabling updates and giving consent is handled differently.
+
+* By giving or revoking consent, users can enable or disable automatic updates
+* If automatic-updates are enabled, but consent is not given, 
+a message is shown telling, that consent was given out of band. By that, defaults from gluon-config-mode-autoupdater 
+and gluon-web-autoupdater are implemented.
+* If consent is given, but updates are disabled (e.g. manually using the shell), the form is inactive.
+
+
+By default, the dialog uses (slightly modified) texts from the Freifunk MoU. The texts can be adjusted using site-specific 
+i18n-files. 
+
+These texts are used:
+
+| Key (e.g. in `site/i18n/de.po` )  | English  | German  |   
+|---|---|---|
+| autoupdater-freifunk:description  | Node operators have the choice to allow remote maintenance. Interventions on the nodes via automatic firmware upgrades are done with explicit agreement of the respective operators. You can configure automatic updates in the <a href="/cgi-bin/config/admin/autoupdater"> Advanced settings</a> section.  | Die Knotenbetreiber*innen haben die Wahl, sich für Fernwartung zu entscheiden. Eingriffe in die Knoten, z.B. Firmwareupdates oder andere Fernwartungsarbeiten geschehen immer mit dem ausdrücklichen Einverständnis der jeweiligen Betreibenden. Weitere Einstellungen findest Du im Bereich <a href="/cgi-bin/config/admin/autoupdater">Erweiterte Einstellungen</a>.  |
+| autoupdater-freifunk:constent_assumed  | <p /><span style="color:red">You have already agreed to remote maintenance via automatic upgrades by downloading and using this software.</span>  | <p /><span style="color:red">Du hast Dich schon mit dem Download und der Benutzung dieser Firmware für eine Fernwartung mittels automatischer Updates entschieden. </span>  |
+| autoupdater-freifunk:disabled_on_shell  | <p />You have disabled automatic updates after giving consent.  | <p />Du hast zugestimmt, aber die Updates ausgeschaltet.  | 
+| autoupdater-freifunk:option_dissent  | Disable - I do not agree  |  Deaktivieren - ich stimme nicht zu | 
+| autoupdater-freifunk:option_consent  | Enable - I agree  | Aktivieren - ich stimme zu  | 
+| autoupdater-freifunk:option_name  | Remote Maintenance via Automatic Updates  | Fernwartung mittels automatischer Updates  | 
+| autoupdater-freifunk:description_admin  | Node operators have the choice to allow remote maintenance. Interventions on the nodes via automatic firmware upgrades are done with explicit agreement of the respective operators.  |  Die Knotenbetreiber*innen haben die Wahl, sich für Fernwartung zu entscheiden. Eingriffe in die Knoten, z.B. Firmwareupdates oder andere Fernwartungsarbeiten geschehen immer mit dem ausdrücklichen Einverständnis der jeweiligen Betreibenden.  | 
+| autoupdater-freifunk:constent_assumed_admin |  <p /><span style="color:red">You have already agreed to remote maintenance via automatic upgrades by downloading and using this software. <br /> You can disable automatic updates by selecting no branch. </span> | <p /><span style="color:red">Du hast Dich schon mit dem Download und der Benutzung dieser Firmware für eine Fernwartung mittels automatischer Updates entschieden. <br /> Du kannst den Auto-Updater deaktivieren, indem Du keinen Branch auswählst. </span>  | 
+| autoupdater-freifunk:disabled_on_shell_admin  | <p />You have manually disabled automatic updates after giving consent.  | <p />Du hast zugestimmt, aber die Updates manuell ausgeschaltet (z.B. per shell)  | 

--- a/package/gluon-config-mode-autoupdater-freifunk/files/etc/config/autoupdater-freifunk
+++ b/package/gluon-config-mode-autoupdater-freifunk/files/etc/config/autoupdater-freifunk
@@ -1,0 +1,2 @@
+config consent 'consent'
+#        option given '0'

--- a/package/gluon-config-mode-autoupdater-freifunk/files/lib/gluon/web/view/model/gluon-config-mode-autoupdater-freifunk.html
+++ b/package/gluon-config-mode-autoupdater-freifunk/files/lib/gluon/web/view/model/gluon-config-mode-autoupdater-freifunk.html
@@ -1,0 +1,46 @@
+<%
+local br = self.orientation == "horizontal" and '&#160;&#160;&#160;' or '<br />'
+local entries = self:entries()
+%>
+
+<% if self.widget == "select" then %>
+<select class="gluon-input-select" data-update="change"<%=
+attr("id", id) ..
+attr("name", id) ..
+attr("size", self.size) ..
+attr("data-type", "minlength(1)") ..
+attr("data-optional", self.optional)
+%>>
+<% for i, entry in pairs(entries) do -%>
+<option<%=
+attr("id", id.."."..entry.key) ..
+attr("value", entry.key) ..
+attr("data-index", i) ..
+attr("data-depends", self:deplist(entry.deps)) ..
+attr("selected", (self:cfgvalue() == entry.key) and "selected")
+%>><%|entry.value%></option>
+<%- end %>
+</select>
+<% elseif self.widget == "radio" then %>
+<div>
+    <% for i, entry in pairs(entries) do %>
+    <label<%=
+    attr("data-index", i) ..
+    attr("data-depends", self:deplist(entry.deps))
+    %>>
+    <input class="gluon-input-radio" data-update="click change" type="radio"<%=
+    attr("id", id.."."..entry.key) ..
+    attr("name", id) ..
+    attr("value", entry.key) ..
+    attr("checked", (self:cfgvalue() == entry.key) and "checked") ..
+    attr("disabled", (self.disabled) and "disabled")
+    %> />
+    <label<%= attr("for", id.."."..entry.key)..
+    attr("style",(self.disabled) and "background-color: #DDD")
+    %>></label>
+    <%|entry.value%>
+    </label>
+    <% if i ~= #entries then write(br) end %>
+    <% end %>
+</div>
+<% end %>

--- a/package/gluon-config-mode-autoupdater-freifunk/i18n/de.po
+++ b/package/gluon-config-mode-autoupdater-freifunk/i18n/de.po
@@ -1,0 +1,122 @@
+msgid ""
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
+"Project-Id-Version: \n"
+"PO-Revision-Date: 2019-05-04 16:49+0200\n"
+"Last-Translator: jan <freifunk@yanosz.net>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"POT-Creation-Date: \n"
+"X-Generator: Poedit 1.8.11\n"
+
+msgid ""
+"<p /><span style=\"color:red\">You have already agreed to remote maintenance "
+"via automatic upgrades by downloading and using this software. <br /> You "
+"can disable automatic updates by selecting no branch. </span>"
+msgstr ""
+"<p /><span style=\"color:red\">Du hast Dich schon mit dem Download und der "
+"Benutzung dieser Firmware für eine Fernwartung mittels automatischer Updates "
+"entschieden. <br /> Du kannst den Auto-Updater deaktivieren, indem Du keinen "
+"Branch auswählst. </span>"
+
+msgid ""
+"<p /><span style=\"color:red\">You have already agreed to remote maintenance "
+"via automatic upgrades by downloading and using this software.</span>"
+msgstr ""
+"<p /><span style=\"color:red\">Du hast Dich schon mit dem Download und der "
+"Benutzung dieser Firmware für eine Fernwartung mittels automatischer Updates "
+"entschieden. </span>"
+
+msgid "<p />You have disabled automatic updates after giving consent."
+msgstr "<p />Du hast zugestimmt, aber die Updates ausgeschaltet."
+
+msgid "<p />You have manually disabled automatic updates after giving consent."
+msgstr ""
+"<p />Du hast zugestimmt, aber die Updates manuell ausgeschaltet (z.B. per "
+"shell)"
+
+msgid "Automatic updates"
+msgstr "Automatische Updates"
+
+msgid "Branch"
+msgstr "Branch"
+
+msgid "Disable - I do not agree"
+msgstr "Deaktivieren - ich stimme nicht zu"
+
+msgid "Enable - I agree"
+msgstr "Aktivieren - ich stimme zu"
+
+msgid ""
+"Node operators have the choice to allow remote maintenance. Interventions on "
+"the nodes via automatic firmware upgrades are done with explicit agreement "
+"of the respective operators."
+msgstr ""
+"Die Knotenbetreiber*innen haben die Wahl, sich für Fernwartung zu "
+"entscheiden. Eingriffe in die Knoten, z.B. Firmwareupdates oder andere "
+"Fernwartungsarbeiten geschehen immer mit dem ausdrücklichen Einverständnis "
+"der jeweiligen Betreibenden."
+
+msgid ""
+"Node operators have the choice to allow remote maintenance. Interventions on "
+"the nodes via automatic firmware upgrades are done with explicit agreement "
+"of the respective operators. You can configure automatic updates in the <a "
+"href=\"/cgi-bin/config/admin/autoupdater\"> Advanced settings</a> section."
+msgstr ""
+"Die Knotenbetreiber*innen haben die Wahl, sich für Fernwartung zu "
+"entscheiden. Eingriffe in die Knoten, z.B. Firmwareupdates oder andere "
+"Fernwartungsarbeiten geschehen immer mit dem ausdrücklichen Einverständnis "
+"der jeweiligen Betreibenden. Weitere Einstellungen findest Du im Bereich <a "
+"href=\"/cgi-bin/config/admin/autoupdater\">Erweiterte Einstellungen</a>."
+
+msgid ""
+"Pick a branch to receive updates from. If you disable automatic updates, "
+"this branch is used when executing autoupdater using the command shell. "
+"Selecting no branch disables automatic updates."
+msgstr ""
+"Wähle einen Branch aus, von dem Du automatisches Updates erhalten willst.  "
+"Falls automatische Updates deaktiviert sind, so wird der Branch als default "
+"verwendet, wenn Du den autoupdater von der Shell aus aufrufst. Ist der "
+"Branch leer, so werden keine automatischen Updates installiert."
+
+msgid "Remote Maintenance via Automatic Updates"
+msgstr "Fernwartung mittels automatischer Updates"
+
+msgid "autoupdater-freifunk:constent_assumed"
+msgstr ""
+
+msgid "autoupdater-freifunk:description"
+msgstr ""
+
+msgid "autoupdater-freifunk:disabled_on_shell"
+msgstr ""
+
+msgid "autoupdater-freifunk:option_consent"
+msgstr ""
+
+msgid "autoupdater-freifunk:option_dissent"
+msgstr ""
+
+msgid "autoupdater-freifunk:option_name"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:constent_assumed_admin"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:description_admin"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:disabled_on_shell_admin"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:option_consent"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:option_dissent"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:option_name"
+msgstr ""

--- a/package/gluon-config-mode-autoupdater-freifunk/i18n/gluon-config-mode-autoupdater-freifunk.pot
+++ b/package/gluon-config-mode-autoupdater-freifunk/i18n/gluon-config-mode-autoupdater-freifunk.pot
@@ -1,0 +1,89 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid ""
+"<p /><span style=\"color:red\">You have already agreed to remote maintenance "
+"via automatic upgrades by downloading and using this software. <br /> You "
+"can disable automatic updates by selecting no branch. </span>"
+msgstr ""
+
+msgid ""
+"<p /><span style=\"color:red\">You have already agreed to remote maintenance "
+"via automatic upgrades by downloading and using this software.</span>"
+msgstr ""
+
+msgid "<p />You have disabled automatic updates after giving consent."
+msgstr ""
+
+msgid "<p />You have manually disabled automatic updates after giving consent."
+msgstr ""
+
+msgid "Automatic updates"
+msgstr ""
+
+msgid "Branch"
+msgstr ""
+
+msgid "Disable - I do not agree"
+msgstr ""
+
+msgid "Enable - I agree"
+msgstr ""
+
+msgid ""
+"Node operators have the choice to allow remote maintenance. Interventions on "
+"the nodes via automatic firmware upgrades are done with explicit agreement "
+"of the respective operators."
+msgstr ""
+
+msgid ""
+"Node operators have the choice to allow remote maintenance. Interventions on "
+"the nodes via automatic firmware upgrades are done with explicit agreement "
+"of the respective operators. You can configure automatic updates in the <a "
+"href=\"/cgi-bin/config/admin/autoupdater\"> Advanced settings</a> section."
+msgstr ""
+
+msgid ""
+"Pick a branch to receive updates from. If you disable automatic updates, "
+"this branch is used when executing autoupdater using the command shell. "
+"Selecting no branch disables automatic updates."
+msgstr ""
+
+msgid "Remote Maintenance via Automatic Updates"
+msgstr ""
+
+msgid "autoupdater-freifunk:constent_assumed"
+msgstr ""
+
+msgid "autoupdater-freifunk:description"
+msgstr ""
+
+msgid "autoupdater-freifunk:disabled_on_shell"
+msgstr ""
+
+msgid "autoupdater-freifunk:option_consent"
+msgstr ""
+
+msgid "autoupdater-freifunk:option_dissent"
+msgstr ""
+
+msgid "autoupdater-freifunk:option_name"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:constent_assumed_admin"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:description_admin"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:disabled_on_shell_admin"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:option_consent"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:option_dissent"
+msgstr ""
+
+msgid "gluon-autoupdater-freifunk:option_name"
+msgstr ""

--- a/package/gluon-config-mode-autoupdater-freifunk/luasrc/lib/gluon/config-mode/controller/admin/autoupdater.lua
+++ b/package/gluon-config-mode-autoupdater-freifunk/luasrc/lib/gluon/config-mode/controller/admin/autoupdater.lua
@@ -1,0 +1,3 @@
+package 'gluon-config-mode-autoupdater-freifunk'
+
+entry({"admin", "autoupdater"}, model("admin/autoupdater"), _("Automatic updates"), 80)

--- a/package/gluon-config-mode-autoupdater-freifunk/luasrc/lib/gluon/config-mode/model/admin/autoupdater.lua
+++ b/package/gluon-config-mode-autoupdater-freifunk/luasrc/lib/gluon/config-mode/model/admin/autoupdater.lua
@@ -1,0 +1,106 @@
+local pkg_i18n = i18n 'gluon-config-mode-autoupdater-freifunk'
+local site_i18n = i18n 'gluon-site'
+
+local uci = require("simple-uci").cursor()
+local autoupdater = uci:get_first("autoupdater", "autoupdater")
+
+
+local consent = uci:get_bool("autoupdater-freifunk", "consent", "given")
+local enabled = uci:get_bool("autoupdater", "settings", "enabled")
+
+-- Usually, the form is active and users can make a choice regarding constent
+-- One exception: Automatic Updates are enabled by default without given consent
+
+-- This exception is based in the idea expressed in the discussion for bug #1618: To be compatible
+-- with existing installation, Automatic updates can be enabled network-wide without asking users for consent
+-- This is relevant, for networks using automatic updates, only.
+local formActive = true
+
+-- Usually, giving consent to automatic updates enables automatic updates. (as expected by users)
+-- Again, there's one exception: If automatic updates are disabled, but consent is given, then we don't
+-- enable automatic updates (since the question is already answered) - a message is shown instead
+local changeAutomaticUpdates = true
+
+local storedValue = uci:get("autoupdater-freifunk", "consent", "given")
+
+-- By default, it is assmed, that out of band consent is not given.
+local warningMsg = ''
+if enabled and  not consent then
+    warningMsg = site_i18n._translate('autoupdater-freifunk:constent_assumed_admin') or pkg_i18n.translate('<p />'
+            .. ' <span style="color:red">You have already agreed to remote maintenance via automatic'
+            .. ' upgrades by downloading and using this software. <br /> You can disable automatic updates by selecting no branch. </span>')
+    formActive = false
+end
+
+if not enabled and consent then
+    warningMsg = site_i18n._translate('autoupdater-freifunk:disabled_on_shell_admin') or
+            pkg_i18n.translate('<p />You have manually disabled automatic updates after giving consent.')
+    formActive = false
+end
+
+local f = Form(pkg_i18n.translate("Automatic updates"))
+local s = f:section(Section,nil, site_i18n._translate('autoupdater-freifunk:description_admin')
+        or pkg_i18n.translate('Node operators have the choice to allow remote maintenance. '..
+        'Interventions on the nodes via automatic firmware upgrades are done with explicit agreement of the ' ..
+        'respective operators.') .. ' ' .. warningMsg)
+local o
+
+local option_name = site_i18n._translate('autoupdater-freifunk:option_name') or
+        pkg_i18n.translate("Remote Maintenance via Automatic Updates")
+
+local dissent_option = site_i18n._translate('autoupdater-freifunk:option_dissent') or
+        pkg_i18n.translate("Disable - I do not agree")
+local consent_option = site_i18n._translate('autoupdater-freifunk:option_consent') or
+        pkg_i18n.translate("Enable - I agree")
+
+configValue = s:option(ListValue, 'given', option_name)
+configValue.default = storedValue
+configValue.subtemplate  = "model/gluon-config-mode-autoupdater-freifunk"
+-- Override entries to remove empty default option from optional field
+function configValue:entries()
+    return {unpack(self.entry_list)}
+end
+configValue.widget = "radio"
+configValue:value("0" , dissent_option)
+configValue:value("1" , consent_option)
+
+-- Inactive form => No choice possible
+if not formActive then
+    configValue.disabled = true
+    configValue.optional = true
+    configValue.default = uci:get("autoupdater", "settings", "enabled")
+end
+
+function configValue:write(data)
+    if(formActive) then
+        uci:set("autoupdater-freifunk", "consent", "given", data)
+        if(formActive and changeAutomaticUpdates) then
+            uci:set("autoupdater", "settings", "enabled", data)
+        end
+    end
+
+end
+
+
+local s = f:section(Section,pkg_i18n.translate('Branch'), site_i18n._translate('autoupdater-freifunk:description_admin') or pkg_i18n.translate('Pick a branch to receive updates from. If you disable automatic'
+        ..' updates, this branch is used when executing autoupdater using the command shell.'
+        .. ' Selecting no branch disables automatic updates.'))
+
+o = s:option(ListValue, "branch", pkg_i18n.translate("Branch"))
+o.optional = true
+uci:foreach("autoupdater", "branch",
+    function (section)
+        o:value(section[".name"])
+    end
+)
+o.default = uci:get("autoupdater", autoupdater, "branch")
+function o:write(data)
+    uci:set("autoupdater", autoupdater, "branch", data)
+end
+
+function f:write()
+    uci:commit("autoupdater")
+    uci:commit("autoupdater-freifunk")
+end
+
+return f

--- a/package/gluon-config-mode-autoupdater-freifunk/luasrc/lib/gluon/config-mode/wizard/0450-autoupdater-freifunk.lua
+++ b/package/gluon-config-mode-autoupdater-freifunk/luasrc/lib/gluon/config-mode/wizard/0450-autoupdater-freifunk.lua
@@ -1,0 +1,91 @@
+return function(form, uci)
+	local pkg_i18n = i18n 'gluon-config-mode-autoupdater-freifunk'
+	local site_i18n = i18n 'gluon-site'
+
+
+	local consent = uci:get_bool("autoupdater-freifunk", "consent", "given")
+	local enabled = uci:get_bool("autoupdater", "settings", "enabled")
+
+	-- Usually, the form is active and users can make a choice regarding constent
+	-- One exception: Automatic Updates are enabled by default without given consent
+
+	-- This exception is based in the idea expressed in the discussion for bug #1618: To be compatible
+	-- with existing installation, Automatic updates can be enabled network-wide without asking users for consent
+	-- This is relevant, for networks using automatic updates, only.
+	local formActive = true
+
+	-- Usually, giving consent to automatic updates enables automatic updates. (as expected by users)
+	-- Again, there's one exception: If automatic updates are disabled, but consent is given, then we don't
+	-- enable automatic updates (since the question is already answered) - a message is shown instead
+	local changeAutomaticUpdates = true
+
+	local storedValue = uci:get("autoupdater-freifunk", "consent", "given")
+
+	-- By default, it is assmed, that out of band consent is not given.
+	local warningMsg = ''
+	if enabled and  not consent then
+		warningMsg = site_i18n._translate('autoupdater-freifunk:constent_assumed')
+				or pkg_i18n.translate('<p /><span style="color:red">You have already agreed to remote maintenance via automatic'
+				..' upgrades by downloading and using this software.</span>')
+		formActive = false
+	end
+
+	if not enabled and consent then
+		warningMsg = site_i18n._translate('autoupdater-freifunk:disabled_on_shell')
+				or pkg_i18n.translate('<p />You have disabled automatic updates after giving consent.')
+		formActive = false
+	end
+
+	local section_desc = site_i18n._translate('autoupdater-freifunk:description')
+			or pkg_i18n.translate('Node operators have the choice to allow remote maintenance. '..
+			'Interventions on the nodes via automatic firmware upgrades are done with explicit agreement of the ' ..
+			'respective operators. You can configure automatic updates in the'..
+			' <a href="/cgi-bin/config/admin/autoupdater"> Advanced settings</a> section.')
+
+	section = form:section(Section, '', section_desc..' '..warningMsg)
+
+
+	local option_name = site_i18n._translate('autoupdater-freifunk:option_name') or
+			pkg_i18n.translate("Remote Maintenance via Automatic Updates")
+
+	local dissent_option = site_i18n._translate('autoupdater-freifunk:option_dissent') or
+			pkg_i18n.translate("Disable - I do not agree")
+	local consent_option = site_i18n._translate('autoupdater-freifunk:option_consent') or
+			pkg_i18n.translate("Enable - I agree")
+
+	configValue = section:option(ListValue, 'given', option_name)
+	configValue.subtemplate  = "model/gluon-config-mode-autoupdater-freifunk"
+	configValue.default = storedValue
+	configValue.widget = "radio"
+	configValue:value("0" , dissent_option)
+	configValue:value("1" , consent_option)
+
+	-- Override entries to remove empty default option from optional field
+	function configValue:entries()
+		return {unpack(self.entry_list)}
+	end
+
+
+	-- Inactive form => No choice possible
+	if not formActive then
+		configValue.disabled = true
+		configValue.optional = true
+		configValue.default =  uci:get("autoupdater", "settings", "enabled")
+	end
+
+	function configValue:write(data)
+		if(formActive) then
+			uci:set("autoupdater-freifunk", "consent", "given", data)
+			if(formActive and changeAutomaticUpdates) then
+				uci:set("autoupdater", "settings", "enabled", data)
+			end
+		end
+
+	end
+	if (formActive) then
+		return {'autoupdater-freifunk', 'autoupdater' }
+	else
+		return {}
+	end
+
+end


### PR DESCRIPTION
This PR addresses #1618 by introducing a consenting auto-updater using a new package. As discussed in #1618 defaults are kept by introducing a new flag consent given: It is still possible to enable automatic updates by default withough asking for consent by using this package (out-of-band).

This package provides an admin-view as well a wizzard view, sharing the radio-button optiion.

I created a new value wrapper for this form, because the original one does not support disabling the controls.