### PR TITLE
ramips: fix R6120 factory image

### DIFF
--- a/patches/openwrt/0021-ramips-fix-R6120-factory-image.patch
+++ b/patches/openwrt/0021-ramips-fix-R6120-factory-image.patch
@@ -1,0 +1,26 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 9 May 2019 18:01:13 +0200
+Subject: ramips: fix R6120 factory image
+
+The factory firmware omits the JFFS2 end-marker while flashing via
+web-interface. Add a 64k padding after the marker fixes this problem.
+
+When the end-marker is not present, OpenWRT won't save the overlayfs
+after initial flash.
+
+Reported-by: Andreas Ziegler <dev@andreas-ziegler.de>
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ramips/image/mt76x8.mk b/target/linux/ramips/image/mt76x8.mk
+index f1bf78e0713a1bc47d4ac384efdac1d08c1bd8bc..a096720b09be18bae450edaab187df8be734fe13 100644
+--- a/target/linux/ramips/image/mt76x8.mk
++++ b/target/linux/ramips/image/mt76x8.mk
+@@ -118,7 +118,7 @@ define Device/netgear_r6120
+   IMAGES += factory.img
+   IMAGE/default := append-kernel | pad-to $$$$(BLOCKSIZE)| append-rootfs | pad-rootfs
+   IMAGE/sysupgrade.bin := $$(IMAGE/default) | append-metadata | check-size $$$$(IMAGE_SIZE)
+-  IMAGE/factory.img := pad-extra 576k | $$(IMAGE/default) | \
++  IMAGE/factory.img := pad-extra 576k | $$(IMAGE/default) | pad-to $$$$(BLOCKSIZE) | \
+ 	sercom-footer | pad-to 128 | zip R6120.bin | sercom-seal
+ endef
+ TARGET_DEVICES += netgear_r6120


### PR DESCRIPTION
The factory firmware omits the JFFS2 end-marker while flashing via
web-interface. Add a 64k padding after the marker fixes this problem.

When the end-marker is not present, OpenWRT won't save the overlayfs
after initial flash.

This patch is currently pending upstream (see https://patchwork.ozlabs.org/patch/1097561/)

This should probably also land in v2018.2.