### PR TITLE
gluon-core gluon-config-mode: fix two bugs in WiFi configuration

### DIFF
--- a/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
+++ b/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
@@ -1,7 +1,7 @@
 return function(form, uci)
-        local platform_info = require 'platform_info'
+	local platform = require 'gluon.platform'
 
-	if not platform_info.is_outdoor_device() then
+	if not platform.is_outdoor_device() then
 		-- only visible on wizard for outdoor devices
 		return
 	end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/180-outdoors
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/180-outdoors
@@ -12,7 +12,7 @@ if uci:get('gluon', 'wireless', 'outdoor') ~= nil then
 end
 
 local sysconfig = require 'gluon.sysconfig'
-local platform_info = require 'platform_info'
+local platform = require 'gluon.platform'
 
 local config = site.wifi5.outdoors('preset')
 local outdoor = false
@@ -22,7 +22,7 @@ if sysconfig.gluon_version then
 	outdoor = false
 elseif config == 'preset' then
 	-- enable outdoor mode through presets on new installs
-	outdoor = platform_info.is_outdoor_device()
+	outdoor = platform.is_outdoor_device()
 else
 	-- enable/disable outdoor mode unconditionally on new installs
 	outdoor = config

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -200,6 +200,29 @@ local function fixup_wan(radio, index)
 	uci:set('wireless', name, 'macaddr', macaddr)
 end
 
+local function configure_mesh_wireless(radio, index, config)
+	local radio_name = radio['.name']
+	local suffix = radio_name:match('^radio(%d+)$')
+
+	local ibss_disabled = is_disabled('ibss_' .. radio_name)
+	local mesh_disabled = is_disabled('mesh_' .. radio_name)
+
+	configure_ibss(config.ibss(), radio, index, suffix,
+		first_non_nil(
+			ibss_disabled,
+			mesh_disabled,
+			config.ibss.disabled(false)
+		)
+	)
+	configure_mesh(config.mesh(), radio, index, suffix,
+		first_non_nil(
+			mesh_disabled,
+			ibss_disabled,
+			config.mesh.disabled(false)
+		)
+	)
+end
+
 util.foreach_radio(uci, function(radio, index, config)
 	local radio_name = radio['.name']
 
@@ -228,6 +251,7 @@ util.foreach_radio(uci, function(radio, index, config)
 	local hwmode = radio.hwmode
 	if hwmode == '11g' or hwmode == '11ng' then
 		uci:set('wireless', radio_name, 'legacy_rates', false)
+		configure_mesh_wireless(radio, index, config)
 	elseif (hwmode == '11a' or hwmode == '11na') then
 		if is_outdoor() then
 			uci:set('wireless', radio_name, 'channels', config.outdoor_chanlist())
@@ -246,23 +270,7 @@ util.foreach_radio(uci, function(radio, index, config)
 			util.remove_from_set(hostapd_options, 'country3=0x4f')
 			uci:set_list('wireless', radio_name, 'hostapd_options', hostapd_options)
 
-			local ibss_disabled = is_disabled('ibss_' .. radio_name)
-			local mesh_disabled = is_disabled('mesh_' .. radio_name)
-
-			configure_ibss(config.ibss(), radio, index, suffix,
-				first_non_nil(
-					ibss_disabled,
-					mesh_disabled,
-					config.ibss.disabled(false)
-				)
-			)
-			configure_mesh(config.mesh(), radio, index, suffix,
-				first_non_nil(
-					mesh_disabled,
-					ibss_disabled,
-					config.mesh.disabled(false)
-				)
-			)
+			configure_mesh_wireless(radio, index, config)
 		end
 	end
 


### PR DESCRIPTION
**gluon-config-mode gluon-core: fix incorrect gluon.platform reference**

The is_outdoor function is placed inside the gluon.platform module, not
the platform_info module. Currently, the outdoor-mode wizard component
and the upgrade script fail due to nil-value calls.

**gluon-core: fix mesh radios not being created**

This commit fixes a bug where on first setup, mesh interfaces won't be
created for 2.4GHz radios.