### PR TITLE
gluon-l3roamd: add missing uc dependency

### DIFF
--- a/package/gluon-l3roamd/Makefile
+++ b/package/gluon-l3roamd/Makefile
@@ -7,7 +7,7 @@ include ../gluon.mk
 
 define Package/gluon-l3roamd
   TITLE:=Configure l3roamd for babel
-  DEPENDS:=+gluon-core +l3roamd
+  DEPENDS:=+gluon-core +l3roamd +uc
 endef
 
 $(eval $(call BuildPackageGluon,gluon-l3roamd))


### PR DESCRIPTION
uc is used in the initscript. It must be set as dependency