### PR TITLE
batman-adv: update to current openwrt-routing / batman-adv v2019.2

### DIFF
--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/310-gluon-mesh-batman-adv-mesh
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/310-gluon-mesh-batman-adv-mesh
@@ -19,7 +19,7 @@ uci:section('batman-adv', 'mesh', 'bat0', {
 	gw_sel_class = gw_sel_class,
 	hop_penalty = 15,
 	routing_algo = routing_algo,
-	multicast_mode = false,
+	multicast_mode = true,
 })
 uci:save('batman-adv')
 

--- a/patches/packages/routing/0003-batman-adv-update-to-current-openwrt-routing-batman-adv-v2019.2.patch
+++ b/patches/packages/routing/0003-batman-adv-update-to-current-openwrt-routing-batman-adv-v2019.2.patch
@@ -1,0 +1,4018 @@
+From: Linus Lüssing <linus.luessing@c0d3.blue>
+Date: Fri, 7 Jun 2019 13:30:36 +0200
+Subject: batman-adv: update to current openwrt-routing / batman-adv v2019.2
+
+This updates the batman-adv OpenWrt package to the current version
+provided in the master branch of the openwrt-routing packages
+repository:
+
+* e26096a batman-adv: Fix duplicated OGMs on NETDEV_UP
+* 1ff00ee batman-adv: upgrade package to latest release 2019.2
+
+Small difference to the original:
+
+* Compat code for batadv_genl_dump_check_consistent()
+* Compat code for cfg80211_sinfo_release_content()
+* 0001-batman-adv-add-compat-hacks.patch kept
+* batctl dependency kept removed
+* config related files unchanged
+
+The new config format was not backported yet to keep this patch small
+and less invasive.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+
+diff --git a/batman-adv/Config.in b/batman-adv/Config.in
+index d45ad57c8ae297a8995bd5b9084501ecc7fff936..8995cdb5c44b0a54cf7097577bcfd203eaf3071a 100644
+--- a/batman-adv/Config.in
++++ b/batman-adv/Config.in
+@@ -1,36 +1,111 @@
++# SPDX-License-Identifier: GPL-2.0
++# Copyright (C) 2007-2019  B.A.T.M.A.N. contributors:
++#
++# Marek Lindner, Simon Wunderlich
+ 
+-config KMOD_BATMAN_ADV_DEBUG_LOG
+-	bool "enable verbose debug logging"
+-	depends on PACKAGE_kmod-batman-adv
+-	depends on KMOD_BATMAN_ADV_DEBUGFS
+-	default n
++#
++# B.A.T.M.A.N meshing protocol
++#
+ 
+-config KMOD_BATMAN_ADV_BLA
+-	bool "enable bridge loop avoidance"
++config BATMAN_ADV_BATMAN_V
++	bool "B.A.T.M.A.N. V protocol"
+ 	depends on PACKAGE_kmod-batman-adv
+ 	default y
++	help
++	  This option enables the B.A.T.M.A.N. V protocol, the successor
++	  of the currently used B.A.T.M.A.N. IV protocol. The main
++	  changes include splitting of the OGM protocol into a neighbor
++	  discovery protocol (Echo Location Protocol, ELP) and a new OGM
++	  Protocol OGMv2 for flooding protocol information through the
++	  network, as well as a throughput based metric.
++	  B.A.T.M.A.N. V is currently considered experimental and not
++	  compatible to B.A.T.M.A.N. IV networks.
+ 
+-config KMOD_BATMAN_ADV_DAT
+-	bool "enable distributed arp table"
++config BATMAN_ADV_BLA
++	bool "Bridge Loop Avoidance"
+ 	depends on PACKAGE_kmod-batman-adv
++	select PACKAGE_kmod-lib-crc16
+ 	default y
++	help
++	  This option enables BLA (Bridge Loop Avoidance), a mechanism
++	  to avoid Ethernet frames looping when mesh nodes are connected
++	  to both the same LAN and the same mesh. If you will never use
++	  more than one mesh node in the same LAN, you can safely remove
++	  this feature and save some space.
+ 
+-config KMOD_BATMAN_ADV_DEBUGFS
+-	bool "enable debugfs support"
++config BATMAN_ADV_DAT
++	bool "Distributed ARP Table"
+ 	depends on PACKAGE_kmod-batman-adv
+ 	default y
++	help
++	  This option enables DAT (Distributed ARP Table), a DHT based
++	  mechanism that increases ARP reliability on sparse wireless
++	  mesh networks. If you think that your network does not need
++	  this option you can safely remove it and save some space.
++
++config BATMAN_ADV_NC
++	bool "Network Coding"
++	depends on PACKAGE_kmod-batman-adv
++	help
++	  This option enables network coding, a mechanism that aims to
++	  increase the overall network throughput by fusing multiple
++	  packets in one transmission.
++	  Note that interfaces controlled by batman-adv must be manually
++	  configured to have promiscuous mode enabled in order to make
++	  network coding work.
++	  If you think that your network does not need this feature you
++	  can safely disable it and save some space.
+ 
+-config KMOD_BATMAN_ADV_MCAST
+-	bool "enable multicast transmission optimization"
++config BATMAN_ADV_MCAST
++	bool "Multicast optimisation"
+ 	depends on PACKAGE_kmod-batman-adv
+ 	default y
++	help
++	  This option enables the multicast optimisation which aims to
++	  reduce the air overhead while improving the reliability of
++	  multicast messages.
+ 
+-config KMOD_BATMAN_ADV_NC
+-	bool "enable network coding [requires promisc mode support]"
++config BATMAN_ADV_DEBUGFS
++	bool "batman-adv debugfs entries"
+ 	depends on PACKAGE_kmod-batman-adv
+-	default n
++	select KERNEL_DEBUG_FS
++	help
++	  Enable this to export routing related debug tables via debugfs.
++	  The information for each soft-interface and used hard-interface can be
++	  found under batman_adv/
+ 
+-config KMOD_BATMAN_ADV_BATMAN_V
+-	bool "enable batman v routing algorithm"
++	  If unsure, say N.
++
++config BATMAN_ADV_DEBUG
++	bool "B.A.T.M.A.N. debugging"
++	depends on PACKAGE_kmod-batman-adv
++	help
++	  This is an option for use by developers; most people should
++	  say N here. This enables compilation of support for
++	  outputting debugging information to the debugfs log or tracing
++	  buffer. The output is controlled via the batadv netdev specific
++	  log_level setting.
++
++config BATMAN_ADV_SYSFS
++	bool "batman-adv sysfs entries"
+ 	depends on PACKAGE_kmod-batman-adv
+ 	default y
++	help
++	  Say Y here if you want to enable batman-adv device configuration and
++	  status interface through sysfs attributes. It is replaced by the
++	  batadv generic netlink family but still used by various userspace
++	  tools and scripts.
++
++	  If unsure, say Y.
++
++config BATMAN_ADV_TRACING
++	bool "B.A.T.M.A.N. tracing support"
++	depends on PACKAGE_kmod-batman-adv
++	select KERNEL_FTRACE
++	select KERNEL_ENABLE_DEFAULT_TRACERS
++	help
++	  This is an option for use by developers; most people should
++	  say N here. Select this option to gather traces like the debug
++	  messages using the generic tracing infrastructure of the kernel.
++	  BATMAN_ADV_DEBUG must also be selected to get trace events for
++	  batadv_dbg.
+diff --git a/batman-adv/Makefile b/batman-adv/Makefile
+index ae434909c90f61efdf0d80b56352c983cfef25b0..fce15a04b948b61b559ee92145e1c8a4886b13b6 100644
+--- a/batman-adv/Makefile
++++ b/batman-adv/Makefile
+@@ -9,9 +9,9 @@ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=batman-adv
+ 
+-PKG_VERSION:=2018.1
+-PKG_RELEASE:=8
+-PKG_HASH:=b866b28dbbe5c9238abbdf5abbc30fc526dea56898ce4c1bd76d5c017843048b
++PKG_VERSION:=2019.2
++PKG_RELEASE:=1
++PKG_HASH:=70c3f6a6cf88d2b25681a76768a52ed92d9fe992ba8e358368b6a8088757adc8
+ 
+ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+ PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
+@@ -27,16 +27,19 @@ define KernelPackage/batman-adv
+   URL:=https://www.open-mesh.org/
+   MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
+   SUBMENU:=Network Support
+-  DEPENDS:=+KMOD_BATMAN_ADV_BLA:kmod-lib-crc16 +kmod-crypto-crc32c +kmod-lib-crc32c +kmod-cfg80211
++  DEPENDS:=+BATMAN_ADV_BLA:kmod-lib-crc16 +kmod-lib-crc32c +kmod-cfg80211
+   TITLE:=B.A.T.M.A.N. Adv
+   FILES:=$(PKG_BUILD_DIR)/net/batman-adv/batman-adv.$(LINUX_KMOD_SUFFIX)
+   AUTOLOAD:=$(call AutoProbe,batman-adv)
+ endef
+ 
+ define KernelPackage/batman-adv/description
+-B.A.T.M.A.N. advanced is a kernel module which allows to
+-build layer 2 mesh networks. This package builds
+-version $(PKG_VERSION) of the kernel module.
++B.A.T.M.A.N. (better approach to mobile ad-hoc networking) is
++a routing protocol for multi-hop ad-hoc mesh networks. The
++networks may be wired or wireless. See
++https://www.open-mesh.org/ for more information and user space
++tools. This package builds version $(PKG_VERSION) of the kernel
++module.
+ endef
+ 
+ define KernelPackage/batman-adv/config
+@@ -49,13 +52,15 @@ endef
+ 
+ PKG_EXTRA_KCONFIG:= \
+ 	CONFIG_BATMAN_ADV=m \
+-	CONFIG_BATMAN_ADV_DEBUG=$(if $(CONFIG_KMOD_BATMAN_ADV_DEBUG_LOG),y,n) \
+-	CONFIG_BATMAN_ADV_DEBUGFS=$(if $(CONFIG_KMOD_BATMAN_ADV_DEBUGFS),y,n) \
+-	CONFIG_BATMAN_ADV_BLA=$(if $(CONFIG_KMOD_BATMAN_ADV_BLA),y,n) \
+-	CONFIG_BATMAN_ADV_DAT=$(if $(CONFIG_KMOD_BATMAN_ADV_DAT),y,n) \
+-	CONFIG_BATMAN_ADV_MCAST=$(if $(CONFIG_KMOD_BATMAN_ADV_MCAST),y,n) \
+-	CONFIG_BATMAN_ADV_NC=$(if $(CONFIG_KMOD_BATMAN_ADV_NC),y,n) \
+-	CONFIG_BATMAN_ADV_BATMAN_V=$(if $(CONFIG_KMOD_BATMAN_ADV_BATMAN_V),y,n) \
++	CONFIG_BATMAN_ADV_DEBUG=$(if $(CONFIG_BATMAN_ADV_DEBUG),y,n) \
++	CONFIG_BATMAN_ADV_DEBUGFS=$(if $(CONFIG_BATMAN_ADV_DEBUGFS),y,n) \
++	CONFIG_BATMAN_ADV_BLA=$(if $(CONFIG_BATMAN_ADV_BLA),y,n) \
++	CONFIG_BATMAN_ADV_DAT=$(if $(CONFIG_BATMAN_ADV_DAT),y,n) \
++	CONFIG_BATMAN_ADV_MCAST=$(if $(CONFIG_BATMAN_ADV_MCAST),y,n) \
++	CONFIG_BATMAN_ADV_NC=$(if $(CONFIG_BATMAN_ADV_NC),y,n) \
++	CONFIG_BATMAN_ADV_BATMAN_V=$(if $(CONFIG_BATMAN_ADV_BATMAN_V),y,n) \
++	CONFIG_BATMAN_ADV_SYSFS=$(if $(CONFIG_BATMAN_ADV_SYSFS),y,n) \
++	CONFIG_BATMAN_ADV_TRACING=$(if $(CONFIG_BATMAN_ADV_TRACING),y,n) \
+ 
+ PKG_EXTRA_CFLAGS:= \
+ 	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=m,%,$(filter %=m,$(PKG_EXTRA_KCONFIG)))) \
+@@ -73,9 +78,9 @@ NOSTDINC_FLAGS = \
+ 	-DBATADV_SOURCE_VERSION=\\\"openwrt-$(PKG_VERSION)-$(PKG_RELEASE)\\\"
+ 
+ COMPAT_SOURCES = \
+-	$(if $(CONFIG_KMOD_BATMAN_ADV_MCAST),../../compat-sources/net/core/skbuff.o,) \
+-	$(if $(CONFIG_KMOD_BATMAN_ADV_MCAST),../../compat-sources/net/ipv4/igmp.o,) \
+-	$(if $(CONFIG_KMOD_BATMAN_ADV_MCAST),../../compat-sources/net/ipv6/mcast_snoop.o,) \
++	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/core/skbuff.o,) \
++	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv4/igmp.o,) \
++	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv6/mcast_snoop.o,) \
+ 
+ define Build/Compile
+ 	+env "batman-adv-y=$(COMPAT_SOURCES)" \
+@@ -89,22 +94,8 @@ define Build/Compile
+ 		modules
+ endef
+ 
+-define Build/Prepare
+-	$(call Build/Prepare/Default)
+-	$(CP) ./files/compat-hacks.h $(PKG_BUILD_DIR)/
+-endef
+-
+-define Build/Clean
+-        rm -rf $(BUILD_DIR)/$(PKG_NAME)/
+-endef
+-
+ define KernelPackage/batman-adv/install
+-	$(INSTALL_DIR) $(1)/etc/config $(1)/etc/hotplug.d/net $(1)/etc/hotplug.d/iface $(1)/lib/batman-adv $(1)/usr/sbin $(1)/lib/netifd/proto
+-	$(INSTALL_DATA) ./files/etc/config/batman-adv $(1)/etc/config
+-	$(INSTALL_DATA) ./files/lib/batman-adv/config.sh $(1)/lib/batman-adv
+-	$(INSTALL_BIN) ./files/etc/hotplug.d/net/99-batman-adv $(1)/etc/hotplug.d/net
+-	$(INSTALL_BIN) ./files/lib/netifd/proto/batadv.sh $(1)/lib/netifd/proto
+-	$(INSTALL_BIN) ./files/lib/netifd/proto/batadv_vlan.sh $(1)/lib/netifd/proto
++	$(CP) ./files/. $(1)/
+ endef
+ 
+ $(eval $(call KernelPackage,batman-adv))
+diff --git a/batman-adv/files/compat-hacks.h b/batman-adv/files/compat-hacks.h
+deleted file mode 100644
+index d35cece49d8bfe38daf061ff8407d2203dd563f8..0000000000000000000000000000000000000000
+--- a/batman-adv/files/compat-hacks.h
++++ /dev/null
+@@ -1,440 +0,0 @@
+-/* Please avoid adding hacks here - instead add it to mac80211/backports.git */
+-
+-#undef CONFIG_MODULE_STRIPPED
+-
+-#include <linux/version.h>	/* LINUX_VERSION_CODE */
+-#include <linux/types.h>
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
+-
+-#define dev_get_iflink(_net_dev) ((_net_dev)->iflink)
+-
+-#endif /* < KERNEL_VERSION(4, 1, 0) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 16, 0)
+-
+-/* Linux 3.15 misses the uapi include.... */
+-#include <uapi/linux/nl80211.h>
+-
+-#endif /* < KERNEL_VERSION(3, 16, 0) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 9, 0)
+-
+-#include <linux/netdevice.h>
+-
+-#define netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info, extack) ({\
+-	BUILD_BUG_ON(upper_priv != NULL); \
+-	BUILD_BUG_ON(upper_info != NULL); \
+-	BUILD_BUG_ON(extack != NULL); \
+-	netdev_set_master(dev, upper_dev); \
+-})
+-
+-#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+-
+-#include <linux/netdevice.h>
+-
+-#define netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info, extack) ({\
+-	BUILD_BUG_ON(upper_priv != NULL); \
+-	BUILD_BUG_ON(upper_info != NULL); \
+-	BUILD_BUG_ON(extack != NULL); \
+-	netdev_master_upper_dev_link(dev, upper_dev); \
+-})
+-
+-#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+-
+-#include <linux/netdevice.h>
+-
+-#define netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info, extack) ({\
+-	BUILD_BUG_ON(extack != NULL); \
+-	netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info); \
+-})
+-
+-#endif /* < KERNEL_VERSION(4, 5, 0) */
+-
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
+-
+-/* for batadv_v_elp_get_throughput which would have used
+- * STATION_INFO_EXPECTED_THROUGHPUT in Linux 4.0.0
+- */
+-#define NL80211_STA_INFO_EXPECTED_THROUGHPUT    28
+-
+-/* wild hack for batadv_getlink_net only */
+-#define get_link_net get_xstats_size || 1 ? fallback_net : (struct net*)netdev->rtnl_link_ops->get_xstats_size
+-
+-#endif /* < KERNEL_VERSION(4, 0, 0) */
+-
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
+-
+-struct sk_buff *skb_checksum_trimmed(struct sk_buff *skb,
+-				     unsigned int transport_len,
+-				     __sum16(*skb_chkf)(struct sk_buff *skb));
+-
+-int ip_mc_check_igmp(struct sk_buff *skb, struct sk_buff **skb_trimmed);
+-
+-int ipv6_mc_check_mld(struct sk_buff *skb, struct sk_buff **skb_trimmed);
+-
+-#endif /* < KERNEL_VERSION(4, 2, 0) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
+-
+-#define IFF_NO_QUEUE	0; dev->tx_queue_len = 0
+-
+-static inline bool hlist_fake(struct hlist_node *h)
+-{
+-	return h->pprev == &h->next;
+-}
+-
+-#endif /* < KERNEL_VERSION(4, 3, 0) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+-
+-#include <linux/ethtool.h>
+-
+-#define ethtool_link_ksettings batadv_ethtool_link_ksettings
+-
+-struct batadv_ethtool_link_ksettings {
+-	struct {
+-		__u32	speed;
+-		__u8	duplex;
+-	} base;
+-};
+-
+-#define __ethtool_get_link_ksettings(__dev, __link_settings) \
+-	batadv_ethtool_get_link_ksettings(__dev, __link_settings)
+-
+-static inline int
+-batadv_ethtool_get_link_ksettings(struct net_device *dev,
+-				  struct ethtool_link_ksettings *link_ksettings)
+-{
+-	struct ethtool_cmd cmd;
+-	int ret;
+-
+-	memset(&cmd, 0, sizeof(cmd));
+-	ret = __ethtool_get_settings(dev, &cmd);
+-
+-	if (ret != 0)
+-		return ret;
+-
+-	link_ksettings->base.duplex = cmd.duplex;
+-	link_ksettings->base.speed = ethtool_cmd_speed(&cmd);
+-
+-	return 0;
+-}
+-
+-#endif /* < KERNEL_VERSION(4, 6, 0) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)
+-
+-#ifdef netif_trans_update
+-#undef netif_trans_update
+-#endif
+-
+-#define netif_trans_update batadv_netif_trans_update
+-static inline void batadv_netif_trans_update(struct net_device *dev)
+-{
+-	dev->trans_start = jiffies;
+-}
+-
+-#endif /* < KERNEL_VERSION(4, 7, 0) */
+-
+-
+-#include_next <linux/netlink.h>
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 7, 0)
+-
+-#include_next <net/netlink.h>
+-
+-static inline bool batadv_nla_need_padding_for_64bit(struct sk_buff *skb);
+-
+-static inline int batadv_nla_align_64bit(struct sk_buff *skb, int padattr)
+-{
+-	if (batadv_nla_need_padding_for_64bit(skb) &&
+-	    !nla_reserve(skb, padattr, 0))
+-		return -EMSGSIZE;
+-
+-	return 0;
+-}
+-
+-static inline struct nlattr *batadv__nla_reserve_64bit(struct sk_buff *skb,
+-						       int attrtype,
+-						       int attrlen, int padattr)
+-{
+-	if (batadv_nla_need_padding_for_64bit(skb))
+-		batadv_nla_align_64bit(skb, padattr);
+-
+-	return __nla_reserve(skb, attrtype, attrlen);
+-}
+-
+-static inline void batadv__nla_put_64bit(struct sk_buff *skb, int attrtype,
+-					 int attrlen, const void *data,
+-					 int padattr)
+-{
+-	struct nlattr *nla;
+-
+-	nla = batadv__nla_reserve_64bit(skb, attrtype, attrlen, padattr);
+-	memcpy(nla_data(nla), data, attrlen);
+-}
+-
+-static inline bool batadv_nla_need_padding_for_64bit(struct sk_buff *skb)
+-{
+-#ifndef CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS
+-	/* The nlattr header is 4 bytes in size, that's why we test
+-	 * if the skb->data _is_ aligned.  A NOP attribute, plus
+-	 * nlattr header for next attribute, will make nla_data()
+-	 * 8-byte aligned.
+-	 */
+-	if (IS_ALIGNED((unsigned long)skb_tail_pointer(skb), 8))
+-		return true;
+-#endif
+-	return false;
+-}
+-
+-static inline int batadv_nla_total_size_64bit(int payload)
+-{
+-	return NLA_ALIGN(nla_attr_size(payload))
+-#ifndef CONFIG_HAVE_EFFICIENT_UNALIGNED_ACCESS
+-		+ NLA_ALIGN(nla_attr_size(0))
+-#endif
+-		;
+-}
+-
+-static inline int batadv_nla_put_64bit(struct sk_buff *skb, int attrtype,
+-				       int attrlen, const void *data,
+-				       int padattr)
+-{
+-	size_t len;
+-
+-	if (batadv_nla_need_padding_for_64bit(skb))
+-		len = batadv_nla_total_size_64bit(attrlen);
+-	else
+-		len = nla_total_size(attrlen);
+-	if (unlikely(skb_tailroom(skb) < len))
+-		return -EMSGSIZE;
+-
+-	batadv__nla_put_64bit(skb, attrtype, attrlen, data, padattr);
+-	return 0;
+-}
+-
+-#ifdef nla_put_u64_64bit
+-#undef nla_put_u64_64bit
+-#endif
+-
+-#define nla_put_u64_64bit(_skb, _attrtype, _value, _padattr) \
+-	batadv_nla_put_u64_64bit(_skb, _attrtype, _value, _padattr)
+-static inline int batadv_nla_put_u64_64bit(struct sk_buff *skb, int attrtype,
+-					   u64 value, int padattr)
+-{
+-	return batadv_nla_put_64bit(skb, attrtype, sizeof(u64), &value,
+-				    padattr);
+-}
+-
+-#endif /* < KERNEL_VERSION(4, 7, 0) */
+-
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
+-
+-#include_next <linux/cache.h>
+-
+-/* hack for netlink.c which marked the family ops as ro */
+-#ifdef __ro_after_init
+-#undef __ro_after_init
+-#endif
+-#define __ro_after_init
+-
+-#endif /* < KERNEL_VERSION(4, 10, 0) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 9)
+-
+-#include <linux/netdevice.h>
+-
+-/* work around missing attribute needs_free_netdev and priv_destructor in
+- * net_device
+- */
+-#define ether_setup(dev) \
+-	void batadv_softif_free2(struct net_device *dev) \
+-	{ \
+-		batadv_softif_free(dev); \
+-		free_netdev(dev); \
+-	} \
+-	void (*t1)(struct net_device *dev) __attribute__((unused)); \
+-	bool t2 __attribute__((unused)); \
+-	ether_setup(dev)
+-#define needs_free_netdev destructor = batadv_softif_free2; t2
+-#define priv_destructor destructor = batadv_softif_free2; t1
+-
+-#endif /* < KERNEL_VERSION(4, 11, 9) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 13, 0)
+-
+-static inline void *batadv_skb_put(struct sk_buff *skb, unsigned int len)
+-{
+-	return (void *)skb_put(skb, len);
+-}
+-#ifdef skb_put
+-#undef skb_put
+-#endif
+-
+-#define skb_put batadv_skb_put
+-
+-static inline void *batadv_skb_put_zero(struct sk_buff *skb, unsigned int len)
+-{
+-	void *tmp = skb_put(skb, len);
+-
+-	memset(tmp, 0, len);
+-
+-	return tmp;
+-}
+-#ifdef skb_put_zero
+-#undef skb_put_zero
+-#endif
+-
+-#define skb_put_zero batadv_skb_put_zero
+-
+-static inline void *batadv_skb_put_data(struct sk_buff *skb, const void *data,
+-				 unsigned int len)
+-{
+-	void *tmp = skb_put(skb, len);
+-
+-	memcpy(tmp, data, len);
+-
+-	return tmp;
+-}
+-#ifdef skb_put_data
+-#undef skb_put_data
+-#endif
+-
+-#define skb_put_data batadv_skb_put_data
+-
+-#endif /* < KERNEL_VERSION(4, 13, 0) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+-
+-#define batadv_softif_slave_add(__dev, __slave_dev, __extack) \
+-	batadv_softif_slave_add(__dev, __slave_dev)
+-
+-#endif /* < KERNEL_VERSION(4, 15, 0) */
+-
+-#ifndef from_timer
+-
+-#define TIMER_DATA_TYPE                unsigned long
+-#define TIMER_FUNC_TYPE                void (*)(TIMER_DATA_TYPE)
+-
+-static inline void timer_setup(struct timer_list *timer,
+-			       void (*callback)(struct timer_list *),
+-			       unsigned int flags)
+-{
+-	__setup_timer(timer, (TIMER_FUNC_TYPE)callback,
+-		      (TIMER_DATA_TYPE)timer, flags);
+-}
+-
+-#define from_timer(var, callback_timer, timer_fieldname) \
+-	container_of(callback_timer, typeof(*var), timer_fieldname)
+-
+-#endif /* !from_timer */
+-	
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 16, 0)
+-
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
+-
+-#include <net/cfg80211.h>
+-
+-/* cfg80211 fix: https://patchwork.kernel.org/patch/10449857/ */
+-static inline int batadv_cfg80211_get_station(struct net_device *dev,
+-					      const u8 *mac_addr,
+-					      struct station_info *sinfo)
+-{
+-	memset(sinfo, 0, sizeof(*sinfo));
+-	return cfg80211_get_station(dev, mac_addr, sinfo);
+-}
+-
+-#define cfg80211_get_station(dev, mac_addr, sinfo) \
+-	batadv_cfg80211_get_station(dev, mac_addr, sinfo)
+-
+-#endif /* < KERNEL_VERSION(4, 18, 0) */
+-
+-
+-#ifdef __CHECK_POLL
+-typedef unsigned __bitwise __poll_t;
+-#else
+-typedef unsigned __poll_t;
+-#endif
+-
+-#endif /* < KERNEL_VERSION(4, 16, 0) */
+-
+-/* <DECLARE_EWMA> */
+-
+-#include <linux/version.h>
+-#include_next <linux/average.h>
+-
+-#include <linux/bug.h>
+-
+-#ifdef DECLARE_EWMA
+-#undef DECLARE_EWMA
+-#endif /* DECLARE_EWMA */
+-
+-/*
+- * Exponentially weighted moving average (EWMA)
+- *
+- * This implements a fixed-precision EWMA algorithm, with both the
+- * precision and fall-off coefficient determined at compile-time
+- * and built into the generated helper funtions.
+- *
+- * The first argument to the macro is the name that will be used
+- * for the struct and helper functions.
+- *
+- * The second argument, the precision, expresses how many bits are
+- * used for the fractional part of the fixed-precision values.
+- *
+- * The third argument, the weight reciprocal, determines how the
+- * new values will be weighed vs. the old state, new values will
+- * get weight 1/weight_rcp and old values 1-1/weight_rcp. Note
+- * that this parameter must be a power of two for efficiency.
+- */
+-
+-#define DECLARE_EWMA(name, _precision, _weight_rcp)			\
+-	struct ewma_##name {						\
+-		unsigned long internal;					\
+-	};								\
+-	static inline void ewma_##name##_init(struct ewma_##name *e)	\
+-	{								\
+-		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
+-		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
+-		/*							\
+-		 * Even if you want to feed it just 0/1 you should have	\
+-		 * some bits for the non-fractional part...		\
+-		 */							\
+-		BUILD_BUG_ON((_precision) > 30);			\
+-		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
+-		e->internal = 0;					\
+-	}								\
+-	static inline unsigned long					\
+-	ewma_##name##_read(struct ewma_##name *e)			\
+-	{								\
+-		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
+-		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
+-		BUILD_BUG_ON((_precision) > 30);			\
+-		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
+-		return e->internal >> (_precision);			\
+-	}								\
+-	static inline void ewma_##name##_add(struct ewma_##name *e,	\
+-					     unsigned long val)		\
+-	{								\
+-		unsigned long internal = READ_ONCE(e->internal);	\
+-		unsigned long weight_rcp = ilog2(_weight_rcp);		\
+-		unsigned long precision = _precision;			\
+-									\
+-		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
+-		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
+-		BUILD_BUG_ON((_precision) > 30);			\
+-		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
+-									\
+-		WRITE_ONCE(e->internal, internal ?			\
+-			(((internal << weight_rcp) - internal) +	\
+-				(val << precision)) >> weight_rcp :	\
+-			(val << precision));				\
+-	}
+-
+-/* </DECLARE_EWMA> */
+diff --git a/batman-adv/patches/0000-batman-adv-add-compat-hacks.patch b/batman-adv/patches/0000-batman-adv-add-compat-hacks.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..efdc0ca39b04b1e19089f94c92afa9a9c346ac48
+--- /dev/null
++++ b/batman-adv/patches/0000-batman-adv-add-compat-hacks.patch
+@@ -0,0 +1,53 @@
++From d7b10f0bc2c5f10cf4e94a7efa9a9553b03c3660 Mon Sep 17 00:00:00 2001
++From: Sven Eckelmann <sven@narfation.org>
++Date: Wed, 9 May 2018 21:07:40 +0200
++Subject: [PATCH 1/6] batman-adv: add compat hacks
++
++---
++ net/batman-adv/main.c              | 2 +-
++ net/batman-adv/tp_meter.c          | 2 +-
++ net/batman-adv/translation-table.c | 2 +-
++ 3 files changed, 3 insertions(+), 3 deletions(-)
++
++diff --git a/net/batman-adv/main.c b/net/batman-adv/main.c
++index 4a89177d..a8a9134d 100644
++--- a/net/batman-adv/main.c
+++++ b/net/batman-adv/main.c
++@@ -7,7 +7,7 @@
++ #include "main.h"
++ 
++ #include <linux/atomic.h>
++-#include <linux/build_bug.h>
+++#include <linux/bug.h>
++ #include <linux/byteorder/generic.h>
++ #include <linux/crc32c.h>
++ #include <linux/device.h>
++diff --git a/net/batman-adv/tp_meter.c b/net/batman-adv/tp_meter.c
++index 82039214..f8a4eaf4 100644
++--- a/net/batman-adv/tp_meter.c
+++++ b/net/batman-adv/tp_meter.c
++@@ -8,7 +8,7 @@
++ #include "main.h"
++ 
++ #include <linux/atomic.h>
++-#include <linux/build_bug.h>
+++#include <linux/bug.h>
++ #include <linux/byteorder/generic.h>
++ #include <linux/cache.h>
++ #include <linux/compiler.h>
++diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
++index 8a482c5e..53f97a79 100644
++--- a/net/batman-adv/translation-table.c
+++++ b/net/batman-adv/translation-table.c
++@@ -9,7 +9,7 @@
++ 
++ #include <linux/atomic.h>
++ #include <linux/bitops.h>
++-#include <linux/build_bug.h>
+++#include <linux/bug.h>
++ #include <linux/byteorder/generic.h>
++ #include <linux/cache.h>
++ #include <linux/compiler.h>
++-- 
++2.20.1
++
+diff --git a/batman-adv/patches/0001-Revert-batman-adv-convert-stream-like-files-from-non.patch b/batman-adv/patches/0001-Revert-batman-adv-convert-stream-like-files-from-non.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..201e32769dce92a33d493d166770ca289e2bb51e
+--- /dev/null
++++ b/batman-adv/patches/0001-Revert-batman-adv-convert-stream-like-files-from-non.patch
+@@ -0,0 +1,55 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Thu, 23 May 2019 19:26:27 +0200
++Subject: Revert "batman-adv: convert stream-like files from nonseekable_open -> stream_open"
++
++OpenWrt's mac80211 package is not yet ready to support the generic netlink
++API of Linux 5.2.
++
++This reverts commit 337ae19a00d4455cf84afa58abfb432f78c882b9.
++
++diff --git a/compat-include/linux/fs.h b/compat-include/linux/fs.h
++index 480722f04ba7ddefc837d5e55a340271e0814b14..c52e0e8e87584d106ab64ef2c522e6ac1ff6e796 100644
++--- a/compat-include/linux/fs.h
+++++ b/compat-include/linux/fs.h
++@@ -31,15 +31,4 @@ static inline struct dentry *batadv_file_dentry(const struct file *file)
++ 
++ #endif /* < KERNEL_VERSION(4, 6, 0) */
++ 
++-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
++-
++-static inline int batadv_stream_open(struct inode *inode, struct file *filp)
++-{
++-	return nonseekable_open(inode, filp);
++-}
++-
++-#define stream_open batadv_stream_open
++-
++-#endif /* < KERNEL_VERSION(5, 2, 0) */
++-
++ #endif	/* _NET_BATMAN_ADV_COMPAT_LINUX_FS_H_ */
++diff --git a/net/batman-adv/icmp_socket.c b/net/batman-adv/icmp_socket.c
++index 0a91c8661357d4ddbea1ba20dcd0df67b8ba5a97..de81b5ecad91afd8d684edbf781c70a3bae38c60 100644
++--- a/net/batman-adv/icmp_socket.c
+++++ b/net/batman-adv/icmp_socket.c
++@@ -65,7 +65,7 @@ static int batadv_socket_open(struct inode *inode, struct file *file)
++ 
++ 	batadv_debugfs_deprecated(file, "");
++ 
++-	stream_open(inode, file);
+++	nonseekable_open(inode, file);
++ 
++ 	socket_client = kmalloc(sizeof(*socket_client), GFP_KERNEL);
++ 	if (!socket_client) {
++diff --git a/net/batman-adv/log.c b/net/batman-adv/log.c
++index f79ebd5b46e95b3b6de717c7ea1ecf44e5c96051..60ce11e16a905e790424a2d7aca81c1f945c1ec2 100644
++--- a/net/batman-adv/log.c
+++++ b/net/batman-adv/log.c
++@@ -90,7 +90,7 @@ static int batadv_log_open(struct inode *inode, struct file *file)
++ 	batadv_debugfs_deprecated(file,
++ 				  "Use tracepoint batadv:batadv_dbg instead\n");
++ 
++-	stream_open(inode, file);
+++	nonseekable_open(inode, file);
++ 	file->private_data = inode->i_private;
++ 	return 0;
++ }
+diff --git a/batman-adv/patches/0001-batman-adv-add-compat-hacks.patch b/batman-adv/patches/0001-batman-adv-add-compat-hacks.patch
+deleted file mode 100644
+index e3876d085db6620f45cd29b9856042a45a8aec48..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0001-batman-adv-add-compat-hacks.patch
++++ /dev/null
+@@ -1,43 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Wed, 9 May 2018 21:07:40 +0200
+-Subject: batman-adv: add compat hacks
+-
+-diff --git a/net/batman-adv/main.c b/net/batman-adv/main.c
+-index 69c0d85bceb3e0a1915e37d278110ee2655c4571..53b329d24461819b4cf0d4118cfa5b0eb8d7261b 100644
+---- a/net/batman-adv/main.c
+-+++ b/net/batman-adv/main.c
+-@@ -19,7 +19,7 @@
+- #include "main.h"
+- 
+- #include <linux/atomic.h>
+--#include <linux/build_bug.h>
+-+#include <linux/bug.h>
+- #include <linux/byteorder/generic.h>
+- #include <linux/crc32c.h>
+- #include <linux/errno.h>
+-diff --git a/net/batman-adv/tp_meter.c b/net/batman-adv/tp_meter.c
+-index 11520de96ccb1a87183e9666066e21731538ccd9..9af0a44dce74e7ead7f2c29ec4d49156bf4c9dd7 100644
+---- a/net/batman-adv/tp_meter.c
+-+++ b/net/batman-adv/tp_meter.c
+-@@ -20,7 +20,7 @@
+- #include "main.h"
+- 
+- #include <linux/atomic.h>
+--#include <linux/build_bug.h>
+-+#include <linux/bug.h>
+- #include <linux/byteorder/generic.h>
+- #include <linux/cache.h>
+- #include <linux/compiler.h>
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index 0225616d5771d0986127322142fc591780fc25b0..91b9a0aaaa2e6fe59b5e4ea2e57b7be375618059 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -21,7 +21,7 @@
+- 
+- #include <linux/atomic.h>
+- #include <linux/bitops.h>
+--#include <linux/build_bug.h>
+-+#include <linux/bug.h>
+- #include <linux/byteorder/generic.h>
+- #include <linux/cache.h>
+- #include <linux/compiler.h>
+diff --git a/batman-adv/patches/0002-Revert-batman-adv-compat-Drop-support-for-genl_ops-s.patch b/batman-adv/patches/0002-Revert-batman-adv-compat-Drop-support-for-genl_ops-s.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..e3b7decb2485acdba681708ca3a545c7c1999b4c
+--- /dev/null
++++ b/batman-adv/patches/0002-Revert-batman-adv-compat-Drop-support-for-genl_ops-s.patch
+@@ -0,0 +1,29 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Thu, 23 May 2019 19:26:36 +0200
++Subject: Revert "batman-adv: compat: Drop support for genl_ops->start"
++
++OpenWrt's mac80211 package is not yet ready to support the generic netlink
++API of Linux 5.2.
++
++This reverts commit 1d30dbe3917d0d6fdb8ba473dfdd6265ac46670b.
++
++diff --git a/compat-include/net/genetlink.h b/compat-include/net/genetlink.h
++index ee5b82288be97193c1a8e8340a2ea7e0c7ce112c..fbfdb733a3dd63c251def43cae416c7fe32cadab 100644
++--- a/compat-include/net/genetlink.h
+++++ b/compat-include/net/genetlink.h
++@@ -42,6 +42,7 @@ enum genl_validate_flags {
++ struct batadv_genl_ops {
++ 	int		       (*doit)(struct sk_buff *skb,
++ 				       struct genl_info *info);
+++	int		       (*start)(struct netlink_callback *cb);
++ 	int		       (*dumpit)(struct sk_buff *skb,
++ 					 struct netlink_callback *cb);
++ 	int		       (*done)(struct netlink_callback *cb);
++@@ -104,6 +105,7 @@ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
++ 
++ 	for (i = 0; i < family->family.n_ops; i++) {
++ 		ops[i].doit = family->ops[i].doit;
+++		ops[i].start = family->ops[i].start;
++ 		ops[i].dumpit = family->ops[i].dumpit;
++ 		ops[i].done = family->ops[i].done;
++ 		ops[i].cmd = family->ops[i].cmd;
+diff --git a/batman-adv/patches/0002-batman-adv-Avoid-race-in-TT-TVLV-allocator-helper.patch b/batman-adv/patches/0002-batman-adv-Avoid-race-in-TT-TVLV-allocator-helper.patch
+deleted file mode 100644
+index 1e3adcad4c08927ca81b1a9875a3f97e41e17e24..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0002-batman-adv-Avoid-race-in-TT-TVLV-allocator-helper.patch
++++ /dev/null
+@@ -1,72 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Wed, 9 May 2018 21:07:40 +0200
+-Subject: batman-adv: Avoid race in TT TVLV allocator helper
+-
+-The functions batadv_tt_prepare_tvlv_local_data and
+-batadv_tt_prepare_tvlv_global_data are responsible for preparing a buffer
+-which can be used to store the TVLV container for TT and add the VLAN
+-information to it.
+-
+-This will be done in three phases:
+-
+-1. count the number of VLANs and their entries
+-2. allocate the buffer using the counters from the previous step and limits
+-   from the caller (parameter tt_len)
+-3. insert the VLAN information to the buffer
+-
+-The step 1 and 3 operate on a list which contains the VLANs. The access to
+-these lists must be protected with an appropriate lock or otherwise they
+-might operate on on different entries. This could for example happen when
+-another context is adding VLAN entries to this list.
+-
+-This could lead to a buffer overflow in these functions when enough entries
+-were added between step 1 and 3 to the VLAN lists that the buffer room for
+-the entries (*tt_change) is smaller then the now required extra buffer for
+-new VLAN entries.
+-
+-Fixes: 21a57f6e7a3b ("batman-adv: make the TT CRC logic VLAN specific")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Antonio Quartulli <a@unstable.cc>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/286be89a33497ba9000aa5c2960f1f4114953522
+-
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index 91b9a0aaaa2e6fe59b5e4ea2e57b7be375618059..2511adb79936782c96ed397265418421b69f617d 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -862,7 +862,7 @@ batadv_tt_prepare_tvlv_global_data(struct batadv_orig_node *orig_node,
+- 	struct batadv_orig_node_vlan *vlan;
+- 	u8 *tt_change_ptr;
+- 
+--	rcu_read_lock();
+-+	spin_lock_bh(&orig_node->vlan_list_lock);
+- 	hlist_for_each_entry_rcu(vlan, &orig_node->vlan_list, list) {
+- 		num_vlan++;
+- 		num_entries += atomic_read(&vlan->tt.num_entries);
+-@@ -900,7 +900,7 @@ batadv_tt_prepare_tvlv_global_data(struct batadv_orig_node *orig_node,
+- 	*tt_change = (struct batadv_tvlv_tt_change *)tt_change_ptr;
+- 
+- out:
+--	rcu_read_unlock();
+-+	spin_unlock_bh(&orig_node->vlan_list_lock);
+- 	return tvlv_len;
+- }
+- 
+-@@ -936,7 +936,7 @@ batadv_tt_prepare_tvlv_local_data(struct batadv_priv *bat_priv,
+- 	u8 *tt_change_ptr;
+- 	int change_offset;
+- 
+--	rcu_read_lock();
+-+	spin_lock_bh(&bat_priv->softif_vlan_list_lock);
+- 	hlist_for_each_entry_rcu(vlan, &bat_priv->softif_vlan_list, list) {
+- 		num_vlan++;
+- 		num_entries += atomic_read(&vlan->tt.num_entries);
+-@@ -974,7 +974,7 @@ batadv_tt_prepare_tvlv_local_data(struct batadv_priv *bat_priv,
+- 	*tt_change = (struct batadv_tvlv_tt_change *)tt_change_ptr;
+- 
+- out:
+--	rcu_read_unlock();
+-+	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+- 	return tvlv_len;
+- }
+- 
+diff --git a/batman-adv/patches/0003-Revert-batman-adv-genetlink-optionally-validate-stri.patch b/batman-adv/patches/0003-Revert-batman-adv-genetlink-optionally-validate-stri.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..c383c6922b002610f1ed19cfbc0697ed1a1ccb51
+--- /dev/null
++++ b/batman-adv/patches/0003-Revert-batman-adv-genetlink-optionally-validate-stri.patch
+@@ -0,0 +1,222 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Thu, 23 May 2019 19:26:45 +0200
++Subject: Revert "batman-adv: genetlink: optionally validate strictly/dumps"
++
++OpenWrt's mac80211 package is not yet ready to support the generic netlink
++API of Linux 5.2.
++
++This reverts commit 2ee47abaeb35ca62bb909830e10b0e973393b853.
++
++diff --git a/compat-include/net/genetlink.h b/compat-include/net/genetlink.h
++index fbfdb733a3dd63c251def43cae416c7fe32cadab..7d17a705273650355f074788e9220fc4981b0db1 100644
++--- a/compat-include/net/genetlink.h
+++++ b/compat-include/net/genetlink.h
++@@ -33,25 +33,6 @@ void batadv_genl_dump_check_consistent(struct netlink_callback *cb,
++ 
++ #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
++ 
++-enum genl_validate_flags {
++-	GENL_DONT_VALIDATE_STRICT		= BIT(0),
++-	GENL_DONT_VALIDATE_DUMP			= BIT(1),
++-	GENL_DONT_VALIDATE_DUMP_STRICT		= BIT(2),
++-};
++-
++-struct batadv_genl_ops {
++-	int		       (*doit)(struct sk_buff *skb,
++-				       struct genl_info *info);
++-	int		       (*start)(struct netlink_callback *cb);
++-	int		       (*dumpit)(struct sk_buff *skb,
++-					 struct netlink_callback *cb);
++-	int		       (*done)(struct netlink_callback *cb);
++-	u8			cmd;
++-	u8			internal_flags;
++-	u8			flags;
++-	u8			validate;
++-};
++-
++ struct batadv_genl_family {
++ 	/* data handled by the actual kernel */
++ 	struct genl_family family;
++@@ -69,7 +50,7 @@ struct batadv_genl_family {
++ 			 struct genl_info *info);
++         void (*post_doit)(const struct genl_ops *ops, struct sk_buff *skb,
++ 			  struct genl_info *info);
++-	const struct batadv_genl_ops *ops;
+++	const struct genl_ops *ops;
++ 	const struct genl_multicast_group *mcgrps;
++ 	unsigned int n_ops;
++ 	unsigned int n_mcgrps;
++@@ -82,6 +63,8 @@ struct batadv_genl_family {
++ 	struct genl_ops *copy_ops;
++ };
++ 
+++#define genl_family batadv_genl_family
+++
++ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
++ {
++ 	struct genl_ops *ops;
++@@ -99,20 +82,12 @@ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
++ 	family->family.n_mcgrps = family->n_mcgrps;
++ 	family->family.module = family->module;
++ 
++-	ops = kzalloc(sizeof(*ops) * family->n_ops, GFP_KERNEL);
+++	ops = kmemdup(family->ops, sizeof(*ops) * family->n_ops, GFP_KERNEL);
++ 	if (!ops)
++ 		return -ENOMEM;
++ 
++-	for (i = 0; i < family->family.n_ops; i++) {
++-		ops[i].doit = family->ops[i].doit;
++-		ops[i].start = family->ops[i].start;
++-		ops[i].dumpit = family->ops[i].dumpit;
++-		ops[i].done = family->ops[i].done;
++-		ops[i].cmd = family->ops[i].cmd;
++-		ops[i].internal_flags = family->ops[i].internal_flags;
++-		ops[i].flags = family->ops[i].flags;
+++	for (i = 0; i < family->family.n_ops; i++)
++ 		ops[i].policy = family->policy;
++-	}
++ 
++ 	family->family.ops = ops;
++ 	family->copy_ops = ops;
++@@ -120,17 +95,6 @@ static inline int batadv_genl_register_family(struct batadv_genl_family *family)
++ 	return genl_register_family(&family->family);
++ }
++ 
++-typedef struct genl_ops batadv_genl_ops_old;
++-
++-#define batadv_pre_doit(__x, __y, __z) \
++-	batadv_pre_doit(const batadv_genl_ops_old *ops, __y, __z)
++-
++-#define batadv_post_doit(__x, __y, __z) \
++-	batadv_post_doit(const batadv_genl_ops_old *ops, __y, __z)
++-
++-#define genl_ops batadv_genl_ops
++-#define genl_family batadv_genl_family
++-
++ #define genl_register_family(family) \
++ 	batadv_genl_register_family((family))
++ 
++diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
++index a67720fad46ca496c932c0306e2f7ec4ed496fc9..e7907308b331ddc3e4917ff7d648bca27a65536b 100644
++--- a/net/batman-adv/netlink.c
+++++ b/net/batman-adv/netlink.c
++@@ -1343,34 +1343,29 @@ static void batadv_post_doit(const struct genl_ops *ops, struct sk_buff *skb,
++ static const struct genl_ops batadv_netlink_ops[] = {
++ 	{
++ 		.cmd = BATADV_CMD_GET_MESH,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		/* can be retrieved by unprivileged users */
++ 		.doit = batadv_netlink_get_mesh,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_TP_METER,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.doit = batadv_netlink_tp_meter_start,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_TP_METER_CANCEL,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.doit = batadv_netlink_tp_meter_cancel,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_ROUTING_ALGOS,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_algo_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_HARDIF,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		/* can be retrieved by unprivileged users */
++ 		.dumpit = batadv_netlink_dump_hardif,
++ 		.doit = batadv_netlink_get_hardif,
++@@ -1379,68 +1374,57 @@ static const struct genl_ops batadv_netlink_ops[] = {
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_TRANSTABLE_LOCAL,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_tt_local_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_TRANSTABLE_GLOBAL,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_tt_global_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_ORIGINATORS,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_orig_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_NEIGHBORS,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_hardif_neigh_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_GATEWAYS,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_gw_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_BLA_CLAIM,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_bla_claim_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_BLA_BACKBONE,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_bla_backbone_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_DAT_CACHE,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_dat_cache_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_MCAST_FLAGS,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.dumpit = batadv_mcast_flags_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_SET_MESH,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.doit = batadv_netlink_set_mesh,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_SET_HARDIF,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.doit = batadv_netlink_set_hardif,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++@@ -1448,7 +1432,6 @@ static const struct genl_ops batadv_netlink_ops[] = {
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_VLAN,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		/* can be retrieved by unprivileged users */
++ 		.doit = batadv_netlink_get_vlan,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++@@ -1456,7 +1439,6 @@ static const struct genl_ops batadv_netlink_ops[] = {
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_SET_VLAN,
++-		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ 		.flags = GENL_ADMIN_PERM,
++ 		.doit = batadv_netlink_set_vlan,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
+diff --git a/batman-adv/patches/0003-batman-adv-Fix-TT-sync-flags-for-intermediate-TT-res.patch b/batman-adv/patches/0003-batman-adv-Fix-TT-sync-flags-for-intermediate-TT-res.patch
+deleted file mode 100644
+index abc1965f2a893208bf3fd6cb47f76f815786443f..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0003-batman-adv-Fix-TT-sync-flags-for-intermediate-TT-res.patch
++++ /dev/null
+@@ -1,177 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Thu, 10 May 2018 19:44:28 +0200
+-Subject: batman-adv: Fix TT sync flags for intermediate TT responses
+-
+-The previous TT sync fix so far only fixed TT responses issued by the
+-target node directly. So far, TT responses issued by intermediate nodes
+-still lead to the wrong flags being added, leading to CRC mismatches.
+-
+-This behaviour was observed at Freifunk Hannover in a 800 nodes setup
+-where a considerable amount of nodes were still infected with 'WI'
+-TT flags even with (most) nodes having the previous TT sync fix applied.
+-
+-I was able to reproduce the issue with intermediate TT responses in a
+-four node test setup and this patch fixes this issue by ensuring to
+-use the per originator instead of the summarized, OR'd ones.
+-
+-Fixes: fa614fd04692 ("batman-adv: fix tt_global_entries flags update")
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/d65daee8617b29c1ddcc949ce3a5ec24f7a1e1af
+-
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index 2511adb79936782c96ed397265418421b69f617d..09bc1ed9fb59c1f76a4227f158d3ac8b73cbd32b 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -1538,6 +1538,8 @@ batadv_tt_global_orig_entry_find(const struct batadv_tt_global_entry *entry,
+-  *  handled by a given originator
+-  * @entry: the TT global entry to check
+-  * @orig_node: the originator to search in the list
+-+ * @flags: a pointer to store TT flags for the given @entry received
+-+ *  from @orig_node
+-  *
+-  * find out if an orig_node is already in the list of a tt_global_entry.
+-  *
+-@@ -1545,7 +1547,8 @@ batadv_tt_global_orig_entry_find(const struct batadv_tt_global_entry *entry,
+-  */
+- static bool
+- batadv_tt_global_entry_has_orig(const struct batadv_tt_global_entry *entry,
+--				const struct batadv_orig_node *orig_node)
+-+				const struct batadv_orig_node *orig_node,
+-+				u8 *flags)
+- {
+- 	struct batadv_tt_orig_list_entry *orig_entry;
+- 	bool found = false;
+-@@ -1553,6 +1556,10 @@ batadv_tt_global_entry_has_orig(const struct batadv_tt_global_entry *entry,
+- 	orig_entry = batadv_tt_global_orig_entry_find(entry, orig_node);
+- 	if (orig_entry) {
+- 		found = true;
+-+
+-+		if (flags)
+-+			*flags = orig_entry->flags;
+-+
+- 		batadv_tt_orig_list_entry_put(orig_entry);
+- 	}
+- 
+-@@ -1731,7 +1738,7 @@ static bool batadv_tt_global_add(struct batadv_priv *bat_priv,
+- 			if (!(common->flags & BATADV_TT_CLIENT_TEMP))
+- 				goto out;
+- 			if (batadv_tt_global_entry_has_orig(tt_global_entry,
+--							    orig_node))
+-+							    orig_node, NULL))
+- 				goto out_remove;
+- 			batadv_tt_global_del_orig_list(tt_global_entry);
+- 			goto add_orig_entry;
+-@@ -2880,23 +2887,46 @@ batadv_tt_req_node_new(struct batadv_priv *bat_priv,
+- }
+- 
+- /**
+-- * batadv_tt_local_valid() - verify that given tt entry is a valid one
+-+ * batadv_tt_local_valid() - verify local tt entry and get flags
+-  * @entry_ptr: to be checked local tt entry
+-  * @data_ptr: not used but definition required to satisfy the callback prototype
+-+ * @flags: a pointer to store TT flags for this client to
+-+ *
+-+ * Checks the validity of the given local TT entry. If it is, then the provided
+-+ * flags pointer is updated.
+-  *
+-  * Return: true if the entry is a valid, false otherwise.
+-  */
+--static bool batadv_tt_local_valid(const void *entry_ptr, const void *data_ptr)
+-+static bool batadv_tt_local_valid(const void *entry_ptr,
+-+				  const void *data_ptr,
+-+				  u8 *flags)
+- {
+- 	const struct batadv_tt_common_entry *tt_common_entry = entry_ptr;
+- 
+- 	if (tt_common_entry->flags & BATADV_TT_CLIENT_NEW)
+- 		return false;
+-+
+-+	if (flags)
+-+		*flags = tt_common_entry->flags;
+-+
+- 	return true;
+- }
+- 
+-+/**
+-+ * batadv_tt_global_valid() - verify global tt entry and get flags
+-+ * @entry_ptr: to be checked global tt entry
+-+ * @data_ptr: an orig_node object (may be NULL)
+-+ * @flags: a pointer to store TT flags for this client to
+-+ *
+-+ * Checks the validity of the given global TT entry. If it is, then the provided
+-+ * flags pointer is updated either with the common (summed) TT flags if data_ptr
+-+ * is NULL or the specific, per originator TT flags otherwise.
+-+ *
+-+ * Return: true if the entry is a valid, false otherwise.
+-+ */
+- static bool batadv_tt_global_valid(const void *entry_ptr,
+--				   const void *data_ptr)
+-+				   const void *data_ptr,
+-+				   u8 *flags)
+- {
+- 	const struct batadv_tt_common_entry *tt_common_entry = entry_ptr;
+- 	const struct batadv_tt_global_entry *tt_global_entry;
+-@@ -2910,7 +2940,8 @@ static bool batadv_tt_global_valid(const void *entry_ptr,
+- 				       struct batadv_tt_global_entry,
+- 				       common);
+- 
+--	return batadv_tt_global_entry_has_orig(tt_global_entry, orig_node);
+-+	return batadv_tt_global_entry_has_orig(tt_global_entry, orig_node,
+-+					       flags);
+- }
+- 
+- /**
+-@@ -2920,25 +2951,34 @@ static bool batadv_tt_global_valid(const void *entry_ptr,
+-  * @hash: hash table containing the tt entries
+-  * @tt_len: expected tvlv tt data buffer length in number of bytes
+-  * @tvlv_buff: pointer to the buffer to fill with the TT data
+-- * @valid_cb: function to filter tt change entries
+-+ * @valid_cb: function to filter tt change entries and to return TT flags
+-  * @cb_data: data passed to the filter function as argument
+-+ *
+-+ * Fills the tvlv buff with the tt entries from the specified hash. If valid_cb
+-+ * is not provided then this becomes a no-op.
+-  */
+- static void batadv_tt_tvlv_generate(struct batadv_priv *bat_priv,
+- 				    struct batadv_hashtable *hash,
+- 				    void *tvlv_buff, u16 tt_len,
+- 				    bool (*valid_cb)(const void *,
+--						     const void *),
+-+						     const void *,
+-+						     u8 *flags),
+- 				    void *cb_data)
+- {
+- 	struct batadv_tt_common_entry *tt_common_entry;
+- 	struct batadv_tvlv_tt_change *tt_change;
+- 	struct hlist_head *head;
+- 	u16 tt_tot, tt_num_entries = 0;
+-+	u8 flags;
+-+	bool ret;
+- 	u32 i;
+- 
+- 	tt_tot = batadv_tt_entries(tt_len);
+- 	tt_change = (struct batadv_tvlv_tt_change *)tvlv_buff;
+- 
+-+	if (!valid_cb)
+-+		return;
+-+
+- 	rcu_read_lock();
+- 	for (i = 0; i < hash->size; i++) {
+- 		head = &hash->table[i];
+-@@ -2948,11 +2988,12 @@ static void batadv_tt_tvlv_generate(struct batadv_priv *bat_priv,
+- 			if (tt_tot == tt_num_entries)
+- 				break;
+- 
+--			if ((valid_cb) && (!valid_cb(tt_common_entry, cb_data)))
+-+			ret = valid_cb(tt_common_entry, cb_data, &flags);
+-+			if (!ret)
+- 				continue;
+- 
+- 			ether_addr_copy(tt_change->addr, tt_common_entry->addr);
+--			tt_change->flags = tt_common_entry->flags;
+-+			tt_change->flags = flags;
+- 			tt_change->vid = htons(tt_common_entry->vid);
+- 			memset(tt_change->reserved, 0,
+- 			       sizeof(tt_change->reserved));
+diff --git a/batman-adv/patches/0004-Revert-batman-adv-genetlink-make-policy-common-to-fa.patch b/batman-adv/patches/0004-Revert-batman-adv-genetlink-make-policy-common-to-fa.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..a5814e7e9295c2f4c908b3dc2e719f12c4d9d8f3
+--- /dev/null
++++ b/batman-adv/patches/0004-Revert-batman-adv-genetlink-make-policy-common-to-fa.patch
+@@ -0,0 +1,256 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Thu, 23 May 2019 19:26:58 +0200
++Subject: Revert "batman-adv: genetlink: make policy common to family"
++
++OpenWrt's mac80211 package is not yet ready to support the generic netlink
++API of Linux 5.2.
++
++This reverts commit acfc9a214d01695d1676313ca80cfd2d9309f633.
++
++diff --git a/compat-include/linux/cache.h b/compat-include/linux/cache.h
++index 9ddda31232ed4b58efcb57dc2ee99ae82d09d6e2..efe440d11d04a1c3999649ba52058ad82e4d6bea 100644
++--- a/compat-include/linux/cache.h
+++++ b/compat-include/linux/cache.h
++@@ -13,8 +13,12 @@
++ #include <linux/version.h>
++ #include_next <linux/cache.h>
++ 
++-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
++ 
+++/* hack for netlink.c which marked the family ops as ro */
+++#ifdef __ro_after_init
+++#undef __ro_after_init
+++#endif
++ #define __ro_after_init
++ 
++ #endif /* < KERNEL_VERSION(4, 6, 0) */
++diff --git a/compat-include/net/genetlink.h b/compat-include/net/genetlink.h
++index 7d17a705273650355f074788e9220fc4981b0db1..58fc24d7147a7f79c2db1976b36351d294f2aa4c 100644
++--- a/compat-include/net/genetlink.h
+++++ b/compat-include/net/genetlink.h
++@@ -30,92 +30,4 @@ void batadv_genl_dump_check_consistent(struct netlink_callback *cb,
++ 
++ #endif /* < KERNEL_VERSION(4, 15, 0) */
++ 
++-
++-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
++-
++-struct batadv_genl_family {
++-	/* data handled by the actual kernel */
++-	struct genl_family family;
++-
++-	/* data which has to be copied to family by
++-	 * batadv_genl_register_family
++-	 */
++-	unsigned int hdrsize;
++-	char name[GENL_NAMSIZ];
++-	unsigned int version;
++-	unsigned int maxattr;
++-	const struct nla_policy *policy;
++-	bool netnsok;
++-        int  (*pre_doit)(const struct genl_ops *ops, struct sk_buff *skb,
++-			 struct genl_info *info);
++-        void (*post_doit)(const struct genl_ops *ops, struct sk_buff *skb,
++-			  struct genl_info *info);
++-	const struct genl_ops *ops;
++-	const struct genl_multicast_group *mcgrps;
++-	unsigned int n_ops;
++-	unsigned int n_mcgrps;
++-	struct module *module;
++-
++-	/* allocated by batadv_genl_register_family and free'd by
++-	 * batadv_genl_unregister_family. Used to modify the usually read-only
++-	 * ops
++-	 */
++-	struct genl_ops *copy_ops;
++-};
++-
++-#define genl_family batadv_genl_family
++-
++-static inline int batadv_genl_register_family(struct batadv_genl_family *family)
++-{
++-	struct genl_ops *ops;
++-	unsigned int i;
++-
++-	family->family.hdrsize = family->hdrsize;
++-	strncpy(family->family.name, family->name, sizeof(family->family.name));
++-	family->family.version = family->version;
++-	family->family.maxattr = family->maxattr;
++-	family->family.netnsok = family->netnsok;
++-	family->family.pre_doit = family->pre_doit;
++-	family->family.post_doit = family->post_doit;
++-	family->family.mcgrps = family->mcgrps;
++-	family->family.n_ops = family->n_ops;
++-	family->family.n_mcgrps = family->n_mcgrps;
++-	family->family.module = family->module;
++-
++-	ops = kmemdup(family->ops, sizeof(*ops) * family->n_ops, GFP_KERNEL);
++-	if (!ops)
++-		return -ENOMEM;
++-
++-	for (i = 0; i < family->family.n_ops; i++)
++-		ops[i].policy = family->policy;
++-
++-	family->family.ops = ops;
++-	family->copy_ops = ops;
++-
++-	return genl_register_family(&family->family);
++-}
++-
++-#define genl_register_family(family) \
++-	batadv_genl_register_family((family))
++-
++-static inline void
++-batadv_genl_unregister_family(struct batadv_genl_family *family)
++-{
++-
++-	genl_unregister_family(&family->family);
++-	kfree(family->copy_ops);
++-}
++-
++-#define genl_unregister_family(family) \
++-	batadv_genl_unregister_family((family))
++-
++-#define genlmsg_put(_skb, _pid, _seq, _family, _flags, _cmd) \
++-	genlmsg_put(_skb, _pid, _seq, &(_family)->family, _flags, _cmd)
++-
++-#define genlmsg_multicast_netns(_family, _net, _skb, _portid, _group, _flags) \
++-	genlmsg_multicast_netns(&(_family)->family, _net, _skb, _portid, \
++-				_group, _flags)
++-
++-#endif /* < KERNEL_VERSION(5, 2, 0) */
++-
++ #endif /* _NET_BATMAN_ADV_COMPAT_NET_GENETLINK_H_ */
++diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
++index e7907308b331ddc3e4917ff7d648bca27a65536b..daf56933223d478399c63360203bcf283d7686a3 100644
++--- a/net/batman-adv/netlink.c
+++++ b/net/batman-adv/netlink.c
++@@ -1344,29 +1344,34 @@ static const struct genl_ops batadv_netlink_ops[] = {
++ 	{
++ 		.cmd = BATADV_CMD_GET_MESH,
++ 		/* can be retrieved by unprivileged users */
+++		.policy = batadv_netlink_policy,
++ 		.doit = batadv_netlink_get_mesh,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_TP_METER,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.doit = batadv_netlink_tp_meter_start,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_TP_METER_CANCEL,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.doit = batadv_netlink_tp_meter_cancel,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_ROUTING_ALGOS,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_algo_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_HARDIF,
++ 		/* can be retrieved by unprivileged users */
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_netlink_dump_hardif,
++ 		.doit = batadv_netlink_get_hardif,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++@@ -1375,57 +1380,68 @@ static const struct genl_ops batadv_netlink_ops[] = {
++ 	{
++ 		.cmd = BATADV_CMD_GET_TRANSTABLE_LOCAL,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_tt_local_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_TRANSTABLE_GLOBAL,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_tt_global_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_ORIGINATORS,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_orig_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_NEIGHBORS,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_hardif_neigh_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_GATEWAYS,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_gw_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_BLA_CLAIM,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_bla_claim_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_BLA_BACKBONE,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_bla_backbone_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_DAT_CACHE,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_dat_cache_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_MCAST_FLAGS,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.dumpit = batadv_mcast_flags_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_SET_MESH,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.doit = batadv_netlink_set_mesh,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_SET_HARDIF,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.doit = batadv_netlink_set_hardif,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++ 				  BATADV_FLAG_NEED_HARDIF,
++@@ -1433,6 +1449,7 @@ static const struct genl_ops batadv_netlink_ops[] = {
++ 	{
++ 		.cmd = BATADV_CMD_GET_VLAN,
++ 		/* can be retrieved by unprivileged users */
+++		.policy = batadv_netlink_policy,
++ 		.doit = batadv_netlink_get_vlan,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++ 				  BATADV_FLAG_NEED_VLAN,
++@@ -1440,6 +1457,7 @@ static const struct genl_ops batadv_netlink_ops[] = {
++ 	{
++ 		.cmd = BATADV_CMD_SET_VLAN,
++ 		.flags = GENL_ADMIN_PERM,
+++		.policy = batadv_netlink_policy,
++ 		.doit = batadv_netlink_set_vlan,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++ 				  BATADV_FLAG_NEED_VLAN,
++@@ -1451,7 +1469,6 @@ struct genl_family batadv_netlink_family __ro_after_init = {
++ 	.name = BATADV_NL_NAME,
++ 	.version = 1,
++ 	.maxattr = BATADV_ATTR_MAX,
++-	.policy = batadv_netlink_policy,
++ 	.netnsok = true,
++ 	.pre_doit = batadv_pre_doit,
++ 	.post_doit = batadv_post_doit,
+diff --git a/batman-adv/patches/0004-batman-adv-prevent-TT-request-storms-by-not-sending-.patch b/batman-adv/patches/0004-batman-adv-prevent-TT-request-storms-by-not-sending-.patch
+deleted file mode 100644
+index 9bf5fd920ba6d258d2c6c046053e65171055d56a..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0004-batman-adv-prevent-TT-request-storms-by-not-sending-.patch
++++ /dev/null
+@@ -1,73 +0,0 @@
+-From: Marek Lindner <mareklindner@neomailbox.ch>
+-Date: Sat, 12 May 2018 00:23:07 +0800
+-Subject: batman-adv: prevent TT request storms by not sending inconsistent TT TLVLs
+-
+-A translation table TVLV changset sent with an OGM consists
+-of a number of headers (one per VLAN) plus the changeset
+-itself (addition and/or deletion of entries).
+-
+-The per-VLAN headers are used by OGM recipients for consistency
+-checks. Said consistency check might determine that a full
+-translation table request is needed to restore consistency. If
+-the TT sender adds per-VLAN headers of empty VLANs into the OGM,
+-recipients are led to believe to have reached an inconsistent
+-state and thus request a full table update. The full table does
+-not contain empty VLANs (due to missing entries) the cycle
+-restarts when the next OGM is issued.
+-
+-Consequently, when the translation table TVLV headers are
+-composed, empty VLANs are to be excluded.
+-
+-Fixes: 21a57f6e7a3b ("batman-adv: make the TT CRC logic VLAN specific")
+-Signed-off-by: Marek Lindner <mareklindner@neomailbox.ch>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/e4687b4be274da6180fc15b327419851fb681ec9
+-
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index 09bc1ed9fb59c1f76a4227f158d3ac8b73cbd32b..dfd484d73f8e569bc60e153ea6ca244ea5757d5c 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -931,15 +931,20 @@ batadv_tt_prepare_tvlv_local_data(struct batadv_priv *bat_priv,
+- 	struct batadv_tvlv_tt_vlan_data *tt_vlan;
+- 	struct batadv_softif_vlan *vlan;
+- 	u16 num_vlan = 0;
+--	u16 num_entries = 0;
+-+	u16 vlan_entries = 0;
+-+	u16 total_entries = 0;
+- 	u16 tvlv_len;
+- 	u8 *tt_change_ptr;
+- 	int change_offset;
+- 
+- 	spin_lock_bh(&bat_priv->softif_vlan_list_lock);
+- 	hlist_for_each_entry_rcu(vlan, &bat_priv->softif_vlan_list, list) {
+-+		vlan_entries = atomic_read(&vlan->tt.num_entries);
+-+		if (vlan_entries < 1)
+-+			continue;
+-+
+- 		num_vlan++;
+--		num_entries += atomic_read(&vlan->tt.num_entries);
+-+		total_entries += vlan_entries;
+- 	}
+- 
+- 	change_offset = sizeof(**tt_data);
+-@@ -947,7 +952,7 @@ batadv_tt_prepare_tvlv_local_data(struct batadv_priv *bat_priv,
+- 
+- 	/* if tt_len is negative, allocate the space needed by the full table */
+- 	if (*tt_len < 0)
+--		*tt_len = batadv_tt_len(num_entries);
+-+		*tt_len = batadv_tt_len(total_entries);
+- 
+- 	tvlv_len = *tt_len;
+- 	tvlv_len += change_offset;
+-@@ -964,6 +969,10 @@ batadv_tt_prepare_tvlv_local_data(struct batadv_priv *bat_priv,
+- 
+- 	tt_vlan = (struct batadv_tvlv_tt_vlan_data *)(*tt_data + 1);
+- 	hlist_for_each_entry_rcu(vlan, &bat_priv->softif_vlan_list, list) {
+-+		vlan_entries = atomic_read(&vlan->tt.num_entries);
+-+		if (vlan_entries < 1)
+-+			continue;
+-+
+- 		tt_vlan->vid = htons(vlan->vid);
+- 		tt_vlan->crc = htonl(vlan->tt.crc);
+- 
+diff --git a/batman-adv/patches/0005-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch b/batman-adv/patches/0005-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..2fc0e196b60f135ac81fe96ce930b52a0c746723
+--- /dev/null
++++ b/batman-adv/patches/0005-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch
+@@ -0,0 +1,77 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Sun, 2 Jun 2019 10:57:31 +0200
++Subject: batman-adv: Fix duplicated OGMs on NETDEV_UP
++
++The state of slave interfaces are handled differently depending on whether
++the interface is up or not. All active interfaces (IFF_UP) will transmit
++OGMs. But for B.A.T.M.A.N. IV, also non-active interfaces are scheduling
++(low TTL) OGMs on active interfaces. The code which setups and schedules
++the OGMs must therefore already be called when the interfaces gets added as
++slave interface and the transmit function must then check whether it has to
++send out the OGM or not on the specific slave interface.
++
++But the commit 0d8468553c3c ("batman-adv: remove ogm_emit and ogm_schedule
++API calls") moved the setup code from the enable function to the activate
++function. The latter is called either when the added slave was already up
++when batadv_hardif_enable_interface processed the new interface or when a
++NETDEV_UP event was received for this slave interfac. As result, each
++NETDEV_UP would schedule a new OGM worker for the interface and thus OGMs
++would be send a lot more than expected.
++
++Fixes: 0d8468553c3c ("batman-adv: remove ogm_emit and ogm_schedule API calls")
++Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
++Signed-off-by: Sven Eckelmann <sven@narfation.org>
++
++Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/c92331e0df3c0c5645ee5a897eb018c5da5e4aa5
++
++diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
++index bd4138ddf7e09a0020d9842d603dc98f21e225c7..240ed70912d6a014c0a48280741989133034396c 100644
++--- a/net/batman-adv/bat_iv_ogm.c
+++++ b/net/batman-adv/bat_iv_ogm.c
++@@ -2337,7 +2337,7 @@ batadv_iv_ogm_neigh_is_sob(struct batadv_neigh_node *neigh1,
++ 	return ret;
++ }
++ 
++-static void batadv_iv_iface_activate(struct batadv_hard_iface *hard_iface)
+++static void batadv_iv_iface_enabled(struct batadv_hard_iface *hard_iface)
++ {
++ 	/* begin scheduling originator messages on that interface */
++ 	batadv_iv_ogm_schedule(hard_iface);
++@@ -2683,8 +2683,8 @@ static void batadv_iv_gw_dump(struct sk_buff *msg, struct netlink_callback *cb,
++ static struct batadv_algo_ops batadv_batman_iv __read_mostly = {
++ 	.name = "BATMAN_IV",
++ 	.iface = {
++-		.activate = batadv_iv_iface_activate,
++ 		.enable = batadv_iv_ogm_iface_enable,
+++		.enabled = batadv_iv_iface_enabled,
++ 		.disable = batadv_iv_ogm_iface_disable,
++ 		.update_mac = batadv_iv_ogm_iface_update_mac,
++ 		.primary_set = batadv_iv_ogm_primary_iface_set,
++diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
++index 79d1731b83066c60f9aef958d2bc343233bce67a..3719cfd026f04093f5d86ffe1b41a41849b2af62 100644
++--- a/net/batman-adv/hard-interface.c
+++++ b/net/batman-adv/hard-interface.c
++@@ -795,6 +795,9 @@ int batadv_hardif_enable_interface(struct batadv_hard_iface *hard_iface,
++ 
++ 	batadv_hardif_recalc_extra_skbroom(soft_iface);
++ 
+++	if (bat_priv->algo_ops->iface.enabled)
+++		bat_priv->algo_ops->iface.enabled(hard_iface);
+++
++ out:
++ 	return 0;
++ 
++diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
++index 74b644738a36bfe063eef6df016278b45a1a0256..e0b25104cbfa9f715df364658621c29faa7ad637 100644
++--- a/net/batman-adv/types.h
+++++ b/net/batman-adv/types.h
++@@ -2129,6 +2129,9 @@ struct batadv_algo_iface_ops {
++ 	/** @enable: init routing info when hard-interface is enabled */
++ 	int (*enable)(struct batadv_hard_iface *hard_iface);
++ 
+++	/** @enabled: notification when hard-interface was enabled (optional) */
+++	void (*enabled)(struct batadv_hard_iface *hard_iface);
+++
++ 	/** @disable: de-init routing info when hard-interface is disabled */
++ 	void (*disable)(struct batadv_hard_iface *hard_iface);
++ 
+diff --git a/batman-adv/patches/0005-batman-adv-don-t-implement-skb_postpush_rcsum-for-li.patch b/batman-adv/patches/0005-batman-adv-don-t-implement-skb_postpush_rcsum-for-li.patch
+deleted file mode 100644
+index 40ce242021fde4a8a5fd69c48c8c2c82737426f2..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0005-batman-adv-don-t-implement-skb_postpush_rcsum-for-li.patch
++++ /dev/null
+@@ -1,26 +0,0 @@
+-From: Antonio Quartulli <a@unstable.cc>
+-Date: Sat, 12 May 2018 03:02:44 +0800
+-Subject: batman-adv: don't implement skb_postpush_rcsum() for linux >=4.4.47
+-
+-skb_postpush_rcsum() has been implemented in 4.4.47 therefore
+-our compat code has to be changed to prevent this function to
+-be implemented when using those kernels.
+-
+-Signed-off-by: Antonio Quartulli <a@unstable.cc>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/b4693d107e0869bf11956fd2d3be4fd0a8671b46
+-
+-diff --git a/compat-include/linux/skbuff.h b/compat-include/linux/skbuff.h
+-index 6f73946496ac15f2fdb856357f16e4e2d8a6e6cd..371bb561eecaf605a5c96f9417546f6bb817724d 100644
+---- a/compat-include/linux/skbuff.h
+-+++ b/compat-include/linux/skbuff.h
+-@@ -77,7 +77,7 @@ struct sk_buff *skb_checksum_trimmed(struct sk_buff *skb,
+- 
+- #endif /* < KERNEL_VERSION(4, 2, 0) */
+- 
+--#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+-+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 4, 47)
+- 
+- static inline void skb_postpush_rcsum(struct sk_buff *skb,
+- 				      const void *start, unsigned int len)
+diff --git a/batman-adv/patches/0006-batman-adv-Fix-bat_ogm_iv-best-gw-refcnt-after-netli.patch b/batman-adv/patches/0006-batman-adv-Fix-bat_ogm_iv-best-gw-refcnt-after-netli.patch
+deleted file mode 100644
+index 5a827bcc0be9330e83b1d9551cd8f0ac50d48c4c..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0006-batman-adv-Fix-bat_ogm_iv-best-gw-refcnt-after-netli.patch
++++ /dev/null
+@@ -1,44 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sat, 2 Jun 2018 17:26:34 +0200
+-Subject: batman-adv: Fix bat_ogm_iv best gw refcnt after netlink dump
+-
+-A reference for the best gateway is taken when the list of gateways in the
+-mesh is sent via netlink. This is necessary to check whether the currently
+-dumped entry is the currently selected gateway or not. This information is
+-then transferred as flag BATADV_ATTR_FLAG_BEST.
+-
+-After the comparison of the current entry is done,
+-batadv_iv_gw_dump_entry() has to decrease the reference counter again.
+-Otherwise the reference will be held and thus prevents a proper shutdown of
+-the batman-adv interfaces (and some of the interfaces enslaved in it).
+-
+-Fixes: fa3228924152 ("batman-adv: add B.A.T.M.A.N. IV bat_gw_dump implementations")
+-Reported-by: Andreas Ziegler <dev@andreas-ziegler.de>
+-Tested-by: Andreas Ziegler <dev@andreas-ziegler.de>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Marek Lindner <mareklindner@neomailbox.ch>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/46360d203c627e71a27d1f8f551c819c7f2353fd
+-
+-diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
+-index be09a98838252f4f0c23cec0625930cf896cd0ff..73bf6a93a3cf1141a34657bf1284893199e04db9 100644
+---- a/net/batman-adv/bat_iv_ogm.c
+-+++ b/net/batman-adv/bat_iv_ogm.c
+-@@ -2732,7 +2732,7 @@ static int batadv_iv_gw_dump_entry(struct sk_buff *msg, u32 portid, u32 seq,
+- {
+- 	struct batadv_neigh_ifinfo *router_ifinfo = NULL;
+- 	struct batadv_neigh_node *router;
+--	struct batadv_gw_node *curr_gw;
+-+	struct batadv_gw_node *curr_gw = NULL;
+- 	int ret = 0;
+- 	void *hdr;
+- 
+-@@ -2780,6 +2780,8 @@ static int batadv_iv_gw_dump_entry(struct sk_buff *msg, u32 portid, u32 seq,
+- 	ret = 0;
+- 
+- out:
+-+	if (curr_gw)
+-+		batadv_gw_node_put(curr_gw);
+- 	if (router_ifinfo)
+- 		batadv_neigh_ifinfo_put(router_ifinfo);
+- 	if (router)
+diff --git a/batman-adv/patches/0007-batman-adv-Fix-bat_v-best-gw-refcnt-after-netlink-du.patch b/batman-adv/patches/0007-batman-adv-Fix-bat_v-best-gw-refcnt-after-netlink-du.patch
+deleted file mode 100644
+index 4f957198ad62816ee8aa7eee59b3b3141fa3610c..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0007-batman-adv-Fix-bat_v-best-gw-refcnt-after-netlink-du.patch
++++ /dev/null
+@@ -1,42 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sat, 2 Jun 2018 17:26:35 +0200
+-Subject: batman-adv: Fix bat_v best gw refcnt after netlink dump
+-
+-A reference for the best gateway is taken when the list of gateways in the
+-mesh is sent via netlink. This is necessary to check whether the currently
+-dumped entry is the currently selected gateway or not. This information is
+-then transferred as flag BATADV_ATTR_FLAG_BEST.
+-
+-After the comparison of the current entry is done,
+-batadv_v_gw_dump_entry() has to decrease the reference counter again.
+-Otherwise the reference will be held and thus prevents a proper shutdown of
+-the batman-adv interfaces (and some of the interfaces enslaved in it).
+-
+-Fixes: 15315a94ad98 ("batman-adv: add B.A.T.M.A.N. V bat_gw_dump implementations")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Marek Lindner <mareklindner@neomailbox.ch>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/2b422b5808183d1084b450b89d9a085a13dd6d2c
+-
+-diff --git a/net/batman-adv/bat_v.c b/net/batman-adv/bat_v.c
+-index ec93337ee2597738e46b87dd72724d5becf3f48e..6baec4e68898c6e992e7522d2ee8c78ce62a1b08 100644
+---- a/net/batman-adv/bat_v.c
+-+++ b/net/batman-adv/bat_v.c
+-@@ -927,7 +927,7 @@ static int batadv_v_gw_dump_entry(struct sk_buff *msg, u32 portid, u32 seq,
+- {
+- 	struct batadv_neigh_ifinfo *router_ifinfo = NULL;
+- 	struct batadv_neigh_node *router;
+--	struct batadv_gw_node *curr_gw;
+-+	struct batadv_gw_node *curr_gw = NULL;
+- 	int ret = 0;
+- 	void *hdr;
+- 
+-@@ -995,6 +995,8 @@ static int batadv_v_gw_dump_entry(struct sk_buff *msg, u32 portid, u32 seq,
+- 	ret = 0;
+- 
+- out:
+-+	if (curr_gw)
+-+		batadv_gw_node_put(curr_gw);
+- 	if (router_ifinfo)
+- 		batadv_neigh_ifinfo_put(router_ifinfo);
+- 	if (router)
+diff --git a/batman-adv/patches/0008-batman-adv-Fix-debugfs-path-for-renamed-hardif.patch b/batman-adv/patches/0008-batman-adv-Fix-debugfs-path-for-renamed-hardif.patch
+deleted file mode 100644
+index 8bd8349a081b250966c39a0adcf18f08252825d8..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0008-batman-adv-Fix-debugfs-path-for-renamed-hardif.patch
++++ /dev/null
+@@ -1,106 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Fri, 1 Jun 2018 19:24:23 +0200
+-Subject: batman-adv: Fix debugfs path for renamed hardif
+-
+-batman-adv is creating special debugfs directories in the init
+-net_namespace for each valid hard-interface (net_device). But it is
+-possible to rename a net_device to a completely different name then the
+-original one.
+-
+-It can therefore happen that a user registers a new net_device which gets
+-the name "wlan0" assigned by default. batman-adv is also adding a new
+-directory under $debugfs/batman-adv/ with the name "wlan0".
+-
+-The user then decides to rename this device to "wl_pri" and registers a
+-different device. The kernel may now decide to use the name "wlan0" again
+-for this new device. batman-adv will detect it as a valid net_device and
+-tries to create a directory with the name "wlan0" under
+-$debugfs/batman-adv/. But there already exists one with this name under
+-this path and thus this fails. batman-adv will detect a problem and
+-rollback the registering of this device.
+-
+-batman-adv must therefore take care of renaming the debugfs directories
+-for hard-interfaces whenever it detects such a net_device rename.
+-
+-Fixes: 3c926a01c8e8 ("batman-adv: add debugfs structure for information per interface")
+-Reported-by: John Soros <sorosj@gmail.com>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/127086f503f6495518b95455efebee33d328f335
+-
+-diff --git a/net/batman-adv/debugfs.c b/net/batman-adv/debugfs.c
+-index 4229b01ac7b54008e023df0ed6546a6d541498ba..7e5de7b9f6d53b846cebfa95bf694a20c640b2d6 100644
+---- a/net/batman-adv/debugfs.c
+-+++ b/net/batman-adv/debugfs.c
+-@@ -19,6 +19,7 @@
+- #include "debugfs.h"
+- #include "main.h"
+- 
+-+#include <linux/dcache.h>
+- #include <linux/debugfs.h>
+- #include <linux/err.h>
+- #include <linux/errno.h>
+-@@ -343,6 +344,25 @@ int batadv_debugfs_add_hardif(struct batadv_hard_iface *hard_iface)
+- 	return -ENOMEM;
+- }
+- 
+-+/**
+-+ * batadv_debugfs_rename_hardif() - Fix debugfs path for renamed hardif
+-+ * @hard_iface: hard interface which was renamed
+-+ */
+-+void batadv_debugfs_rename_hardif(struct batadv_hard_iface *hard_iface)
+-+{
+-+	const char *name = hard_iface->net_dev->name;
+-+	struct dentry *dir;
+-+	struct dentry *d;
+-+
+-+	dir = hard_iface->debug_dir;
+-+	if (!dir)
+-+		return;
+-+
+-+	d = debugfs_rename(dir->d_parent, dir, dir->d_parent, name);
+-+	if (!d)
+-+		pr_err("Can't rename debugfs dir to %s\n", name);
+-+}
+-+
+- /**
+-  * batadv_debugfs_del_hardif() - delete the base directory for a hard interface
+-  *  in debugfs.
+-diff --git a/net/batman-adv/debugfs.h b/net/batman-adv/debugfs.h
+-index 37b069698b04b369e68e4e8a31c3ac01575b0178..8538a7a75e937f50f8efdbf2fe879b4ac8dafadb 100644
+---- a/net/batman-adv/debugfs.h
+-+++ b/net/batman-adv/debugfs.h
+-@@ -32,6 +32,7 @@ void batadv_debugfs_destroy(void);
+- int batadv_debugfs_add_meshif(struct net_device *dev);
+- void batadv_debugfs_del_meshif(struct net_device *dev);
+- int batadv_debugfs_add_hardif(struct batadv_hard_iface *hard_iface);
+-+void batadv_debugfs_rename_hardif(struct batadv_hard_iface *hard_iface);
+- void batadv_debugfs_del_hardif(struct batadv_hard_iface *hard_iface);
+- 
+- #else
+-@@ -59,6 +60,11 @@ int batadv_debugfs_add_hardif(struct batadv_hard_iface *hard_iface)
+- 	return 0;
+- }
+- 
+-+static inline
+-+void batadv_debugfs_rename_hardif(struct batadv_hard_iface *hard_iface)
+-+{
+-+}
+-+
+- static inline
+- void batadv_debugfs_del_hardif(struct batadv_hard_iface *hard_iface)
+- {
+-diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+-index c405d15befd60bdabf9f50813c3bee446238d539..dc2763b1110727cc5dee62d555dd7c7b50f3b463 100644
+---- a/net/batman-adv/hard-interface.c
+-+++ b/net/batman-adv/hard-interface.c
+-@@ -1051,6 +1051,9 @@ static int batadv_hard_if_event(struct notifier_block *this,
+- 		if (batadv_is_wifi_hardif(hard_iface))
+- 			hard_iface->num_bcasts = BATADV_NUM_BCASTS_WIRELESS;
+- 		break;
+-+	case NETDEV_CHANGENAME:
+-+		batadv_debugfs_rename_hardif(hard_iface);
+-+		break;
+- 	default:
+- 		break;
+- 	}
+diff --git a/batman-adv/patches/0009-batman-adv-Fix-debugfs-path-for-renamed-softif.patch b/batman-adv/patches/0009-batman-adv-Fix-debugfs-path-for-renamed-softif.patch
+deleted file mode 100644
+index 40ea64866ebf2078ecf86ad6bf988361c98c7305..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0009-batman-adv-Fix-debugfs-path-for-renamed-softif.patch
++++ /dev/null
+@@ -1,134 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Fri, 1 Jun 2018 19:24:24 +0200
+-Subject: batman-adv: Fix debugfs path for renamed softif
+-
+-batman-adv is creating special debugfs directories in the init
+-net_namespace for each created soft-interface (batadv net_device). But it
+-is possible to rename a net_device to a completely different name then the
+-original one.
+-
+-It can therefore happen that a user registers a new batadv net_device with
+-the name "bat0". batman-adv is then also adding a new directory under
+-$debugfs/batman-adv/ with the name "wlan0".
+-
+-The user then decides to rename this device to "bat1" and registers a
+-different batadv device with the name "bat0". batman-adv will then try to
+-create a directory with the name "bat0" under $debugfs/batman-adv/ again.
+-But there already exists one with this name under this path and thus this
+-fails. batman-adv will detect a problem and rollback the registering of
+-this device.
+-
+-batman-adv must therefore take care of renaming the debugfs directories for
+-soft-interfaces whenever it detects such a net_device rename.
+-
+-Fixes: 230202d4b530 ("batman-adv: Move device for icmp injection to debugfs")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/3f2237bb191cd17654a4d5a5badfd6e7379c4b37
+-
+-diff --git a/net/batman-adv/debugfs.c b/net/batman-adv/debugfs.c
+-index 7e5de7b9f6d53b846cebfa95bf694a20c640b2d6..87479c60670ebfbe2ad3df17130f1289d657df7b 100644
+---- a/net/batman-adv/debugfs.c
+-+++ b/net/batman-adv/debugfs.c
+-@@ -433,6 +433,26 @@ int batadv_debugfs_add_meshif(struct net_device *dev)
+- 	return -ENOMEM;
+- }
+- 
+-+/**
+-+ * batadv_debugfs_rename_meshif() - Fix debugfs path for renamed softif
+-+ * @dev: net_device which was renamed
+-+ */
+-+void batadv_debugfs_rename_meshif(struct net_device *dev)
+-+{
+-+	struct batadv_priv *bat_priv = netdev_priv(dev);
+-+	const char *name = dev->name;
+-+	struct dentry *dir;
+-+	struct dentry *d;
+-+
+-+	dir = bat_priv->debug_dir;
+-+	if (!dir)
+-+		return;
+-+
+-+	d = debugfs_rename(dir->d_parent, dir, dir->d_parent, name);
+-+	if (!d)
+-+		pr_err("Can't rename debugfs dir to %s\n", name);
+-+}
+-+
+- /**
+-  * batadv_debugfs_del_meshif() - Remove interface dependent debugfs entries
+-  * @dev: netdev struct of the soft interface
+-diff --git a/net/batman-adv/debugfs.h b/net/batman-adv/debugfs.h
+-index 8538a7a75e937f50f8efdbf2fe879b4ac8dafadb..08a592ffbee5203ac4994fc49bf9c187c2e66f8e 100644
+---- a/net/batman-adv/debugfs.h
+-+++ b/net/batman-adv/debugfs.h
+-@@ -30,6 +30,7 @@ struct net_device;
+- void batadv_debugfs_init(void);
+- void batadv_debugfs_destroy(void);
+- int batadv_debugfs_add_meshif(struct net_device *dev);
+-+void batadv_debugfs_rename_meshif(struct net_device *dev);
+- void batadv_debugfs_del_meshif(struct net_device *dev);
+- int batadv_debugfs_add_hardif(struct batadv_hard_iface *hard_iface);
+- void batadv_debugfs_rename_hardif(struct batadv_hard_iface *hard_iface);
+-@@ -50,6 +51,10 @@ static inline int batadv_debugfs_add_meshif(struct net_device *dev)
+- 	return 0;
+- }
+- 
+-+static inline void batadv_debugfs_rename_meshif(struct net_device *dev)
+-+{
+-+}
+-+
+- static inline void batadv_debugfs_del_meshif(struct net_device *dev)
+- {
+- }
+-diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+-index dc2763b1110727cc5dee62d555dd7c7b50f3b463..2f0d42f2f913e74cf10c0c6ce89320434994cac5 100644
+---- a/net/batman-adv/hard-interface.c
+-+++ b/net/batman-adv/hard-interface.c
+-@@ -989,6 +989,32 @@ void batadv_hardif_remove_interfaces(void)
+- 	rtnl_unlock();
+- }
+- 
+-+/**
+-+ * batadv_hard_if_event_softif() - Handle events for soft interfaces
+-+ * @event: NETDEV_* event to handle
+-+ * @net_dev: net_device which generated an event
+-+ *
+-+ * Return: NOTIFY_* result
+-+ */
+-+static int batadv_hard_if_event_softif(unsigned long event,
+-+				       struct net_device *net_dev)
+-+{
+-+	struct batadv_priv *bat_priv;
+-+
+-+	switch (event) {
+-+	case NETDEV_REGISTER:
+-+		batadv_sysfs_add_meshif(net_dev);
+-+		bat_priv = netdev_priv(net_dev);
+-+		batadv_softif_create_vlan(bat_priv, BATADV_NO_FLAGS);
+-+		break;
+-+	case NETDEV_CHANGENAME:
+-+		batadv_debugfs_rename_meshif(net_dev);
+-+		break;
+-+	}
+-+
+-+	return NOTIFY_DONE;
+-+}
+-+
+- static int batadv_hard_if_event(struct notifier_block *this,
+- 				unsigned long event, void *ptr)
+- {
+-@@ -997,12 +1023,8 @@ static int batadv_hard_if_event(struct notifier_block *this,
+- 	struct batadv_hard_iface *primary_if = NULL;
+- 	struct batadv_priv *bat_priv;
+- 
+--	if (batadv_softif_is_valid(net_dev) && event == NETDEV_REGISTER) {
+--		batadv_sysfs_add_meshif(net_dev);
+--		bat_priv = netdev_priv(net_dev);
+--		batadv_softif_create_vlan(bat_priv, BATADV_NO_FLAGS);
+--		return NOTIFY_DONE;
+--	}
+-+	if (batadv_softif_is_valid(net_dev))
+-+		return batadv_hard_if_event_softif(event, net_dev);
+- 
+- 	hard_iface = batadv_hardif_get_by_netdev(net_dev);
+- 	if (!hard_iface && (event == NETDEV_REGISTER ||
+diff --git a/batman-adv/patches/0010-batman-adv-Avoid-storing-non-TT-sync-flags-on-singul.patch b/batman-adv/patches/0010-batman-adv-Avoid-storing-non-TT-sync-flags-on-singul.patch
+deleted file mode 100644
+index e086b152088bc101dc68f7d34b6a4f54c716e54b..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0010-batman-adv-Avoid-storing-non-TT-sync-flags-on-singul.patch
++++ /dev/null
+@@ -1,34 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Thu, 7 Jun 2018 00:46:23 +0200
+-Subject: batman-adv: Avoid storing non-TT-sync flags on singular entries too
+-
+-Since commit 382d020fe3fa ("batman-adv: fix TT sync flag inconsistencies")
+-TT sync flags and TT non-sync'd flags are supposed to be stored
+-separately.
+-
+-The previous patch missed to apply this separation on a TT entry with
+-only a single TT orig entry.
+-
+-This is a minor fix because with only a single TT orig entry the DDoS
+-issue the former patch solves does not apply.
+-
+-Fixes: 382d020fe3fa ("batman-adv: fix TT sync flag inconsistencies")
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/beb6246b2339852b6a429ae9259a8eb30a685041
+-
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index dfd484d73f8e569bc60e153ea6ca244ea5757d5c..8b0f30457a2eda3c0791da9c8876fc1768170d76 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -1705,7 +1705,8 @@ static bool batadv_tt_global_add(struct batadv_priv *bat_priv,
+- 		ether_addr_copy(common->addr, tt_addr);
+- 		common->vid = vid;
+- 
+--		common->flags = flags;
+-+		common->flags = flags & (~BATADV_TT_SYNC_MASK);
+-+
+- 		tt_global_entry->roam_at = 0;
+- 		/* node must store current time in case of roaming. This is
+- 		 * needed to purge this entry out on timeout (if nobody claims
+diff --git a/batman-adv/patches/0011-batman-adv-Fix-multicast-TT-issues-with-bogus-ROAM-f.patch b/batman-adv/patches/0011-batman-adv-Fix-multicast-TT-issues-with-bogus-ROAM-f.patch
+deleted file mode 100644
+index 8b06596a2aa9768f243aff8ca2a04531fc7c0f29..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0011-batman-adv-Fix-multicast-TT-issues-with-bogus-ROAM-f.patch
++++ /dev/null
+@@ -1,43 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Thu, 7 Jun 2018 00:46:24 +0200
+-Subject: batman-adv: Fix multicast TT issues with bogus ROAM flags
+-
+-When a (broken) node wrongly sends multicast TT entries with a ROAM
+-flag then this causes any receiving node to drop all entries for the
+-same multicast MAC address announced by other nodes, leading to
+-packet loss.
+-
+-Fix this DoS vector by only storing TT sync flags. For multicast TT
+-non-sync'ing flag bits like ROAM are unused so far anyway.
+-
+-Fixes: 405cc1e5a81e ("batman-adv: Modified forwarding behaviour for multicast packets")
+-Reported-by: Leonardo Mörlein <me@irrelefant.net>
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/c7054ffae0c3b08bb4bef3cffee1e0a543e14096
+-
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index 8b0f30457a2eda3c0791da9c8876fc1768170d76..9efbdd6348c4d69c525b3e0574d2b24db838c086 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -1705,7 +1705,8 @@ static bool batadv_tt_global_add(struct batadv_priv *bat_priv,
+- 		ether_addr_copy(common->addr, tt_addr);
+- 		common->vid = vid;
+- 
+--		common->flags = flags & (~BATADV_TT_SYNC_MASK);
+-+		if (!is_multicast_ether_addr(common->addr))
+-+			common->flags = flags & (~BATADV_TT_SYNC_MASK);
+- 
+- 		tt_global_entry->roam_at = 0;
+- 		/* node must store current time in case of roaming. This is
+-@@ -1769,7 +1770,8 @@ static bool batadv_tt_global_add(struct batadv_priv *bat_priv,
+- 		 * TT_CLIENT_TEMP, therefore they have to be copied in the
+- 		 * client entry
+- 		 */
+--		common->flags |= flags & (~BATADV_TT_SYNC_MASK);
+-+		if (!is_multicast_ether_addr(common->addr))
+-+			common->flags |= flags & (~BATADV_TT_SYNC_MASK);
+- 
+- 		/* If there is the BATADV_TT_CLIENT_ROAM flag set, there is only
+- 		 * one originator left in the list and we previously received a
+diff --git a/batman-adv/patches/0012-batman-adv-Avoid-probe-ELP-information-leak.patch b/batman-adv/patches/0012-batman-adv-Avoid-probe-ELP-information-leak.patch
+deleted file mode 100644
+index b58de4d59b5362a32876b8283c07adcd7bb5f607..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0012-batman-adv-Avoid-probe-ELP-information-leak.patch
++++ /dev/null
+@@ -1,32 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Fri, 31 Aug 2018 15:08:44 +0200
+-Subject: batman-adv: Avoid probe ELP information leak
+-
+-The probe ELPs for WiFi interfaces are expanded to contain at least
+-BATADV_ELP_MIN_PROBE_SIZE bytes. This is usually a lot more than the
+-number of bytes which the template ELP packet requires.
+-
+-These extra padding bytes were not initialized and thus could contain data
+-which were previously stored at the same location. It is therefore required
+-to set it to some predefined or random values to avoid leaking private
+-information from the system transmitting these kind of packets.
+-
+-Fixes: bedcadfaa92b ("batman-adv: ELP - send unicast ELP packets for throughput sampling")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Antonio Quartulli <a@unstable.cc>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/6c876e572f592c31132a55b5fb8427e168e5fb3c
+-
+-diff --git a/net/batman-adv/bat_v_elp.c b/net/batman-adv/bat_v_elp.c
+-index 28687493599f5ba10b8813c18d803582210bc292..371028f82a0669e86155fee39ba955cbbde48e60 100644
+---- a/net/batman-adv/bat_v_elp.c
+-+++ b/net/batman-adv/bat_v_elp.c
+-@@ -228,7 +228,7 @@ batadv_v_elp_wifi_neigh_probe(struct batadv_hardif_neigh_node *neigh)
+- 		 * the packet to be exactly of that size to make the link
+- 		 * throughput estimation effective.
+- 		 */
+--		skb_put(skb, probe_len - hard_iface->bat_v.elp_skb->len);
+-+		skb_put_zero(skb, probe_len - hard_iface->bat_v.elp_skb->len);
+- 
+- 		batadv_dbg(BATADV_DBG_BATMAN, bat_priv,
+- 			   "Sending unicast (probe) ELP packet on interface %s to %pM\n",
+diff --git a/batman-adv/patches/0013-batman-adv-Fix-segfault-when-writing-to-throughput_o.patch b/batman-adv/patches/0013-batman-adv-Fix-segfault-when-writing-to-throughput_o.patch
+deleted file mode 100644
+index 2e3deb92562ad56f68745475a316a967798037f1..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0013-batman-adv-Fix-segfault-when-writing-to-throughput_o.patch
++++ /dev/null
+@@ -1,42 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Fri, 31 Aug 2018 16:46:47 +0200
+-Subject: batman-adv: Fix segfault when writing to throughput_override
+-
+-The per hardif sysfs file "batman_adv/throughput_override" prints the
+-resulting change as info text when the users writes to this file. It uses
+-the helper function batadv_info to add it at the same time to the kernel
+-ring buffer and to the batman-adv debug log (when CONFIG_BATMAN_ADV_DEBUG
+-is enabled).
+-
+-The function batadv_info requires as first parameter the batman-adv softif
+-net_device. This parameter is then used to find the private buffer which
+-contains the debug log for this batman-adv interface. But
+-batadv_store_throughput_override used as first argument the slave
+-net_device. This slave device doesn't have the batadv_priv private data
+-which is access by batadv_info.
+-
+-Writing to this file with CONFIG_BATMAN_ADV_DEBUG enabled can either lead
+-to a segfault or to memory corruption.
+-
+-Fixes: c513176e4b7a ("batman-adv: add throughput override attribute to hard_ifaces")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Marek Lindner <mareklindner@neomailbox.ch>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/ddf99b78e255530cbadc0f67656a549e19520280
+-
+-diff --git a/net/batman-adv/sysfs.c b/net/batman-adv/sysfs.c
+-index f2eef43bd2ec5b798ba552ff14eedcfa734b39d6..3a76e8970c025ca6917d6cd15d1382f685cd3532 100644
+---- a/net/batman-adv/sysfs.c
+-+++ b/net/batman-adv/sysfs.c
+-@@ -1090,8 +1090,9 @@ static ssize_t batadv_store_throughput_override(struct kobject *kobj,
+- 	if (old_tp_override == tp_override)
+- 		goto out;
+- 
+--	batadv_info(net_dev, "%s: Changing from: %u.%u MBit to: %u.%u MBit\n",
+--		    "throughput_override",
+-+	batadv_info(hard_iface->soft_iface,
+-+		    "%s: %s: Changing from: %u.%u MBit to: %u.%u MBit\n",
+-+		    "throughput_override", net_dev->name,
+- 		    old_tp_override / 10, old_tp_override % 10,
+- 		    tp_override / 10, tp_override % 10);
+- 
+diff --git a/batman-adv/patches/0014-batman-adv-Fix-segfault-when-writing-to-sysfs-elp_in.patch b/batman-adv/patches/0014-batman-adv-Fix-segfault-when-writing-to-sysfs-elp_in.patch
+deleted file mode 100644
+index aaf9145bd722cb865be4180fdb7becbf3d5df07d..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0014-batman-adv-Fix-segfault-when-writing-to-sysfs-elp_in.patch
++++ /dev/null
+@@ -1,105 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Fri, 31 Aug 2018 16:56:29 +0200
+-Subject: batman-adv: Fix segfault when writing to sysfs elp_interval
+-
+-The per hardif sysfs file "batman_adv/elp_interval" is using the generic
+-functions to store/show uint values. The helper __batadv_store_uint_attr
+-requires the softif net_device as parameter to print the resulting change
+-as info text when the users writes to this file. It uses the helper
+-function batadv_info to add it at the same time to the kernel ring buffer
+-and to the batman-adv debug log (when CONFIG_BATMAN_ADV_DEBUG is enabled).
+-
+-The function batadv_info requires as first parameter the batman-adv softif
+-net_device. This parameter is then used to find the private buffer which
+-contains the debug log for this batman-adv interface. But
+-batadv_store_throughput_override used as first argument the slave
+-net_device. This slave device doesn't have the batadv_priv private data
+-which is access by batadv_info.
+-
+-Writing to this file with CONFIG_BATMAN_ADV_DEBUG enabled can either lead
+-to a segfault or to memory corruption.
+-
+-Fixes: ec46535b8275 ("batman-adv: Add hard_iface specific sysfs wrapper macros for UINT")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Marek Lindner <mareklindner@neomailbox.ch>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/848be9859b0109a6e428f92f21f2e660153b1c75
+-
+-diff --git a/net/batman-adv/sysfs.c b/net/batman-adv/sysfs.c
+-index 3a76e8970c025ca6917d6cd15d1382f685cd3532..09427fc6494a157554d8b19f3481a878a9f97bba 100644
+---- a/net/batman-adv/sysfs.c
+-+++ b/net/batman-adv/sysfs.c
+-@@ -188,7 +188,8 @@ ssize_t batadv_store_##_name(struct kobject *kobj,			\
+- 									\
+- 	return __batadv_store_uint_attr(buff, count, _min, _max,	\
+- 					_post_func, attr,		\
+--					&bat_priv->_var, net_dev);	\
+-+					&bat_priv->_var, net_dev,	\
+-+					NULL);	\
+- }
+- 
+- #define BATADV_ATTR_SIF_SHOW_UINT(_name, _var)				\
+-@@ -262,7 +263,9 @@ ssize_t batadv_store_##_name(struct kobject *kobj,			\
+- 									\
+- 	length = __batadv_store_uint_attr(buff, count, _min, _max,	\
+- 					  _post_func, attr,		\
+--					  &hard_iface->_var, net_dev);	\
+-+					  &hard_iface->_var,		\
+-+					  hard_iface->soft_iface,	\
+-+					  net_dev);			\
+- 									\
+- 	batadv_hardif_put(hard_iface);				\
+- 	return length;							\
+-@@ -356,10 +359,12 @@ __batadv_store_bool_attr(char *buff, size_t count,
+- 
+- static int batadv_store_uint_attr(const char *buff, size_t count,
+- 				  struct net_device *net_dev,
+-+				  struct net_device *slave_dev,
+- 				  const char *attr_name,
+- 				  unsigned int min, unsigned int max,
+- 				  atomic_t *attr)
+- {
+-+	char ifname[IFNAMSIZ + 3] = "";
+- 	unsigned long uint_val;
+- 	int ret;
+- 
+-@@ -385,8 +390,11 @@ static int batadv_store_uint_attr(const char *buff, size_t count,
+- 	if (atomic_read(attr) == uint_val)
+- 		return count;
+- 
+--	batadv_info(net_dev, "%s: Changing from: %i to: %lu\n",
+--		    attr_name, atomic_read(attr), uint_val);
+-+	if (slave_dev)
+-+		snprintf(ifname, sizeof(ifname), "%s: ", slave_dev->name);
+-+
+-+	batadv_info(net_dev, "%s: %sChanging from: %i to: %lu\n",
+-+		    attr_name, ifname, atomic_read(attr), uint_val);
+- 
+- 	atomic_set(attr, uint_val);
+- 	return count;
+-@@ -397,12 +405,13 @@ static ssize_t __batadv_store_uint_attr(const char *buff, size_t count,
+- 					void (*post_func)(struct net_device *),
+- 					const struct attribute *attr,
+- 					atomic_t *attr_store,
+--					struct net_device *net_dev)
+-+					struct net_device *net_dev,
+-+					struct net_device *slave_dev)
+- {
+- 	int ret;
+- 
+--	ret = batadv_store_uint_attr(buff, count, net_dev, attr->name, min, max,
+--				     attr_store);
+-+	ret = batadv_store_uint_attr(buff, count, net_dev, slave_dev,
+-+				     attr->name, min, max, attr_store);
+- 	if (post_func && ret)
+- 		post_func(net_dev);
+- 
+-@@ -571,7 +580,7 @@ static ssize_t batadv_store_gw_sel_class(struct kobject *kobj,
+- 	return __batadv_store_uint_attr(buff, count, 1, BATADV_TQ_MAX_VALUE,
+- 					batadv_post_gw_reselect, attr,
+- 					&bat_priv->gw.sel_class,
+--					bat_priv->soft_iface);
+-+					bat_priv->soft_iface, NULL);
+- }
+- 
+- static ssize_t batadv_show_gw_bwidth(struct kobject *kobj,
+diff --git a/batman-adv/patches/0015-batman-adv-fix-backbone_gw-refcount-on-queue_work-fa.patch b/batman-adv/patches/0015-batman-adv-fix-backbone_gw-refcount-on-queue_work-fa.patch
+deleted file mode 100644
+index ed34fec3d4a2f2e9c99ac314c339609a0880ae50..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0015-batman-adv-fix-backbone_gw-refcount-on-queue_work-fa.patch
++++ /dev/null
+@@ -1,42 +0,0 @@
+-From: Marek Lindner <mareklindner@neomailbox.ch>
+-Date: Fri, 7 Sep 2018 05:45:54 +0800
+-Subject: batman-adv: fix backbone_gw refcount on queue_work() failure
+-
+-The backbone_gw refcounter is to be decreased by the queued work and
+-currently is never decreased if the queue_work() call fails.
+-Fix by checking the queue_work() return value and decrease refcount
+-if necessary.
+-
+-Signed-off-by: Marek Lindner <mareklindner@neomailbox.ch>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/24d83a50421c1c5d39cd9c015516a1a293ae8d0c
+-
+-diff --git a/net/batman-adv/bridge_loop_avoidance.c b/net/batman-adv/bridge_loop_avoidance.c
+-index a2de5a44bd41bf5c3d521d29b72e0b225a3ace05..58c093caf49e804c1e11426959d70e79f1729d41 100644
+---- a/net/batman-adv/bridge_loop_avoidance.c
+-+++ b/net/batman-adv/bridge_loop_avoidance.c
+-@@ -1772,6 +1772,7 @@ batadv_bla_loopdetect_check(struct batadv_priv *bat_priv, struct sk_buff *skb,
+- {
+- 	struct batadv_bla_backbone_gw *backbone_gw;
+- 	struct ethhdr *ethhdr;
+-+	bool ret;
+- 
+- 	ethhdr = eth_hdr(skb);
+- 
+-@@ -1795,8 +1796,13 @@ batadv_bla_loopdetect_check(struct batadv_priv *bat_priv, struct sk_buff *skb,
+- 	if (unlikely(!backbone_gw))
+- 		return true;
+- 
+--	queue_work(batadv_event_workqueue, &backbone_gw->report_work);
+--	/* backbone_gw is unreferenced in the report work function function */
+-+	ret = queue_work(batadv_event_workqueue, &backbone_gw->report_work);
+-+
+-+	/* backbone_gw is unreferenced in the report work function function
+-+	 * if queue_work() call was successful
+-+	 */
+-+	if (!ret)
+-+		batadv_backbone_gw_put(backbone_gw);
+- 
+- 	return true;
+- }
+diff --git a/batman-adv/patches/0016-batman-adv-fix-hardif_neigh-refcount-on-queue_work-f.patch b/batman-adv/patches/0016-batman-adv-fix-hardif_neigh-refcount-on-queue_work-f.patch
+deleted file mode 100644
+index e9fe15286181bf81bb4ab19d33478a8c00f8468b..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0016-batman-adv-fix-hardif_neigh-refcount-on-queue_work-f.patch
++++ /dev/null
+@@ -1,40 +0,0 @@
+-From: Marek Lindner <mareklindner@neomailbox.ch>
+-Date: Fri, 7 Sep 2018 05:45:55 +0800
+-Subject: batman-adv: fix hardif_neigh refcount on queue_work() failure
+-
+-The hardif_neigh refcounter is to be decreased by the queued work and
+-currently is never decreased if the queue_work() call fails.
+-Fix by checking the queue_work() return value and decrease refcount
+-if necessary.
+-
+-Signed-off-by: Marek Lindner <mareklindner@neomailbox.ch>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/85100b602c127cecf1bcfd620d20eb867d685df2
+-
+-diff --git a/net/batman-adv/bat_v_elp.c b/net/batman-adv/bat_v_elp.c
+-index 371028f82a0669e86155fee39ba955cbbde48e60..83b46654449df72ceda6ca3177f72e7faf0603ab 100644
+---- a/net/batman-adv/bat_v_elp.c
+-+++ b/net/batman-adv/bat_v_elp.c
+-@@ -255,6 +255,7 @@ static void batadv_v_elp_periodic_work(struct work_struct *work)
+- 	struct batadv_priv *bat_priv;
+- 	struct sk_buff *skb;
+- 	u32 elp_interval;
+-+	bool ret;
+- 
+- 	bat_v = container_of(work, struct batadv_hard_iface_bat_v, elp_wq.work);
+- 	hard_iface = container_of(bat_v, struct batadv_hard_iface, bat_v);
+-@@ -316,8 +317,11 @@ static void batadv_v_elp_periodic_work(struct work_struct *work)
+- 		 * may sleep and that is not allowed in an rcu protected
+- 		 * context. Therefore schedule a task for that.
+- 		 */
+--		queue_work(batadv_event_workqueue,
+--			   &hardif_neigh->bat_v.metric_work);
+-+		ret = queue_work(batadv_event_workqueue,
+-+				 &hardif_neigh->bat_v.metric_work);
+-+
+-+		if (!ret)
+-+			batadv_hardif_neigh_put(hardif_neigh);
+- 	}
+- 	rcu_read_unlock();
+- 
+diff --git a/batman-adv/patches/0017-batman-adv-Prevent-duplicated-gateway_node-entry.patch b/batman-adv/patches/0017-batman-adv-Prevent-duplicated-gateway_node-entry.patch
+deleted file mode 100644
+index c319f079b5257fa4e3b0b5cf4b33864e135f47fc..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0017-batman-adv-Prevent-duplicated-gateway_node-entry.patch
++++ /dev/null
+@@ -1,78 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 6 Sep 2018 14:35:24 +0200
+-Subject: batman-adv: Prevent duplicated gateway_node entry
+-
+-The function batadv_gw_node_add is responsible for adding new gw_node to
+-the gateway_list. It is expecting that the caller already checked that
+-there is not already an entry with the same key or not.
+-
+-But the lock for the list is only held when the list is really modified.
+-This could lead to duplicated entries because another context could create
+-an entry with the same key between the check and the list manipulation.
+-
+-The check and the manipulation of the list must therefore be in the same
+-locked code section.
+-
+-Fixes: bc3538cabac5 ("batman-adv: adding gateway functionality")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Marek Lindner <mareklindner@neomailbox.ch>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/69b3ca714eba608fe79a51ccd89ce7050ee0b770
+-
+-diff --git a/net/batman-adv/gateway_client.c b/net/batman-adv/gateway_client.c
+-index 8b198ee798c910b40997ed9ca867fc931c53dcc3..140c61a3f1ecfec4fe23c5ddca19e18e2e86fd56 100644
+---- a/net/batman-adv/gateway_client.c
+-+++ b/net/batman-adv/gateway_client.c
+-@@ -32,6 +32,7 @@
+- #include <linux/kernel.h>
+- #include <linux/kref.h>
+- #include <linux/list.h>
+-+#include <linux/lockdep.h>
+- #include <linux/netdevice.h>
+- #include <linux/netlink.h>
+- #include <linux/rculist.h>
+-@@ -348,6 +349,9 @@ void batadv_gw_check_election(struct batadv_priv *bat_priv,
+-  * @bat_priv: the bat priv with all the soft interface information
+-  * @orig_node: originator announcing gateway capabilities
+-  * @gateway: announced bandwidth information
+-+ *
+-+ * Has to be called with the appropriate locks being acquired
+-+ * (gw.list_lock).
+-  */
+- static void batadv_gw_node_add(struct batadv_priv *bat_priv,
+- 			       struct batadv_orig_node *orig_node,
+-@@ -355,6 +359,8 @@ static void batadv_gw_node_add(struct batadv_priv *bat_priv,
+- {
+- 	struct batadv_gw_node *gw_node;
+- 
+-+	lockdep_assert_held(&bat_priv->gw.list_lock);
+-+
+- 	if (gateway->bandwidth_down == 0)
+- 		return;
+- 
+-@@ -369,10 +375,8 @@ static void batadv_gw_node_add(struct batadv_priv *bat_priv,
+- 	gw_node->bandwidth_down = ntohl(gateway->bandwidth_down);
+- 	gw_node->bandwidth_up = ntohl(gateway->bandwidth_up);
+- 
+--	spin_lock_bh(&bat_priv->gw.list_lock);
+- 	kref_get(&gw_node->refcount);
+- 	hlist_add_head_rcu(&gw_node->list, &bat_priv->gw.gateway_list);
+--	spin_unlock_bh(&bat_priv->gw.list_lock);
+- 
+- 	batadv_dbg(BATADV_DBG_BATMAN, bat_priv,
+- 		   "Found new gateway %pM -> gw bandwidth: %u.%u/%u.%u MBit\n",
+-@@ -428,11 +432,14 @@ void batadv_gw_node_update(struct batadv_priv *bat_priv,
+- {
+- 	struct batadv_gw_node *gw_node, *curr_gw = NULL;
+- 
+-+	spin_lock_bh(&bat_priv->gw.list_lock);
+- 	gw_node = batadv_gw_node_get(bat_priv, orig_node);
+- 	if (!gw_node) {
+- 		batadv_gw_node_add(bat_priv, orig_node, gateway);
+-+		spin_unlock_bh(&bat_priv->gw.list_lock);
+- 		goto out;
+- 	}
+-+	spin_unlock_bh(&bat_priv->gw.list_lock);
+- 
+- 	if (gw_node->bandwidth_down == ntohl(gateway->bandwidth_down) &&
+- 	    gw_node->bandwidth_up == ntohl(gateway->bandwidth_up))
+diff --git a/batman-adv/patches/0018-batman-adv-Prevent-duplicated-nc_node-entry.patch b/batman-adv/patches/0018-batman-adv-Prevent-duplicated-nc_node-entry.patch
+deleted file mode 100644
+index 5a79707a934e77bd225b0ad4122d0c76d8e7ae40..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0018-batman-adv-Prevent-duplicated-nc_node-entry.patch
++++ /dev/null
+@@ -1,87 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 6 Sep 2018 14:35:25 +0200
+-Subject: batman-adv: Prevent duplicated nc_node entry
+-
+-The function batadv_nc_get_nc_node is responsible for adding new nc_nodes
+-to the in_coding_list and out_coding_list. It first checks whether the
+-entry already is in the list or not. If it is, then the creation of a new
+-entry is aborted.
+-
+-But the lock for the list is only held when the list is really modified.
+-This could lead to duplicated entries because another context could create
+-an entry with the same key between the check and the list manipulation.
+-
+-The check and the manipulation of the list must therefore be in the same
+-locked code section.
+-
+-Fixes: 3ed7ada3f0bb ("batman-adv: network coding - detect coding nodes and remove these after timeout")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Marek Lindner <mareklindner@neomailbox.ch>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/bab8447ad1850b25188f9652c0c52f8e58acd656
+-
+-diff --git a/net/batman-adv/network-coding.c b/net/batman-adv/network-coding.c
+-index c3578444f3cbe759a5385ac460ccb9d41ae1c4de..34caf129a9bf5531360f798be6a7059bad26a50f 100644
+---- a/net/batman-adv/network-coding.c
+-+++ b/net/batman-adv/network-coding.c
+-@@ -854,24 +854,6 @@ batadv_nc_get_nc_node(struct batadv_priv *bat_priv,
+- 	spinlock_t *lock; /* Used to lock list selected by "int in_coding" */
+- 	struct list_head *list;
+- 
+--	/* Check if nc_node is already added */
+--	nc_node = batadv_nc_find_nc_node(orig_node, orig_neigh_node, in_coding);
+--
+--	/* Node found */
+--	if (nc_node)
+--		return nc_node;
+--
+--	nc_node = kzalloc(sizeof(*nc_node), GFP_ATOMIC);
+--	if (!nc_node)
+--		return NULL;
+--
+--	/* Initialize nc_node */
+--	INIT_LIST_HEAD(&nc_node->list);
+--	kref_init(&nc_node->refcount);
+--	ether_addr_copy(nc_node->addr, orig_node->orig);
+--	kref_get(&orig_neigh_node->refcount);
+--	nc_node->orig_node = orig_neigh_node;
+--
+- 	/* Select ingoing or outgoing coding node */
+- 	if (in_coding) {
+- 		lock = &orig_neigh_node->in_coding_list_lock;
+-@@ -881,13 +863,34 @@ batadv_nc_get_nc_node(struct batadv_priv *bat_priv,
+- 		list = &orig_neigh_node->out_coding_list;
+- 	}
+- 
+-+	spin_lock_bh(lock);
+-+
+-+	/* Check if nc_node is already added */
+-+	nc_node = batadv_nc_find_nc_node(orig_node, orig_neigh_node, in_coding);
+-+
+-+	/* Node found */
+-+	if (nc_node)
+-+		goto unlock;
+-+
+-+	nc_node = kzalloc(sizeof(*nc_node), GFP_ATOMIC);
+-+	if (!nc_node)
+-+		goto unlock;
+-+
+-+	/* Initialize nc_node */
+-+	INIT_LIST_HEAD(&nc_node->list);
+-+	kref_init(&nc_node->refcount);
+-+	ether_addr_copy(nc_node->addr, orig_node->orig);
+-+	kref_get(&orig_neigh_node->refcount);
+-+	nc_node->orig_node = orig_neigh_node;
+-+
+- 	batadv_dbg(BATADV_DBG_NC, bat_priv, "Adding nc_node %pM -> %pM\n",
+- 		   nc_node->addr, nc_node->orig_node->orig);
+- 
+- 	/* Add nc_node to orig_node */
+--	spin_lock_bh(lock);
+- 	kref_get(&nc_node->refcount);
+- 	list_add_tail_rcu(&nc_node->list, list);
+-+
+-+unlock:
+- 	spin_unlock_bh(lock);
+- 
+- 	return nc_node;
+diff --git a/batman-adv/patches/0019-batman-adv-Prevent-duplicated-softif_vlan-entry.patch b/batman-adv/patches/0019-batman-adv-Prevent-duplicated-softif_vlan-entry.patch
+deleted file mode 100644
+index db83ad219c2896112b544dced073b5fa92fa2a20..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0019-batman-adv-Prevent-duplicated-softif_vlan-entry.patch
++++ /dev/null
+@@ -1,78 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 6 Sep 2018 14:35:26 +0200
+-Subject: batman-adv: Prevent duplicated softif_vlan entry
+-
+-The function batadv_softif_vlan_get is responsible for adding new
+-softif_vlan to the softif_vlan_list. It first checks whether the entry
+-already is in the list or not. If it is, then the creation of a new entry
+-is aborted.
+-
+-But the lock for the list is only held when the list is really modified.
+-This could lead to duplicated entries because another context could create
+-an entry with the same key between the check and the list manipulation.
+-
+-The check and the manipulation of the list must therefore be in the same
+-locked code section.
+-
+-Fixes: 952cebb57518 ("batman-adv: add per VLAN interface attribute framework")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/023d3f64207e8b6a6e6d0718d98e239c5545ef0c
+-
+-diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+-index edeffcb9f3a24e1b53c2b4d705fb260717ac09c4..79d6ab78359db9c6a5df14e2e204c611ab134dfc 100644
+---- a/net/batman-adv/soft-interface.c
+-+++ b/net/batman-adv/soft-interface.c
+-@@ -574,15 +574,20 @@ int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+- 	struct batadv_softif_vlan *vlan;
+- 	int err;
+- 
+-+	spin_lock_bh(&bat_priv->softif_vlan_list_lock);
+-+
+- 	vlan = batadv_softif_vlan_get(bat_priv, vid);
+- 	if (vlan) {
+- 		batadv_softif_vlan_put(vlan);
+-+		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+- 		return -EEXIST;
+- 	}
+- 
+- 	vlan = kzalloc(sizeof(*vlan), GFP_ATOMIC);
+--	if (!vlan)
+-+	if (!vlan) {
+-+		spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+- 		return -ENOMEM;
+-+	}
+- 
+- 	vlan->bat_priv = bat_priv;
+- 	vlan->vid = vid;
+-@@ -590,17 +595,23 @@ int batadv_softif_create_vlan(struct batadv_priv *bat_priv, unsigned short vid)
+- 
+- 	atomic_set(&vlan->ap_isolation, 0);
+- 
+--	err = batadv_sysfs_add_vlan(bat_priv->soft_iface, vlan);
+--	if (err) {
+--		kfree(vlan);
+--		return err;
+--	}
+--
+--	spin_lock_bh(&bat_priv->softif_vlan_list_lock);
+- 	kref_get(&vlan->refcount);
+- 	hlist_add_head_rcu(&vlan->list, &bat_priv->softif_vlan_list);
+- 	spin_unlock_bh(&bat_priv->softif_vlan_list_lock);
+- 
+-+	/* batadv_sysfs_add_vlan cannot be in the spinlock section due to the
+-+	 * sleeping behavior of the sysfs functions and the fs_reclaim lock
+-+	 */
+-+	err = batadv_sysfs_add_vlan(bat_priv->soft_iface, vlan);
+-+	if (err) {
+-+		/* ref for the function */
+-+		batadv_softif_vlan_put(vlan);
+-+
+-+		/* ref for the list */
+-+		batadv_softif_vlan_put(vlan);
+-+		return err;
+-+	}
+-+
+- 	/* add a new TT local entry. This one will be marked with the NOPURGE
+- 	 * flag
+- 	 */
+diff --git a/batman-adv/patches/0020-batman-adv-Prevent-duplicated-global-TT-entry.patch b/batman-adv/patches/0020-batman-adv-Prevent-duplicated-global-TT-entry.patch
+deleted file mode 100644
+index 5594cff1ad1f8b7a91e5c5e3f147bbf5af17db0f..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0020-batman-adv-Prevent-duplicated-global-TT-entry.patch
++++ /dev/null
+@@ -1,56 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 6 Sep 2018 14:35:27 +0200
+-Subject: batman-adv: Prevent duplicated global TT entry
+-
+-The function batadv_tt_global_orig_entry_add is responsible for adding new
+-tt_orig_list_entry to the orig_list. It first checks whether the entry
+-already is in the list or not. If it is, then the creation of a new entry
+-is aborted.
+-
+-But the lock for the list is only held when the list is really modified.
+-This could lead to duplicated entries because another context could create
+-an entry with the same key between the check and the list manipulation.
+-
+-The check and the manipulation of the list must therefore be in the same
+-locked code section.
+-
+-Fixes: c5eb5bb30321 ("batman-adv: add reference counting for type batadv_tt_orig_list_entry")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Marek Lindner <mareklindner@neomailbox.ch>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/79097255a1a3e1bd1949be309af941181fbc7b36
+-
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index 9efbdd6348c4d69c525b3e0574d2b24db838c086..7502cb54c152d06d78c88d9f8fb841cada9f3b5d 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -1613,6 +1613,8 @@ batadv_tt_global_orig_entry_add(struct batadv_tt_global_entry *tt_global,
+- {
+- 	struct batadv_tt_orig_list_entry *orig_entry;
+- 
+-+	spin_lock_bh(&tt_global->list_lock);
+-+
+- 	orig_entry = batadv_tt_global_orig_entry_find(tt_global, orig_node);
+- 	if (orig_entry) {
+- 		/* refresh the ttvn: the current value could be a bogus one that
+-@@ -1635,11 +1637,9 @@ batadv_tt_global_orig_entry_add(struct batadv_tt_global_entry *tt_global,
+- 	orig_entry->flags = flags;
+- 	kref_init(&orig_entry->refcount);
+- 
+--	spin_lock_bh(&tt_global->list_lock);
+- 	kref_get(&orig_entry->refcount);
+- 	hlist_add_head_rcu(&orig_entry->list,
+- 			   &tt_global->orig_list);
+--	spin_unlock_bh(&tt_global->list_lock);
+- 	atomic_inc(&tt_global->orig_list_count);
+- 
+- sync_flags:
+-@@ -1647,6 +1647,8 @@ batadv_tt_global_orig_entry_add(struct batadv_tt_global_entry *tt_global,
+- out:
+- 	if (orig_entry)
+- 		batadv_tt_orig_list_entry_put(orig_entry);
+-+
+-+	spin_unlock_bh(&tt_global->list_lock);
+- }
+- 
+- /**
+diff --git a/batman-adv/patches/0021-batman-adv-Prevent-duplicated-tvlv-handler.patch b/batman-adv/patches/0021-batman-adv-Prevent-duplicated-tvlv-handler.patch
+deleted file mode 100644
+index 183099845e0224f9de50337d7a440b51c2a4758d..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0021-batman-adv-Prevent-duplicated-tvlv-handler.patch
++++ /dev/null
+@@ -1,56 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 6 Sep 2018 14:35:28 +0200
+-Subject: batman-adv: Prevent duplicated tvlv handler
+-
+-The function batadv_tvlv_handler_register is responsible for adding new
+-tvlv_handler to the handler_list. It first checks whether the entry
+-already is in the list or not. If it is, then the creation of a new entry
+-is aborted.
+-
+-But the lock for the list is only held when the list is really modified.
+-This could lead to duplicated entries because another context could create
+-an entry with the same key between the check and the list manipulation.
+-
+-The check and the manipulation of the list must therefore be in the same
+-locked code section.
+-
+-Fixes: 0b6aa0d43767 ("batman-adv: tvlv - basic infrastructure")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Marek Lindner <mareklindner@neomailbox.ch>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/acabad79e01740525cf4ff8ce6e9a210b683d420
+-
+-diff --git a/net/batman-adv/tvlv.c b/net/batman-adv/tvlv.c
+-index a637458205d16bf838f796383d8cc15ac861801b..40e69c9346d22c09481544b8b4dec56cad88b64a 100644
+---- a/net/batman-adv/tvlv.c
+-+++ b/net/batman-adv/tvlv.c
+-@@ -529,15 +529,20 @@ void batadv_tvlv_handler_register(struct batadv_priv *bat_priv,
+- {
+- 	struct batadv_tvlv_handler *tvlv_handler;
+- 
+-+	spin_lock_bh(&bat_priv->tvlv.handler_list_lock);
+-+
+- 	tvlv_handler = batadv_tvlv_handler_get(bat_priv, type, version);
+- 	if (tvlv_handler) {
+-+		spin_unlock_bh(&bat_priv->tvlv.handler_list_lock);
+- 		batadv_tvlv_handler_put(tvlv_handler);
+- 		return;
+- 	}
+- 
+- 	tvlv_handler = kzalloc(sizeof(*tvlv_handler), GFP_ATOMIC);
+--	if (!tvlv_handler)
+-+	if (!tvlv_handler) {
+-+		spin_unlock_bh(&bat_priv->tvlv.handler_list_lock);
+- 		return;
+-+	}
+- 
+- 	tvlv_handler->ogm_handler = optr;
+- 	tvlv_handler->unicast_handler = uptr;
+-@@ -547,7 +552,6 @@ void batadv_tvlv_handler_register(struct batadv_priv *bat_priv,
+- 	kref_init(&tvlv_handler->refcount);
+- 	INIT_HLIST_NODE(&tvlv_handler->list);
+- 
+--	spin_lock_bh(&bat_priv->tvlv.handler_list_lock);
+- 	kref_get(&tvlv_handler->refcount);
+- 	hlist_add_head_rcu(&tvlv_handler->list, &bat_priv->tvlv.handler_list);
+- 	spin_unlock_bh(&bat_priv->tvlv.handler_list_lock);
+diff --git a/batman-adv/patches/0022-batman-adv-Use-explicit-tvlv-padding-for-ELP-packets.patch b/batman-adv/patches/0022-batman-adv-Use-explicit-tvlv-padding-for-ELP-packets.patch
+deleted file mode 100644
+index 2f6c1f961bf5e75ccb8be17d3a62a0985e53a790..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0022-batman-adv-Use-explicit-tvlv-padding-for-ELP-packets.patch
++++ /dev/null
+@@ -1,52 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Tue, 30 Oct 2018 12:17:10 +0100
+-Subject: batman-adv: Use explicit tvlv padding for ELP packets
+-
+-The announcement messages of batman-adv COMPAT_VERSION 15 have the
+-possibility to announce additional information via a dynamic TVLV part.
+-This part is optional for the ELP packets and currently not parsed by the
+-Linux implementation. Still out-of-tree versions are using it to transport
+-things like neighbor hashes to optimize the rebroadcast behavior.
+-
+-Since the ELP broadcast packets are smaller than the minimal ethernet
+-packet, it often has to be padded. This is often done (as specified in
+-RFC894) with octets of zero and thus work perfectly fine with the TVLV
+-part (making it a zero length and thus empty). But not all ethernet
+-compatible hardware seems to follow this advice. To avoid ambiguous
+-situations when parsing the TVLV header, just force the 4 bytes (TVLV
+-length + padding) after the required ELP header to zero.
+-
+-Fixes: a4b88af77e28 ("batman-adv: ELP - adding basic infrastructure")
+-Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/974337ee9773c4bd0a2d5c322306cf2bea445e11
+-
+-diff --git a/net/batman-adv/bat_v_elp.c b/net/batman-adv/bat_v_elp.c
+-index 83b46654449df72ceda6ca3177f72e7faf0603ab..9aa3c7b2e9bad6c50b2939b6dbf5a9a2e713b93b 100644
+---- a/net/batman-adv/bat_v_elp.c
+-+++ b/net/batman-adv/bat_v_elp.c
+-@@ -339,19 +339,21 @@ static void batadv_v_elp_periodic_work(struct work_struct *work)
+-  */
+- int batadv_v_elp_iface_enable(struct batadv_hard_iface *hard_iface)
+- {
+-+	static const size_t tvlv_padding = sizeof(__be32);
+- 	struct batadv_elp_packet *elp_packet;
+- 	unsigned char *elp_buff;
+- 	u32 random_seqno;
+- 	size_t size;
+- 	int res = -ENOMEM;
+- 
+--	size = ETH_HLEN + NET_IP_ALIGN + BATADV_ELP_HLEN;
+-+	size = ETH_HLEN + NET_IP_ALIGN + BATADV_ELP_HLEN + tvlv_padding;
+- 	hard_iface->bat_v.elp_skb = dev_alloc_skb(size);
+- 	if (!hard_iface->bat_v.elp_skb)
+- 		goto out;
+- 
+- 	skb_reserve(hard_iface->bat_v.elp_skb, ETH_HLEN + NET_IP_ALIGN);
+--	elp_buff = skb_put_zero(hard_iface->bat_v.elp_skb, BATADV_ELP_HLEN);
+-+	elp_buff = skb_put_zero(hard_iface->bat_v.elp_skb,
+-+				BATADV_ELP_HLEN + tvlv_padding);
+- 	elp_packet = (struct batadv_elp_packet *)elp_buff;
+- 
+- 	elp_packet->packet_type = BATADV_ELP;
+diff --git a/batman-adv/patches/0023-batman-adv-Expand-merged-fragment-buffer-for-full-pa.patch b/batman-adv/patches/0023-batman-adv-Expand-merged-fragment-buffer-for-full-pa.patch
+deleted file mode 100644
+index 6bdb6bc1678d15407ddfaba2a039ed5ff040375c..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0023-batman-adv-Expand-merged-fragment-buffer-for-full-pa.patch
++++ /dev/null
+@@ -1,41 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Wed, 7 Nov 2018 23:09:12 +0100
+-Subject: batman-adv: Expand merged fragment buffer for full packet
+-
+-The complete size ("total_size") of the fragmented packet is stored in the
+-fragment header and in the size of the fragment chain. When the fragments
+-are ready for merge, the skbuff's tail of the first fragment is expanded to
+-have enough room after the data pointer for at least total_size. This means
+-that it gets expanded by total_size - first_skb->len.
+-
+-But this is ignoring the fact that after expanding the buffer, the fragment
+-header is pulled by from this buffer. Assuming that the tailroom of the
+-buffer was already 0, the buffer after the data pointer of the skbuff is
+-now only total_size - len(fragment_header) large. When the merge function
+-is then processing the remaining fragments, the code to copy the data over
+-to the merged skbuff will cause an skb_over_panic when it tries to actually
+-put enough data to fill the total_size bytes of the packet.
+-
+-The size of the skb_pull must therefore also be taken into account when the
+-buffer's tailroom is expanded.
+-
+-Fixes: 9b3eab61754d ("batman-adv: Receive fragmented packets and merge")
+-Reported-by: Martin Weinelt <martin@darmstadt.freifunk.net>
+-Co-authored-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: other, https://patchwork.open-mesh.org/patch/17616/
+-
+-diff --git a/net/batman-adv/fragmentation.c b/net/batman-adv/fragmentation.c
+-index 0fddc17106bd8a0e3f064fee9adba7c226f34682..5b71a289d04fc80de6c20e7a24d621727c77825a 100644
+---- a/net/batman-adv/fragmentation.c
+-+++ b/net/batman-adv/fragmentation.c
+-@@ -275,7 +275,7 @@ batadv_frag_merge_packets(struct hlist_head *chain)
+- 	kfree(entry);
+- 
+- 	packet = (struct batadv_frag_packet *)skb_out->data;
+--	size = ntohs(packet->total_size);
+-+	size = ntohs(packet->total_size) + hdr_size;
+- 
+- 	/* Make room for the rest of the fragments. */
+- 	if (pskb_expand_head(skb_out, 0, size - skb_out->len, GFP_ATOMIC) < 0) {
+diff --git a/batman-adv/patches/0024-batman-adv-Avoid-WARN-on-net_device-without-parent-i.patch b/batman-adv/patches/0024-batman-adv-Avoid-WARN-on-net_device-without-parent-i.patch
+deleted file mode 100644
+index 0d8aa2cd6467709a20cc490ac21cdd66d41183f6..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0024-batman-adv-Avoid-WARN-on-net_device-without-parent-i.patch
++++ /dev/null
+@@ -1,45 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sun, 30 Dec 2018 12:46:01 +0100
+-Subject: batman-adv: Avoid WARN on net_device without parent in netns
+-
+-It is not allowed to use WARN* helpers on potential incorrect input from
+-the user or transient problems because systems configured as panic_on_warn
+-will reboot due to such a problem.
+-
+-A NULL return value of __dev_get_by_index can be caused by various problems
+-which can either be related to the system configuration or problems
+-(incorrectly returned network namespaces) in other (virtual) net_device
+-drivers. batman-adv should not cause a (harmful) WARN in this situation and
+-instead only report it via a simple message.
+-
+-Fixes: 3d48811b27f5 ("batman-adv: prevent using any virtual device created on batman-adv as hard-interface")
+-Reported-by: syzbot+c764de0fcfadca9a8595@syzkaller.appspotmail.com
+-Reported-by: Dmitry Vyukov <dvyukov@google.com>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/59ad04405be86f648fd83d81d2fd0a78f215a43b
+-
+-diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+-index 2f0d42f2f913e74cf10c0c6ce89320434994cac5..08690d06b7be2b25ca3f009394763c7083c70644 100644
+---- a/net/batman-adv/hard-interface.c
+-+++ b/net/batman-adv/hard-interface.c
+-@@ -20,7 +20,6 @@
+- #include "main.h"
+- 
+- #include <linux/atomic.h>
+--#include <linux/bug.h>
+- #include <linux/byteorder/generic.h>
+- #include <linux/errno.h>
+- #include <linux/gfp.h>
+-@@ -179,8 +178,10 @@ static bool batadv_is_on_batman_iface(const struct net_device *net_dev)
+- 	parent_dev = __dev_get_by_index((struct net *)parent_net,
+- 					dev_get_iflink(net_dev));
+- 	/* if we got a NULL parent_dev there is something broken.. */
+--	if (WARN(!parent_dev, "Cannot find parent device"))
+-+	if (!parent_dev) {
+-+		pr_err("Cannot find parent device\n");
+- 		return false;
+-+	}
+- 
+- 	if (batadv_mutual_parents(net_dev, net, parent_dev, parent_net))
+- 		return false;
+diff --git a/batman-adv/patches/0025-batman-adv-Force-mac-header-to-start-of-data-on-xmit.patch b/batman-adv/patches/0025-batman-adv-Force-mac-header-to-start-of-data-on-xmit.patch
+deleted file mode 100644
+index f7fe6ce5893d466e09181ee3b9688da91036c8c6..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0025-batman-adv-Force-mac-header-to-start-of-data-on-xmit.patch
++++ /dev/null
+@@ -1,36 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Mon, 31 Dec 2018 22:46:09 +0100
+-Subject: batman-adv: Force mac header to start of data on xmit
+-
+-The caller of ndo_start_xmit may not already have called
+-skb_reset_mac_header. The returned value of skb_mac_header/eth_hdr
+-therefore can be in the wrong position and even outside the current skbuff.
+-This for example happens when the user binds to the device using a
+-PF_PACKET-SOCK_RAW with enabled qdisc-bypass:
+-
+-  int opt = 4;
+-  setsockopt(sock, SOL_PACKET, PACKET_QDISC_BYPASS, &opt, sizeof(opt));
+-
+-Since eth_hdr is used all over the codebase, the batadv_interface_tx
+-function must always take care of resetting it.
+-
+-Fixes: fe28a94c01e1 ("batman-adv: receive packets directly using skbs")
+-Reported-by: syzbot+9d7405c7faa390e60b4e@syzkaller.appspotmail.com
+-Reported-by: syzbot+7d20bc3f1ddddc0f9079@syzkaller.appspotmail.com
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/74c4b0c50f19f986752ee18ed393732f4eed7a66
+-
+-diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+-index 79d6ab78359db9c6a5df14e2e204c611ab134dfc..d3f540ba2a1388a8aa693a539d01d6a1cad95b44 100644
+---- a/net/batman-adv/soft-interface.c
+-+++ b/net/batman-adv/soft-interface.c
+-@@ -221,6 +221,8 @@ static int batadv_interface_tx(struct sk_buff *skb,
+- 
+- 	netif_trans_update(soft_iface);
+- 	vid = batadv_get_vid(skb, 0);
+-+
+-+	skb_reset_mac_header(skb);
+- 	ethhdr = eth_hdr(skb);
+- 
+- 	switch (ntohs(ethhdr->h_proto)) {
+diff --git a/batman-adv/patches/0026-batman-adv-fix-uninit-value-in-batadv_interface_tx.patch b/batman-adv/patches/0026-batman-adv-fix-uninit-value-in-batadv_interface_tx.patch
+deleted file mode 100644
+index dd2edad454f00ba4f895750f9c90fb8166213927..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0026-batman-adv-fix-uninit-value-in-batadv_interface_tx.patch
++++ /dev/null
+@@ -1,95 +0,0 @@
+-From: Eric Dumazet <edumazet@google.com>
+-Date: Mon, 11 Feb 2019 14:41:22 -0800
+-Subject: batman-adv: fix uninit-value in batadv_interface_tx()
+-
+-KMSAN reported batadv_interface_tx() was possibly using a
+-garbage value [1]
+-
+-batadv_get_vid() does have a pskb_may_pull() call
+-but batadv_interface_tx() does not actually make sure
+-this did not fail.
+-
+-[1]
+-BUG: KMSAN: uninit-value in batadv_interface_tx+0x908/0x1e40 net/batman-adv/soft-interface.c:231
+-CPU: 0 PID: 10006 Comm: syz-executor469 Not tainted 4.20.0-rc7+ #5
+-Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+-Call Trace:
+- __dump_stack lib/dump_stack.c:77 [inline]
+- dump_stack+0x173/0x1d0 lib/dump_stack.c:113
+- kmsan_report+0x12e/0x2a0 mm/kmsan/kmsan.c:613
+- __msan_warning+0x82/0xf0 mm/kmsan/kmsan_instr.c:313
+- batadv_interface_tx+0x908/0x1e40 net/batman-adv/soft-interface.c:231
+- __netdev_start_xmit include/linux/netdevice.h:4356 [inline]
+- netdev_start_xmit include/linux/netdevice.h:4365 [inline]
+- xmit_one net/core/dev.c:3257 [inline]
+- dev_hard_start_xmit+0x607/0xc40 net/core/dev.c:3273
+- __dev_queue_xmit+0x2e42/0x3bc0 net/core/dev.c:3843
+- dev_queue_xmit+0x4b/0x60 net/core/dev.c:3876
+- packet_snd net/packet/af_packet.c:2928 [inline]
+- packet_sendmsg+0x8306/0x8f30 net/packet/af_packet.c:2953
+- sock_sendmsg_nosec net/socket.c:621 [inline]
+- sock_sendmsg net/socket.c:631 [inline]
+- __sys_sendto+0x8c4/0xac0 net/socket.c:1788
+- __do_sys_sendto net/socket.c:1800 [inline]
+- __se_sys_sendto+0x107/0x130 net/socket.c:1796
+- __x64_sys_sendto+0x6e/0x90 net/socket.c:1796
+- do_syscall_64+0xbc/0xf0 arch/x86/entry/common.c:291
+- entry_SYSCALL_64_after_hwframe+0x63/0xe7
+-RIP: 0033:0x441889
+-Code: 18 89 d0 c3 66 2e 0f 1f 84 00 00 00 00 00 0f 1f 00 48 89 f8 48 89 f7 48 89 d6 48 89 ca 4d 89 c2 4d 89 c8 4c 8b 4c 24 08 0f 05 <48> 3d 01 f0 ff ff 0f 83 bb 10 fc ff c3 66 2e 0f 1f 84 00 00 00 00
+-RSP: 002b:00007ffdda6fd468 EFLAGS: 00000216 ORIG_RAX: 000000000000002c
+-RAX: ffffffffffffffda RBX: 0000000000000002 RCX: 0000000000441889
+-RDX: 000000000000000e RSI: 00000000200000c0 RDI: 0000000000000003
+-RBP: 0000000000000003 R08: 0000000000000000 R09: 0000000000000000
+-R10: 0000000000000000 R11: 0000000000000216 R12: 00007ffdda6fd4c0
+-R13: 00007ffdda6fd4b0 R14: 0000000000000000 R15: 0000000000000000
+-
+-Uninit was created at:
+- kmsan_save_stack_with_flags mm/kmsan/kmsan.c:204 [inline]
+- kmsan_internal_poison_shadow+0x92/0x150 mm/kmsan/kmsan.c:158
+- kmsan_kmalloc+0xa6/0x130 mm/kmsan/kmsan_hooks.c:176
+- kmsan_slab_alloc+0xe/0x10 mm/kmsan/kmsan_hooks.c:185
+- slab_post_alloc_hook mm/slab.h:446 [inline]
+- slab_alloc_node mm/slub.c:2759 [inline]
+- __kmalloc_node_track_caller+0xe18/0x1030 mm/slub.c:4383
+- __kmalloc_reserve net/core/skbuff.c:137 [inline]
+- __alloc_skb+0x309/0xa20 net/core/skbuff.c:205
+- alloc_skb include/linux/skbuff.h:998 [inline]
+- alloc_skb_with_frags+0x1c7/0xac0 net/core/skbuff.c:5220
+- sock_alloc_send_pskb+0xafd/0x10e0 net/core/sock.c:2083
+- packet_alloc_skb net/packet/af_packet.c:2781 [inline]
+- packet_snd net/packet/af_packet.c:2872 [inline]
+- packet_sendmsg+0x661a/0x8f30 net/packet/af_packet.c:2953
+- sock_sendmsg_nosec net/socket.c:621 [inline]
+- sock_sendmsg net/socket.c:631 [inline]
+- __sys_sendto+0x8c4/0xac0 net/socket.c:1788
+- __do_sys_sendto net/socket.c:1800 [inline]
+- __se_sys_sendto+0x107/0x130 net/socket.c:1796
+- __x64_sys_sendto+0x6e/0x90 net/socket.c:1796
+- do_syscall_64+0xbc/0xf0 arch/x86/entry/common.c:291
+- entry_SYSCALL_64_after_hwframe+0x63/0xe7
+-
+-Fixes: 48628bb9419f ("batman-adv: softif bridge loop avoidance")
+-Signed-off-by: Eric Dumazet <edumazet@google.com>
+-Reported-by: syzbot <syzkaller@googlegroups.com>
+-Cc:	Marek Lindner <mareklindner@neomailbox.ch>
+-Cc:	Simon Wunderlich <sw@simonwunderlich.de>
+-Cc:	Antonio Quartulli <a@unstable.cc>
+-Signed-off-by: David S. Miller <davem@davemloft.net>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/35482922b38bb5f5b03b0e92bc58cec2b7c77cdf
+-
+-diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+-index d3f540ba2a1388a8aa693a539d01d6a1cad95b44..97e28907a0acbb3d64d8ceebf7b1df13dc396300 100644
+---- a/net/batman-adv/soft-interface.c
+-+++ b/net/batman-adv/soft-interface.c
+-@@ -227,6 +227,8 @@ static int batadv_interface_tx(struct sk_buff *skb,
+- 
+- 	switch (ntohs(ethhdr->h_proto)) {
+- 	case ETH_P_8021Q:
+-+		if (!pskb_may_pull(skb, sizeof(*vhdr)))
+-+			goto dropped;
+- 		vhdr = vlan_eth_hdr(skb);
+- 
+- 		/* drop batman-in-batman packets to prevent loops */
+diff --git a/batman-adv/patches/0027-batman-adv-Reduce-claim-hash-refcnt-only-for-removed.patch b/batman-adv/patches/0027-batman-adv-Reduce-claim-hash-refcnt-only-for-removed.patch
+deleted file mode 100644
+index 7a2f9998aa606dec514e74fd406a7bed87c54e42..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0027-batman-adv-Reduce-claim-hash-refcnt-only-for-removed.patch
++++ /dev/null
+@@ -1,65 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sat, 23 Feb 2019 15:09:04 +0100
+-Subject: batman-adv: Reduce claim hash refcnt only for removed entry
+-
+-The batadv_hash_remove is a function which searches the hashtable for an
+-entry using a needle, a hashtable bucket selection function and a compare
+-function. It will lock the bucket list and delete an entry when the compare
+-function matches it with the needle. It returns the pointer to the
+-hlist_node which matches or NULL when no entry matches the needle.
+-
+-The batadv_bla_del_claim is not itself protected in anyway to avoid that
+-any other function is modifying the hashtable between the search for the
+-entry and the call to batadv_hash_remove. It can therefore happen that the
+-entry either doesn't exist anymore or an entry was deleted which is not the
+-same object as the needle. In such an situation, the reference counter (for
+-the reference stored in the hashtable) must not be reduced for the needle.
+-Instead the reference counter of the actually removed entry has to be
+-reduced.
+-
+-Otherwise the reference counter will underflow and the object might be
+-freed before all its references were dropped. The kref helpers reported
+-this problem as:
+-
+-  refcount_t: underflow; use-after-free.
+-
+-Fixes: a9ce0dc43e2c ("batman-adv: add basic bridge loop avoidance code")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/3a7af70ae7c4209324dbb08b91e013c17108bdd6
+-
+-diff --git a/net/batman-adv/bridge_loop_avoidance.c b/net/batman-adv/bridge_loop_avoidance.c
+-index 58c093caf49e804c1e11426959d70e79f1729d41..0842080a71f4ac89b3fbebc4b95c6c27d1cc4254 100644
+---- a/net/batman-adv/bridge_loop_avoidance.c
+-+++ b/net/batman-adv/bridge_loop_avoidance.c
+-@@ -803,6 +803,8 @@ static void batadv_bla_del_claim(struct batadv_priv *bat_priv,
+- 				 const u8 *mac, const unsigned short vid)
+- {
+- 	struct batadv_bla_claim search_claim, *claim;
+-+	struct batadv_bla_claim *claim_removed_entry;
+-+	struct hlist_node *claim_removed_node;
+- 
+- 	ether_addr_copy(search_claim.addr, mac);
+- 	search_claim.vid = vid;
+-@@ -813,10 +815,18 @@ static void batadv_bla_del_claim(struct batadv_priv *bat_priv,
+- 	batadv_dbg(BATADV_DBG_BLA, bat_priv, "%s(): %pM, vid %d\n", __func__,
+- 		   mac, batadv_print_vid(vid));
+- 
+--	batadv_hash_remove(bat_priv->bla.claim_hash, batadv_compare_claim,
+--			   batadv_choose_claim, claim);
+--	batadv_claim_put(claim); /* reference from the hash is gone */
+-+	claim_removed_node = batadv_hash_remove(bat_priv->bla.claim_hash,
+-+						batadv_compare_claim,
+-+						batadv_choose_claim, claim);
+-+	if (!claim_removed_node)
+-+		goto free_claim;
+- 
+-+	/* reference from the hash is gone */
+-+	claim_removed_entry = hlist_entry(claim_removed_node,
+-+					  struct batadv_bla_claim, hash_entry);
+-+	batadv_claim_put(claim_removed_entry);
+-+
+-+free_claim:
+- 	/* don't need the reference from hash_find() anymore */
+- 	batadv_claim_put(claim);
+- }
+diff --git a/batman-adv/patches/0028-batman-adv-Reduce-tt_local-hash-refcnt-only-for-remo.patch b/batman-adv/patches/0028-batman-adv-Reduce-tt_local-hash-refcnt-only-for-remo.patch
+deleted file mode 100644
+index a6ffb25175abb6a6942eb69b3b20c86d60ac9b07..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0028-batman-adv-Reduce-tt_local-hash-refcnt-only-for-remo.patch
++++ /dev/null
+@@ -1,69 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sat, 23 Feb 2019 15:09:05 +0100
+-Subject: batman-adv: Reduce tt_local hash refcnt only for removed entry
+-
+-The batadv_hash_remove is a function which searches the hashtable for an
+-entry using a needle, a hashtable bucket selection function and a compare
+-function. It will lock the bucket list and delete an entry when the compare
+-function matches it with the needle. It returns the pointer to the
+-hlist_node which matches or NULL when no entry matches the needle.
+-
+-The batadv_tt_local_remove is not itself protected in anyway to avoid that
+-any other function is modifying the hashtable between the search for the
+-entry and the call to batadv_hash_remove. It can therefore happen that the
+-entry either doesn't exist anymore or an entry was deleted which is not the
+-same object as the needle. In such an situation, the reference counter (for
+-the reference stored in the hashtable) must not be reduced for the needle.
+-Instead the reference counter of the actually removed entry has to be
+-reduced.
+-
+-Otherwise the reference counter will underflow and the object might be
+-freed before all its references were dropped. The kref helpers reported
+-this problem as:
+-
+-  refcount_t: underflow; use-after-free.
+-
+-Fixes: af912d77181f ("batman-adv: protect tt_local_entry from concurrent delete events")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/0c86a0511e97de502276900c5d6f22b09e042d21
+-
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index 7502cb54c152d06d78c88d9f8fb841cada9f3b5d..d2ecfdbdc64956b238f0554b4c354df9a9e9f26a 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -1332,9 +1332,10 @@ u16 batadv_tt_local_remove(struct batadv_priv *bat_priv, const u8 *addr,
+- 			   unsigned short vid, const char *message,
+- 			   bool roaming)
+- {
+-+	struct batadv_tt_local_entry *tt_removed_entry;
+- 	struct batadv_tt_local_entry *tt_local_entry;
+- 	u16 flags, curr_flags = BATADV_NO_FLAGS;
+--	void *tt_entry_exists;
+-+	struct hlist_node *tt_removed_node;
+- 
+- 	tt_local_entry = batadv_tt_local_hash_find(bat_priv, addr, vid);
+- 	if (!tt_local_entry)
+-@@ -1363,15 +1364,18 @@ u16 batadv_tt_local_remove(struct batadv_priv *bat_priv, const u8 *addr,
+- 	 */
+- 	batadv_tt_local_event(bat_priv, tt_local_entry, BATADV_TT_CLIENT_DEL);
+- 
+--	tt_entry_exists = batadv_hash_remove(bat_priv->tt.local_hash,
+-+	tt_removed_node = batadv_hash_remove(bat_priv->tt.local_hash,
+- 					     batadv_compare_tt,
+- 					     batadv_choose_tt,
+- 					     &tt_local_entry->common);
+--	if (!tt_entry_exists)
+-+	if (!tt_removed_node)
+- 		goto out;
+- 
+--	/* extra call to free the local tt entry */
+--	batadv_tt_local_entry_put(tt_local_entry);
+-+	/* drop reference of remove hash entry */
+-+	tt_removed_entry = hlist_entry(tt_removed_node,
+-+				       struct batadv_tt_local_entry,
+-+				       common.hash_entry);
+-+	batadv_tt_local_entry_put(tt_removed_entry);
+- 
+- out:
+- 	if (tt_local_entry)
+diff --git a/batman-adv/patches/0029-batman-adv-Reduce-tt_global-hash-refcnt-only-for-rem.patch b/batman-adv/patches/0029-batman-adv-Reduce-tt_global-hash-refcnt-only-for-rem.patch
+deleted file mode 100644
+index cd08563d374202e859ceb73938201e3a4c60ade4..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0029-batman-adv-Reduce-tt_global-hash-refcnt-only-for-rem.patch
++++ /dev/null
+@@ -1,66 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sat, 23 Feb 2019 15:09:06 +0100
+-Subject: batman-adv: Reduce tt_global hash refcnt only for removed entry
+-
+-The batadv_hash_remove is a function which searches the hashtable for an
+-entry using a needle, a hashtable bucket selection function and a compare
+-function. It will lock the bucket list and delete an entry when the compare
+-function matches it with the needle. It returns the pointer to the
+-hlist_node which matches or NULL when no entry matches the needle.
+-
+-The batadv_tt_global_free is not itself protected in anyway to avoid that
+-any other function is modifying the hashtable between the search for the
+-entry and the call to batadv_hash_remove. It can therefore happen that the
+-entry either doesn't exist anymore or an entry was deleted which is not the
+-same object as the needle. In such an situation, the reference counter (for
+-the reference stored in the hashtable) must not be reduced for the needle.
+-Instead the reference counter of the actually removed entry has to be
+-reduced.
+-
+-Otherwise the reference counter will underflow and the object might be
+-freed before all its references were dropped. The kref helpers reported
+-this problem as:
+-
+-  refcount_t: underflow; use-after-free.
+-
+-Fixes: 7bad46397eff ("batman-adv: protect the local and the global trans-tables with rcu")
+-Reported-by: Martin Weinelt <martin@linuxlounge.net>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Antonio Quartulli <a@unstable.cc>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/bd6df24da0063fe50828c287d05bdc1876f4f6cc
+-
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index d2ecfdbdc64956b238f0554b4c354df9a9e9f26a..554fd886e652c7c206ff43a5627d342ccbcc2123 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -616,14 +616,26 @@ static void batadv_tt_global_free(struct batadv_priv *bat_priv,
+- 				  struct batadv_tt_global_entry *tt_global,
+- 				  const char *message)
+- {
+-+	struct batadv_tt_global_entry *tt_removed_entry;
+-+	struct hlist_node *tt_removed_node;
+-+
+- 	batadv_dbg(BATADV_DBG_TT, bat_priv,
+- 		   "Deleting global tt entry %pM (vid: %d): %s\n",
+- 		   tt_global->common.addr,
+- 		   batadv_print_vid(tt_global->common.vid), message);
+- 
+--	batadv_hash_remove(bat_priv->tt.global_hash, batadv_compare_tt,
+--			   batadv_choose_tt, &tt_global->common);
+--	batadv_tt_global_entry_put(tt_global);
+-+	tt_removed_node = batadv_hash_remove(bat_priv->tt.global_hash,
+-+					     batadv_compare_tt,
+-+					     batadv_choose_tt,
+-+					     &tt_global->common);
+-+	if (!tt_removed_node)
+-+		return;
+-+
+-+	/* drop reference of remove hash entry */
+-+	tt_removed_entry = hlist_entry(tt_removed_node,
+-+				       struct batadv_tt_global_entry,
+-+				       common.hash_entry);
+-+	batadv_tt_global_entry_put(tt_removed_entry);
+- }
+- 
+- /**
+diff --git a/batman-adv/patches/0030-batman-adv-mcast-fix-multicast-tt-tvlv-worker-lockin.patch b/batman-adv/patches/0030-batman-adv-mcast-fix-multicast-tt-tvlv-worker-lockin.patch
+deleted file mode 100644
+index 3f3f3d90d94fd868c2aa5fa565a68b649bb85b67..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0030-batman-adv-mcast-fix-multicast-tt-tvlv-worker-lockin.patch
++++ /dev/null
+@@ -1,103 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Wed, 24 Apr 2019 03:19:14 +0200
+-Subject: batman-adv: mcast: fix multicast tt/tvlv worker locking
+-
+-Syzbot has reported some issues with the locking assumptions made for
+-the multicast tt/tvlv worker: It was able to trigger the WARN_ON() in
+-batadv_mcast_mla_tt_retract() and batadv_mcast_mla_tt_add().
+-While hard/not reproduceable for us so far it seems that the
+-delayed_work_pending() we use might not be quite safe from reordering.
+-
+-Therefore this patch adds an explicit, new spinlock to protect the
+-update of the mla_list and flags in bat_priv and then removes the
+-WARN_ON(delayed_work_pending()).
+-
+-Reported-by: syzbot+83f2d54ec6b7e417e13f@syzkaller.appspotmail.com
+-Reported-by: syzbot+050927a651272b145a5d@syzkaller.appspotmail.com
+-Reported-by: syzbot+979ffc89b87309b1b94b@syzkaller.appspotmail.com
+-Reported-by: syzbot+f9f3f388440283da2965@syzkaller.appspotmail.com
+-Fixes: 40b384052672 ("batman-adv: Use own timer for multicast TT and TVLV updates")
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/b736cf8119cfbc9d95fef90c8832fdec6e8f29c7
+-
+-diff --git a/net/batman-adv/main.c b/net/batman-adv/main.c
+-index 53b329d24461819b4cf0d4118cfa5b0eb8d7261b..0286c651468443197434ccf0fcf25aaa66a0c7e9 100644
+---- a/net/batman-adv/main.c
+-+++ b/net/batman-adv/main.c
+-@@ -160,6 +160,7 @@ int batadv_mesh_init(struct net_device *soft_iface)
+- 	spin_lock_init(&bat_priv->tt.commit_lock);
+- 	spin_lock_init(&bat_priv->gw.list_lock);
+- #ifdef CONFIG_BATMAN_ADV_MCAST
+-+	spin_lock_init(&bat_priv->mcast.mla_lock);
+- 	spin_lock_init(&bat_priv->mcast.want_lists_lock);
+- #endif
+- 	spin_lock_init(&bat_priv->tvlv.container_list_lock);
+-diff --git a/net/batman-adv/multicast.c b/net/batman-adv/multicast.c
+-index a35f597e8c8bf4f15ad0f01aff29849d2bebe36f..39640d3d6fbdf8244344db6e79f2d769eb0972d9 100644
+---- a/net/batman-adv/multicast.c
+-+++ b/net/batman-adv/multicast.c
+-@@ -325,8 +325,6 @@ static void batadv_mcast_mla_list_free(struct hlist_head *mcast_list)
+-  * translation table except the ones listed in the given mcast_list.
+-  *
+-  * If mcast_list is NULL then all are retracted.
+-- *
+-- * Do not call outside of the mcast worker! (or cancel mcast worker first)
+-  */
+- static void batadv_mcast_mla_tt_retract(struct batadv_priv *bat_priv,
+- 					struct hlist_head *mcast_list)
+-@@ -334,8 +332,6 @@ static void batadv_mcast_mla_tt_retract(struct batadv_priv *bat_priv,
+- 	struct batadv_hw_addr *mcast_entry;
+- 	struct hlist_node *tmp;
+- 
+--	WARN_ON(delayed_work_pending(&bat_priv->mcast.work));
+--
+- 	hlist_for_each_entry_safe(mcast_entry, tmp, &bat_priv->mcast.mla_list,
+- 				  list) {
+- 		if (mcast_list &&
+-@@ -359,8 +355,6 @@ static void batadv_mcast_mla_tt_retract(struct batadv_priv *bat_priv,
+-  *
+-  * Adds multicast listener announcements from the given mcast_list to the
+-  * translation table if they have not been added yet.
+-- *
+-- * Do not call outside of the mcast worker! (or cancel mcast worker first)
+-  */
+- static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+- 				    struct hlist_head *mcast_list)
+-@@ -368,8 +362,6 @@ static void batadv_mcast_mla_tt_add(struct batadv_priv *bat_priv,
+- 	struct batadv_hw_addr *mcast_entry;
+- 	struct hlist_node *tmp;
+- 
+--	WARN_ON(delayed_work_pending(&bat_priv->mcast.work));
+--
+- 	if (!mcast_list)
+- 		return;
+- 
+-@@ -658,7 +650,10 @@ static void batadv_mcast_mla_update(struct work_struct *work)
+- 	priv_mcast = container_of(delayed_work, struct batadv_priv_mcast, work);
+- 	bat_priv = container_of(priv_mcast, struct batadv_priv, mcast);
+- 
+-+	spin_lock(&bat_priv->mcast.mla_lock);
+- 	__batadv_mcast_mla_update(bat_priv);
+-+	spin_unlock(&bat_priv->mcast.mla_lock);
+-+
+- 	batadv_mcast_start_timer(bat_priv);
+- }
+- 
+-diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+-index 476b052ad9824d4cbcd6218dce40b603e3400fd2..6d07898d8d1a21007b3e68d5d2511b478110f659 100644
+---- a/net/batman-adv/types.h
+-+++ b/net/batman-adv/types.h
+-@@ -1215,6 +1215,11 @@ struct batadv_priv_mcast {
+- 	/** @num_disabled: number of nodes that have no mcast tvlv */
+- 	atomic_t num_disabled;
+- 
+-+	/**
+-+	 * @mla_lock: a lock protecting mla_list and mla_flags
+-+	 */
+-+	spinlock_t mla_lock;
+-+
+- 	/**
+- 	 * @num_want_all_unsnoopables: number of nodes wanting unsnoopable IP
+- 	 *  traffic
+diff --git a/batman-adv/patches/0031-batman-adv-fix-for-leaked-TVLV-handler.patch b/batman-adv/patches/0031-batman-adv-fix-for-leaked-TVLV-handler.patch
+deleted file mode 100644
+index ce24a36c4a7b546c0824669449cd860859a8b692..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0031-batman-adv-fix-for-leaked-TVLV-handler.patch
++++ /dev/null
+@@ -1,28 +0,0 @@
+-From: Jeremy Sowden <jeremy@azazel.net>
+-Date: Tue, 21 May 2019 20:58:57 +0100
+-Subject: batman-adv: fix for leaked TVLV handler.
+-
+-A handler for BATADV_TVLV_ROAM was being registered when the
+-translation-table was initialized, but not unregistered when the
+-translation-table was freed.  Unregister it.
+-
+-Fixes: 3de4e64df0f1 ("batman-adv: tvlv - convert roaming adv packet to use tvlv unicast packets")
+-Reported-by: syzbot+d454a826e670502484b8@syzkaller.appspotmail.com
+-Signed-off-by: Jeremy Sowden <jeremy@azazel.net>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/87445d81c360a5f9833546114e98ffd2c1fd3a4d
+-
+-diff --git a/net/batman-adv/translation-table.c b/net/batman-adv/translation-table.c
+-index 554fd886e652c7c206ff43a5627d342ccbcc2123..c29aadc5bd8b2020ba67779c517cc1e4ea9f6569 100644
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -3821,6 +3821,8 @@ static void batadv_tt_purge(struct work_struct *work)
+-  */
+- void batadv_tt_free(struct batadv_priv *bat_priv)
+- {
+-+	batadv_tvlv_handler_unregister(bat_priv, BATADV_TVLV_ROAM, 1);
+-+
+- 	batadv_tvlv_container_unregister(bat_priv, BATADV_TVLV_TT, 1);
+- 	batadv_tvlv_handler_unregister(bat_priv, BATADV_TVLV_TT, 1);
+- 
+diff --git a/batman-adv/patches/0032-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch b/batman-adv/patches/0032-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch
+deleted file mode 100644
+index e8902cd900e25f0739c870781186c71bcf1ae4bb..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0032-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch
++++ /dev/null
+@@ -1,77 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sun, 2 Jun 2019 10:57:31 +0200
+-Subject: batman-adv: Fix duplicated OGMs on NETDEV_UP
+-
+-The state of slave interfaces are handled differently depending on whether
+-the interface is up or not. All active interfaces (IFF_UP) will transmit
+-OGMs. But for B.A.T.M.A.N. IV, also non-active interfaces are scheduling
+-(low TTL) OGMs on active interfaces. The code which setups and schedules
+-the OGMs must therefore already be called when the interfaces gets added as
+-slave interface and the transmit function must then check whether it has to
+-send out the OGM or not on the specific slave interface.
+-
+-But the commit 0d8468553c3c ("batman-adv: remove ogm_emit and ogm_schedule
+-API calls") moved the setup code from the enable function to the activate
+-function. The latter is called either when the added slave was already up
+-when batadv_hardif_enable_interface processed the new interface or when a
+-NETDEV_UP event was received for this slave interfac. As result, each
+-NETDEV_UP would schedule a new OGM worker for the interface and thus OGMs
+-would be send a lot more than expected.
+-
+-Fixes: 0d8468553c3c ("batman-adv: remove ogm_emit and ogm_schedule API calls")
+-Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/c92331e0df3c0c5645ee5a897eb018c5da5e4aa5
+-
+-diff --git a/net/batman-adv/bat_iv_ogm.c b/net/batman-adv/bat_iv_ogm.c
+-index 73bf6a93a3cf1141a34657bf1284893199e04db9..0b7b36fa0d5cd440ddef141ad27acfe7b20aee43 100644
+---- a/net/batman-adv/bat_iv_ogm.c
+-+++ b/net/batman-adv/bat_iv_ogm.c
+-@@ -2485,7 +2485,7 @@ batadv_iv_ogm_neigh_is_sob(struct batadv_neigh_node *neigh1,
+- 	return ret;
+- }
+- 
+--static void batadv_iv_iface_activate(struct batadv_hard_iface *hard_iface)
+-+static void batadv_iv_iface_enabled(struct batadv_hard_iface *hard_iface)
+- {
+- 	/* begin scheduling originator messages on that interface */
+- 	batadv_iv_ogm_schedule(hard_iface);
+-@@ -2825,8 +2825,8 @@ static void batadv_iv_gw_dump(struct sk_buff *msg, struct netlink_callback *cb,
+- static struct batadv_algo_ops batadv_batman_iv __read_mostly = {
+- 	.name = "BATMAN_IV",
+- 	.iface = {
+--		.activate = batadv_iv_iface_activate,
+- 		.enable = batadv_iv_ogm_iface_enable,
+-+		.enabled = batadv_iv_iface_enabled,
+- 		.disable = batadv_iv_ogm_iface_disable,
+- 		.update_mac = batadv_iv_ogm_iface_update_mac,
+- 		.primary_set = batadv_iv_ogm_primary_iface_set,
+-diff --git a/net/batman-adv/hard-interface.c b/net/batman-adv/hard-interface.c
+-index 08690d06b7be2b25ca3f009394763c7083c70644..36f0962040d16af4f9ed82629ff03ce85c83ed57 100644
+---- a/net/batman-adv/hard-interface.c
+-+++ b/net/batman-adv/hard-interface.c
+-@@ -821,6 +821,9 @@ int batadv_hardif_enable_interface(struct batadv_hard_iface *hard_iface,
+- 
+- 	batadv_hardif_recalc_extra_skbroom(soft_iface);
+- 
+-+	if (bat_priv->algo_ops->iface.enabled)
+-+		bat_priv->algo_ops->iface.enabled(hard_iface);
+-+
+- out:
+- 	return 0;
+- 
+-diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+-index 6d07898d8d1a21007b3e68d5d2511b478110f659..86f37db7dd01592aff95ada5ba5441667971e1bc 100644
+---- a/net/batman-adv/types.h
+-+++ b/net/batman-adv/types.h
+-@@ -2126,6 +2126,9 @@ struct batadv_algo_iface_ops {
+- 	/** @enable: init routing info when hard-interface is enabled */
+- 	int (*enable)(struct batadv_hard_iface *hard_iface);
+- 
+-+	/** @enabled: notification when hard-interface was enabled (optional) */
+-+	void (*enabled)(struct batadv_hard_iface *hard_iface);
+-+
+- 	/** @disable: de-init routing info when hard-interface is disabled */
+- 	void (*disable)(struct batadv_hard_iface *hard_iface);
+- 
+diff --git a/batman-adv/src/compat-hacks.h b/batman-adv/src/compat-hacks.h
+new file mode 100644
+index 0000000000000000000000000000000000000000..ab7c55b35cdca8670c95b154e5d4f4e5bccba2a5
+--- /dev/null
++++ b/batman-adv/src/compat-hacks.h
+@@ -0,0 +1,300 @@
++/* Please avoid adding hacks here - instead add it to mac80211/backports.git */
++
++#undef CONFIG_MODULE_STRIPPED
++
++#include <linux/version.h>	/* LINUX_VERSION_CODE */
++#include <linux/types.h>
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
++
++#define dev_get_iflink(_net_dev) ((_net_dev)->iflink)
++
++#endif /* < KERNEL_VERSION(4, 1, 0) */
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
++
++#include <linux/netdevice.h>
++
++#define netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info, extack) ({\
++	BUILD_BUG_ON(upper_priv != NULL); \
++	BUILD_BUG_ON(upper_info != NULL); \
++	BUILD_BUG_ON(extack != NULL); \
++	netdev_master_upper_dev_link(dev, upper_dev); \
++})
++
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
++
++#include <linux/netdevice.h>
++
++#define netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info, extack) ({\
++	BUILD_BUG_ON(extack != NULL); \
++	netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info); \
++})
++
++#endif /* < KERNEL_VERSION(4, 5, 0) */
++
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
++
++/* wild hack for batadv_getlink_net only */
++#define get_link_net get_xstats_size || 1 ? fallback_net : (struct net*)netdev->rtnl_link_ops->get_xstats_size
++
++#endif /* < KERNEL_VERSION(4, 0, 0) */
++
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
++
++struct sk_buff *skb_checksum_trimmed(struct sk_buff *skb,
++				     unsigned int transport_len,
++				     __sum16(*skb_chkf)(struct sk_buff *skb));
++
++int ip_mc_check_igmp(struct sk_buff *skb);
++int ipv6_mc_check_mld(struct sk_buff *skb);
++
++#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0)
++
++#include_next <linux/igmp.h>
++#include_next <net/addrconf.h>
++
++static inline int batadv_ipv6_mc_check_mld1(struct sk_buff *skb)
++{
++	return ipv6_mc_check_mld(skb, NULL);
++}
++
++static inline int batadv_ipv6_mc_check_mld2(struct sk_buff *skb,
++					    struct sk_buff **skb_trimmed)
++{
++	return ipv6_mc_check_mld(skb, skb_trimmed);
++}
++
++#define ipv6_mc_check_mld_get(_1, _2, ipv6_mc_check_mld_name, ...) ipv6_mc_check_mld_name
++#define ipv6_mc_check_mld(...) \
++	ipv6_mc_check_mld_get(__VA_ARGS__, batadv_ipv6_mc_check_mld2, batadv_ipv6_mc_check_mld1)(__VA_ARGS__)
++
++static inline int batadv_ip_mc_check_igmp1(struct sk_buff *skb)
++{
++	return ip_mc_check_igmp(skb, NULL);
++}
++
++static inline int batadv_ip_mc_check_igmp2(struct sk_buff *skb,
++					   struct sk_buff **skb_trimmed)
++{
++	return ip_mc_check_igmp(skb, skb_trimmed);
++}
++
++#define ip_mc_check_igmp_get(_1, _2, ip_mc_check_igmp_name, ...) ip_mc_check_igmp_name
++#define ip_mc_check_igmp(...) \
++	ip_mc_check_igmp_get(__VA_ARGS__, batadv_ip_mc_check_igmp2, batadv_ip_mc_check_igmp1)(__VA_ARGS__)
++
++#endif /* < KERNEL_VERSION(4, 2, 0) */
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
++
++#define IFF_NO_QUEUE	0; dev->tx_queue_len = 0
++
++static inline bool hlist_fake(struct hlist_node *h)
++{
++	return h->pprev == &h->next;
++}
++
++#endif /* < KERNEL_VERSION(4, 3, 0) */
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
++
++#include <linux/ethtool.h>
++
++#define ethtool_link_ksettings batadv_ethtool_link_ksettings
++
++struct batadv_ethtool_link_ksettings {
++	struct {
++		__u32	speed;
++		__u8	duplex;
++		__u8    autoneg;
++	} base;
++};
++
++#define __ethtool_get_link_ksettings(__dev, __link_settings) \
++	batadv_ethtool_get_link_ksettings(__dev, __link_settings)
++
++static inline int
++batadv_ethtool_get_link_ksettings(struct net_device *dev,
++				  struct ethtool_link_ksettings *link_ksettings)
++{
++	struct ethtool_cmd cmd;
++	int ret;
++
++	memset(&cmd, 0, sizeof(cmd));
++	ret = __ethtool_get_settings(dev, &cmd);
++
++	if (ret != 0)
++		return ret;
++
++	link_ksettings->base.duplex = cmd.duplex;
++	link_ksettings->base.speed = ethtool_cmd_speed(&cmd);
++	link_ksettings->base.autoneg = cmd.autoneg;
++
++	return 0;
++}
++
++#endif /* < KERNEL_VERSION(4, 6, 0) */
++
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
++
++#include_next <linux/cache.h>
++
++/* hack for netlink.c which marked the family ops as ro */
++#ifdef __ro_after_init
++#undef __ro_after_init
++#endif
++#define __ro_after_init
++
++#endif /* < KERNEL_VERSION(4, 10, 0) */
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 9)
++
++#include <linux/netdevice.h>
++
++/* work around missing attribute needs_free_netdev and priv_destructor in
++ * net_device
++ */
++#define ether_setup(dev) \
++	void batadv_softif_free2(struct net_device *dev) \
++	{ \
++		batadv_softif_free(dev); \
++		free_netdev(dev); \
++	} \
++	void (*t1)(struct net_device *dev) __attribute__((unused)); \
++	bool t2 __attribute__((unused)); \
++	ether_setup(dev)
++#define needs_free_netdev destructor = batadv_softif_free2; t2
++#define priv_destructor destructor = batadv_softif_free2; t1
++
++#endif /* < KERNEL_VERSION(4, 11, 9) */
++
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
++
++#define batadv_softif_slave_add(__dev, __slave_dev, __extack) \
++	batadv_softif_slave_add(__dev, __slave_dev)
++
++#include_next <net/genetlink.h>
++
++static inline
++void batadv_genl_dump_check_consistent(struct netlink_callback *cb,
++				       void *user_hdr)
++{
++	struct genl_family genl_family = {
++		.hdrsize = 0,
++	};
++
++	genl_dump_check_consistent(cb, user_hdr, &genl_family);
++}
++
++#define genl_dump_check_consistent batadv_genl_dump_check_consistent
++
++#endif /* < KERNEL_VERSION(4, 15, 0) */
++
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 18, 0)
++
++#define cfg80211_sinfo_release_content(sinfo)
++
++#endif /* < KERNEL_VERSION(4, 18, 0) */
++
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
++
++static inline int batadv_access_ok(int type, const void __user *p,
++				   unsigned long size)
++{
++	return access_ok(type, p, size);
++}
++
++#ifdef access_ok
++#undef access_ok
++#endif
++
++#define access_ok_get(_1, _2, _3 , access_ok_name, ...) access_ok_name
++#define access_ok(...) \
++	access_ok_get(__VA_ARGS__, access_ok3, access_ok2)(__VA_ARGS__)
++
++#define access_ok2(addr, size)	batadv_access_ok(VERIFY_WRITE, (addr), (size))
++#define access_ok3(type, addr, size)	batadv_access_ok((type), (addr), (size))
++
++#endif /* < KERNEL_VERSION(5, 0, 0) */
++
++/* <DECLARE_EWMA> */
++
++#include <linux/version.h>
++#include_next <linux/average.h>
++
++#include <linux/bug.h>
++
++#ifdef DECLARE_EWMA
++#undef DECLARE_EWMA
++#endif /* DECLARE_EWMA */
++
++/*
++ * Exponentially weighted moving average (EWMA)
++ *
++ * This implements a fixed-precision EWMA algorithm, with both the
++ * precision and fall-off coefficient determined at compile-time
++ * and built into the generated helper funtions.
++ *
++ * The first argument to the macro is the name that will be used
++ * for the struct and helper functions.
++ *
++ * The second argument, the precision, expresses how many bits are
++ * used for the fractional part of the fixed-precision values.
++ *
++ * The third argument, the weight reciprocal, determines how the
++ * new values will be weighed vs. the old state, new values will
++ * get weight 1/weight_rcp and old values 1-1/weight_rcp. Note
++ * that this parameter must be a power of two for efficiency.
++ */
++
++#define DECLARE_EWMA(name, _precision, _weight_rcp)			\
++	struct ewma_##name {						\
++		unsigned long internal;					\
++	};								\
++	static inline void ewma_##name##_init(struct ewma_##name *e)	\
++	{								\
++		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
++		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
++		/*							\
++		 * Even if you want to feed it just 0/1 you should have	\
++		 * some bits for the non-fractional part...		\
++		 */							\
++		BUILD_BUG_ON((_precision) > 30);			\
++		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
++		e->internal = 0;					\
++	}								\
++	static inline unsigned long					\
++	ewma_##name##_read(struct ewma_##name *e)			\
++	{								\
++		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
++		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
++		BUILD_BUG_ON((_precision) > 30);			\
++		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
++		return e->internal >> (_precision);			\
++	}								\
++	static inline void ewma_##name##_add(struct ewma_##name *e,	\
++					     unsigned long val)		\
++	{								\
++		unsigned long internal = READ_ONCE(e->internal);	\
++		unsigned long weight_rcp = ilog2(_weight_rcp);		\
++		unsigned long precision = _precision;			\
++									\
++		BUILD_BUG_ON(!__builtin_constant_p(_precision));	\
++		BUILD_BUG_ON(!__builtin_constant_p(_weight_rcp));	\
++		BUILD_BUG_ON((_precision) > 30);			\
++		BUILD_BUG_ON_NOT_POWER_OF_2(_weight_rcp);		\
++									\
++		WRITE_ONCE(e->internal, internal ?			\
++			(((internal << weight_rcp) - internal) +	\
++				(val << precision)) >> weight_rcp :	\
++			(val << precision));				\
++	}
++
++/* </DECLARE_EWMA> */


### PR DESCRIPTION
This updates the batman-adv OpenWrt package to the current version provided in the master branch of the openwrt-routing packages repository (minus config changes).

The second patch then enables the batman-adv multicast optimizations again.

