### PR TITLE
Add minimal docker environment

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,0 +1,26 @@
+FROM debian:buster-slim
+
+RUN apt update && apt install -y --no-install-recommends \
+    ca-certificates \
+    file \
+    git \
+    subversion \
+    python \
+    build-essential \
+    gawk \
+    unzip \
+    libncurses5-dev \
+    zlib1g-dev \
+    libssl-dev \
+    libelf-dev \
+    wget \
+    time \
+    ecdsautils \
+    lua-check \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -d /gluon gluon
+USER gluon
+
+VOLUME /gluon
+WORKDIR /gluon


### PR DESCRIPTION
This will be a useful precursor for continuous integration.

I'm running NixOS at home and I use this container to build OpenWrt and Gluon.

Once merged we should set up automatic builds in the Docker Hub.