### PR TITLE
Add luacheck config

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,105 @@
+codes = true
+std = "min"
+self = false
+
+read_globals = {
+	"getfenv",
+	"setfenv",
+	"unpack",
+}
+
+include_files = {
+	"**/*.lua",
+	"package/**/files/lib/gluon/ebtables/*",
+	"package/**/luasrc/**/*",
+	"targets/*",
+}
+
+exclude_files = {
+	"**/*.mk",
+}
+
+files["package/**/check_site.lua"] = {
+	read_globals = {
+		"alternatives",
+		"extend",
+		"in_domain",
+		"in_site",
+		"need",
+		"need_alphanumeric_key",
+		"need_array",
+		"need_array_of",
+		"need_boolean",
+		"need_chanlist",
+		"need_domain_name",
+		"need_number",
+		"need_one_of",
+		"need_string",
+		"need_string_array",
+		"need_string_array_match",
+		"need_string_match",
+		"need_table",
+		"need_value",
+		"obsolete",
+		"table_keys",
+		"this_domain",
+	},
+}
+
+files["package/**/files/lib/gluon/ebtables/*"] = {
+	read_globals = {
+		"chain",
+		"rule",
+	},
+	max_line_length = false,
+}
+
+files["package/**/luasrc/lib/gluon/config-mode/*"] = {
+	globals = {
+		"DynamicList",
+		"Flag",
+		"Form",
+		"i18n",
+		"ListValue",
+		"renderer.render",
+		"renderer.render_string",
+		"Section",
+		"TextValue",
+		"_translate",
+		"translate",
+		"translatef",
+		"Value",
+	},
+}
+
+files["package/**/luasrc/lib/gluon/**/controller/*"] = {
+	read_globals = {
+		"_",
+		"alias",
+		"call",
+		"entry",
+		"model",
+		"node",
+		"template",
+	},
+}
+
+files["targets/*"] = {
+	read_globals = {
+		"config",
+		"defaults",
+		"device",
+		"env",
+		"envtrue",
+		"exec",
+		"exec_capture",
+		"exec_capture_raw",
+		"exec_raw",
+		"factory_image",
+		"include",
+		"no_opkg",
+		"packages",
+		"sysupgrade_image",
+		"try_config",
+	},
+}

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -10,7 +10,6 @@ read_globals = {
 
 include_files = {
 	"**/*.lua",
-	"package/**/files/lib/gluon/ebtables/*",
 	"package/**/luasrc/**/*",
 	"targets/*",
 }
@@ -46,14 +45,6 @@ files["package/**/check_site.lua"] = {
 	},
 }
 
-files["package/**/files/lib/gluon/ebtables/*"] = {
-	read_globals = {
-		"chain",
-		"rule",
-	},
-	max_line_length = false,
-}
-
 files["package/**/luasrc/lib/gluon/config-mode/*"] = {
 	globals = {
 		"DynamicList",
@@ -82,6 +73,14 @@ files["package/**/luasrc/lib/gluon/**/controller/*"] = {
 		"node",
 		"template",
 	},
+}
+
+files["package/**/luasrc/lib/gluon/ebtables/*"] = {
+	read_globals = {
+		"chain",
+		"rule",
+	},
+	max_line_length = false,
 }
 
 files["targets/*"] = {


### PR DESCRIPTION
In the mumble developer meeting the lua linter `luacheck` was suggested for the CI pipeline.

As i played around with it, and already have some `.luacheckrc` snippets for Gluon i want to add the config file and try to fix warnings found by luacheck.

In the `check_site.lua` files the following issues where fixed
* `line is too long (137 > 120)` -> what is the maximum line length that should be used in Gluon? 120 is the default by luacheck
* `unused loop variable k, v` -> replaced by `_`
* `setting non-standard global variable from, to` -> add `local`
* `line contains trailing whitespace` -> removed