### PR TITLE
gluon-mesh-vpn-core: fix luacheck warnings

### DIFF
--- a/package/gluon-mesh-vpn-core/luasrc/usr/bin/gluon-wan
+++ b/package/gluon-mesh-vpn-core/luasrc/usr/bin/gluon-wan
@@ -21,12 +21,11 @@ if ok ~= 0 then
 	io.stderr:write(string.format("gluon-wan: unable to change to group: %s\n", err))
 	os.exit(1)
 end
+local args = {[0] = arg[1], unpack(arg)}
+table.remove(args, 1)
 
-arg[0] = arg[1]
-table.remove(arg, 1)
-print(arg[0], unpack(arg))
-
-ok, err = unistd.execp(arg[0], arg)
+local _
+_, err = unistd.execp(args[0], args)
 
 io.stderr:write(string.format("gluon-wan: exec failed: %s\n", err))
 os.exit(1)


### PR DESCRIPTION
./gluon-wan:25:1: (W122) setting read-only field ? of global arg
./gluon-wan:29:1: (W311) value assigned to variable ok is unused