### PR TITLE
gluon-mesh-vpn-core: move common VPN config to gluon UCI package

### DIFF
--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/mesh-vpn/update-config
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/mesh-vpn/update-config
@@ -1,0 +1,48 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+local unistd = require 'posix.unistd'
+
+local vpn
+if unistd.access('/lib/gluon/mesh-vpn/fastd') then
+	vpn = 'fastd'
+elseif unistd.access('/lib/gluon/mesh-vpn/tunneldigger') then
+	vpn = 'tunneldigger'
+end
+
+local vpn_config = {
+	enabled = uci:get_bool('gluon', 'mesh_vpn', 'enabled'),
+	limit_enabled = uci:get_bool('gluon', 'mesh_vpn', 'limit_enabled'),
+	limit_egress = uci:get('gluon', 'mesh_vpn', 'limit_egress'),
+	limit_ingress = uci:get('gluon', 'mesh_vpn', 'limit_ingress'),
+}
+
+uci:delete('simple-tc', 'mesh_vpn')
+uci:section('simple-tc', 'interface', 'mesh_vpn', {
+	ifname = 'mesh-vpn',
+	enabled = vpn_config.limit_enabled,
+	limit_egress = vpn_config.limit_egress,
+})
+
+if vpn == 'fastd' then
+	uci:set('fastd', 'mesh_vpn', 'enabled', vpn_config.enabled)
+	uci:set('simple-tc', 'mesh_vpn', 'limit_ingress', vpn_config.limit_ingress)
+else
+	uci:set('fastd', 'mesh_vpn', 'enabled', false)
+end
+uci:save('fastd')
+
+if vpn == 'tunneldigger' then
+	uci:set('tunneldigger', 'mesh_vpn', 'enabled', vpn_config.enabled)
+
+	if vpn_config.limit_enabled then
+		uci:set('tunneldigger', 'mesh_vpn', 'limit_bw_down', vpn_config.limit_ingress)
+	else
+		uci:delete('tunneldigger', 'mesh_vpn', 'limit_bw_down')
+	end
+else
+	uci:set('tunneldigger', 'mesh_vpn', 'enabled', false)
+end
+uci:save('tunneldigger')
+
+uci:save('simple-tc')

--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
@@ -24,16 +24,6 @@ if unistd.access('/etc/config/gluon-simple-tc') then
 	os.rename('/etc/config/gluon-simple-tc', '/etc/config/simple-tc')
 end
 
-if not uci:get('simple-tc', 'mesh_vpn') then
-	uci:section('simple-tc', 'interface', 'mesh_vpn', {
-		ifname = 'mesh-vpn',
-		enabled = site.mesh_vpn.bandwidth_limit.enabled(false),
-		limit_ingress = site.mesh_vpn.bandwidth_limit.ingress(),
-		limit_egress = site.mesh_vpn.bandwidth_limit.egress(),
-	})
-	uci:save('simple-tc')
-end
-
 
 -- The previously used user and group are removed, we now have a generic group
 users.remove_user('gluon-fastd')
@@ -49,42 +39,59 @@ uci:save('firewall')
 
 
 -- VPN migration
-local has_fastd = unistd.access('/lib/gluon/mesh-vpn/fastd')
-local fastd_enabled = uci:get('fastd', 'mesh_vpn', 'enabled')
-
-local has_tunneldigger = (not has_fastd) and unistd.access('/lib/gluon/mesh-vpn/tunneldigger')
-local tunneldigger_enabled = uci:get('tunneldigger', 'mesh_vpn', 'enabled')
-
-local enabled
-
--- If the installed VPN package has its enabled state set, keep the value
-if has_fastd and fastd_enabled then
-	enabled = fastd_enabled == '1'
-elseif has_tunneldigger and tunneldigger_enabled then
-	enabled = tunneldigger_enabled == '1'
--- Otherwise, migrate the other package's value if any is set
-elseif fastd_enabled or tunneldigger_enabled then
-	enabled = fastd_enabled == '1' or tunneldigger_enabled == '1'
--- If nothing is set, use the default
-else
-	enabled = site.mesh_vpn.enabled(false)
-end
-
-if has_fastd then
-	uci:set('fastd', 'mesh_vpn', 'enabled', enabled)
-else
-	uci:delete('fastd', 'mesh_vpn')
-end
-uci:save('fastd')
-
-if has_tunneldigger then
-	uci:set('tunneldigger', 'mesh_vpn', 'enabled', enabled)
-	if site.mesh_vpn.bandwidth_limit.enabled(false) then
-		uci:set('tunneldigger', 'mesh_vpn', 'limit_bw_down', site.mesh_vpn.bandwidth_limit.ingress())
-		uci:set('simple-tc', 'mesh_vpn', 'limit_ingress', 0)
-		uci:save('simple-tc')
+if not uci:get('gluon', 'mesh_vpn') then
+	local vpn
+	if unistd.access('/lib/gluon/mesh-vpn/fastd') then
+		vpn = 'fastd'
+	elseif unistd.access('/lib/gluon/mesh-vpn/tunneldigger') then
+		vpn = 'tunneldigger'
 	end
-else
-	uci:delete('tunneldigger', 'mesh_vpn')
+
+	local fastd_enabled = uci:get('fastd', 'mesh_vpn', 'enabled')
+	local tunneldigger_enabled = uci:get('tunneldigger', 'mesh_vpn', 'enabled')
+
+	local enabled
+
+	-- If the installed VPN package has its enabled state set, keep the value
+	if vpn == 'fastd' and fastd_enabled then
+		enabled = fastd_enabled == '1'
+	elseif vpn == 'tunneldigger' and tunneldigger_enabled then
+		enabled = tunneldigger_enabled == '1'
+	-- Otherwise, migrate the other package's value if any is set
+	elseif fastd_enabled or tunneldigger_enabled then
+		enabled = fastd_enabled == '1' or tunneldigger_enabled == '1'
+	-- If nothing is set, use the default
+	else
+		enabled = site.mesh_vpn.enabled(false)
+	end
+
+
+	local limit_enabled = tonumber((uci:get('simple-tc', 'mesh_vpn', 'enabled')))
+	if limit_enabled == nil then
+		limit_enabled = site.mesh_vpn.bandwidth_limit.enabled(false)
+	end
+
+	local limit_ingress = tonumber((uci:get('tunneldigger', 'mesh_vpn', 'limit_bw_down')))
+	if limit_ingress == nil then
+		limit_ingress = tonumber((uci:get('simple-tc', 'mesh_vpn', 'limit_ingress')))
+	end
+	if limit_ingress == nil then
+		limit_ingress = site.mesh_vpn.bandwidth_limit.ingress()
+	end
+
+	local limit_egress = tonumber((uci:get('simple-tc', 'mesh_vpn', 'limit_egress')))
+	if limit_egress == nil then
+		limit_egress = site.mesh_vpn.bandwidth_limit.egress()
+	end
+
+
+	uci:section('gluon', 'mesh_vpn', 'mesh_vpn', {
+		enabled = enabled,
+		limit_enabled = limit_enabled,
+		limit_ingress = limit_ingress,
+		limit_egress = limit_egress,
+	})
+	uci:save('gluon')
 end
-uci:save('tunneldigger')
+
+os.execute('exec /lib/gluon/mesh-vpn/update-config')

--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
@@ -20,11 +20,6 @@ uci:section('network', 'interface', 'mesh_vpn', {
 uci:save('network')
 
 
-if unistd.access('/etc/config/gluon-simple-tc') then
-	os.rename('/etc/config/gluon-simple-tc', '/etc/config/simple-tc')
-end
-
-
 -- The previously used user and group are removed, we now have a generic group
 users.remove_user('gluon-fastd')
 users.remove_group('gluon-fastd')

--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
@@ -52,7 +52,7 @@ uci:save('firewall')
 local has_fastd = unistd.access('/lib/gluon/mesh-vpn/fastd')
 local fastd_enabled = uci:get('fastd', 'mesh_vpn', 'enabled')
 
-local has_tunneldigger = unistd.access('/lib/gluon/mesh-vpn/tunneldigger')
+local has_tunneldigger = (not has_fastd) and unistd.access('/lib/gluon/mesh-vpn/tunneldigger')
 local tunneldigger_enabled = uci:get('tunneldigger', 'mesh_vpn', 'enabled')
 
 local enabled


### PR DESCRIPTION
More testing is welcome - in particular, I didn't do any actual testing with tunneldigger. Of course, migration from old configs needs to work correctly as well.

The first two commits should also be cherry-picked for v2018.2.x.

Fixes #1736.
