### PR TITLE
gluon-core: fix outdoor board names

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -24,9 +24,16 @@ end
 
 function M.is_outdoor_device()
 	if M.match('ar71xx', 'generic', {
-		'cpe510-520-v1',
-		'ubnt-nano-m',
-		'ubnt-nano-m-xw',
+		'bullet-m',
+		'cpe510',
+		'lbe-m5',
+		'loco-m-xw',
+		'nanostation-m',
+		'nanostation-m-xw',
+		'rocket-m',
+		'rocket-m-ti',
+		'rocket-m-xw',
+		'unifi-outdoor',
 	}) then
 		return true
 


### PR DESCRIPTION
The board names for CPE510, Nanostation Loco M5 and Nanostation M5 are incorrect.

I've personally verified the names against a CPE510 v1.1 and a Nanostation Loco M2 (XM).

Sorry for the mess.