### PR TITLE
scripts: fix luacheck warnings

### DIFF
--- a/scripts/common.inc.lua
+++ b/scripts/common.inc.lua
@@ -1,8 +1,8 @@
 env = setmetatable({}, {
-	__index = function(t, k) return os.getenv(k) end
+	__index = function(_, k) return os.getenv(k) end
 })
 envtrue = setmetatable({}, {
-	__index = function(t, k) return (tonumber(os.getenv(k)) or 0) > 0 end
+	__index = function(_, k) return (tonumber(os.getenv(k)) or 0) > 0 end
 })
 
 assert(env.GLUON_SITEDIR)
@@ -117,7 +117,10 @@ end
 local image_mt = {
 	__index = {
 		dest_name = function(image, name, site, release)
-			return env.GLUON_IMAGEDIR..'/'..image.subdir, 'gluon-'..(site or site_code)..'-'..(release or env.GLUON_RELEASE)..'-'..name..image.out_suffix..image.extension
+			return env.GLUON_IMAGEDIR .. '/' .. image.subdir,
+				'gluon-' .. (site or site_code) .. '-'
+				.. (release or env.GLUON_RELEASE) .. '-'
+				.. name .. image.out_suffix .. image.extension
 		end,
 	},
 }

--- a/scripts/copy_output.lua
+++ b/scripts/copy_output.lua
@@ -40,7 +40,8 @@ for _, image in ipairs(images) do
 	clean(image, image.image)
 
 	local destdir, destname = image:dest_name(image.image)
-	local source = string.format('openwrt/bin/targets/%s/openwrt-%s-%s%s%s', bindir, openwrt_target, image.name, image.in_suffix, image.extension)
+	local source = string.format('openwrt/bin/targets/%s/openwrt-%s-%s%s%s', bindir,
+		openwrt_target, image.name, image.in_suffix, image.extension)
 
 	exec {'cp', source, destdir..'/'..destname}
 

--- a/scripts/target_config.inc.lua
+++ b/scripts/target_config.inc.lua
@@ -69,7 +69,8 @@ for _, dev in ipairs(devices) do
 		handle_pkg(pkg)
 	end
 
-	config_message(string.format("unable to enable device '%s'", profile), 'CONFIG_TARGET_DEVICE_%s_DEVICE_%s=y', openwrt_config_target, profile)
+	config_message(string.format("unable to enable device '%s'", profile),
+		'CONFIG_TARGET_DEVICE_%s_DEVICE_%s=y', openwrt_config_target, profile)
 	config('CONFIG_TARGET_DEVICE_PACKAGES_%s_DEVICE_%s="%s"',
 		openwrt_config_target, profile, device_pkgs)
 end

--- a/scripts/target_config_check.lua
+++ b/scripts/target_config_check.lua
@@ -49,7 +49,7 @@ end
 
 function config_package(pkg, value)
 	local pattern = string.format('CONFIG_PACKAGE_%s=%s', pkg, value)
-	local ret
+	local res
 	if value == 'y' then
 		res = check_config(pattern)
 	else


### PR DESCRIPTION
This pr is trying to fix the following issues:
```
    scripts/common.inc.lua:2:21: (W212) unused argument t
    scripts/common.inc.lua:5:21: (W212) unused argument t
    scripts/common.inc.lua:120:121: (W631) line is too long (161 > 120)

    scripts/copy_output.lua:43:121: (W631) line is too long (143 > 120)

    scripts/target_config.inc.lua:72:121: (W631) line is too long (142 > 120)

    scripts/target_config_check.lua:52:8: (W211) unused variable ret
    scripts/target_config_check.lua:52:8: (W431) shadowing upvalue ret on line 4
    scripts/target_config_check.lua:54:3: (W111) setting non-standard global variable res
    scripts/target_config_check.lua:56:3: (W111) setting non-standard global variable res
    scripts/target_config_check.lua:59:9: (W113) accessing undefined variable res
```

Some issues are left and i am unsure, how to handle these:

```
    scripts/target_config.lua:11:1: (W121) setting read-only global variable try_config
    scripts/target_config.lua:14:25: (W212) unused argument msg
```