### PR TITLE
docs: Add information, how to automatically check your code

### DIFF
--- a/docs/dev/basics.rst
+++ b/docs/dev/basics.rst
@@ -54,16 +54,18 @@ commits, making `git reflog` the only way to recover them!
 
 Development Guidelines
 ----------------------
-lua should be used instead of sh whenever sensible. The following criteria
+Lua should be used instead of sh whenever sensible. The following criteria
 should be considered:
 
-- Is the script doing more than just executing external commands? if so, use lua
-- Is the script parsing/editing json-data? If so, use lua for speed
+- Is the script doing more than just executing external commands? if so, use Lua
+- Is the script parsing/editing json-data? If so, use Lua for speed
 - When using sh, use jsonfilter instead of json_* functions for speed
 
 Code formatting may sound like a topic for the pedantic, however it helps if
-the code in the project is formatted in the same way. The following rules
+the code in the project is formatted in the same way. The following basic rules
 apply:
 
 - use tabs instead of spaces
 - trailing whitespaces must be eliminated
+
+If you add Lua scripts to gluon, check formatting with ``luacheck``.


### PR DESCRIPTION
I think on Docker hub we will test with Jenkins if the commit is valid and throw errors automatically. A user that want s to contribute should be able to do so before they commit, and check in their own dockerhub instance beforehand.

This PR can be added more optins, when the Jenkins tests (#1759) are finished and we have a running build  check there