### PR TITLE
doc/dev/package: Fix path to gluon.mk

### DIFF
--- a/docs/dev/packages.rst
+++ b/docs/dev/packages.rst
@@ -10,7 +10,7 @@ Gluon package makefiles
 As many packages share the same or a similar structure, Gluon provides a ``package/gluon.mk`` that
 can be included for common definitions. This file replaces OpenWrt's ``$(INCLUDE_DIR)/package.mk``;
 it is usually included as ``include ../gluon.mk`` from Gluon core packages, or as
-``include $(TOPDIR)../package/gluon.mk`` from feeds.
+``include $(TOPDIR)/../package/gluon.mk`` from feeds.
 
 Provided macros
 ***************


### PR DESCRIPTION
$(TOPDIR) does not contain a trailing slash.
Thus the 'gluon.mk'-include must include
the trailing slash. (Just like the link to
$(INCLUDE_DIR)/package.mk does.)

Signed-off-by: Chris Fiege <chris@tinyhost.de>