### PR TITLE
ramips-mt76x8: add support for TP-Link TL-MR3420 v5

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -381,6 +381,7 @@ ramips-mt76x8
 
 * TP-Link
 
+  - TL-MR3420 v5 [#80211s]_
   - TL-WR841N v13 [#80211s]_
   - Archer C50 v3 [#80211s]_
   - Archer C50 v4 [#80211s]_

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -25,6 +25,13 @@ device('tp-link-archer-c50-v4', 'tplink_c50-v4', {
 	factory = false,
 })
 
+device('tp-link-tl-mr3420-v5', 'tplink_tl-mr3420-v5', {
+	factory = false,
+	extra_images = {
+		{'-squashfs-tftp-recovery', '-bootloader', '.bin'},
+	},
+})
+
 device('tp-link-tl-wr841n-v13', 'tl-wr841n-v13', {
 	factory = false,
 	extra_images = {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [ ] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity [not working in stock either]
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

how to restore to stock:
use stock image without its first 512 bytes and do tftp