### PR TITLE
gluon-authorized-keys: Force installation of gluon-lock-password

### DIFF
--- a/package/gluon-authorized-keys/Makefile
+++ b/package/gluon-authorized-keys/Makefile
@@ -7,7 +7,7 @@ include ../gluon.mk
 
 define Package/gluon-authorized-keys
   TITLE:=Fill /etc/dropbear/authorized_keys from site.conf
-  DEPENDS:=+gluon-core
+  DEPENDS:=+gluon-core +gluon-lock-password
 endef
 
 $(eval $(call BuildPackageGluon,gluon-authorized-keys))


### PR DESCRIPTION
The gluon-authorized-keys is usually installed to use SSH keys to authenticate a user before being allowed to access device. To make this useful, it is also required to disable passwordless SSH access to the device.

This new dependency is only required when the user doesn't have gluon-setup-mode enabled already.

Fixes: #1777
Reported-by: yanosz <github@yanosz.net>
Fixes: a753fa79e30f ("gluon-authorized-keys: add keys from site.conf")