### PR TITLE
ramips-rt305x: mark boards with 4M flash as broken

### DIFF
--- a/targets/ramips-rt305x
+++ b/targets/ramips-rt305x
@@ -4,6 +4,7 @@ config '# CONFIG_KERNEL_KALLSYMS is not set'
 
 device('a5-v11', 'a5-v11', {
 	deprecated = true, -- 4/32
+	broken = true,
 })
 
 
@@ -11,6 +12,7 @@ device('a5-v11', 'a5-v11', {
 
 device('d-link-dir-615-h1', 'dir-615-h1', {
 	deprecated = true, -- 4/32
+	broken = true,
 })
 
 device('d-link-dir-615-d', 'dir-615-d', {
@@ -21,6 +23,7 @@ device('d-link-dir-615-d', 'dir-615-d', {
 		'd-link-dir-615-d4',
 	},
 	deprecated = true, -- 4/32
+	broken = true,
 })
 
 


### PR DESCRIPTION
This adds the broken flag to devices with 4MB flash. They tend to lose
their configuration because of missing space for the overlayfs. For this
reason, the boards are marked as broken.

This has been observed in the network of Freifunk Darmstadt with a D-Link DIR-615L which went offline after the update to Gluon 2018.2. https://meshviewer.darmstadt.freifunk.net/#/en/map/1cbdb9ae419a

This issue is also known upstream https://forum.openwrt.org/t/report-devices-here-with-18-06-0-provided-image-too-big-to-save-overlay/18161