### PR TITLE
ramips: add support for ASUS RT-AC57U

### DIFF
--- a/patches/openwrt/0024-ramips-add-support-for-ASUS-RT-AC57U.patch
+++ b/patches/openwrt/0024-ramips-add-support-for-ASUS-RT-AC57U.patch
@@ -1,0 +1,292 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sun, 23 Jun 2019 15:10:01 +0200
+Subject: ramips: add support for ASUS RT-AC57U
+
+SoC:   MediaTek MT7621AT
+RAM:   128M (Winbond W631GG6KB-15)
+FLASH: 16MB (Spansion S25FL128SA)
+WiFi:  MediaTek MT7603EN bgn 2SS
+WiFi:  MediaTek MT7612EN nac 2SS
+BTN:   Reset - WPS
+LED:    - Power
+        - LAN {1-4}
+        - WAN
+        - WiFi 2.4 GHz
+        - WiFi 5 GHz
+        - USB
+UART:  UART is present next to the Power LED.
+       TX - RX - GND - 3V3 / 57600-8N1
+       3V3 is the nearest one to the Power LED.
+
+Installation
+------------
+Via TFTP:
+1. Set your computers IP-Address to 192.168.1.75.
+2. Power up the Router with the Reset button pressed.
+3. Release the Reset button after 5 seconds.
+4. Upload OpenWRT sysupgrade image via TFTP:
+ > tftp -4 -v -m binary 192.168.1.1 -c put <IMAGE>
+
+Via SSH:
+Note: User/password for SSH is identical with the one used in the
+Web-interface.
+1. Complete the initial setup wizard.
+2. Activate SSH under "Administration" -> "System".
+3. Transfer the OpenWrt sysupgrade image via scp:
+ > scp owrt.bin admin@192.168.1.1:/tmp
+4. Connect via SSH to the router.
+ > ssh admin@192.168.1.1
+5. Write the OpenWrt image to flash.
+ > mtd-write -i /tmp/owrt.bin -d linux
+6. Reboot the router
+ > reboot
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ramips/base-files/etc/board.d/02_network b/target/linux/ramips/base-files/etc/board.d/02_network
+index 9424c7ddfd64f9149a24ff91e63b71990265d211..7ceec7742aa7a0248ea3c31053b9adda2b247c9c 100755
+--- a/target/linux/ramips/base-files/etc/board.d/02_network
++++ b/target/linux/ramips/base-files/etc/board.d/02_network
+@@ -186,6 +186,7 @@ ramips_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"1:lan" "2:lan" "3:lan" "4:lan" "6t@eth0"
+ 		;;
++	asus,rt-ac57u|\
+ 	atp-52b|\
+ 	awm002-evb-4M|\
+ 	awm002-evb-8M|\
+@@ -413,6 +414,11 @@ ramips_setup_macs()
+ 	wmdr-143n)
+ 		lan_mac=$(cat /sys/class/net/eth0/address)
+ 		;;
++	asus,rt-ac57u|\
++	vr500)
++		lan_mac=$(mtd_get_mac_binary factory 57344)
++		wan_mac=$(mtd_get_mac_binary factory 57350)
++		;;
+ 	all0239-3g|\
+ 	carambola|\
+ 	freestation5|\
+@@ -541,10 +547,6 @@ ramips_setup_macs()
+ 		lan_mac=$(mtd_get_mac_ascii u-boot-env LAN_MAC_ADDR)
+ 		wan_mac=$(mtd_get_mac_ascii u-boot-env WAN_MAC_ADDR)
+ 		;;
+-	vr500)
+-		lan_mac=$(mtd_get_mac_binary factory 57344)
+-		wan_mac=$(mtd_get_mac_binary factory 57350)
+-		;;
+ 	w306r-v20)
+ 		lan_mac=$(cat /sys/class/net/eth0/address)
+ 		wan_mac=$(macaddr_add "$lan_mac" 5)
+diff --git a/target/linux/ramips/base-files/etc/diag.sh b/target/linux/ramips/base-files/etc/diag.sh
+index 097cc6df569518f64dbfd641eeccc1a4b1b37a2b..16e482c3879ff727faea9ffde31da634004fee93 100644
+--- a/target/linux/ramips/base-files/etc/diag.sh
++++ b/target/linux/ramips/base-files/etc/diag.sh
+@@ -141,6 +141,7 @@ get_status_led() {
+ 	youhua,wr1200js)
+ 		status_led="$boardname:blue:wps"
+ 		;;
++	asus,rt-ac57u|\
+ 	d240|\
+ 	dap-1350|\
+ 	na930|\
+diff --git a/target/linux/ramips/base-files/lib/upgrade/platform.sh b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+index 7213b22d0c2734488bd96bc34e921f08649b8c2f..e4d813341b0e4d1ac804ee8cf0ec258e9c08fcd1 100755
+--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
+@@ -27,6 +27,7 @@ platform_check_image() {
+ 	ar725w|\
+ 	asl26555-8M|\
+ 	asl26555-16M|\
++	asus,rt-ac57u|\
+ 	awapn2403|\
+ 	awm002-evb-4M|\
+ 	awm002-evb-8M|\
+diff --git a/target/linux/ramips/dts/RT-AC57U.dts b/target/linux/ramips/dts/RT-AC57U.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..649240b837275f968ac732878996b1597c37d05d
+--- /dev/null
++++ b/target/linux/ramips/dts/RT-AC57U.dts
+@@ -0,0 +1,150 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++/dts-v1/;
++
++#include "mt7621.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	compatible = "asus,rt-ac57u", "mediatek,mt7621-soc";
++	model = "ASUS RT-AC57U";
++
++	aliases {
++		led-boot = &led_power;
++		led-failsafe = &led_power;
++		led-running = &led_power;
++		led-upgrade = &led_power;
++	};
++
++	memory@0 {
++		device_type = "memory";
++		reg = <0x0 0x8000000>;
++	};
++
++	chosen {
++		bootargs = "console=ttyS0,57600";
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led_power: power {
++			label = "rt-ac57u:blue:power";
++			gpios = <&gpio1 16 GPIO_ACTIVE_LOW>;
++		};
++
++		usb {
++			label = "rt-ac57u:blue:usb";
++			gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	keys {
++		compatible = "gpio-keys-polled";
++		poll-interval = <20>;
++
++		wps {
++			label = "wps";
++			gpios = <&gpio1 11 GPIO_ACTIVE_HIGH>;
++			linux,code = <KEY_WPS_BUTTON>;
++		};
++
++		reset {
++			label = "reset";
++			gpios = <&gpio1 9 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++		};
++	};
++
++	led-regulator {
++		compatible = "regulator-fixed";
++		regulator-name = "LED-Power";
++		gpio = <&gpio1 14 GPIO_ACTIVE_LOW>;
++		regulator-min-microvolt = <3300000>;
++		regulator-max-microvolt = <3300000>;
++		regulator-always-on;
++	};
++};
++
++&spi0 {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <10000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "u-boot";
++				reg = <0x0 0x30000>;
++				read-only;
++			};
++
++			partition@30000 {
++				label = "config";
++				reg = <0x30000 0x10000>;
++				read-only;
++			};
++
++			factory: partition@40000 {
++				label = "factory";
++				reg = <0x40000 0x10000>;
++				read-only;
++			};
++
++			partition@50000 {
++				compatible = "denx,uimage";
++				label = "firmware";
++				reg = <0x50000 0xfb0000>;
++			};
++		};
++	};
++};
++
++&pcie {
++	status = "okay";
++
++	pcie0 {
++		wifi@0,0 {
++			reg = <0x0000 0 0 0 0>;
++			mediatek,mtd-eeprom = <&factory 0x8000>;
++			device_type = "pci";
++
++			led {
++				led-sources = <2>;
++				led-active-low;
++			};
++		};
++	};
++
++	pcie1 {
++		wifi@0,0 {
++			reg = <0x0000 0 0 0 0>;
++			mediatek,mtd-eeprom = <&factory 0x0000>;
++			device_type = "pci";
++
++			led {
++				led-active-low;
++			};
++		};
++	};
++};
++
++&ethernet {
++	mtd-mac-address = <&factory 0x4e000>;
++};
++
++&pinctrl {
++	state_default: pinctrl0 {
++		gpio {
++			ralink,group = "sdhci";
++			ralink,function = "gpio";
++		};
++	};
++};
+diff --git a/target/linux/ramips/image/mt7621.mk b/target/linux/ramips/image/mt7621.mk
+index c8de8bd5ff7d1bec4de5c4ffd84a589892871ecb..e0f8cc65ebbfc93b4bfd765db5e62b5afda27c40 100644
+--- a/target/linux/ramips/image/mt7621.mk
++++ b/target/linux/ramips/image/mt7621.mk
+@@ -49,6 +49,14 @@ define Device/11acnas
+ endef
+ TARGET_DEVICES += 11acnas
+ 
++define Device/asus_rt-ac57u
++  DTS := RT-AC57U
++  DEVICE_TITLE := ASUS RT-AC57U
++  IMAGE_SIZE := $(ralink_default_fw_size_16M)
++  DEVICE_PACKAGES := kmod-mt7603 kmod-mt76x2 kmod-usb3 kmod-usb-ledtrig-usbport wpad-basic
++endef
++TARGET_DEVICES += asus_rt-ac57u
++
+ define Device/dir-860l-b1
+   DTS := DIR-860L-B1
+   BLOCKSIZE := 64k
+diff --git a/target/linux/ramips/mt7621/config-4.14 b/target/linux/ramips/mt7621/config-4.14
+index 2ea80a3ab0c174374fa8febc19031ff5a4dae4c3..0e060237802f2b1d6918f65894368934c225cb17 100644
+--- a/target/linux/ramips/mt7621/config-4.14
++++ b/target/linux/ramips/mt7621/config-4.14
+@@ -228,6 +228,8 @@ CONFIG_RCU_STALL_COMMON=y
+ CONFIG_REGMAP=y
+ CONFIG_REGMAP_I2C=y
+ CONFIG_REGMAP_SPI=y
++CONFIG_REGULATOR=y
++CONFIG_REGULATOR_FIXED_VOLTAGE=y
+ CONFIG_RESET_CONTROLLER=y
+ CONFIG_RFS_ACCEL=y
+ CONFIG_RPS=y

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -1,3 +1,10 @@
+-- ASUS
+
+device('asus-rt-ac57u', 'asus_rt-ac57u', {
+	factory = false,
+})
+
+
 -- D-Link
 
 device('d-link-dir-860l-b1', 'dir-860l-b1', {


### PR DESCRIPTION
The ASUS RT-AC57U is a relatively new device (~4 Months on the German market)with a MT7621 2C/4T CPU and Dualband AC Wave 1 2x2 WiFi.

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] tftp
  - [x] other: SSH
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
    `asus-rt-ac57u`
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`