### PR TITLE
ar71xx-nand: add support for Aerohive HiveAP 121

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -47,6 +47,8 @@ elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1',
                                             'archer-c59-v1', 'archer-c60-v1',
                                             'archer-c7'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')
+elseif platform.match('ar71xx', 'nand', {'hiveap-121'}) then
+  table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ipq40xx', nil, {'avm,fritzbox-4040',
                                        'openmesh,a42', 'openmesh,a62'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')

--- a/patches/openwrt/0025-ar71xx-fix-HiveAP-121-PLL-for-1000M.patch
+++ b/patches/openwrt/0025-ar71xx-fix-HiveAP-121-PLL-for-1000M.patch
@@ -1,0 +1,27 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 30 Jul 2019 19:16:21 +0200
+Subject: ar71xx: fix HiveAP 121 PLL for 1000M
+
+The Aerohive HiveAP 121 has the wrong PLL value set for Gigabit speeds,
+leading to packet-loss. 10M and 100M work fine.
+
+This commit sets the Gigabit Ethernet PLL value to the correct value,
+fixing packet loss.
+
+COnfirmed with iperf and floodping.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ar71xx/files/arch/mips/ath79/mach-hiveap-121.c b/target/linux/ar71xx/files/arch/mips/ath79/mach-hiveap-121.c
+index 363d73dd5328ad9ce4be166c926fb22e8bf54684..5cbb2054f7c58c8329abea08d99cd4cdec767587 100644
+--- a/target/linux/ar71xx/files/arch/mips/ath79/mach-hiveap-121.c
++++ b/target/linux/ar71xx/files/arch/mips/ath79/mach-hiveap-121.c
+@@ -111,7 +111,7 @@ static void __init hiveap_121_setup(void)
+ 	ath79_eth0_data.mii_bus_dev = &ath79_mdio0_device.dev;
+ 	ath79_eth0_data.phy_if_mode = PHY_INTERFACE_MODE_RGMII;
+ 	ath79_eth0_data.phy_mask = BIT(HIVEAP_121_LAN_PHYADDR);
+-	ath79_eth0_pll_data.pll_1000 = 0x0e000000;
++	ath79_eth0_pll_data.pll_1000 = 0x06000000;
+ 	ath79_eth0_pll_data.pll_100 = 0x00000101;
+ 	ath79_eth0_pll_data.pll_10 = 0x00001313;
+ 	ath79_register_eth(0);

--- a/targets/ar71xx-nand
+++ b/targets/ar71xx-nand
@@ -11,6 +11,11 @@ defaults {
 }
 
 
+-- Aerohive
+
+device('aerohive-hiveap-121', 'hiveap-121')
+
+
 -- Netgear
 
 device('netgear-wndr3700v4', 'wndr3700v4', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] tftp
  - [x] other: serial
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
    `aerohive-hiveap-121`
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds - device does not have radio leds 
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only - no outdoor device
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`