### PR TITLE
ar71xx-generic: Fix packages for GL.iNet AR750

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -118,7 +118,7 @@ device('gl.inet-gl-ar300m', 'gl-ar300m', {
 device('gl.inet-gl-ar750', 'gl-ar750', {
 	factory = false,
 	manifest_aliases = {'gl-ar750'},
-	packages = ATH10K_PACKAGES,
+	packages = ATH10K_PACKAGES_QCA9887,
 })
 
 


### PR DESCRIPTION
The profile for GL.iNet AR750 currently selects ATH10K_PACKAGES, but this device actually has a QCA9887 which needs another driver.
This commit fixes the issue by setting ATH10K_PACKAGES_QCA9887 instead.