### PR TITLE
scripts/update.sh: add verbose error message when commit cannot be found

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -20,6 +20,9 @@ for module in $GLUON_MODULES; do
 
 	if ! git branch -f base "$commit" 2>/dev/null; then
 		git fetch "$repo" "$branch"
-		git branch -f base "$commit"
+		git branch -f base "$commit" || {
+		  echo "unable to find commit \"$commit\" on branch \"$branch\" in repo \"$repo\"." >&2
+		  exit 1
+		}
 	fi
 done


### PR DESCRIPTION
This displays the branch, repo and commitID that was attempted to update to but
failed. Users then can compare this output to the configuration they meant to
activate in modules and hopefully better find their typos.