### PR TITLE
ramips-mt7621: fixes for ASUS RT-AC57U

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -365,6 +365,10 @@ ramips-mt7620 [#80211s]_
 ramips-mt7621
 ^^^^^^^^^^^^^
 
+* ASUS
+
+  - RT-AC57U [#80211s]_
+
 * D-Link
 
   - DIR-860L (B1) [#80211s]_

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -2,6 +2,7 @@
 
 device('asus-rt-ac57u', 'asus_rt-ac57u', {
 	factory = false,
+	broken = (env.GLUON_WLAN_MESH ~= '11s'),
 })
 
 


### PR DESCRIPTION
The initial patch didn't add the device to the Documentation and lacked the broken flag for IBSS, as IBSS is not yet tested on the MT7603/MT7612.