### PR TITLE
redistribute routes toward internet, utilize missing values from site

### DIFF
--- a/package/gluon-l3roamd/check_site.lua
+++ b/package/gluon-l3roamd/check_site.lua
@@ -1,0 +1,3 @@
+need_string_match(in_domain({'prefix6'}), '^[%x:]+/64$', true)
+need_string_match(in_domain({'node_client_prefix6'}), '^[%x:]+/64$', false)
+need_string_match(in_domain({'prefix4'}), '^%d+.%d+.%d+.%d+/%d+$', false)

--- a/package/gluon-l3roamd/files/etc/init.d/gluon-l3roamd
+++ b/package/gluon-l3roamd/files/etc/init.d/gluon-l3roamd
@@ -39,6 +39,12 @@ start_service () {
 	for dev in $(gluon-list-mesh-interfaces); do echo " -m $dev"; done
 	[ "$(ifstatus local_node | jsonfilter -e '@.up')" = 'true' ] && echo ' -i local-node'
 	)
+
+	local prefix4="$(lua -e 'prefix4 = require("gluon.site").prefix4() if prefix4 then print(" -p " .. prefix4) end')"
+	local prefix6="$(lua -e 'print(" -p " .. require("gluon.site").prefix6())')"
+	local localip="$(uci get network.loopback.ip6addr | cut -d/ -f1)"
+	local roamingprefix="$(lua -e 'roamingprefix = require("gluon.site").node_client_prefix6() if roamingprefix then print(" -P " .. roamingprefix) end')"
+
 	/sbin/sysctl -w net.ipv6.neigh.default.gc_thresh1=2
 	/sbin/sysctl -w net.ipv4.neigh.default.gc_thresh1=2
 
@@ -46,7 +52,7 @@ start_service () {
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param respawn ${respawn_threshold:-3660} ${respawn_timeout:-5} ${respawn_retry:-0}
-	procd_set_param command "$PROG" -s /var/run/l3roamd.sock -p $(lua -e 'print(require("gluon.site").prefix6())') $interfaces -t 254 -a $(uci get network.loopback.ip6addr | cut -d/ -f1) -4 0:0:0:0:0:ffff::/96 -b br-client
+	procd_set_param command "$PROG" -s /var/run/l3roamd.sock $prefix4 $prefix6 $interfaces -t 254 -a $localip -b br-client $roamingprefix
 	procd_close_instance
 }
 

--- a/package/gluon-mesh-babel/Makefile
+++ b/package/gluon-mesh-babel/Makefile
@@ -10,7 +10,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-babel
   TITLE:=Babel mesh
-  DEPENDS:=+gluon-core +babeld +mmfd +libiwinfo +libgluonutil +firewall +libjson-c +libnl-tiny +libubus +libubox +libblobmsg-json +libbabelhelper +luabitop
+  DEPENDS:=+gluon-core +babeld +mmfd +libiwinfo +libgluonutil +firewall +libjson-c +libnl-tiny +libubus +libubox +libblobmsg-json +libbabelhelper +luabitop +gluon-l3roamd
   PROVIDES:=gluon-mesh-provider
 endef
 

--- a/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
+++ b/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
@@ -14,6 +14,8 @@ file:write("redistribute ip " .. site.next_node.ip6() .. "/128 deny\n")
 file:write("redistribute ip " .. site.prefix6() .. " eq 128  allow\n")
 file:write("redistribute ip " .. site.node_client_prefix6() .. " eq 128  allow\n")
 file:write("redistribute ip " .. site.node_prefix6() .. " eq 128  allow\n")
+file:write("redistribute ip 2000::/3 allow\n")
+
 file:write("redistribute local if br-wan deny\n")
 file:write("redistribute local ip 0.0.0.0/0 deny\n")
 file:close()


### PR DESCRIPTION
this fixes two issues:
* redistribute the routes towards the internet
* correctly check for and use values from site.conf: prefix4 prefix6 and client_node_prefix6