### PR TITLE
resize x86 rootfs to 36 MB and kernel to 16 MB

### DIFF
--- a/targets/x86.inc
+++ b/targets/x86.inc
@@ -12,3 +12,6 @@ packages 'kmod-ath9k'
 packages $ATH10K_PACKAGES
 packages 'kmod-gpio-button-hotplug' 'kmod-gpio-nct5104d' 'kmod-hwmon-core' 'kmod-leds-gpio' 'kmod-leds-apu2' 'kmod-sp5100_tco'
 packages 'kmod-usb-core' 'kmod-usb-ohci' 'kmod-usb2' 'kmod-usb3' 'kmod-usb-serial'
+
+config 'CONFIG_TARGET_KERNEL_PARTSIZE=16'
+config 'CONFIG_TARGET_ROOTFS_PARTSIZE=110'


### PR DESCRIPTION
By default, OpenWRT 18.06 uses 256 MB rootfs and 16 MB kernel partition size, see `config/Config-images.in`:
```
     config TARGET_KERNEL_PARTSIZE
         int "Kernel partition size (in MB)"
         depends on GRUB_IMAGES || USES_BOOT_PART
         default 16
 
     config TARGET_ROOTFS_PARTSIZE
         int "Root filesystem partition size (in MB)"
         depends on GRUB_IMAGES || USES_ROOTFS_PART || TARGET_ROOTFS_EXT4FS || TARGET_rb532 || TARGET_mvebu || TARGET_uml
         default 256
         help
           Select the root filesystem partition size.
```

This will result in an image larger than 256 MB. However, some x86 devices such as Futros will have just a 256 MB CF card and thus won't be able to upgrade (in my observations).

To resolve, make kernel and rootfs as small as possible for x86, allowing x86 devices with 256 MB disk to upgrade.