### PR TITLE
docs: remove Netgear WNDR3700 v5

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -55,7 +55,7 @@ ar71xx-generic
 
 * Netgear
 
-  - WNDR3700 (v1, v2, v5)
+  - WNDR3700 (v1, v2)
   - WNDR3800
   - WNDRMAC (v2)
 


### PR DESCRIPTION
Reason:
* the device is part of the target `ramips-mt7621` (not `ar71xx-generic`)
* the device is marked as broken https://github.com/freifunk-gluon/gluon/blob/master/targets/ramips-mt7621#L18