### PR TITLE
docs, targets: mark and document several targets and devices as deprecated

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -149,8 +149,8 @@ ar71xx-nand
 
   - NBG6716 [#ath10k]_
 
-ar71xx-tiny
------------
+ar71xx-tiny [#deprecated]_
+--------------------------
 
 * D-Link
 
@@ -291,8 +291,8 @@ ramips-mt76x8 [#80211s]_
 
   - VoCore2
 
-ramips-rt305x [#80211s]_
-------------------------
+ramips-rt305x [#80211s]_ [#deprecated]_
+---------------------------------------
 
 * A5-V11
 
@@ -338,6 +338,10 @@ See also: :doc:`x86`
 
 Footnotes
 ---------
+
+.. [#deprecated]
+  The device or target is reaching its end of life soon. This means that support
+  in the next major release of Gluon is doubtful.
 
 .. [#ath10k]
   Device uses the ath10k WLAN driver. Images are built for 11s by default unless GLUON_WLAN_MESH

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -10,13 +10,13 @@ ar71xx-generic
 
 * ALFA Network
 
-  - AP121
+  - AP121 [#deprecated]_
   - AP121F
-  - AP121U
-  - Hornet-UB
-  - Tube2H
-  - N2
-  - N5
+  - AP121U [#deprecated]_
+  - Hornet-UB [#deprecated]_
+  - Tube2H [#deprecated]_
+  - N2 [#deprecated]_
+  - N5 [#deprecated]_
 
 * Allnet
 

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -25,13 +25,16 @@ device('alfa-network-ap121f', 'ap121f', {
 device('alfa-network-hornet-ub', 'hornet-ub', {
 	profile = 'HORNETUB',
 	aliases = { 'alfa-network-ap121', 'alfa-network-ap121u' },
+	deprecated = true,  -- kernel partition too small with OpenWrt 19.07
 })
 
 device('alfa-network-tube2h', 'tube2h-8M', {
 	profile = 'TUBE2H8M',
+	deprecated = true,  -- kernel partition too small with OpenWrt 19.07
 })
 device('alfa-network-n2-n5', 'alfa-nx', {
 	profile = 'ALFANX',
+	deprecated = true,  -- kernel partition too small with OpenWrt 19.07
 })
 
 


### PR DESCRIPTION
As per https://github.com/freifunk-gluon/gluon/pull/1791#issuecomment-533021677

https://shells.darmstadt.ccc.de/~hexa/gluon/1822/user/supported_devices.html