### PR TITLE
ar71xx-generic: add ath10k packages to OCEDO Koala

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -181,6 +181,7 @@ device('netgear-wnr2200', 'wnr2200', {
 
 device('ocedo-koala', 'koala', {
 	factory = false,
+	packages = ATH10K_PACKAGES,
 })
 
 


### PR DESCRIPTION
The OCEDO Koala was missing the correct package definition. Because of
this, firmware is potentially built with the wrong ath10k firmware /
driver.