### PR TITLE
ath79-generic: add support for TP-Link Archer C6v2

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -180,6 +180,13 @@ ar71xx-tiny [#deprecated]_
   - TL-WR940N (v1, v2, v3, v4, v5, v6)
   - TL-WR941ND (v2, v3, v4, v5, v6)
 
+ath79-generic
+--------------
+
+* TP-Link
+
+  - Archer C6 (v2)
+
 brcm2708-bcm2708
 ----------------
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -1,0 +1,13 @@
+local ATH10K_PACKAGES = {}
+local ATH10K_PACKAGES_QCA9887 = {}
+local ATH10K_PACKAGES_QCA9888 = {}
+if env.GLUON_WLAN_MESH == '11s' then
+	ATH10K_PACKAGES = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca988x', '-ath10k-firmware-qca988x-ct'}
+	ATH10K_PACKAGES_QCA9887 = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca9887', '-ath10k-firmware-qca9887-ct'}
+	ATH10K_PACKAGES_QCA9888 = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca9888', '-ath10k-firmware-qca9888-ct'}
+end
+
+-- TP-Link
+
+device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2')
+

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -5,6 +5,7 @@ ifneq ($(GLUON_DEPRECATED),0)
 $(eval $(call GluonTarget,ar71xx,tiny))
 endif
 $(eval $(call GluonTarget,ar71xx,nand))
+$(eval $(call GluonTarget,ath79,generic))
 $(eval $(call GluonTarget,brcm2708,bcm2708))
 $(eval $(call GluonTarget,brcm2708,bcm2709))
 $(eval $(call GluonTarget,mpc85xx,generic))


### PR DESCRIPTION
* [x]  must be flashable from vendor firmware  
  * [x]  via vendor UI with factory image
* [x]  must support upgrade mechanism
  * [x]  must have working sysupgrade 
    * [x]  must keep/forget configuration (if applicable) _think `sysupgrade [-n]` or `firstboot`_
  * [x]  must have working autoupdate   _usually means: gluon profile name must match image name_
'root@ffc-d80d176b3354:~# lua -e 'print(require("platform_info").get_image_name())'
tp-link-archer-c6-v2

* wired network  
  * [X]  should support all network ports on the device
  * [X]  must have correct port assignment (WAN/LAN)
* wifi
  * [X]  association with AP must be possible  
  * [X]  association with 802.11s mesh must be working  
  * [X]  ap/mesh mode must work in parallel 
* led mapping
  * power/sys led
    * [X]  lit while the device is on
    * [X]  should display config mode blink sequence
      (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  * radio leds
    * [x]  should map to their respective radio
    * [x]  should show activity
  * switchport leds
    * [x]  should map to their respective port (or switch, if only one led present) 
    * [x]  should show link state and activity 
* [X]  wps button must return device into config mode
* [X]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)