### PR TITLE
ipq806x-generic: add full support for NETGEAR R7800

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -217,6 +217,13 @@ ipq40xx-generic [#80211s]_
   - NBG6617
   - WRE6606
 
+ipq806x-generic [#80211s]_
+--------------------------
+
+* NETGEAR
+
+  - R7800
+
 mpc85xx-generic
 ---------------
 

--- a/modules
+++ b/modules
@@ -2,7 +2,7 @@ GLUON_FEEDS='packages routing luci gluon'
 
 OPENWRT_REPO=https://git.openwrt.org/openwrt/openwrt.git
 OPENWRT_BRANCH=openwrt-19.07
-OPENWRT_COMMIT=22c443c20cab4760b201ccd9995a4ed6053aa810
+OPENWRT_COMMIT=d6d9f582907630c77309a13a42781010adfff441
 
 PACKAGES_PACKAGES_REPO=https://github.com/openwrt/packages.git
 PACKAGES_PACKAGES_BRANCH=openwrt-19.07

--- a/targets/ipq806x-generic
+++ b/targets/ipq806x-generic
@@ -21,13 +21,8 @@ device('tp-link-archer-c2600', 'tplink_c2600', {
 -- QCA9984
 --
 
--- -- ToDo --
--- The BROKEN flag for the target can be removed when switching to an OpenWrt base newer than 18.06,
--- as in 18.06 the LEDs are not yet functional. This is already fixed in the current OpenWrt master.
-
 -- NETGEAR
 device('netgear-nighthawk-x4s-r7800', 'netgear_r7800', {
 	factory_ext = '.img',
 	packages = QCA9984_PACKAGES,
-	broken = true,
 })

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -17,6 +17,7 @@ $(eval $(call GluonTarget,x86,64))
 
 ifneq ($(GLUON_WLAN_MESH_11s)$(BROKEN),)
 $(eval $(call GluonTarget,ipq40xx,generic))
+$(eval $(call GluonTarget,ipq806x,generic))
 $(eval $(call GluonTarget,ramips,mt7620))
 $(eval $(call GluonTarget,ramips,mt76x8))
 $(eval $(call GluonTarget,ramips,rt305x))
@@ -25,6 +26,5 @@ endif
 ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,ar71xx,mikrotik)) # BROKEN: no sysupgrade support
 $(eval $(call GluonTarget,brcm2708,bcm2710)) # BROKEN: Untested
-$(eval $(call GluonTarget,ipq806x,generic)) # BROKEN: See target file for details
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No AP+IBSS or 11s support
 endif


### PR DESCRIPTION
The NETGEAR R7800 was previously only supported as BROKEN in Gluon. With OpenWrt 19.07, the remaining bugs are ironed out, so the broken flag for target as well as device can be removed.

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] other: tftp, nmrpflash
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
     > root@64367-r7800:~# lua -e 'print(require("platform_info").get_image_name())'
     > netgear-nighthawk-x4s-r7800
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)