### PR TITLE
lantiq-xway:  support for AVM FRITZ!Box 7312

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -224,6 +224,13 @@ ipq806x-generic [#80211s]_
 
   - R7800
 
+lantiq-xway
+-----------
+
+* AVM
+
+  - FRITZ!Box 7312 [#avmflash]_
+
 mpc85xx-generic
 ---------------
 

--- a/targets/lantiq-xway
+++ b/targets/lantiq-xway
@@ -1,0 +1,3 @@
+device('avm-fritz-box-7312', 'avm_fritz7312', {
+	factory = false,
+})

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -7,6 +7,7 @@ endif
 $(eval $(call GluonTarget,ar71xx,nand))
 $(eval $(call GluonTarget,brcm2708,bcm2708))
 $(eval $(call GluonTarget,brcm2708,bcm2709))
+$(eval $(call GluonTarget,lantiq,xway))
 $(eval $(call GluonTarget,mpc85xx,generic))
 $(eval $(call GluonTarget,mpc85xx,p1020))
 $(eval $(call GluonTarget,ramips,mt7621))


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: EVA
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [?] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] xxxxx/xxx/phone button must return device into config mode
- [ ] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
~
