### PR TITLE
gluon-setup-mode: allows DECT button to enter setup mode

### DIFF
--- a/docs/features/configmode.rst
+++ b/docs/features/configmode.rst
@@ -14,7 +14,7 @@ Activating Config Mode
 ----------------------
 
 Config Mode is automatically entered at the first boot. You can re-enter
-Config Mode by pressing and holding the RESET/WPS button for about three
+Config Mode by pressing and holding the RESET/WPS/DECT button for about three
 seconds. The device should reboot (all LEDs will turn off briefly) and
 Config Mode will be available.
 

--- a/package/gluon-setup-mode/files/etc/hotplug.d/button/50-gluon-setup-mode
+++ b/package/gluon-setup-mode/files/etc/hotplug.d/button/50-gluon-setup-mode
@@ -12,7 +12,7 @@ wait_setup_mode() {
 }
 
 
-if [ "$BUTTON" = wps -o "$BUTTON" = reset ]; then
+if [ "$BUTTON" = wps -o "$BUTTON" = reset -o "$BUTTON" = phone ]; then
 	case "$ACTION" in
 		pressed)
 			wait_setup_mode &


### PR DESCRIPTION
many AVM devices do not have RESET/WPS buttons. So use the otherwise unused DECT/PHONE button to boot the device into setup mode.

This patch allows to enter the setup-mode by pressing the phone button
(often labeled as DECT) in addition to WPS and reset button.

This patch is necessary to allow supporting boards without a WPS and reset
button (e.g. AVM FRITZ!Box 7312).
