### PR TITLE
ar71xx-generic: refactor image profiles / add alias for UniFi AC-LR

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -421,6 +421,11 @@ device('ubiquiti-unifi-ac-lite', 'ubnt-unifiac-lite', {
 	aliases = {'ubiquiti-unifi-ac-lite-mesh'},
 })
 
+device('ubiquiti-unifi-ac-lr', 'ubnt-unifiac-lr', {
+	factory = false,
+	packages = ATH10K_PACKAGES,
+})
+
 device('ubiquiti-unifi-ac-pro', 'ubnt-unifiac-pro', {
 	factory = false,
 	packages = ATH10K_PACKAGES,


### PR DESCRIPTION
 ar71xx-generic: consolidate Ubiquiti UniFi AC images

OpenWrt generated images for the following devices are identical:

 - UniFi AC Lite / UniFi AC Mesh / UniFi AC LR
 - UniFi AC Pro / UniFi AC Mesh Pro

Gluon currently outputs devices as a separate image. However, as the
model detection is done at run-time, a symlink to one image would have
the same effect.

To save some space, create aliases for the devices instead of dedicated
profiles.

-------

 ar71xx-generic: add alias for UniFi AC LR

As upstream now has model detection for the Ubiquiti UniFi AC LR, we
need to provide an autoupdater image matching the expected filename.

Closes #1834