### PR TITLE
ath79: add GLinet and AVM-devices

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -2,6 +2,20 @@
 -- local ATH10K_PACKAGES_QCA9887 = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca9887', '-ath10k-firmware-qca9887-ct'}
 local ATH10K_PACKAGES_QCA9888 = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca9888', '-ath10k-firmware-qca9888-ct'}
 
+-- GL Innovations
+
+device('gl-inet-gl-ar150', 'glinet_gl-ar150', {
+	factory = false,
+})
+
+device('gl-inet-gl-ar300m-lite', 'glinet_gl-ar300m-lite', {
+	factory = false,
+})
+
+device('gl-inet-gl-ar300m', 'glinet_gl-ar300m-nor', {
+	factory = false,
+})
+
 -- TP-Link
 
 device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -24,10 +24,6 @@ device('gl-inet-gl-ar300m-lite', 'glinet_gl-ar300m-lite', {
 	factory = false,
 })
 
-device('gl-inet-gl-ar300m', 'glinet_gl-ar300m-nor', {
-	factory = false,
-})
-
 -- TP-Link
 
 device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -2,6 +2,18 @@
 -- local ATH10K_PACKAGES_QCA9887 = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca9887', '-ath10k-firmware-qca9887-ct'}
 local ATH10K_PACKAGES_QCA9888 = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca9888', '-ath10k-firmware-qca9888-ct'}
 
+-- AVM
+
+device('avm-fritz-box-4020', 'avm_fritz4020', {
+	factory = false,
+	packages = {'fritz-tffs'},
+})
+
+device('avm-fritz-wlan-repeater-300e', 'avm_fritz300e', {
+	factory = false,
+	packages = {'fritz-tffs'},
+})
+
 -- GL Innovations
 
 device('gl-inet-gl-ar150', 'glinet_gl-ar150', {


### PR DESCRIPTION
This adds the following devices, which are already present in ar71xx:

* AVM Fritz!BOX 4020, WLAN-Repeater 300e
* GLinet AR150, GLinet AR300m (lite)
  * GLinet AR300m gets disabled, as done in OpenWRT