### PR TITLE
targets: add Fritz!BOX specific packages

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -47,14 +47,17 @@ device('allnet-all0315n', 'all0315n', {
 
 device('avm-fritz-box-4020', 'fritz4020', {
 	factory = false,
+	packages = {'fritz-tffs'},
 })
 
 device('avm-fritz-wlan-repeater-300e', 'fritz300e', {
 	factory = false,
+	packages = {'fritz-tffs'},
 })
 
 device('avm-fritz-wlan-repeater-450e', 'fritz450e', {
 	factory = false,
+	packages = {'fritz-tffs'},
 })
 
 

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -26,6 +26,9 @@ device('avm-fritz-box-4040', 'avm_fritzbox-4040', {
 	extra_images = {
 		{'-squashfs-eva', '-bootloader', '.bin'},
 	},
+	packages = {
+		'fritz-caldata', 'fritz-tffs',
+	}
 })
 
 


### PR DESCRIPTION
During building a firmware with a stripped down package-list I realized that the Fritz!BOX boards depend on the fritz-tffs and fritz-caldata package.