### PR TITLE
ramips-mt7621: add support for Netgear R6220

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -280,6 +280,10 @@ ramips-mt7621
 
   - DIR-860L (B1)
 
+* NETGEAR
+
+  - R6220
+
 * Ubiquiti
 
   - EdgeRouter X

--- a/modules
+++ b/modules
@@ -2,7 +2,7 @@ GLUON_FEEDS='packages routing luci gluon'
 
 OPENWRT_REPO=https://git.openwrt.org/openwrt/openwrt.git
 OPENWRT_BRANCH=openwrt-19.07
-OPENWRT_COMMIT=d6d9f582907630c77309a13a42781010adfff441
+OPENWRT_COMMIT=5d30ff1bc6e5a4f0d1f65f12aa062caf5278ab08
 
 PACKAGES_PACKAGES_REPO=https://github.com/openwrt/packages.git
 PACKAGES_PACKAGES_BRANCH=openwrt-19.07

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -12,6 +12,10 @@ device('d-link-dir-860l-b1', 'dir-860l-b1')
 
 -- Netgear
 
+device('netgear-r6220', 'r6220', {
+	factory_ext = '.img',
+})
+
 device('netgear-wndr3700v5', 'wndr3700v5', {
 	factory = false,
 	broken = true, -- untested


### PR DESCRIPTION
The NETGEAR R7800 was previously only supported as BROKEN in Gluon. With OpenWrt 19.07, the remaining bugs are ironed out, so the broken flag for target as well as device can be removed.

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] other: nmrpflash
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
     > netgear-r6220
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)