### PR TITLE
ipq40xx: add support for AVM FritzRepeater 1200

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -204,6 +204,7 @@ ipq40xx-generic
 * AVM
 
   - FRITZ!Box 4040 [#avmflash]_
+  - FRITZ!Repeater 1200 [#eva_ramboot]_
 
 * GL.iNet
 
@@ -367,3 +368,7 @@ Footnotes
 
 .. [#avmflash]
   For instructions on how to flash AVM devices, visit https://fritzfla.sh
+
+.. [#eva_ramboot]
+  For instructions on how to flash AVM NAND devices, see the respective
+  commit which added support in OpenWrt.

--- a/patches/openwrt/0006-ipq-wifi-add-AVM-FRITZ-Repeater-1200-bdf.patch
+++ b/patches/openwrt/0006-ipq-wifi-add-AVM-FRITZ-Repeater-1200-bdf.patch
@@ -1,0 +1,87 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 21 Sep 2019 18:59:28 +0200
+Subject: ipq-wifi: add AVM FRITZ!Repeater 1200 bdf
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/package/firmware/ipq-wifi/Makefile b/package/firmware/ipq-wifi/Makefile
+index 922064b7f78b80670cdb1ec7e9f86ede224cb7fb..eb7c2df1aa36ded7774a772c8a7e02b2acb81b40 100644
+--- a/package/firmware/ipq-wifi/Makefile
++++ b/package/firmware/ipq-wifi/Makefile
+@@ -27,6 +27,7 @@ ALLWIFIBOARDS:= \
+ 	alfa-network_ap120c-ac \
+ 	asus_map-ac2200 \
+ 	avm_fritzbox-7530 \
++	avm_fritzrepeater-1200 \
+ 	avm_fritzrepeater-3000 \
+ 	engenius_eap1300 \
+ 	engenius_ens620ext \
+@@ -98,6 +99,7 @@ endef
+ $(eval $(call generate-ipq-wifi-package,alfa-network_ap120c-ac,ALFA Network AP120C-AC))
+ $(eval $(call generate-ipq-wifi-package,asus_map-ac2200,ASUS MAP-AC2200))
+ $(eval $(call generate-ipq-wifi-package,avm_fritzbox-7530,AVM FRITZ!Box 7530))
++$(eval $(call generate-ipq-wifi-package,avm_fritzrepeater-1200,AVM FRITZRepeater 1200))
+ $(eval $(call generate-ipq-wifi-package,avm_fritzrepeater-3000,AVM FRITZ!Repeater 3000))
+ $(eval $(call generate-ipq-wifi-package,engenius_eap1300,EnGenius EAP1300))
+ $(eval $(call generate-ipq-wifi-package,engenius_ens620ext,EnGenius ENS620EXT))
+diff --git a/package/firmware/ipq-wifi/board-avm_fritzrepeater-1200.qca4019 b/package/firmware/ipq-wifi/board-avm_fritzrepeater-1200.qca4019
+new file mode 100644
+index 0000000000000000000000000000000000000000..d78a49d4dbf3fc22c40a83d052fc7c55542ff8e3
+GIT binary patch
+literal 24332
+zcmeHPTTl~O8a_d8Dk`0XTL?`^xFjwK5Lk^61wv#JXn|o7A-XOgC<!pcfLx4IQVuF&
+zL`Ib1VgxBv<kIUZ<?4*e?CQAAmZsc&nKxhdZ62h`+S>AEojsjSAdzHD5LPbzhtuaj
+zf1m&S|M|L;bocql=Nak3^a4dfe6~=Qo1QNRH8nK=N_`x$1wal<*^#>KrIlr|Wi@Ky
+zfl9Sjs4m|gZ*G;<mg>rhrZ_&fp;V_X{i1$*df_f%X1=mOm0zK)D6Oy12@}Ne@iaIN
+z2ad^!oA9U6z?$Rqq(Wl+&4a)LlmM{K$De2dxaB6o+84eYi9nD@3<W@9V&cEwya7_C
+zH+cK6^QqRdhUv)b!!{0}J$=7dCm9L+0_FXE&fA-2cKO5E5HG6`Ia>AEI@MvulP*S_
+z?YC}bNDd%hGX{&oq}y5?$9?ExTw)|*X10X^+eBeo3as3c_3Jlobj!g(XRZU=r!Z+d
+z#);F$BK8@)8kuNs*Qk}M)K?SzZO!GXY~{8`qy4Abb?VQRTON%;txlb<{OwyPx9<vK
+z!0XY8lkHXNU8=NKWBsR^D^-|M`sgOnO{G*ypu^erMrcbR9bz_v*TWOXnu}D)%2?>y
+z+I&DIhuyCCw?o%#3IEYV|Al6)Dqj+Bafq?c?*px7C?DuzzngNf$HQ@JC7|SZX3NX^
+zWU%VXEKU5Lz|`?8b!}VAqjs~hAC4aG%{<N51()=W?d{!mnp4Lpy?<GKEW3)gD=_W;
+zQ0=LdN<ncb_Vi}+H@T-pbzuj-9c%2}bynEOKKSH{_E=^GSIJ0zJY3tFRU5rKP=4dO
+zx<}Feo5s+}`x6ZVamT~8jFRPr5|ynL0WY7m>o;sd7y&^cp<&_HPyE@M_>7$utCw93
+zFNgr3(L6jnXvB8S8ZR#|Z;SYhbT*YJo}I|!Gb1B;@GpuR5y9g|aJhw^zQA&YVmBJq
+zSX2Z$I~y7b3b0HGSij!en+zopMDe)XaM)n_{O9evcL7i%ZG<t*&&R{l^S|b<G~mde
+z9A)vg+HrV20*BWg?-(Zv5s7b+=tx4ioUp*?NG_LyvRT1Uo4*Zu@_0OAAULXJypORt
+zLIpt)Bppph63_%hd*tZx)-xSlJ#!Txwa5dv6go;5(Vx>17RnN_Fn`n^2}Wh8OeA|Q
+zL$c5;Q5KelrXdPcjEY6#=VBxoO%^3%@n}3EL1&UM4mnn5a*|4CvZB;E$Hx^&7%1a4
+z0|`Y#MWI**n(;aV$wsq9*;pc)_&O0uK~qF27<mwEx8_hJ^ozbF&Ry*p<G5{!`be4m
+zW^t@JdcVxqwi2#MsX4fE^eL1ml$;<yof=Mnu`{nql<W|o8WaK)0u%xi0u%xi0;?E-
+zAaM{9PXA2&8InuiD&C5u(tWK0^2;s^-F|Glwch%>SI>>H)+!4YV-+7lYU(Qm0asTD
+zT<y2aaKZLf8YW)=0P7~h;N*+<YxtxZKBGq2Axs{RLq7b5+S0Lcp_uavHY>!#dFE2G
+zML^+%L;QlE0&60_rDR*`r|U%@1f(SaV4x$kKq#G-`l6-g`yxOJq@HO20e^oiXaOJr
+z@DRwOg2Wpx<nvgI6xwB8f|oKM!9QRjYIE`TM1W6=7iR?SfA#Wb@Y7E}n`=TR3MDHS
+zfnRR<F+DuW;R*x*G!IYTZ=hU-Vx93lC?8|Pir|Oq;N*|a>X_)L$WK|wl{<2+j$EC?
+z@(POfm6TT+IxqHI9vmJSzcqR9;a`6E@rC<4Y}WDIyK-GNy@7ch6r;CUS3=EepqQ-9
+zx(aGu|HQ;?))i3qL3HY|^3h#3r@_if)Ri^koWlJFJG!r2$L~)4&6&QkP??<#^Bogm
+zqihiyV*>d*If9{>2*czc>0J^cMWrGsmb75^*RxUG(E`PR2ujZsXCgWDE#fW64!Ww3
+zc+DNd`aNf@m&+}VyWIN(m$~;?H;o2~_f4H<CU}5_dmrFKA_Olhc?9<!08dZSV!!46
+zZZ7v8au8CjWxm{d80CBWNB}G}_nyd+h=JM#a?F9B<<#4Cp3|7^=K}ZM&f9TZcewX}
+z!C*KnY&IJZ#m~>row9cAVsh`(n1jrh4*$==4i=}4v9U3y`{wR|$J$2b?swI)DwlMr
+zNxO1-EJ2i9Nt^0JAwVHOA+TH#C@E1DlH7Yb-G2i)3pcs<C8Ym`4IXbu|APmuW3pKA
+znrgv?;@(^C%pO?p(0)y!xc4*YxI%%qLi&I2>&kN!Th=|Po6{vHxaeErjcm)iC-je`
+z-bZ0Y!~^e#FKliv?9>l^cub!$RpXd3!N8twGgaZ)MzJAm>aMX{f4DeP5;b)jA2#SU
+z#S%90|6-SWV)$UX%hZgkjA;hp^d*xX-)oc^;_yl1phi=iBZ-~*v+;tyrdTH75Dv!P
+zm>4kKXF7==GUge!PY;;R;MK<6dLjO;p<AO<$R%Rv(50`oI$Y_E5dhfj9IiFwYqm^Z
+zGj-ujh9Zp=pEC4o>J>Zr!R826n!RL7#y%n?qp2OQ(#wk@r-w}Eah+keW(WSAp;yzO
+zQ1C;i?inwcQwk?iy3)so5qeBt;Rp0P6fEf4hO6~5MJWC!<AA0{kuHfdeTNSjnl*bQ
+zEW%-+PY?~JyG<>4i9T5oGTm!x#mn_lMF>o!SAV29TOu&s#rq68O|Bx6j39t1oi{b%
+zMS8J<IsLWiD6WDUV!DrCg;=IZ&{ub+E*l#)8Hx}x0-S?8vIH;nsgztffD}p;N=^`1
+z38#jWsZr)ti@@D8$9}&vLC6mAzSdT~Z>u;WY@=^|cV?^LFssZj^ZVh7bKCX2LqWxV
+z?P^k`3Znypz3yB(R+S|a$At!;A1v%hILgs%%6WRT`a)VuR87eKXMO6ttufI-06ZEv
+zTCK<s3B$tfjU4VyJ0Z}~cRwCgccr%Qs)P4G8K^6fZHZzB`#rc;eMq4|x&918f6mE-
+z`hYzfcHX~Pb|LvVrz&9YLu2*6Jb7#+;yF3gpxde7@&j1yy}7578iI@c6nDn{a7l6^
+zye44(WKaD8<&Ib$!+X@&P^ZMil7P_30bNJNvDlix{AYj6Ivd*@a?pRzt?r|mT)BWt
+z_a5%8{UWbGm=wyr(W`FTab)u$M)viQ+P;)lo{qWy#(8a-JcY+*GyA?Suh^LtD-K|t
+z>)7*Ul7_pNo_2e*?sCpKeq(UOsy%V2iBkxy00chvmpFWE#Q`3JZCZt-NhKBYqoN|=
+zAN&;#4lg2t8&T-BWPXWbE-&6nz4u+Pb^Ez7tknCp3l_rx{FI48V15X=O8i*pe)G$A
+z#duNNd&rAlMBe^V;@LaOWvQRYBal;1a^Mj&kDlPzuWJ>w$RSsL^EPfeS;7x*-exXW
+z{XG-RTzY~}@6)ml7NYjzn7Q`^-`-2`PcsLf<l(<u>hoXC`4QZBPsoig>KXZAF}U%I
+zjjc1zz199HdG|zYihDo1G&c{8;@-~#G|FXZBjC!Ku`|BCt$k_Fa{k#--227;*8KJH
+F{|7QKi|GIW
+
+literal 0
+HcmV?d00001
+

--- a/patches/openwrt/0007-ipq40xx-add-support-for-AVM-FRITZ-Repeater-1200.patch
+++ b/patches/openwrt/0007-ipq40xx-add-support-for-AVM-FRITZ-Repeater-1200.patch
@@ -1,0 +1,374 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 10 Sep 2019 21:07:23 +0200
+Subject: ipq40xx: add support for AVM FRITZ!Repeater 1200
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/ipq40xx/base-files/etc/board.d/02_network b/target/linux/ipq40xx/base-files/etc/board.d/02_network
+index 6a7b09cc603a245e98c37305c1f25c2cc11694ae..01825b8bac46eec6325de00396d96307c946f975 100755
+--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
++++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
+@@ -39,10 +39,7 @@ ipq40xx_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
+ 		;;
+-	avm,fritzrepeater-3000|\
+-	compex,wpj428)
+-		ucidef_set_interface_lan "eth0 eth1"
+-		;;
++	avm,fritzrepeater-1200|\
+ 	engenius,eap1300|\
+ 	meraki,mr33|\
+ 	netgear,ex6100v2|\
+@@ -50,6 +47,10 @@ ipq40xx_setup_interfaces()
+ 	zyxel,wre6606)
+ 		ucidef_set_interface_lan "eth0"
+ 		;;
++	avm,fritzrepeater-3000|\
++	compex,wpj428)
++		ucidef_set_interface_lan "eth0 eth1"
++		;;
+ 	glinet,gl-b1300)
+ 		ucidef_set_interfaces_lan_wan "eth0" "eth1"
+ 		ucidef_add_switch "switch0" \
+diff --git a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 5f7e5f4923f19ecd78a981be55230cfcd3779146..b0035ce8a394b6e87d7d89b9f55a6ec7c66e448e 100644
+--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -148,6 +148,7 @@ case "$FIRMWARE" in
+ 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
+ 		;;
+ 	avm,fritzbox-7530 |\
++	avm,fritzrepeater-1200 |\
+ 	avm,fritzrepeater-3000)
+ 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C000 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
+ 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x207 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
+@@ -209,6 +210,7 @@ case "$FIRMWARE" in
+ 		/usr/bin/fritz_cal_extract -i 1 -s 0x400 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader_config")
+ 		;;
+ 	avm,fritzbox-7530 |\
++	avm,fritzrepeater-1200 |\
+ 	avm,fritzrepeater-3000)
+ 		/usr/bin/fritz_cal_extract -i 1 -s 0x3C800 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
+ 		/usr/bin/fritz_cal_extract -i 1 -s 0x3D000 -e 0x208 -l 12064 -o /lib/firmware/$FIRMWARE $(find_mtd_chardev "urlader0") || \
+diff --git a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+index 2abafabbd0589c07bcd2ceee766d3d7675ba9716..a7b7da1bf378f7cc19e960c497bc52efb3bae4fb 100644
+--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+@@ -49,6 +49,7 @@ platform_do_upgrade() {
+ 	8dev,jalapeno |\
+ 	alfa-network,ap120c-ac |\
+ 	avm,fritzbox-7530 |\
++	avm,fritzrepeater-1200 |\
+ 	avm,fritzrepeater-3000 |\
+ 	qxwlan,e2600ac-c2)
+ 		nand_do_upgrade "$1"
+diff --git a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-fritzrepeater-1200.dts b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-fritzrepeater-1200.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..4d02f8a8384f386c92c70ef24b677ee95058a1bf
+--- /dev/null
++++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-fritzrepeater-1200.dts
+@@ -0,0 +1,262 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "qcom-ipq4019.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/soc/qcom,tcsr.h>
++
++/ {
++	model = "AVM FRITZ!Repeater 1200";
++	compatible = "avm,fritzrepeater-1200";
++
++	aliases {
++		led-boot = &power_green;
++		led-failsafe = &power_red;
++		led-running = &power_green;
++		led-upgrade = &power_red;
++	};
++
++	soc {
++		mdio@90000 {
++			status = "okay";
++			pinctrl-0 = <&mdio_pins>;
++			pinctrl-names = "default";
++		};
++
++		tcsr@1949000 {
++			compatible = "qcom,tcsr";
++			reg = <0x1949000 0x100>;
++			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
++		};
++
++		ess_tcsr@1953000 {
++			compatible = "qcom,tcsr";
++			reg = <0x1953000 0x1000>;
++			qcom,ess-interface-select = <TCSR_ESS_PSGMII_RGMII5>;
++		};
++
++		tcsr@1957000 {
++			compatible = "qcom,tcsr";
++			reg = <0x1957000 0x100>;
++			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
++		};
++
++		crypto@8e3a000 {
++			status = "okay";
++		};
++
++		watchdog@b017000 {
++			status = "okay";
++		};
++
++		ess-switch@c000000 {
++			switch_mac_mode = <0x3>; /* mac mode for RGMII RMII */
++			switch_lan_bmp = <0x0>; /* lan port bitmap */
++			switch_wan_bmp = <0x10>; /* wan port bitmap */
++		};
++
++		edma@c080000 {
++			status = "okay";
++			phy-mode = "rgmii-rxid";
++			qcom,num_gmac = <1>;
++			qcom,single-phy;
++		};
++	};
++
++	key {
++		compatible = "gpio-keys";
++
++		wps {
++			label = "WPS button";
++			gpios = <&tlmm 10 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_WPS_BUTTON>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		power_red: power_red {
++			label = "fritzwlan-1200:red:power";
++			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
++		};
++
++		power_green: power_green {
++			label = "fritzwlan-1200:green:power";
++			gpios = <&tlmm 45 GPIO_ACTIVE_HIGH>;
++		};
++
++		power_yellow {
++			label = "fritzwlan-1200:yellow:power";
++			gpios = <&tlmm 49 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&tlmm {
++	serial_0_pins: serial_pinmux {
++		mux {
++			pins = "gpio16", "gpio17";
++			function = "blsp_uart0";
++			bias-disable;
++		};
++	};
++
++	nand_pins: nand_pins {
++		pullups {
++			pins = "gpio53", "gpio58", "gpio59";
++			function = "qpic";
++			bias-pull-up;
++		};
++
++		pulldowns {
++			pins = "gpio54", "gpio55", "gpio56",
++				"gpio57", "gpio60", "gpio61",
++				"gpio62", "gpio63", "gpio64",
++				"gpio65", "gpio66", "gpio67",
++				"gpio68", "gpio69";
++			function = "qpic";
++			bias-pull-down;
++		};
++	};
++
++	mdio_pins: mdio_pinmux {
++		mux_1 {
++			pins = "gpio6";
++			function = "mdio";
++			bias-pull-up;
++		};
++		mux_2 {
++			pins = "gpio7";
++			function = "mdc";
++			bias-pull-up;
++		};
++	};
++
++	phy-reset {
++		line-name = "PHY-reset";
++		gpios = <19 GPIO_ACTIVE_HIGH>;
++		gpio-hog;
++		output-high;
++	};
++
++	phy-reset-2 {
++		line-name = "PHY-reset-2";
++		gpios = <47 GPIO_ACTIVE_HIGH>;
++		gpio-hog;
++		output-high;
++	};
++};
++
++&nand {
++	pinctrl-0 = <&nand_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++
++	nand@0 {
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "SBL1";
++				reg = <0x000000 0x80000>;
++				read-only;
++			};
++
++			partition@80000 {
++				label = "MIBIB";
++				reg = <0x080000 0x80000>;
++				read-only;
++			};
++
++			partition@100000 {
++				label = "QSEE";
++				reg = <0x100000 0x80000>;
++				read-only;
++			};
++
++			partition@180000 {
++				label = "CDT";
++				reg = <0x180000 0x40000>;
++				read-only;
++			};
++
++			partition@1c0000 {
++				label = "QSEE_B";
++				reg = <0x1c0000 0x80000>;
++				read-only;
++			};
++
++			partition@240000 {
++				label = "urlader0";
++				reg = <0x240000 0x40000>;
++				read-only;
++			};
++
++			partition@280000 {
++				label = "urlader1";
++				reg = <0x280000 0x40000>;
++				read-only;
++			};
++
++			partition@2c0000 {
++				label = "nand-tffs";
++				reg = <0x2c0000 0x840000>;
++				read-only;
++			};
++
++			partition@b00000 {
++				/* 'kernel1' in AVM firmware */
++				label = "uboot0";
++				reg = <0xb00000 0x400000>;
++			};
++
++			partition@f00000 {
++				/* 'kernel2' in AVM firmware */
++				label = "uboot1";
++				reg = <0xf00000 0x400000>;
++			};
++
++			partition@1300000 {
++				label = "ubi";
++				reg = <0x1300000 0x6d00000>;
++			};
++		};
++	};
++};
++
++&cryptobam {
++	status = "okay";
++};
++
++&blsp_dma {
++	status = "okay";
++};
++
++&blsp1_uart1 {
++	pinctrl-0 = <&serial_0_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&qpic_bam {
++	status = "okay";
++};
++
++&wifi0 {
++	status = "okay";
++	qcom,ath10k-calibration-variant = "AVM-FRITZRepeater-1200";
++};
++
++&wifi1 {
++	status = "okay";
++	qcom,ath10k-calibration-variant = "AVM-FRITZRepeater-1200";
++};
++
++&gmac0 {
++	qcom,phy_mdio_addr = <0>;
++	qcom,poll_required = <1>;
++	vlan_tag = <0 0x20>;
++};
+diff --git a/target/linux/ipq40xx/image/Makefile b/target/linux/ipq40xx/image/Makefile
+index 3a9b58de4f01f17ac9df368729035d630eb32b04..bdbbcbe851e60ee5a445c576a870a87a46c57fee 100644
+--- a/target/linux/ipq40xx/image/Makefile
++++ b/target/linux/ipq40xx/image/Makefile
+@@ -138,6 +138,15 @@ define Device/avm_fritzbox-7530
+ endef
+ TARGET_DEVICES += avm_fritzbox-7530
+ 
++define Device/avm_fritzrepeater-1200
++	$(call Device/FitImageLzma)
++	DEVICE_DTS := qcom-ipq4019-fritzrepeater-1200
++	DEVICE_TITLE := AVM Fritz!Repeater 1200
++	DEVICE_PACKAGES := fritz-caldata fritz-tffs-nand ipq-wifi-avm_fritzrepeater-1200
++	IMAGES := sysupgrade.bin
++endef
++TARGET_DEVICES += avm_fritzrepeater-1200
++
+ define Device/avm_fritzrepeater-3000
+ 	$(call Device/FitImageLzma)
+ 	DEVICE_DTS := qcom-ipq4019-fritzrepeater-3000
+diff --git a/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch b/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch
+index bb539155e98b75df5dd88e39f6405af5a82e0320..f7efd415f1f1c000867793b3b133e44b3e50b0fd 100644
+--- a/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch
++++ b/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch
+@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
+ 
+ --- a/arch/arm/boot/dts/Makefile
+ +++ b/arch/arm/boot/dts/Makefile
+-@@ -697,7 +697,30 @@ dtb-$(CONFIG_ARCH_QCOM) += \
++@@ -697,7 +697,31 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+  	qcom-apq8074-dragonboard.dtb \
+  	qcom-apq8084-ifc6540.dtb \
+  	qcom-apq8084-mtp.dtb \
+@@ -30,6 +30,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
+ +	qcom-ipq4019-a62.dtb \
+ +	qcom-ipq4019-ap.dk04.1-c1.dtb \
+ +	qcom-ipq4019-fritzbox-7530.dtb \
+++	qcom-ipq4019-fritzrepeater-1200.dtb \
+ +	qcom-ipq4019-fritzrepeater-3000.dtb \
+ +	qcom-ipq4019-linksys_ea8300.dtb \
+ +	qcom-ipq4019-map-ac2200.dtb \

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -28,6 +28,10 @@ device('avm-fritz-box-4040', 'avm_fritzbox-4040', {
 	},
 })
 
+device('avm-fritz-repeater-1200', 'avm_fritzrepeater-1200', {
+	factory = false,
+})
+
 
 -- GL.iNet
 


### PR DESCRIPTION
The AVM FRITZ!Repeater 1200 is an IPQ4019 based WiFI Repeater / Access Point. It features 256M of RAM and 128M of NAND flash at a price point of ~55 Euro (< 50€ when on sale). Thus it should qualify for a backport.

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] other: EVA ramboot & OpenWrt initramfs
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
     > avm-fritz-repeater-1200
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [ ] should map to their respective radio (No LED)
    - [ ] should show activity (No LED)
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)