### PR TITLE
ramips-mt7620: add support for tp-link archer c20 v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -303,6 +303,7 @@ ramips-mt7620
 * TP-Link  
 
   - Archer C2 v1
+  - Archer C20 (v1)
   - Archer C20i
   - Archer C50 v1
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -61,7 +61,7 @@ elseif platform.match('mpc85xx', 'p1020', {'aerohive,hiveap-330'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('mpc85xx', 'p1020', {'ocedo,panda'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')
-elseif platform.match('ramips', 'mt7620', {'miwifi-mini', 'tplink,c2-v1', 'c20i', 'c50'}) then
+elseif platform.match('ramips', 'mt7620', {'miwifi-mini', 'tplink,c2-v1', 'c20-v1', 'c20i', 'c50'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ramips', 'mt7621', {'dir-860l-b1'}) then
   table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -31,7 +31,6 @@ device('nexx-wt3020-8m', 'wt3020-8M', {
 	},
 })
 
-
 -- TP-Link
 
 local tplink_region_suffix = ''
@@ -42,6 +41,8 @@ end
 device('tp-link-archer-c2-v1', 'tplink_c2-v1', {
         factory = false,
 })
+
+device('tp-link-archer-c20-v1', 'tplink_c20-v1')
 
 device('tp-link-archer-c20i', 'ArcherC20i')
 


### PR DESCRIPTION
* [x]  must be flashable from vendor firmware  
  * [x]  webinterface
* [x]  must support upgrade mechanism
  * [x]  must have working sysupgrade 
    * [x]  must keep/forget configuration (if applicable) _think `sysupgrade [-n]` or `firstboot`_
  * [x]  must have working autoupdate   _usually means: gluon profile name must match image name_
'tp-link-archer-c20-v1'
* wired network  
  * [X]  should support all network ports on the device
  * [X]  must have correct port assignment (WAN/LAN)
* wifi
  * [X]  association with AP must be possible  
  * [X]  association with 802.11s mesh must be working  
  * [X]  ap/mesh mode must work in parallel 
* led mapping
  * power/sys led
    * [X]  lit while the device is on
    * [X]  should display config mode blink sequence
      (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  * radio leds
    * [x]  should map to their respective radio 
    * [x]  should show activity
  * switchport leds
    * [x]  should map to their respective port (or switch, if only one led present) 
    * [x]  should show link state and activity 
* [X]  wps button must return device into config mode
* [X]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
