### PR TITLE
ath79-generic: add support for OCEDO Raccoon

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -187,6 +187,10 @@ ath79-generic
 
   - WiFi pro 1200i
 
+  * OCEDO
+
+  - Raccoon
+
 * TP-Link
 
   - Archer C6 (v2)

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -50,6 +50,8 @@ elseif platform.match('ar71xx', 'generic', {'archer-c5', 'archer-c58-v1',
   table.insert(try_files, 1, '/sys/class/net/eth1/address')
 elseif platform.match('ar71xx', 'nand', {'hiveap-121'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
+elseif platform.match('ath79', 'generic', {'ocedo,raccoon'}) then
+  table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ipq40xx', 'generic', {'avm,fritzbox-4040',
                                              'openmesh,a42', 'openmesh,a62'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -11,6 +11,12 @@ device('devolo-wifi-pro-1200i', 'devolo_dvl1200i', {
 	factory = false,
 })
 
+-- OCEDO
+
+device('ocedo-raccoon', 'ocedo_raccoon', {
+	factory = false,
+})
+
 -- TP-Link
 
 device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] other: U-Boot pushbutton initramfs
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
     > ocedo-raccoon
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)