### PR TITLE
docs: add mt76 to supported chipsets

### DIFF
--- a/docs/dev/hardware.rst
+++ b/docs/dev/hardware.rst
@@ -5,7 +5,7 @@ for new hardware to Gluon.
 
 Hardware requirements
 ---------------------
-Having an ath9k (or ath10k) based WLAN adapter is highly recommended,
+Having an ath9k, ath10k or mt76 based WLAN adapter is highly recommended,
 although other chipsets may also work. VAP (multiple SSID) support
 is a requirement.
 


### PR DESCRIPTION
The docs previously only listed ath9k and ath10k based chipsets as fully
supported by Gluon, however we also support mt76.