### PR TITLE
ath79-generic: add support for devolo WiFi pro 1200i

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -183,6 +183,10 @@ ar71xx-tiny [#deprecated]_
 ath79-generic
 --------------
 
+* devolo
+
+  - WiFi pro 1200i
+
 * TP-Link
 
   - Archer C6 (v2)

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -5,6 +5,12 @@ local ATH10K_PACKAGES_QCA9888 = {
 	'-ath10k-firmware-qca9888-ct',
 }
 
+-- devolo
+
+device('devolo-wifi-pro-1200i', 'devolo_dvl1200i', {
+	factory = false,
+})
+
 -- TP-Link
 
 device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] other: sysupgrade in vendor firmware
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
     > devolo-wifi-pro-1200i
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [ ] should map to their respective radio (no WiFi LED)
    - [ ] should show activity (no WiFi LED)
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
    - All MAC addresses are printed on the label - 5GHz MAC matches primary MAC