### PR TITLE
ath79-generic: add support for devolo WiFi pro 1750c

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -186,6 +186,7 @@ ath79-generic
 * devolo
 
   - WiFi pro 1200i
+  - WiFi pro 1750c
   - WiFi pro 1750i
 
   * OCEDO

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -19,6 +19,11 @@ device('devolo-wifi-pro-1200i', 'devolo_dvl1200i', {
 	factory = false,
 })
 
+device('devolo-wifi-pro-1750c', 'devolo_dvl1750c', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 device('devolo-wifi-pro-1750i', 'devolo_dvl1750i', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] other: sysupgrade in vendor firmware
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
     > devolo-wifi-pro-1750c
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [ ] should map to their respective radio (no WiFi LED)
    - [ ] should show activity (no WiFi LED)
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
    - All MAC addresses are printed on the label - 5GHz MAC matches primary MAC