### PR TITLE
gluon-private-wifi: add support for WPA3 encryption

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,8 +133,8 @@ ifneq ($(filter __ERROR__,$(GLUON_FEATURES_standard) $(GLUON_FEATURES_tiny)),)
 endif
 
 $(eval $(call merge_lists,GLUON_DEFAULT_PACKAGES,$(GLUON_DEFAULT_PACKAGES) $(GLUON_SITE_PACKAGES)))
-$(eval $(call merge_lists,GLUON_CLASS_PACKAGES_standard,$(GLUON_FEATURE_PACKAGES_standard)))
-$(eval $(call merge_lists,GLUON_CLASS_PACKAGES_tiny,$(GLUON_FEATURE_PACKAGES_tiny)))
+$(eval $(call merge_lists,GLUON_CLASS_PACKAGES_standard,$(GLUON_FEATURE_PACKAGES_standard) $(GLUON_SITE_PACKAGES_standard)))
+$(eval $(call merge_lists,GLUON_CLASS_PACKAGES_tiny,$(GLUON_FEATURE_PACKAGES_tiny) $(GLUON_SITE_PACKAGES_tiny)))
 
 
 LUA := openwrt/staging_dir/hostpkg/bin/lua

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,8 @@ lint-sh: FORCE
 	@scripts/lint-sh.sh
 
 GLUON_DEFAULT_PACKAGES := hostapd-mini
+GLUON_CLASS_PACKAGES_standard :=
+GLUON_CLASS_PACKAGES_tiny :=
 
 GLUON_FEATURE_PACKAGES := $(shell scripts/features.sh '$(GLUON_FEATURES)' || echo '__ERROR__')
 ifneq ($(filter __ERROR__,$(GLUON_FEATURE_PACKAGES)),)
@@ -144,12 +146,12 @@ config: $(LUA) FORCE
 	$(foreach conf,site $(patsubst $(GLUON_SITEDIR)/%.conf,%,$(wildcard $(GLUON_SITEDIR)/domains/*.conf)),$(call CheckSite,$(conf)))
 
 	@$(GLUON_CONFIG_VARS) \
-		$(LUA) scripts/target_config.lua '$(GLUON_TARGET)' '$(GLUON_PACKAGES)' \
+		$(LUA) scripts/target_config.lua '$(GLUON_TARGET)' '$(GLUON_DEFAULT_PACKAGES)' '$(GLUON_CLASS_PACKAGES_standard)' '$(GLUON_CLASS_PACKAGES_tiny)' \
 		> openwrt/.config
 	+@$(OPENWRTMAKE) defconfig
 
 	@$(GLUON_CONFIG_VARS) \
-		$(LUA) scripts/target_config_check.lua '$(GLUON_TARGET)' '$(GLUON_PACKAGES)'
+		$(LUA) scripts/target_config_check.lua '$(GLUON_TARGET)' '$(GLUON_DEFAULT_PACKAGES)' '$(GLUON_CLASS_PACKAGES_standard)' '$(GLUON_CLASS_PACKAGES_tiny)'
 
 
 all: config

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,6 @@ lint-lua: FORCE
 lint-sh: FORCE
 	@scripts/lint-sh.sh
 
-GLUON_DEFAULT_PACKAGES := hostapd-mini
 define merge_lists
   $(1) :=
   $(foreach pkg,$(2),

--- a/docs/dev/hardware.rst
+++ b/docs/dev/hardware.rst
@@ -9,6 +9,18 @@ Having an ath9k, ath10k or mt76 based WLAN adapter is highly recommended,
 although other chipsets may also work. VAP (multiple SSID) support
 is a requirement.
 
+.. _device-class-definition:
+
+Device classes
+--------------
+Gluon currently is aware of two device classes. Depending on the device class, different
+features can be installed onto the device.
+
+The ``tiny`` device-class contains devices with the following limitations:
+
+* All devices with less than 64 MB of system memory
+* All devices with less than 7 MB of usable firmware space
+* Devices using a single ath10k radio and less than 128MB of system memory
 
 .. _hardware-adding-profiles:
 

--- a/docs/features/private-wlan.rst
+++ b/docs/features/private-wlan.rst
@@ -4,6 +4,14 @@ Private WLAN
 It is possible to set up a private WLAN that bridges the WAN port and is separated from the mesh network.
 Please note that you should not enable ``mesh_on_wan`` simultaneously.
 
+The private WLAN is encrypted using WPA2 by default. On devices with enough flash and a supported radio,
+WPA3 or WPA2/WPA3 mixed-mode can be used instead of WPA2. For this to work, the ``wireless-encryption-wpa3``
+feature has to be added to ``GLUON_FEATURES``.
+
+It is recommended to enable IEEE 802.11w management frame protection for WPA2/WPA3 networks, however this
+can lead to connectivity problems for older clients. In this case, management frame protection can be
+made optional or completely disabled in the advanced settings tab.
+
 The private WLAN can be enabled through the config mode if the package ``gluon-web-private-wifi`` is installed.
 You may also enable a private WLAN using the command line::
 

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -545,6 +545,14 @@ GLUON_SITE_PACKAGES
     default package set. It is also possible to remove packages from the
     default set by prepending a minus sign to the package name.
 
+GLUON_SITE_PACKAGES_standard
+    Defines a list of additional packages to include or exclude for devices of
+    the standard device-class.
+
+GLUON_SITE_PACKAGES_tiny
+    Defines a list of additional packages to include or exclude for devices of
+    the tiny device-class.
+
 GLUON_RELEASE
     The current release version Gluon should use.
 

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -527,8 +527,18 @@ GLUON_DEPRECATED
     deployments of low-flash devices are required).
 
 GLUON_FEATURES
-    Defines a list of features to include. The feature list is used to generate
-    the default package set.
+    Defines a list of features to include. Depending on the device, the feature list
+    defined from this value is combined with the feature list for either the standard
+    or the tiny device-class. The resulting feature list is used to generate the default
+    package set.
+
+GLUON_FEATURES_standard
+    Defines a list of additional features to include or exclude for devices of
+    the standard device-class.
+
+GLUON_FEATURES_tiny
+    Defines a list of additional features to include or exclude for devices of
+    the tiny device-class.
 
 GLUON_SITE_PACKAGES
     Defines a list of packages which should be installed in addition to the

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -10,9 +10,9 @@ ar71xx-generic
 
 * ALFA Network
 
-  - AP121 [#deprecated]_
+  - AP121 [#deprecated]_  [#device-class-tiny]_
   - AP121F
-  - AP121U [#deprecated]_
+  - AP121U [#deprecated]_  [#device-class-tiny]_
 
 * Allnet
 
@@ -47,7 +47,7 @@ ar71xx-generic
 
 * Linksys
 
-  - WRT160NL
+  - WRT160NL  [#device-class-tiny]_
 
 * Netgear
 
@@ -82,7 +82,7 @@ ar71xx-generic
   - CPE220 (v1.1)
   - CPE510 (v1.0, v1.1)
   - CPE520 (v1.1)
-  - RE450 (v1)
+  - RE450 (v1)  [#device-class-tiny]_
   - TD-W8970 (v1) [#lan_as_wan]_
   - TL-WDR3500 (v1)
   - TL-WDR3600 (v1)
@@ -97,16 +97,16 @@ ar71xx-generic
 
 * Ubiquiti
 
-  - Air Gateway
-  - Air Gateway LR
-  - Air Gateway PRO
-  - Air Router
-  - Bullet M2/M5
-  - Loco M2/M5
+  - Air Gateway  [#device-class-tiny]_
+  - Air Gateway LR  [#device-class-tiny]_
+  - Air Gateway PRO  [#device-class-tiny]_
+  - Air Router  [#device-class-tiny]_
+  - Bullet M2/M5  [#device-class-tiny]_
+  - Loco M2/M5  [#device-class-tiny]_
   - Loco M2/M5 XW
-  - Nanostation M2/M5
+  - Nanostation M2/M5  [#device-class-tiny]_
   - Nanostation M2/M5 XW
-  - Picostation M2
+  - Picostation M2  [#device-class-tiny]_
   - Rocket M2/M5
   - Rocket M2/M5 Ti
   - Rocket M2/M5 XW
@@ -146,8 +146,8 @@ ar71xx-nand
 
   - NBG6716
 
-ar71xx-tiny [#deprecated]_
---------------------------
+ar71xx-tiny [#deprecated]_ [#device-class-tiny]_
+------------------------------------------------
 
 * D-Link
 
@@ -245,7 +245,7 @@ ipq40xx-generic
 * ZyXEL
 
   - NBG6617
-  - WRE6606
+  - WRE6606  [#device-class-tiny]_
 
 ipq806x-generic
 ---------------
@@ -372,8 +372,8 @@ ramips-mt76x8
 
   - VoCore2
 
-ramips-rt305x [#deprecated]_
-----------------------------
+ramips-rt305x [#deprecated]_  [#device-class-tiny]_
+---------------------------------------------------
 
 * A5-V11
 
@@ -423,6 +423,12 @@ Footnotes
 .. [#deprecated]
   The device or target is reaching its end of life soon. This means that support
   in the next major release of Gluon is doubtful.
+
+.. [#device-class-tiny]
+  These devices only support a subset of Gluons capabilities due to flash or memory
+  size constraints. Devices are classified as tiny in they provide less than 7M of usable
+  flash space or have a low amount of system memory. For more information, see the
+  developer documentation: :ref:`device-class-definition`.
 
 .. [#avmflash]
   For instructions on how to flash AVM devices, visit https://fritzfla.sh

--- a/package/features
+++ b/package/features
@@ -32,3 +32,6 @@ packages 'mesh-batman-adv-15' \
 
 packages 'mesh-babel' \
 	'gluon-radvd'
+
+packages '!wireless-encryption-wpa3' \
+	'hostapd-mini'

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -35,6 +35,15 @@ function M.contains(table, value)
 	return false
 end
 
+function M.file_contains_line(path, value)
+	for line in io.lines(path) do
+		if line == value then
+			return true
+		end
+	end
+	return false
+end
+
 function M.add_to_set(t, itm)
 	for _,v in ipairs(t) do
 		if v == itm then return false end

--- a/package/gluon-web-private-wifi/i18n/de.po
+++ b/package/gluon-web-private-wifi/i18n/de.po
@@ -13,17 +13,41 @@ msgstr ""
 msgid "8-63 characters"
 msgstr "8-63 Zeichen"
 
+msgid "Disabled"
+msgstr "Deaktiviert"
+
 msgid "Enabled"
 msgstr "Aktiviert"
+
+msgid "Encryption"
+msgstr "Verschlüsselung"
 
 msgid "Key"
 msgstr "Schlüssel"
 
+msgid "Management Frame Protection"
+msgstr ""
+
 msgid "Name (SSID)"
 msgstr "Name (SSID)"
 
+msgid "Optional"
+msgstr ""
+
 msgid "Private WLAN"
 msgstr "Privates WLAN"
+
+msgid "Required"
+msgstr "Aktiviert"
+
+msgid "WPA2"
+msgstr ""
+
+msgid "WPA2 / WPA3"
+msgstr ""
+
+msgid "WPA3"
+msgstr ""
 
 msgid ""
 "Your node can additionally extend your private network by bridging the WAN "

--- a/package/gluon-web-private-wifi/i18n/fr.po
+++ b/package/gluon-web-private-wifi/i18n/fr.po
@@ -13,17 +13,41 @@ msgstr ""
 msgid "8-63 characters"
 msgstr "8-63 charactères"
 
+msgid "Disabled"
+msgstr ""
+
 msgid "Enabled"
 msgstr "Activé"
+
+msgid "Encryption"
+msgstr ""
 
 msgid "Key"
 msgstr "Clé"
 
+msgid "Management Frame Protection"
+msgstr ""
+
 msgid "Name (SSID)"
 msgstr "Nom (SSID)"
 
+msgid "Optional"
+msgstr ""
+
 msgid "Private WLAN"
 msgstr "Wi-Fi privé"
+
+msgid "Required"
+msgstr ""
+
+msgid "WPA2"
+msgstr ""
+
+msgid "WPA2 / WPA3"
+msgstr ""
+
+msgid "WPA3"
+msgstr ""
 
 msgid ""
 "Your node can additionally extend your private network by bridging the WAN "

--- a/package/gluon-web-private-wifi/i18n/gluon-web-private-wifi.pot
+++ b/package/gluon-web-private-wifi/i18n/gluon-web-private-wifi.pot
@@ -4,16 +4,40 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "8-63 characters"
 msgstr ""
 
+msgid "Disabled"
+msgstr ""
+
 msgid "Enabled"
+msgstr ""
+
+msgid "Encryption"
 msgstr ""
 
 msgid "Key"
 msgstr ""
 
+msgid "Management Frame Protection"
+msgstr ""
+
 msgid "Name (SSID)"
 msgstr ""
 
+msgid "Optional"
+msgstr ""
+
 msgid "Private WLAN"
+msgstr ""
+
+msgid "Required"
+msgstr ""
+
+msgid "WPA2"
+msgstr ""
+
+msgid "WPA2 / WPA3"
+msgstr ""
+
+msgid "WPA3"
 msgstr ""
 
 msgid ""

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
@@ -1,5 +1,6 @@
 local uci = require("simple-uci").cursor()
 local util = require 'gluon.util'
+local platform = require 'gluon.platform'
 
 -- where to read the configuration from
 local primary_iface = 'wan_radio0'
@@ -26,6 +27,25 @@ key:depends(enabled, true)
 key.datatype = "wpakey"
 key.default = uci:get('wireless', primary_iface, "key")
 
+local encryption = s:option(ListValue, "encryption", translate("Encryption"))
+encryption:depends(enabled, true)
+encryption:value("psk2", translate("WPA2"))
+if platform.device_supports_wpa3() then
+	encryption:value("psk3-mixed", translate("WPA2 / WPA3"))
+	encryption:value("psk3", translate("WPA3"))
+end
+encryption.default = uci:get('wireless', primary_iface, 'encryption') or "psk2"
+
+local mfp = s:option(ListValue, "mfp", translate("Management Frame Protection"))
+mfp:depends(enabled, true)
+mfp:value("0", translate("Disabled"))
+if platform.device_supports_mfp(uci) then
+	mfp:value("1", translate("Optional"))
+	mfp:value("2", translate("Required"))
+end
+mfp.default = uci:get('wireless', primary_iface, 'ieee80211w') or "0"
+
+
 function f:write()
 	util.foreach_radio(uci, function(radio, index)
 		local radio_name = radio['.name']
@@ -34,16 +54,23 @@ function f:write()
 		if enabled.data then
 			local macaddr = util.get_wlan_mac(uci, radio, index, 4)
 
-			uci:section('wireless', "wifi-iface", name, {
+			uci:section('wireless', 'wifi-iface', name, {
 				device     = radio_name,
-				network    = "wan",
+				network    = 'wan',
 				mode       = 'ap',
-				encryption = 'psk2',
+				encryption = encryption.data,
 				ssid       = ssid.data,
 				key        = key.data,
 				macaddr    = macaddr,
 				disabled   = false,
 			})
+
+			-- hostapd-mini won't start in case 802.11w is configured
+			if platform.device_supports_mfp(uci) then
+				uci:set('wireless', name, 'ieee80211w', mfp.data)
+			else
+				uci:delete('wireless', name, 'ieee80211w')
+			end
 		else
 			uci:set('wireless', name, "disabled", true)
 		end

--- a/package/gluon-wireless-encryption/Makefile
+++ b/package/gluon-wireless-encryption/Makefile
@@ -1,0 +1,20 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-wireless-encryption
+PKG_RELEASE:=1
+
+include ../gluon.mk
+
+define Package/gluon-wireless-encryption-wpa3
+  DEPENDS:=+hostapd-openssl
+  TITLE:=Package for supporting WPA3 encrypted wireless networks
+endef
+
+define Package/gluon-wireless-encryption-wpa3/install
+	$(INSTALL_DIR) $(1)/lib/gluon/features
+
+	touch $(1)/lib/gluon/features/wpa2
+	touch $(1)/lib/gluon/features/wpa3
+endef
+
+$(eval $(call BuildPackageGluon,gluon-wireless-encryption-wpa3))

--- a/scripts/target_config_lib.lua
+++ b/scripts/target_config_lib.lua
@@ -7,6 +7,10 @@ return function(funcs)
 
 	local target = arg[1]
 	local extra_packages = arg[2]
+	local class_packages = {
+		standard = arg[3],
+		tiny = arg[4],
+	}
 
 	local openwrt_config_target
 	if env.SUBTARGET ~= '' then
@@ -64,13 +68,19 @@ END_MAKE
 			end
 			device_pkgs = device_pkgs .. ' ' .. pkg
 		end
+		local function handle_pkgs(pkgs)
+			local packages = string.gmatch(pkgs or '', '%S+')
+			for pkg in packages do
+				handle_pkg(pkg)
+			end
+		end
 
 		for _, pkg in ipairs(dev.options.packages or {}) do
 			handle_pkg(pkg)
 		end
-		for pkg in string.gmatch(site_packages(dev.image), '%S+') do
-			handle_pkg(pkg)
-		end
+		handle_pkgs(site_packages(dev.image))
+
+		handle_pkgs(class_packages[dev.options.class])
 
 		funcs.config_message(lib.config, string.format("unable to enable device '%s'", profile),
 			'CONFIG_TARGET_DEVICE_%s_DEVICE_%s=y', openwrt_config_target, profile)

--- a/scripts/target_lib.lua
+++ b/scripts/target_lib.lua
@@ -44,6 +44,7 @@ local default_options = {
 	aliases = {},
 	manifest_aliases = {},
 	packages = {},
+	class = "standard",
 	deprecated = false,
 	broken = false,
 }

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -35,6 +35,7 @@ device('8devices-carambola2-board', 'carambola2', {
 
 device('alfa-network-ap121f', 'ap121f', {
 	factory = false,
+	class = 'tiny', -- 32M ath9k
 })
 
 
@@ -129,6 +130,7 @@ device('gl.inet-gl-ar750', 'gl-ar750', {
 
 device('linksys-wrt160nl', 'wrt160nl', {
 	profile = 'WRT160NL',
+	class = 'tiny', -- 32M ath9k
 })
 
 
@@ -262,23 +264,28 @@ device('tp-link-wbs210-v1.20', 'wbs210-v1')
 device('tp-link-wbs510-v1.20', 'wbs510-v1')
 
 device('tp-link-tl-wr710n-v1', 'tl-wr710n-v1', {
+	class = 'tiny', -- 32M ath9k
 	packages = { 'zram-swap' },
 })
 device('tp-link-tl-wr710n-v2.1', 'tl-wr710n-v2.1', {
+	class = 'tiny', -- 32M ath9k
 	packages = { 'zram-swap' },
 })
 
 device('tp-link-tl-wr810n-v1', 'tl-wr810n-v1')
 
 device('tp-link-tl-wr842n-nd-v1', 'tl-wr842n-v1', {
+	class = 'tiny', -- 32M ath9k
 	packages = { 'zram-swap' },
 })
 device('tp-link-tl-wr842n-nd-v2', 'tl-wr842n-v2', {
+	class = 'tiny', -- 32M ath9k
 	packages = { 'zram-swap' },
 })
 device('tp-link-tl-wr842n-nd-v3', 'tl-wr842n-v3')
 
 device('tp-link-tl-wr1043n-nd-v1', 'tl-wr1043nd-v1', {
+	class = 'tiny', -- 32M ath9k
 	packages = { 'zram-swap' },
 })
 device('tp-link-tl-wr1043n-nd-v2', 'tl-wr1043nd-v2')
@@ -312,11 +319,13 @@ device('tp-link-archer-c7-v5', 'archer-c7-v5', {
 device('tp-link-archer-c25-v1', 'archer-c25-v1', {
 	packages = ATH10K_PACKAGES_QCA9887,
 	broken = true, -- OOM with 5GHz enabled in most environments
+	class = 'tiny', -- 64M ath9k + ath10k
 })
 
 device('tp-link-archer-c58-v1', 'archer-c58-v1', {
 	packages = ATH10K_PACKAGES_QCA9888,
 	broken = true, -- OOM with 5GHz enabled in most environments
+	class = 'tiny', -- 64M ath9k + ath10k
 })
 
 device('tp-link-archer-c59-v1', 'archer-c59-v1', {
@@ -326,25 +335,30 @@ device('tp-link-archer-c59-v1', 'archer-c59-v1', {
 device('tp-link-archer-c60-v1', 'archer-c60-v1', {
 	packages = ATH10K_PACKAGES_QCA9888,
 	broken = true, -- OOM with 5GHz enabled in most environments
+	class = 'tiny', -- 64M ath9k + ath10k
 })
 
 device('tp-link-archer-c60-v2', 'archer-c60-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
 	broken = true, -- OOM with 5GHz enabled in most environments
+	class = 'tiny', -- 64M ath9k + ath10k
 })
 
 device('tp-link-re355', 're355-v1', {
 	packages = ATH10K_PACKAGES,
 	broken = true, -- OOM with 5GHz enabled in most environments if device is 64M RAM variant
+	class = 'tiny', -- Only 6M of usable Firmware space
 })
 
 device('tp-link-tl-wr902ac-v1', 'tl-wr902ac-v1', {
 	packages = ATH10K_PACKAGES_QCA9887,
 	broken = true, -- OOM due to insufficient RAM for ath10k expected
+	class = 'tiny', -- 64M ath9k + ath10k
 })
 
 device('tp-link-re450', 're450-v1', {
 	packages = ATH10K_PACKAGES,
+	class = 'tiny', -- Only 6M of usable Firmware space
 })
 
 
@@ -352,11 +366,16 @@ device('tp-link-re450', 're450-v1', {
 
 device('ubiquiti-airgateway', 'ubnt-air-gateway', {
 	aliases = {'ubiquiti-airgateway-lr'},
+	class = 'tiny', -- 32M ath9k
 })
 
-device('ubiquiti-airgateway-pro', 'ubnt-air-gateway-pro')
+device('ubiquiti-airgateway-pro', 'ubnt-air-gateway-pro', {
+	class = 'tiny', -- 32M ath9k
+})
 
-device('ubiquiti-airrouter', 'ubnt-airrouter')
+device('ubiquiti-airrouter', 'ubnt-airrouter', {
+	class = 'tiny', -- 32M ath9k
+})
 
 device('ubiquiti-bullet-m', 'ubnt-bullet-m', {
 	aliases = {
@@ -367,6 +386,7 @@ device('ubiquiti-bullet-m', 'ubnt-bullet-m', {
 		'ubiquiti-picostation-m2',
 	},
 	packages = { 'zram-swap' },
+	class = 'tiny', -- 32M ath9k
 })
 
 device('ubiquiti-rocket-m', 'ubnt-rocket-m', {
@@ -382,6 +402,7 @@ device('ubiquiti-nanostation-m', 'ubnt-nano-m', {
 		'ubiquiti-nanostation-m5',
 	},
 	packages = { 'zram-swap' },
+	class = 'tiny', -- 32M ath9k
 })
 
 device('ubiquiti-loco-m-xw', 'ubnt-loco-m-xw', {
@@ -426,6 +447,7 @@ device('ubiquiti-unifiap-outdoor+', 'ubnt-unifi-outdoor-plus')
 
 device('ubiquiti-ls-sr71', 'ubnt-ls-sr71', {
 	broken = true, -- untested
+	class = 'tiny', -- 32M ath9k
 })
 
 device('ubiquiti-unifi-ac-lite', 'ubnt-unifiac-lite', {

--- a/targets/ar71xx-tiny
+++ b/targets/ar71xx-tiny
@@ -12,6 +12,7 @@ packages {
 
 defaults {
 	deprecated = true, -- 4/32
+	class = 'tiny',
 }
 
 

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -87,6 +87,7 @@ device('zyxel-nbg6617', 'zyxel_nbg6617')
 
 device('zyxel-wre6606', 'zyxel_wre6606', {
 	factory = false,
+	class = 'tiny', -- 128M ath10k + ath10k
 })
 
 

--- a/targets/ramips-rt305x
+++ b/targets/ramips-rt305x
@@ -3,6 +3,10 @@ config 'CONFIG_GLUON_SPECIALIZE_KERNEL=y'
 
 no_opkg()
 
+defaults {
+	class = 'tiny',  -- 32M RAM
+}
+
 local STRIP_USB_PACKAGES = {
 	'-kmod-usb-core',
 	'-kmod-usb-dwc2',


### PR DESCRIPTION
This commit adds WPA3 encryption for Gluon's Private WiFi feature.

It allows node operators to select between three encryption modes:
 - WPA2 (old standard - no MFP)
 - WPA2/WPA3 mixed-mode (optional MFP)
 - WPA3 (mandatory MFP)

MFP is supported by all drivers which are currently fully supported by Gluon (rt2800, mt76, ath9k, ath10k).

As we need to include a OpenSSL library for WPA3, this PR also includes a mechanic to define a featureset. This way, packages can be included at compile-time as well as the featureset retrieved at run-time to decide, which functions can be supported in a devices featureset.

This Pull-Request still needs documentation written, so It's labeled as RFC.

fixes #1826 