### PR TITLE
gluon-mesh-babel: Fix packets leaving wrong interface

### DIFF
--- a/package/gluon-mesh-babel/Makefile
+++ b/package/gluon-mesh-babel/Makefile
@@ -10,7 +10,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-babel
   TITLE:=Babel mesh
-  DEPENDS:=+gluon-core +babeld +mmfd +libiwinfo +libgluonutil +firewall +libjson-c +libnl-tiny +libubus +libubox +libblobmsg-json +libbabelhelper +luabitop +gluon-l3roamd
+  DEPENDS:=+gluon-core +babeld +gluon-mmfd +libiwinfo +libgluonutil +firewall +libjson-c +libnl-tiny +libubus +libubox +libblobmsg-json +libbabelhelper +luabitop
   PROVIDES:=gluon-mesh-provider
 endef
 

--- a/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
+++ b/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
@@ -1,6 +1,8 @@
 #!/usr/bin/lua
 
 local site = require 'gluon.site'
+local uci = require('simple-uci').cursor()
+local nodeip = uci:get('network', 'loopback', 'ip6addr'):match('^[^/]+')
 local babelconf='/etc/gluon-babeld.conf'
 
 local file = io.open(babelconf, "w")
@@ -15,7 +17,7 @@ file:write("redistribute ip " .. site.prefix6() .. " eq 128  allow\n")
 file:write("redistribute ip " .. site.node_client_prefix6() .. " eq 128  allow\n")
 file:write("redistribute ip " .. site.node_prefix6() .. " eq 128  allow\n")
 file:write("redistribute ip 2000::/3 allow\n")
-
 file:write("redistribute local if br-wan deny\n")
 file:write("redistribute local ip 0.0.0.0/0 deny\n")
+file:write("install pref-src " .. nodeip .."\n")
 file:close()


### PR DESCRIPTION
when there is dual-stack on wan packets might leak out there that should be routed through the Freifunk. iNow that we have babeld 1.9 we can utilize the respective babeld feature and fix that issue.