### PR TITLE
ath79-generic: add support for devolo WiFi pro 1750x

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -187,6 +187,7 @@ ath79-generic
 
   - WiFi pro 1200i
   - WiFi pro 1750i
+  - WiFi pro 1750x
 
   * OCEDO
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -44,6 +44,9 @@ function M.is_outdoor_device()
 	elseif M.match('ar71xx', 'generic', {'unifiac-pro'}) and
 		M.get_model() == 'Ubiquiti UniFi-AC-MESH-PRO' then
 		return true
+
+	elseif M.match('ath79', 'generic', {'devolo,dvl1750x'}) then
+		return true
 	end
 
 	return false

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -24,6 +24,11 @@ device('devolo-wifi-pro-1750i', 'devolo_dvl1750i', {
 	factory = false,
 })
 
+device('devolo-wifi-pro-1750x', 'devolo_dvl1750x', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 -- OCEDO
 
 device('ocedo-raccoon', 'ocedo_raccoon', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: sysupgrade from vendor firmware via SSH
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [ ] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - matches 5Ghz Wifi mac adress 
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [x] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`