### PR TITLE
ath79-generic: add support for devolo WiFi pro 1200e

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -185,6 +185,7 @@ ath79-generic
 
 * devolo
 
+  - WiFi pro 1200e
   - WiFi pro 1200i
   - WiFi pro 1750c
   - WiFi pro 1750i

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -14,6 +14,11 @@ local ATH10K_PACKAGES_QCA9888 = {
 
 -- devolo
 
+device('devolo-wifi-pro-1200e', 'devolo_dvl1200e', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 device('devolo-wifi-pro-1200i', 'devolo_dvl1200i', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: sysupgrade via SSH on the Vendor Firmware
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) 
  - all mac addresses are printed on the label, matches 5Ghz wifi mac
(https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - no radio leds
  - switchport leds
     - no switchport leds

While the port assignment on the device is correct by policy (there are 2 LAN Ports an no WAN Ports), this however is not the behavior I would expect as a user. Especially since only the first LAN port supports PoE. Two WAN ports are not very useful for devices with only two ports, because they could only be used in a Mesh-on-WAN scenario.
Using one as LAN port and the other one as WAN port is from my point of view the better choice.

 A descion on this would affect the devolo WiFi pro 1750e as well, wich I intend to add in a future pull request.
