### PR TITLE
ath79-generic: add support for devolo WiFi pro 1750e

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -187,6 +187,7 @@ ath79-generic
 
   - WiFi pro 1200i
   - WiFi pro 1750c
+  - WiFi pro 1750e
   - WiFi pro 1750i
   - WiFi pro 1750x
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -24,6 +24,11 @@ device('devolo-wifi-pro-1750c', 'devolo_dvl1750c', {
 	factory = false,
 })
 
+device('devolo-wifi-pro-1750e', 'devolo_dvl1750e', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 device('devolo-wifi-pro-1750i', 'devolo_dvl1750i', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: sysupgrade via SSH on the Vendor Firmware
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - no radio led
  - switchport leds
    - no switchport leds


Has the same "issues" regarding the LAN Port mappings as the Devolo WiFi pro 1200e.
See #1882