### PR TITLE
ar71xx-generic: add alias for wndr3800chmychart

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -154,6 +154,7 @@ device('netgear-wndr3700v2', 'wndr3700v2', {
 })
 
 device('netgear-wndr3800', 'wndr3800', {
+	aliases = {'netgear-wndr3800chmychart'},
 	factory_ext = '.img',
 })
 


### PR DESCRIPTION
We've got a device which is an regular Netgear netgear-wndr3800 on the outside, but call themself: wndr3800chmychart

I did copy the netgear-wndr3800 lines from the manifest, to add netgear-wndr3800chmychart entries:
https://github.com/ffac/manifest/commit/60d352fa559a9e1fe0aae66c84a4c3d462eafa55#diff-b2c233cac29bcba7ef1003550f02bc94

That worked as expected, the device accepted the netgear-wndr3800 firmware and is now online with the new firmware:
https://map.aachen.freifunk.net/#!/en/map/08bd43baa736