### PR TITLE
docs: clarify WAN port on LAN-only devices

### DIFF
--- a/docs/dev/wan.rst
+++ b/docs/dev/wan.rst
@@ -11,6 +11,11 @@ There are two cases in which the WAN port is used:
 After the VPN connection has been established, the node should be able to reach
 the mesh's DNS servers and use these for all other name resolution.
 
+If the device does not feature a WAN port, the LAN port is configured as WAN port.
+In case such a device has multiple LAN ports, all these can be used as WAN.
+Devices, which feature a "hybrid" port (labled as WAN/LAN), this port is used as WAN.
+
+This behavior can be reversed using the ``single_as_lan`` site.conf option.
 
 Routing tables
 ~~~~~~~~~~~~~~

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -185,10 +185,10 @@ ath79-generic
 
 * devolo
 
-  - WiFi pro 1200e
+  - WiFi pro 1200e [#lan_as_wan]_
   - WiFi pro 1200i
   - WiFi pro 1750c
-  - WiFi pro 1750e
+  - WiFi pro 1750e [#lan_as_wan]_
   - WiFi pro 1750i
   - WiFi pro 1750x
 
@@ -396,3 +396,6 @@ Footnotes
 .. [#eva_ramboot]
   For instructions on how to flash AVM NAND devices, see the respective
   commit which added support in OpenWrt.
+
+.. [#lan_as_wan]
+  All LAN ports on this device are used as WAN.


### PR DESCRIPTION
At the December 2019 review day, the behavior for LAN only devices was defined. Such devices will use each LAN port as WAN.