### PR TITLE
lantiq-xrx200: add support for AVM FRITZ!Box 7360 (v1, v2) and 7360 SL

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -250,6 +250,8 @@ lantiq-xrx200
 
 * AVM
 
+  - FRITZ!Box 7360 (v1, v2) [#avmflash]_ [#lan_as_wan]_
+  - FRITZ!Box 7360 SL [#avmflash]_ [#lan_as_wan]_
   - FRITZ!Box 7362 SL [#eva_ramboot]_ [#lan_as_wan]_
   - FRITZ!Box 7412 [#eva_ramboot]_
 

--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -1,3 +1,8 @@
+device('avm-fritz-box-7360-sl', 'avm_fritz7360sl', {
+        factory = false,
+        aliases = {'avm-fritz-box-7360-v1', 'avm-fritz-box-7360-v2'},
+})
+
 device('avm-fritz-box-7362-sl', 'avm_fritz7362sl', {
         factory = false,
 })


### PR DESCRIPTION
    * [x]  must be flashable from vendor firmware
      
      * [ ]  webinterface
      * [ ]  tftp
      * [x]  other: fritzfla.sh script or adam2 ftp

    * [x]  must support upgrade mechanism
      
      * [x]  must have working sysupgrade
        
        * [x]  must keep/forget configuration (if applicable)
          _think `sysupgrade [-n]` or `firstboot`_
      * [?] must have working autoupdate
        _usually means: gluon profile name must match image name_

    * [x]  wps button must return device into config mode

    * [n/a]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)

    * wired network
      
      * [x]  should support all network ports on the device
      * [x]  must have correct port assignment (WAN/LAN)

    * wifi (if applicable)
      
      * [x]  association with AP must be possible on all radios
      * [x]  association with 802.11s mesh must be working on all radios
      * [x]  ap/mesh mode must work in parallel on all radios

    * led mapping
      
      * power/sys led (_critical, because led definitions are setup on firstboot only_)
        
        * [x]  lit while the device is on
        * [x]  should display config mode blink sequence
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
      * radio leds
        
        * [x]  should map to their respective radio
        * [x]  should show activity
      * switchport leds
        
        * [n/a]  should map to their respective port (or switch, if only one led present)
        * [n/a]  should show link state and activity

    * outdoor devices only
      
      * [n/a]  added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
        ~
All three versions share the same Hardware except the Flash (32MB for v2 else 16MB) and no POTS for SL. Tested on v2 so the bigger Flash is definitely no Issue.
Flashing with modified fritzfla.sh script successfully tested.