### PR TITLE
lantiq-xway: add support for AVM FRITZ!Box 7320, 7330 and 7330 SL

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -261,6 +261,9 @@ lantiq-xway
 * AVM
 
   - FRITZ!Box 7312 [#avmflash]_
+  - FRITZ!Box 7320 [#avmflash]_ [#lan_as_wan]_
+  - FRITZ!Box 7330 [#avmflash]_ [#lan_as_wan]_
+  - FRITZ!Box 7330 SL [#avmflash]_ [#lan_as_wan]_
 
 mpc85xx-generic
 ---------------

--- a/targets/lantiq-xway
+++ b/targets/lantiq-xway
@@ -1,3 +1,8 @@
 device('avm-fritz-box-7312', 'avm_fritz7312', {
 	factory = false,
 })
+
+device('avm-fritz-box-7320', 'avm_fritz7320', {
+        factory = false,
+        aliases = {'avm-fritz-box-7330', 'avm-fritz-box-7330-sl'},
+})


### PR DESCRIPTION
    * [x]  must be flashable from vendor firmware
      
      * [ ]  webinterface
      * [ ]  tftp
      * [x]  other: fritzfla.sh script or adam2 ftp

    * [x]  must support upgrade mechanism
      
      * [x]  must have working sysupgrade
        
        * [x]  must keep/forget configuration (if applicable)
          _think `sysupgrade [-n]` or `firstboot`_
      * [?] must have working autoupdate
        _usually means: gluon profile name must match image name_

    * [x]  wps button must return device into config mode

    * [n/a]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)

    * wired network
      
      * [x]  should support all network ports on the device
      * [x]  must have correct port assignment (WAN/LAN)

    * wifi (if applicable)
      
      * [x]  association with AP must be possible on all radios
      * [x]  association with 802.11s mesh must be working on all radios
      * [x]  ap/mesh mode must work in parallel on all radios

    * led mapping
      
      * power/sys led (_critical, because led definitions are setup on firstboot only_)
        
        * [x]  lit while the device is on
        * [x]  should display config mode blink sequence
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
      * radio leds
        
        * [x]  should map to their respective radio (with included patch)
        * [x]  should show activity (with included patch)
      * switchport leds
        
        * [n/a]  should map to their respective port (or switch, if only one led present)
        * [n/a]  should show link state and activity

    * outdoor devices only
      
      * [n/a]  added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
        ~
All three versions share the same Hardware except no POTS for SL nariant. Tested on 7330 SL.
Flashing with modified fritzfla.sh script successfully tested.