### PR TITLE
mpc85xx-p1020: add support for Enterasys WS-AP3710i

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -276,6 +276,10 @@ mpc85xx-p1020
 
   - HiveAP 330
 
+* Enterasys
+
+  - WS-AP3710i
+
 * OCEDO
 
   - Panda

--- a/targets/mpc85xx-p1020
+++ b/targets/mpc85xx-p1020
@@ -4,6 +4,14 @@ device('aerohive-hiveap-330', 'hiveap-330', {
         factory = false,
 })
 
+
+-- Enterasys
+
+device('enterasys-ws-ap3710i', 'ws-ap3710i', {
+	factory = false,
+})
+
+
 -- OCEDO
 
 device('ocedo-panda', 'panda', {


### PR DESCRIPTION
The Enterasys / Extreme Networks WS-AP3710i is a ceiling / wall mount PoE powered access point.
It has a dual-core PowerPC processor and dualband WiFi radios.

It can be acquired for cheap (~15 Euros) second hand from IT redistributors.

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: sysupgrade via initramfs / serial console
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *enterasys-ws-ap3710i*
- [x] reset/wps/phone button must return device into config mode
  - Reset button recessed at the bottom of the device
- [x] primary mac should match address on device label (or packaging) 
  - all mac addresses are printed on the label, matches Radio 1 (5 GHz) wifi mac
(https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
  - radio leds
    - [x]  should map to their respective radio
    - [x]  should show activity
  - switchport leds
    - [x]  should map to their respective port (or switch, if only one led present)
    - [x]  should show link state and activity

