### PR TITLE
ipq40xx: add support for Aruba AP-303

### DIFF
--- a/patches/openwrt/0007-ipq-wifi-add-BDF-for-Aruba-AP-303.patch
+++ b/patches/openwrt/0007-ipq-wifi-add-BDF-for-Aruba-AP-303.patch
@@ -1,0 +1,92 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sun, 15 Dec 2019 23:02:54 +0100
+Subject: ipq-wifi: add BDF for Aruba AP-303
+
+The BDF originates from the vendor-firmware.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+(cherry picked from commit 4113d8a2554adf5ecee55cc07956eafad378eaff)
+
+diff --git a/package/firmware/ipq-wifi/Makefile b/package/firmware/ipq-wifi/Makefile
+index eb7c2df1aa36ded7774a772c8a7e02b2acb81b40..cc0505b97c6a04bafd88972cf6ce7890a637c33b 100644
+--- a/package/firmware/ipq-wifi/Makefile
++++ b/package/firmware/ipq-wifi/Makefile
+@@ -25,6 +25,7 @@ endef
+ 
+ ALLWIFIBOARDS:= \
+ 	alfa-network_ap120c-ac \
++	aruba_ap-303 \
+ 	asus_map-ac2200 \
+ 	avm_fritzbox-7530 \
+ 	avm_fritzrepeater-1200 \
+@@ -97,6 +98,7 @@ endef
+ # Add $(eval $(call generate-ipq-wifi-package,<devicename>,<display name>))
+ 
+ $(eval $(call generate-ipq-wifi-package,alfa-network_ap120c-ac,ALFA Network AP120C-AC))
++$(eval $(call generate-ipq-wifi-package,aruba_ap-303,Aruba AP-303))
+ $(eval $(call generate-ipq-wifi-package,asus_map-ac2200,ASUS MAP-AC2200))
+ $(eval $(call generate-ipq-wifi-package,avm_fritzbox-7530,AVM FRITZ!Box 7530))
+ $(eval $(call generate-ipq-wifi-package,avm_fritzrepeater-1200,AVM FRITZRepeater 1200))
+diff --git a/package/firmware/ipq-wifi/board-aruba_ap-303.qca4019 b/package/firmware/ipq-wifi/board-aruba_ap-303.qca4019
+new file mode 100644
+index 0000000000000000000000000000000000000000..4848115cfbe3a4a0ed6b17cac929731ecbd7968c
+GIT binary patch
+literal 24316
+zcmeHPdr(tX8b1l)p-UHTNDu)pAp}Se0tBi-!W$`%6c7~&un1I<M58<m4?`F1_@EFG
+zfm#qEXc?48Q$)t%1F%?IJEP40v48CBA8luLw|}fVw5!gvGrOyM?hO}02ql3q<#9ha
+z=X~e8-#O<yzk5jTz30c>6BFeZwJ$y}AjvN}B`Pfz$mMbX<(NN~1F#FGd_`$kUSYm(
+zzFg|}UZJ$ePkJaU0I%hr$SXO7RRsaQWqBpiyyGXsqDmC`d45r;enA02aybRIXTiQ$
+z{(Fv6D8Qnc9-NN#>(d1&AQynm*7jHxFaWR*!ZjM6>t{S38|w;yprD{vFJ4eY3@h-<
+z-!4WF$pUt;M0u#+u2DM@cmo9<o32e4-TK}{-42{)MS-YT8nB=KA&y`%68dZzvGj;%
+zJAvBfnQ>V_`vZ+ET^9yjw-&*$wzjskw6xF>07kKy8YxWZr<)vMT{juo&5WBJl$pvJ
+zSBe@2uw^qXb0;%4&|Y78I5R0hICi_exl*3FFCluYul;;oiF8lGj<J5Il}ghR-u?y3
+z<F9$%VC>WOy2|{_1bA?;y|Gf7nVJwj){D78n-DgruPe_KCxqe+o_PC!v0LpI;0W&~
+zgp7R#8_4hmJ+PC)%p@TfcGpx{l$j<Bm~P-bH@-z`l~5LOnR}RQFc%NQwe^6K;hC*1
+zYj=HKdB|b!bl0Sb=920-IsYItdbF>&E$%$G#3{F}KdUX|Jgd|puct0g5t8q<cU!`P
+z#^Y7HrM_9r@UMC+KTbK%FWvUuz5epHckBJiT?>XU6jp>E=A|Pc_n}{`jGyHYexpa)
+z8eg})+@<jDr)8b~)ow)&xoZn0GFk!wOY2R)d&>@SU~bv!vW@t_*D0~j*k2Ra54<44
+zGAfly!Ey@=__b^`E!H<{G6I~Qyq_vSIUEo8>&bR^_h7rT+37SJ;+lkrg)CPdfsBl_
+zWH#Fk4)pWSFMfRe8oL4#@;p7Xw*UV4*B^9knBz8EYbuTQKj>!%PuOhxmoH!ZTkE^h
+zQ5Oxs>k&9eQFX%rmay^oy5hs-a5%Vu>&0fVaLp_>UjzM_W;28hf+9#18ifR+fk=_!
+zRP~t;8=70^D?l_Y4@^?%D4kD#N=KYgXTG!89<@iD&}cN8AN@2MNkkL*iQ-5!5{X9z
+zsDLkcDnNFjyZF1r0cZdsL}!9fUpK7I#3T~UL`ACe&W|yWIG_$w4u}it!gmqJpfOW1
+zND`XFPZ9^AK~q6UC>qKS6>Cp|ZjKM7g?`0zZ0#0(s2<Qwp34-SuNH%<p}&`<+SbE0
+zDLDsY&OV6}iP8cHkV|6$VCI-NBuaA-AS)ySBmyJ?BmyJ?Bmx^4fh~e9h#UPK!8=F_
+zeWze25<#~i1f=CRT_1X+n-jPGrj_%@*hGlg#@N88kes@S2)vvpCU&q=?$dOIMY}iF
+zZ_$ocmxDOFP&NDv09aP2x`v<WmwZ28Utjp7n}x1U4F>1q!}Wsktx^q!Hyz)q)K=GO
+zoF7djK!C#!ycz%kffr-~xxvJNR46t~SlLJq1Z=jeD_c)mpnblT&CYJ-0FjUaUY!7-
+z#TubR1_QvgL4XK|Xt`DhpfahOvtem(k8e884~Vp^8wB1A+A^rrLvRNI?k-blHXlQ|
+z28Ed52$bd6#2N6zwQKmBg-UNPPtI?dv^#g&y*lmgoH%t~Mt1I@LRDi+Ye!f2&4Iz;
+zk<l+6fAh@r13LS7rd_$N8E=5^gNo_3#7-!_2P%%PC3Zpa{ZFx=me>I`9mEA&tbcUZ
+z%raPCff}=CoSdFh&~W)`kLJ$!*9+<E3zgZ~FkUkdSJaj7DrSJ#*RhBg74ya7SP=X=
+z7!jc&zDOKww)^YZQBBbt1&#<xj}ycp$@Cq99Y{Dm^9uGezYpSjjwsj4Esm+2`@lsx
+z_pP233MAZDG~x_!W*4x)IQLBJ8XOwPV6wwG_mF@_V5M8~BrC?bzpXnCrvEDEUf+49
+zzBuO|MP{6#qUF9@TUl7rX4vll48Jjsia$KVkvGV>*BuD^e+C^f1J|FyU;r!;;^^oI
+zutbQ7^|zo9O_y4-fz<*{BN<(cKQSIMS&pfWHI9R`Q7+)GZ~m87zSOtRt#@=xPIh$J
+z+RmlJ%=Iy)wjsB2$w?ctL{=e6#)NGiAEXw5z3>BC;Y0;D{!GEsIar?io&qX3RM0m-
+z1^qu!!LtzyFeRb^yHOg52(ttT)56l)JRy+1kO+_nY&ZmFIrD}%_y76l-@pIvyT3qG
+z!a_rK!Uv_0b8llsqdtHB4`|cp+)q8%a_-ajrKM^)`>$U7G-ZAsz9G)NzdxUkC2X$&
+zduq<ccO90m`EJJ_!n5Hnfmt*|3ykF4Yws{0%-(2jK-HM%C%SBVt&T&cMQg=#Z0+ju
+z?J<3slzUHc2KJzP^x51yjM<u@zZYHGw?pGC>M~`z#Q)p7<L&AyWsXERen)*-SuBYY
+zdX5iix>ZV<MCgkBpV)(k-dq41G^-WL{SyA<pyrb5ge*-W)C{Y;WHL#z(0BZEb(2yq
+zi59Z32BQ<+-T-%#DbtndllL?oDuryXWT)ny>awgPK2|7z4Vsn5hz4U5-aIh*Kyy`9
+z2K#+`d{Fa=s!Ar2h&1D>cG=1J-CQSpgrl-7ZAjx2Fr>-5ns)VRm0Y%a{Fdgrx(+r@
+z*4$UM$;#s6xh~@)>W}b{+^~=yKH~BKoNA}$qFSNKg(0ccXH~^YiRPBNQznm(68cZx
+z*IZXs$_@yfwGDV)*c_VFr&I;XWO(qZszR13@rQx5DHW0=A#d`I=8CFBmJ-jw8hkOq
+zgDBk|Z&R15a+I-?Bk*9UGFz4i!@LHuj1;2qXotF778Ab}Z}1q-!4z4Am-=K##+*PB
+zB@(3t5LgdOV}YrW<_(KL>(KEV5iNeTE@js=e`t@r=v}q-_{qz0XL!ZV`L=NnyANLo
+zQ+gcPBDpqn@<w#Cf31sRXs|$?cxn3|T~1u=N^b}}#gf@2f7N@eDYC{>zBNZRxW7|)
+z$*qbmtL@F{5S&95^!$;V#g`*L;FZw#KkAb<N7Q&6bIPge-+$Gw*17EWd3}TBpF}or
+ztF{!X+LO-)o@5?)YxmvW{H9&itfS1VFYhY*Qrf*wJIXb;6xT!R*k$yCb!{o<g3FvF
+zw(+<74}K*4z)jA~>Cs3#V=uB4NN#U`sakZFU2HEI?ks7Dsq&ROrak#AvEH|GYk~cN
+z-oYbXaZQ|4jDps_<5wf<yeb%ZH`=7N;R>H44oN*XPh1H-<59xMxzd~07FF+FO3!KO
+zkzNs<^C)%5zR+;s{a_h8iyk@DSK5($fm`l$c*8Cna^fTc>i~h}zJUY22WwUg;4xU6
+zE40Voz~Sl1fxqzW8!QiZceZ;vST%3pn9qkNDEBsI+pnKL20^*sWVSI3z)zY;1PmfD
+zk8=M~&&^oEhq?Xq!q{llMLGBQ>t)~ra4xR!eZAQ1X^ph;*FG+*f4xJlJ!C>*eEV+r
+z#z~GXOppZ=2|4(iyLmNON}QN2ao#+YHqDy{lvv2w_X*(?ul{+G5$Yp=apGx^6Q9v~
+z^YKb>;`PTfcYPtQJz@VX`S#e@B<CLA>so3?a_*Ok9NBKwB4Es(@j^U%UHht?;4%Xv
+NIrrxNmNc!u{{!hMI2Hf^
+
+literal 0
+HcmV?d00001
+

--- a/patches/openwrt/0008-ipq40xx-add-support-for-Aruba-AP-303.patch
+++ b/patches/openwrt/0008-ipq40xx-add-support-for-Aruba-AP-303.patch
@@ -1,0 +1,646 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Wed, 23 Oct 2019 22:25:14 +0200
+Subject: ipq40xx: add support for Aruba AP-303
+
+Hardware
+--------
+
+SoC:   Qualcomm IPQ4029
+RAM:   512M DDR3
+FLASH: - 128MB NAND (Macronix MX30LF1G18AC)
+       - 4MB SPI-NOR (Macronix MX25R3235F)
+TPM:   Atmel AT97SC3203
+BLE:   Texas Instruments CC2540T
+       attached to ttyMSM0
+ETH:   Atheros AR8035
+LED:   WiFi (amber / green)
+       System (red / green)
+BTN:   Reset
+
+To connect to the serial console, you can solder to the labled pads next
+to the USB port or use your Aruba supplied UARt adapter.
+
+Do NOT plug a standard USB cable into the Console labled USB-port!
+Aruba/HPE simply put UART on the micro-USB pins. You can solder yourself
+an adapter cable:
+
+VCC - NC
+ D+ - TX
+ D- - RX
+GND - GND
+
+The console setting in bootloader and OS is 9600 8N1. Voltage level is
+3.3V.
+
+To enable a full list of commands in the U-Boot "help" command, execute
+the literal "diag" command.
+
+Installation
+------------
+
+1. Get the OpenWrt initramfs image. Rename it to ipq40xx.ari and put it
+   into the TFTP server root directory. Configure the TFTP server to
+   be reachable at 192.168.1.75/24. Connect the machine running the TFTP
+   server to the ethernet port of the access point.
+
+2. Connect to the serial console. Interrupt autobooting by pressing
+   Enter when prompted.
+
+3. Configure the bootargs and bootcmd for OpenWrt.
+   $ setenv bootargs_openwrt "setenv bootargs console=ttyMSM1,9600n8"
+   $ setenv nandboot_openwrt "run bootargs_openwrt; ubi part aos1;
+     ubi read 0x85000000 kernel; bootm 0x85000000"
+   $ setenv ramboot_openwrt "run bootargs_openwrt;
+     setenv ipaddr 192.168.1.105; setenv serverip 192.168.1.75;
+     netget; set fdt_high 0x87000000; bootm"
+   $ setenv bootcmd "run nandboot_openwrt"
+   $ saveenv
+
+4. Load OpenWrt into RAM:
+   $ run ramboot_openwrt
+
+5. After OpenWrt booted, transfer the OpenWrt sysupgrade image to the
+   /tmp folder on the device.
+
+6. Flash OpenWrt:
+   $ ubidetach -p /dev/mtd1
+   $ ubiformat /dev/mtd1
+   $ sysupgrade -n /tmp/openwrt-sysupgrade.bin
+
+To go back to the stock firmware, simply reset the bootcmd in the
+bootloader to the original value:
+
+  $ setenv bootcmd "boot"
+  $ saveenv
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+(cherry picked from commit 102c8c55f217606cdbdc9a449667e034676b3e75)
+
+diff --git a/target/linux/ipq40xx/base-files/etc/board.d/02_network b/target/linux/ipq40xx/base-files/etc/board.d/02_network
+index 01825b8bac46eec6325de00396d96307c946f975..49dd570242533068adf2c9df89e78560ba5f70eb 100755
+--- a/target/linux/ipq40xx/base-files/etc/board.d/02_network
++++ b/target/linux/ipq40xx/base-files/etc/board.d/02_network
+@@ -39,6 +39,7 @@ ipq40xx_setup_interfaces()
+ 		ucidef_add_switch "switch0" \
+ 			"0u@eth0" "1:lan" "2:lan" "3:lan" "4:lan"
+ 		;;
++	aruba,ap-303|\
+ 	avm,fritzrepeater-1200|\
+ 	engenius,eap1300|\
+ 	meraki,mr33|\
+diff --git a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index b0035ce8a394b6e87d7d89b9f55a6ec7c66e448e..15a2f2c09f8a92cc0accfbf9a977dbeb3355570d 100644
+--- a/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ipq40xx/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -137,6 +137,10 @@ case "$FIRMWARE" in
+ 	qcom,ap-dk01.1-c1)
+ 		ath10kcal_extract "ART" 4096 12064
+ 		;;
++	aruba,ap-303)
++		ath10kcal_extract "ART" 4096 12064
++		ath10kcal_patch_mac_crc $(mtd_get_mac_binary mfginfo 29)
++		;;
+ 	asus,map-ac2200)
+ 		ath10kcal_ubi_extract "Factory" 4096 12064
+ 		;;
+@@ -199,6 +203,10 @@ case "$FIRMWARE" in
+ 	qcom,ap-dk01.1-c1)
+ 		ath10kcal_extract "ART" 20480 12064
+ 		;;
++	aruba,ap-303)
++		ath10kcal_extract "ART" 20480 12064
++		ath10kcal_patch_mac_crc $(macaddr_add $(mtd_get_mac_binary mfginfo 29) +1)
++		;;
+ 	asus,map-ac2200)
+ 		ath10kcal_ubi_extract "Factory" 20480 12064
+ 		;;
+diff --git a/target/linux/ipq40xx/base-files/etc/inittab b/target/linux/ipq40xx/base-files/etc/inittab
+index 809bba5e5ff49869429c91cf791cea73ab67d14e..3181021a0592720657b815c3eac803a57f4ea438 100644
+--- a/target/linux/ipq40xx/base-files/etc/inittab
++++ b/target/linux/ipq40xx/base-files/etc/inittab
+@@ -2,3 +2,4 @@
+ ::sysinit:/etc/init.d/rcS S boot
+ ::shutdown:/etc/init.d/rcS K shutdown
+ ttyMSM0::askfirst:/usr/libexec/login.sh
++ttyMSM1::askfirst:/usr/libexec/login.sh
+diff --git a/target/linux/ipq40xx/base-files/lib/preinit/06_set_preinit_iface_ipq40xx.sh b/target/linux/ipq40xx/base-files/lib/preinit/06_set_preinit_iface_ipq40xx.sh
+index be4b6322cb6a91f489dfec237ac6b79ce079e0eb..a0dec1042a3dd7416ece3307666c8ecf9d15d277 100644
+--- a/target/linux/ipq40xx/base-files/lib/preinit/06_set_preinit_iface_ipq40xx.sh
++++ b/target/linux/ipq40xx/base-files/lib/preinit/06_set_preinit_iface_ipq40xx.sh
+@@ -4,6 +4,7 @@ set_preinit_iface() {
+ 	. /lib/functions.sh
+ 
+ 	case $(board_name) in
++	aruba,ap-303| \
+ 	asus,rt-ac58u| \
+ 	avm,fritzbox-4040| \
+ 	glinet,gl-b1300| \
+diff --git a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+index a7b7da1bf378f7cc19e960c497bc52efb3bae4fb..7253139497a8a8b9fab49cef3fce5eabe98d8002 100644
+--- a/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ipq40xx/base-files/lib/upgrade/platform.sh
+@@ -48,6 +48,7 @@ platform_do_upgrade() {
+ 	case "$(board_name)" in
+ 	8dev,jalapeno |\
+ 	alfa-network,ap120c-ac |\
++	aruba,ap-303 |\
+ 	avm,fritzbox-7530 |\
+ 	avm,fritzrepeater-1200 |\
+ 	avm,fritzrepeater-3000 |\
+diff --git a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-ap-303.dts b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-ap-303.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..7929494d027aca5c696910232a36d484f5ce6562
+--- /dev/null
++++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4029-ap-303.dts
+@@ -0,0 +1,418 @@
++// SPDX-License-Identifier: GPL-2.0 OR MIT
++
++#include "qcom-ipq4019.dtsi"
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/soc/qcom,tcsr.h>
++
++/ {
++	model = "Aruba AP-303";
++	compatible = "aruba,ap-303";
++
++	aliases {
++		led-boot = &led_system_green;
++		led-failsafe = &led_system_red;
++		led-running = &led_system_green;
++		led-upgrade = &led_system_red;
++	};
++
++	memory {
++		device_type = "memory";
++		reg = <0x80000000 0x10000000>;
++	};
++
++	soc {
++		mdio@90000 {
++			status = "okay";
++			pinctrl-0 = <&mdio_pins>;
++			pinctrl-names = "default";
++
++			/delete-node/ ethernet-phy@0;
++			/delete-node/ ethernet-phy@2;
++			/delete-node/ ethernet-phy@3;
++			/delete-node/ ethernet-phy@4;
++
++			ethernet-phy@5 {
++				reg = <0x5>;
++			};
++		};
++
++		counter@4a1000 {
++			compatible = "qcom,qca-gcnt";
++			reg = <0x4a1000 0x4>;
++		};
++
++		ess_tcsr@1953000 {
++			compatible = "qcom,tcsr";
++			reg = <0x1953000 0x1000>;
++			qcom,ess-interface-select = <TCSR_ESS_PSGMII_RGMII5>;
++		};
++
++		tcsr@1949000 {
++			compatible = "qcom,tcsr";
++			reg = <0x1949000 0x100>;
++			qcom,wifi_glb_cfg = <TCSR_WIFI_GLB_CFG>;
++		};
++
++		tcsr@1957000 {
++			compatible = "qcom,tcsr";
++			reg = <0x1957000 0x100>;
++			qcom,wifi_noc_memtype_m0_m2 = <TCSR_WIFI_NOC_MEMTYPE_M0_M2>;
++		};
++
++		blsp1_uart2: serial@78b0000 {
++		};
++
++		crypto@8e3a000 {
++			status = "okay";
++		};
++
++		watchdog@b017000 {
++			status = "okay";
++		};
++
++		ess-switch@c000000 {
++			switch_mac_mode = <0x3>; /* mac mode for RGMII RMII */
++			switch_lan_bmp = <0x0>; /* lan port bitmap */
++			switch_wan_bmp = <0x10>; /* wan port bitmap */
++		};
++
++		edma@c080000 {
++			qcom,single-phy;
++			qcom,num_gmac = <1>;
++			phy-mode = "rgmii-id";
++			status = "okay";
++		};
++
++		i2c_0: i2c@78b7000 {
++			pinctrl-0 = <&i2c_0_pins>;
++			pinctrl-names = "default";
++			status = "ok";
++
++			tpm@29 {
++				/* No Driver */
++				compatible = "atmel,at97sc3203";
++				reg = <0x29>;
++				read-only;
++			};
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		wifi_green {
++			label = "ap-303:green:wifi";
++			gpios = <&tlmm 39 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "phy0tpt";
++		};
++
++		wifi_amber {
++			label = "ap-303:amber:wifi";
++			gpios = <&tlmm 40 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "phy1tpt";
++		};
++
++		led_system_red: system_red {
++			label = "ap-303:red:system";
++			gpios = <&tlmm 46 GPIO_ACTIVE_HIGH>;
++		};
++
++		led_system_green: system_green {
++			label = "ap-303:green:system";
++			gpios = <&tlmm 47 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "Reset button";
++			gpios = <&tlmm 50 GPIO_ACTIVE_LOW>;
++			linux,code = <KEY_RESTART>;
++		};
++	};
++};
++
++&blsp_dma {
++	status = "okay";
++};
++
++&blsp1_uart1 {
++	/* Texas Instruments CC2540T BLE radio */
++	pinctrl-0 = <&serial_0_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&blsp1_uart2 {
++	pinctrl-0 = <&serial_1_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++};
++
++&cryptobam {
++	status = "okay";
++};
++
++&gmac0 {
++	qcom,phy_mdio_addr = <5>;
++	qcom,poll_required = <1>;
++	vlan_tag = <0 0x20>;
++};
++
++&qpic_bam {
++	status = "okay";
++};
++
++&tlmm {
++	/*
++	 * In addition to the Pins listed below,
++	 * the following GPIOs have "features":
++	 * 54 - out - active low to force HW reset
++	 * 41 - out - active low to reset TPM
++	 * 43 - out - active low to reset BLE radio
++	 * 19 - in  - active high when DC powered
++	 */
++	mdio_pins: mdio_pinmux {
++		mux_1 {
++			pins = "gpio6";
++			function = "mdio";
++			bias-pull-up;
++		};
++		mux_2 {
++			pins = "gpio7";
++			function = "mdc";
++			bias-pull-up;
++		};
++	};
++
++	nand_pins: nand_pins {
++		pullups {
++			pins = "gpio53", "gpio58", "gpio59";
++			function = "qpic";
++			bias-pull-up;
++		};
++
++		pulldowns {
++			pins = "gpio54", "gpio55", "gpio56",
++				"gpio57", "gpio60", "gpio61",
++				"gpio62", "gpio63", "gpio64",
++				"gpio65", "gpio66", "gpio67",
++				"gpio68", "gpio69";
++			function = "qpic";
++			bias-pull-down;
++		};
++	};
++
++	spi_0_pins: spi_0_pinmux {
++		pin {
++			function = "blsp_spi0";
++			pins = "gpio13", "gpio14", "gpio15";
++			drive-strength = <12>;
++			bias-disable;
++		};
++		pin_cs {
++			function = "gpio";
++			pins = "gpio12";
++			drive-strength = <2>;
++			bias-disable;
++			output-high;
++		};
++	};
++	i2c_0_pins: i2c_0_pinmux {
++		mux {
++			pins = "gpio10", "gpio11";
++			function = "blsp_i2c0";
++			drive-strength = <4>;
++			bias-disable;
++		};
++	};
++
++	serial_0_pins: serial_0_pinmux {
++		mux {
++			pins = "gpio16", "gpio17";
++			function = "blsp_uart0";
++			bias-disable;
++		};
++	};
++
++	serial_1_pins: serial_1_pinmux {
++		mux {
++			pins = "gpio8", "gpio9";
++			function = "blsp_uart1";
++			bias-disable;
++		};
++	};
++
++	phy-reset {
++		line-name = "PHY-reset";
++		gpios = <42 GPIO_ACTIVE_HIGH>;
++		gpio-hog;
++		output-high;
++	};
++};
++
++&nand {
++	pinctrl-0 = <&nand_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++
++	nand@0 {
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				/* 'aos0' in Aruba firmware */
++				label = "aos0";
++				reg = <0x0 0x2000000>;
++				read-only;
++			};
++
++			partition@2000000 {
++				/* 'aos1' in AVM firmware */
++				label = "ubi";
++				reg = <0x2000000 0x2000000>;
++			};
++
++			partition@4000000 {
++				label = "aruba-ubifs";
++				reg = <0x4000000 0x4000000>;
++				read-only;
++			};
++		};
++	};
++};
++
++&blsp1_spi1 {
++	pinctrl-0 = <&spi_0_pins>;
++	pinctrl-names = "default";
++	status = "okay";
++	cs-gpios = <&tlmm 12 GPIO_ACTIVE_HIGH>;
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <24000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			/*
++			 * There is no partition map for the NOR flash
++			 * in the stock firmware.
++			 *
++			 * All partitions here are based on offsets
++			 * found in the U-Boot GPL code and information
++			 * from smem.
++			 */
++
++			partition@0 {
++				label = "sbl1";
++				reg = <0x0 0x40000>;
++				read-only;
++			};
++
++			partition@40000 {
++				label = "mibib";
++				reg = <0x40000 0x20000>;
++				read-only;
++			};
++
++			partition@60000 {
++				label = "qsee";
++				reg = <0x60000 0x60000>;
++				read-only;
++			};
++
++			partition@c0000 {
++				label = "cdt";
++				reg = <0xc0000 0x10000>;
++				read-only;
++			};
++
++			partition@d0000 {
++				label = "ddrparams";
++				reg = <0xd0000 0x10000>;
++				read-only;
++			};
++
++			partition@e0000 {
++				label = "ART";
++				reg = <0xe0000 0x10000>;
++				read-only;
++			};
++
++			partition@f0000 {
++				label = "appsbl";
++				reg = <0xf0000 0xf0000>;
++				read-only;
++			};
++
++			partition@1e0000 {
++				label = "mfginfo";
++				reg = <0x1e0000 0x10000>;
++				read-only;
++			};
++
++			partition@1f0000 {
++				label = "apcd";
++				reg = <0x1f0000 0x10000>;
++				read-only;
++			};
++
++			partition@200000 {
++				label = "osss";
++				reg = <0x200000 0x180000>;
++				read-only;
++			};
++
++			partition@380000 {
++				/* This is empty */
++				label = "appsblenv";
++				reg = <0x380000 0x10000>;
++				read-only;
++			};
++
++			partition@390000 {
++				label = "pds";
++				reg = <0x390000 0x10000>;
++				read-only;
++			};
++
++			partition@3a0000 {
++				label = "fcache";
++				reg = <0x3a0000 0x10000>;
++				read-only;
++			};
++
++			partition@3b0000 {
++				/* Called osss1 in smem */
++				label = "u-boot-env-bak";
++				reg = <0x3b0000 0x10000>;
++				read-only;
++			};
++
++			partition@3f0000 {
++				label = "u-boot-env";
++				reg = <0x3f0000 0x10000>;
++				read-only;
++			};
++		};
++	};
++};
++
++&wifi0 {
++	status = "okay";
++	qcom,ath10k-calibration-variant = "Aruba-AP-303";
++};
++
++&wifi1 {
++	status = "okay";
++	qcom,ath10k-calibration-variant = "Aruba-AP-303";
++};
+diff --git a/target/linux/ipq40xx/image/Makefile b/target/linux/ipq40xx/image/Makefile
+index 98c81726d9c12bd466df2150c3e98a76cfb46f78..68dcbc59a42f6d8360b87c7b4e74cd34f697b465 100644
+--- a/target/linux/ipq40xx/image/Makefile
++++ b/target/linux/ipq40xx/image/Makefile
+@@ -85,6 +85,15 @@ define Device/alfa-network_ap120c-ac
+ endef
+ TARGET_DEVICES += alfa-network_ap120c-ac
+ 
++define Device/aruba_ap-303
++	$(call Device/FitImageLzma)
++	DEVICE_TITLE := Aruba AP-303
++	DEVICE_DTS := qcom-ipq4029-ap-303
++	DEVICE_PACKAGES := ipq-wifi-aruba_ap-303
++	IMAGES := sysupgrade.bin
++endef
++TARGET_DEVICES += aruba_ap-303
++
+ define Device/asus_map-ac2200
+ 	$(call Device/FitImageLzma)
+ 	DEVICE_DTS := qcom-ipq4019-map-ac2200
+diff --git a/target/linux/ipq40xx/patches-4.14/304-mtd-spi-nor-Add-support-for-mx25r3235f.patch b/target/linux/ipq40xx/patches-4.14/304-mtd-spi-nor-Add-support-for-mx25r3235f.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..d95923a1610d4764538e79bb783702903edcdcad
+--- /dev/null
++++ b/target/linux/ipq40xx/patches-4.14/304-mtd-spi-nor-Add-support-for-mx25r3235f.patch
+@@ -0,0 +1,26 @@
++From 158acdbf0336f601971637f988b57a6a67a0869b Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Sun, 15 Dec 2019 13:10:50 +0100
++Subject: [PATCH] mtd: spi-nor: Add support for mx25r3235f
++
++Add MTD support for the Macronix MX25R3235F SPI NOR chip from Macronix.
++The chip has 4MB of total capacity, divided into a total of 64 sectors,
++each 64KB sized. The chip also supports 4KB large sectors.
++Additionally, it supports dual and quad read modes.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ drivers/mtd/spi-nor/spi-nor.c | 2 ++
++ 1 file changed, 2 insertions(+)
++
++--- a/drivers/mtd/spi-nor/spi-nor.c
+++++ b/drivers/mtd/spi-nor/spi-nor.c
++@@ -1024,6 +1024,8 @@ static const struct flash_info spi_nor_i
++ 	{ "mx25l3205d",  INFO(0xc22016, 0, 64 * 1024,  64, SECT_4K) },
++ 	{ "mx25l3255e",  INFO(0xc29e16, 0, 64 * 1024,  64, SECT_4K) },
++ 	{ "mx25l6405d",  INFO(0xc22017, 0, 64 * 1024, 128, SECT_4K) },
+++	{ "mx25r3235f",  INFO(0xc22816, 0, 64 * 1024,  64,
+++			 SECT_4K | SPI_NOR_DUAL_READ | SPI_NOR_QUAD_READ) },
++ 	{ "mx25u3235f",	 INFO(0xc22536, 0, 64 * 1024, 64, 0) },
++ 	{ "mx25u2033e",  INFO(0xc22532, 0, 64 * 1024,   4, SECT_4K) },
++ 	{ "mx25u4035",   INFO(0xc22533, 0, 64 * 1024,   8, SECT_4K) },
+diff --git a/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch b/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch
+index f7efd415f1f1c000867793b3b133e44b3e50b0fd..fc8a88336491c2ac7c2a93fafb1f2b6fd38695be 100644
+--- a/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch
++++ b/target/linux/ipq40xx/patches-4.14/901-arm-boot-add-dts-files.patch
+@@ -10,7 +10,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
+ 
+ --- a/arch/arm/boot/dts/Makefile
+ +++ b/arch/arm/boot/dts/Makefile
+-@@ -697,7 +697,31 @@ dtb-$(CONFIG_ARCH_QCOM) += \
++@@ -697,7 +697,32 @@ dtb-$(CONFIG_ARCH_QCOM) += \
+  	qcom-apq8074-dragonboard.dtb \
+  	qcom-apq8084-ifc6540.dtb \
+  	qcom-apq8084-mtp.dtb \
+@@ -37,6 +37,7 @@ Signed-off-by: John Crispin <john@phrozen.org>
+ +	qcom-ipq4019-qxwlan-e2600ac-c1.dtb \
+ +	qcom-ipq4019-qxwlan-e2600ac-c2.dtb \
+ +	qcom-ipq4028-wpj428.dtb \
+++	qcom-ipq4029-ap-303.dtb \
+ +	qcom-ipq4029-gl-b1300.dtb \
+ +	qcom-ipq4029-mr33.dtb \
+  	qcom-ipq8064-ap148.dtb \

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -19,6 +19,13 @@ defaults {
 }
 
 
+-- Aruba
+
+device('aruba-ap-303', 'aruba_ap-303', {
+	factory = false,
+})
+
+
 -- AVM
 
 device('avm-fritz-box-4040', 'avm_fritzbox-4040', {


### PR DESCRIPTION
this commit adds support for the Aruba AP-303 Wireless access point. The device is as well amrketed as the Aruba InstantOn AP11 for around 70 Euro.

As the Device supports 802.11ac Wave 2 MU-MIMO, has a Quad-Core IPQ4029 ARM SoC and 512 MB (!) of DDR3 RAM, it is a compelling alternative to the Ubiquiti UniFi AC Lite.

Installation instructions are available at the OpenWrt Wiki: https://openwrt.org/toh/aruba/aruba_ap-303




-----

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] other: TFTP initramfs via U-Boot 
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
     > aruba-ap-303
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
- [x] reset/wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)