### PR TITLE
patches/openwrt: add set TARGET_ROOTFS_PARTSIZE to make combined imag…

### DIFF
--- a/patches/openwrt/0006-build-set-TARGET_ROOTFS_PARTSIZE-to-make-combined-im.patch
+++ b/patches/openwrt/0006-build-set-TARGET_ROOTFS_PARTSIZE-to-make-combined-im.patch
@@ -1,0 +1,35 @@
+From 78d7abf981e54d547636eefe63a0053f8df9e735 Mon Sep 17 00:00:00 2001
+From: Matthias Schiffer <mschiffer@universe-factory.net>
+Date: Sat, 21 Sep 2019 13:21:36 +0200
+Subject: [PATCH] build: set TARGET_ROOTFS_PARTSIZE to make combined image fit
+ in 128MB
+
+Change TARGET_ROOTFS_PARTSIZE from 128 to 104 MiB, so the whole image
+(bootloader + boot + root) will fit on a 128MB CF card by default.
+
+With these settings, the generated images (tested on x86-generic and
+x86-64) have 126,353,408 bytes; the smallest CF card marketed as "128MB"
+that I found a datasheet for (a Transcend TS128MCF80) has 126,959,616
+bytes.
+
+Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
+---
+ config/Config-images.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/config/Config-images.in b/config/Config-images.in
+index 8548c7cd24..dc7a9cbd54 100644
+--- a/config/Config-images.in
++++ b/config/Config-images.in
+@@ -274,7 +274,7 @@ menu "Target Images"
+ 	config TARGET_ROOTFS_PARTSIZE
+ 		int "Root filesystem partition size (in MB)"
+ 		depends on GRUB_IMAGES || USES_ROOTFS_PART || TARGET_ROOTFS_EXT4FS || TARGET_omap || TARGET_rb532 || TARGET_sunxi || TARGET_uml
+-		default 256
++		default 104
+ 		help
+ 		  Select the root filesystem partition size.
+ 
+-- 
+2.24.1
+


### PR DESCRIPTION
…e fit in 128MB

Backport the change from OpenWRT master as discussed in PR #1814