### PR TITLE
docs: site example: add validation script and travis config

### DIFF
--- a/docs/site-example/.travis.yml
+++ b/docs/site-example/.travis.yml
@@ -1,0 +1,15 @@
+language: bash
+
+addons:
+  apt:
+    packages:
+    - lua5.1
+    - luarocks
+  
+install:
+  - eval $(luarocks path --bin)
+  - luarocks install --local lua-cjson
+  - luarocks install --local luacheck
+
+script:
+  - bash tests/validate_site.sh

--- a/docs/site-example/tests/.luacheckrc
+++ b/docs/site-example/tests/.luacheckrc
@@ -1,0 +1,242 @@
+codes = true
+std = "lua51"
+self = false
+
+include_files = {
+	"*.lua",
+	"/**/files/lib/gluon/ebtables/*",
+	"/**/luasrc/**/*",
+}
+
+-- files["scripts/check_site.lua"] = {
+--	allow_defined = true,
+--	module = true,
+-- }
+
+files["/**/check_site.lua"] = {
+	globals = {
+		"alternatives",
+		"extend",
+		"in_domain",
+		"in_site",
+		"need",
+		"need_alphanumeric_key",
+		"need_array",
+		"need_array_of",
+		"need_boolean",
+		"need_chanlist",
+		"need_domain_name",
+		"need_number",
+		"need_one_of",
+		"need_string",
+		"need_string_array",
+		"need_string_array_match",
+		"need_string_match",
+		"need_table",
+		"need_value",
+		"obsolete",
+		"table_keys",
+		"this_domain",
+	},
+}
+
+files["/**/files/lib/gluon/ebtables/*"] = {
+	globals = {
+		"site",
+	},
+	new_read_globals = {
+		"chain",
+		"rule",
+	},
+	max_line_length = false,
+}
+
+files["/**/luasrc/lib/gluon/config-mode/*"] = {
+	globals = {
+		"DynamicList",
+		"Flag",
+		"Form",
+		"i18n",
+		"ListValue",
+		"renderer.render",
+		"renderer.render_string",
+		"Section",
+		"TextValue",
+		"_translate",
+		"translate",
+		"translatef",
+		"Value",
+	},
+}
+
+files["/**/luasrc/lib/gluon/**/controller/*"] = {
+	new_read_globals = {
+		"_",
+		"alias",
+		"call",
+		"entry",
+		"model",
+		"node",
+		"template",
+	},
+}
+
+files["/**/gluon-client-bridge/luasrc/usr/lib/lua/gluon/client_bridge.lua"] = {
+	globals = {
+		"next_node_macaddr",
+	},
+}
+
+files["/**/gluon-config-mode-geo-location-osm/luasrc/usr/lib/lua/gluon/config-mode/geo-location-osm.lua"] = {
+--	allow_defined = true,
+--	module = true,
+	globals = {
+		"help",
+		"MapValue",
+		"options",
+	},
+}
+
+files["/**/gluon-core/luasrc/usr/lib/lua/gluon/*"] = {
+	globals = {
+		"_M",
+	},
+}
+
+files["/**/gluon-core/luasrc/usr/lib/lua/gluon/iputil.lua"] = {
+--	allow_defined = true,
+--	module = true,
+	globals = {
+		"IPv6",
+		"mac_to_ip",
+	},
+}
+
+files["/**/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua"] = {
+--	allow_defined = true,
+--	module = true,
+	globals = {
+		"is_outdoor_device",
+		"match",
+	},
+	new_read_globals = {
+		-- globals provided by platform_info
+		"get_board_name",
+		"get_image_name",
+		"get_model",
+		"get_subtarget",
+		"get_target",
+	},
+}
+
+files["/**/gluon-core/luasrc/usr/lib/lua/gluon/users.lua"] = {
+	globals = {
+		"remove_group",
+		"remove_user",
+	},
+}
+
+files["/**/gluon-core/luasrc/usr/lib/lua/gluon/util.lua"] = {
+--	allow_defined = true,
+--	module = true,
+	globals = {
+		"add_to_set",
+		"contains",
+		"default_hostname",
+		"domain_seed_bytes",
+		"exec",
+		"find_phy",
+		"foreach_radio",
+		"generate_mac",
+		"get_mesh_devices",
+		"get_uptime",
+		"get_wlan_mac",
+		"glob",
+		"node_id",
+		"readfile",
+		"remove_from_set",
+		"replace_prefix",
+		"trim",
+	},
+}
+
+files["/**/gluon-web/luasrc/usr/lib/lua/gluon/web/*"] = {
+	globals = {
+		"Http",
+		"HTTP_MAX_CONTENT",
+		"mimedecode_message_body",
+		"parse_message_body",
+		"urldecode",
+		"urldecode_params",
+		"urlencode",
+	},
+}
+
+files["/**/gluon-web/luasrc/usr/lib/lua/gluon/web/util.lua"] = {
+	globals = {
+		"class",
+		"instanceof",
+		"pcdata",
+	},
+}
+
+files["/**/gluon-web-admin/luasrc/lib/gluon/config-mode/controller/admin/upgrade.lua"] = {
+	globals = {
+		"file",
+	},
+}
+
+files["/**/gluon-web-mesh-vpn-fastd/luasrc/lib/gluon/config-mode/model/admin/mesh_vpn_fastd.lua"] = {
+	globals = {
+		"gluon",
+	},
+}
+
+files["/**/gluon-web-model/luasrc/usr/lib/lua/gluon/web/model/datatypes.lua"] = {
+--	allow_defined = true,
+--	module = true,
+	globals = {
+		"bool",
+		"float",
+		"imax",
+		"imin",
+		"integer",
+		"ip4addr",
+		"ip6addr",
+		"ipaddr",
+		"irange",
+		"max",
+		"maxlength",
+		"min",
+		"minlength",
+		"range",
+		"ufloat",
+		"uinteger",
+		"wpakey",
+	},
+}
+
+files["/**/gluon-web-model/luasrc/usr/lib/lua/gluon/web/model/classes.lua"] = {
+--	allow_defined = true,
+	globals = {
+		"AbstractValue",
+		"DynamicList",
+		"Flag",
+		"Form",
+		"FORM_INVALID",
+		"FORM_NODATA",
+		"FORM_VALID",
+		"ListValue",
+		"Node",
+		"Section",
+		"Template",
+		"TextValue",
+		"Value",
+	},
+}
+
+files["/**/gluon-web-osm/luasrc/usr/lib/lua/gluon/*"] = {
+	globals = {
+		"MapValue",
+	},
+}

--- a/docs/site-example/tests/site_config.lua
+++ b/docs/site-example/tests/site_config.lua
@@ -1,0 +1,10 @@
+local site = os.getenv('GLUON_SITEDIR') .. '/'
+local config = os.getenv('GLUON_SITE_CONFIG')
+
+local function loader()
+   coroutine.yield('return ')
+   coroutine.yield(io.open(site..config):read('*a'))
+end
+
+-- setfenv doesn't work with Lua 5.2 anymore, but we're using 5.1
+return setfenv(assert(load(coroutine.wrap(loader), config)), {})()

--- a/docs/site-example/tests/validate_site.sh
+++ b/docs/site-example/tests/validate_site.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -uo pipefail
+
+# validate_site.sh checks if the site.conf is valid json
+GLUON_REPO="https://github.com/rubo77/gluon"
+GLUON_BRANCH='ssid-changer'
+GLUON_PACKAGES_REPO="https://github.com/freifunk-gluon/packages"
+GLUON_PACKAGES_BRANCH='master'
+
+P="$(pwd)"
+echo "####### check if lua5.1 is installed ..."
+which lua5.1 
+if [ "$?" == 1 ]; then
+  echo lua5.1 not present!
+  echo install with sudo apt install lua5.1
+  exit 1
+fi
+
+CONFIGS="site.conf"
+if [ -d "domains" ]; then
+  CONFIGS="$CONFIGS "domains/*
+fi
+
+for c in $CONFIGS; do
+  echo "####### validating lua $c ..."
+  GLUON_SITEDIR="." GLUON_SITE_CONFIG="$c" lua5.1 tests/site_config.lua
+  if [ "$?" == 1 ]; then
+    exit 1
+  else
+    echo "OK: $c"
+  fi
+done
+
+for BASHFILE in "$P"/*.sh; do
+    [ -f "$BASHFILE" ] || continue
+  echo "####### validating $BASHFILE ..."
+  bash -n "$BASHFILE"
+  if [ "$?" == 0 ]; then
+    echo "OK: $BASHFILE"
+  fi
+done
+
+echo "####### validating $P/modules ..."
+GLUON_SITE_FEEDS="none"
+source "$P/modules"
+testpath=/tmp/site-validate
+rm -Rf "$testpath"
+mkdir -p "$testpath/packages"
+cd "$testpath/packages"
+if [ "$GLUON_SITE_FEEDS" != "none" ]; then
+  for feed in $GLUON_SITE_FEEDS; do
+    echo "####### checking PACKAGES_${feed^^}_REPO ..."
+    repo_var="PACKAGES_${feed^^}_REPO"
+    commit_var="PACKAGES_${feed^^}_COMMIT"
+    branch_var="PACKAGES_${feed^^}_BRANCH"
+    repo="${!repo_var}"
+    commit="${!commit_var}"
+    branch="${!branch_var}"
+    if [ "$repo" == "" ]; then
+      echo "repo $repo_var missing"
+      exit 1
+    fi
+    if [ "$commit" == "" ]; then
+      echo "commit $commit_var missing"
+      exit 1
+    fi
+  	if [ "$branch" == "" ]; then
+      echo "branch $branch_var missing"
+      exit 1
+    fi
+    git clone -b "$branch" --depth 1000 --single-branch "$repo" "$feed"
+    if [ "$?" != "0" ]; then exit 1; fi
+    cd "$feed"
+    echo "git checkout $commit"
+    git checkout "$commit"
+    if [ "$?" != "0" ]; then exit 1; fi
+    cd -
+  done
+fi
+
+echo "####### Lua linter check for all package feeds ..."
+~/.luarocks/bin/luacheck --config "$P/tests/.luacheckrc" "$testpath/packages"
+
+echo "####### downloading $GLUON_PACKAGES_REPO ..."
+git clone -b "$GLUON_PACKAGES_BRANCH" --depth 1  --single-branch "$GLUON_PACKAGES_REPO"
+
+echo "####### downloading gluon ..."
+cd "$testpath"
+git init gluon
+cd gluon
+git remote add origin "$GLUON_REPO"
+git config core.sparsecheckout true
+echo "package/*" >> .git/info/sparse-checkout
+git pull --depth 1 origin "$GLUON_BRANCH"
+cp -a package/ "$testpath/packages"
+cd "$testpath/packages/package"
+
+echo "####### validating GLUON_SITE_PACKAGES from $P/site.mk ..."
+# ignore non-gluon packages and standard gluon features
+sed '0,/^GLUON_LANGS/d' "$P/site.mk" | sed '/GLUON_TARGET/,$d' | egrep -v '(#|G|iwinfo|iptables|haveged|vim|socat|tar|mesh-batman-adv-1[45]|web-advanced|web-wizard)'> "$testpath"/site.mk.sh
+sed -i 's/\s\\$//g;/^$/d' "$testpath"/site.mk.sh
+sed -i 's/gluon-mesh-batman-adv-1[45]/gluon-mesh-batman-adv/g' "$testpath"/site.mk.sh
+sed -i 's/gluon-config-mode-geo-location-with-map/gluon-config-mode-geo-location/g' $testpath/site.mk.sh
+cat "$testpath"/site.mk.sh |
+while read packet; do
+  if [ "$packet" != "" ]; then
+    echo -n "# $packet"
+    FOUND="$(find "$testpath/packages/" -type d -name "$packet")"
+    if [ "$FOUND" '!=' '' ]; then
+      echo " found in $(echo "$FOUND"|sed 's|'"$testpath/packages"'||g')"
+    else
+      # check again with prefix gluon-
+      FOUND="$(find "$testpath/packages/" -type d -name "gluon-$packet")"
+      if [ "$FOUND" '!=' '' ]; then
+        echo " found as FEATURE in $(echo "$FOUND"|sed 's|'"$testpath/packages"'||g')"
+      else
+        echo
+        echo "ERROR: $packet missing"
+        exit 1
+      fi
+    fi
+  fi
+done

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -734,6 +734,16 @@ modules
 .. literalinclude:: ../site-example/modules
   :language: makefile
 
+.travis.yml and ``test`` folder
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The test folder contains a validation script that can be called in your site
+folder if you want to validate the external packages you defined in your
+``modules`` file. Travis can be added to your git repository to automatically
+validate new commits to your site repository. It can also be called manually in
+your console with ``bash tests/validate_site.sh``.
+
+
 site-repos in the wild
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
# .travis.yml and test folder

The test folder contains a validation script, that can be called in your site folder if you want to validate the external packages, you defined in your modules file. Travis can be added to your git repository to automatically validate new commits to your site repository. It can also be called manually in your console with `bash tests/validate_site.sh`.

the validate_site.sh script will

- create a temporary test-folder
- clone the latest commit of gluon there
- check for valid repositories and commit-IDs in `modules`
- clone all defined repositories in their defined commit in `modules` 
- Lua linter check for all package feeds (call `luacheck`) in their checked-out state
- check if all packages defined in site.mk exist in either gluon or the checked out packages
- call `bash -n` on all (potentioally) existing `*.sh` scripts in the site folder

If used in GitHub you get those nice green hooks after each commit. Example: https://github.com/freifunk-kiel/site-ffki/commits/next