### PR TITLE
ramips-mt7620: remove broken flag for Xiaomi MiWifi Mini

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -300,6 +300,10 @@ ramips-mt7620
 
   - WT3020AD/F/H
 
+# Xiaomi
+
+  - MiWiFi Mini
+
 ramips-mt7621
 -------------
 

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -36,5 +36,4 @@ device('nexx-wt3020-8m', 'wt3020-8M', {
 
 device('xiaomi-miwifi-mini', 'miwifi-mini', {
 	factory = false,
-	broken = true, -- 2.4GHz WiFi is unstable
 })


### PR DESCRIPTION
WiFi driver is stable now.
Router is running for 8 days now and both WiFi radios still work.
The running device:
https://hannover.freifunk.net/karte/#/de/map/6409807bbc0e

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: 
There are two ways to flash. Both are written in the OpenWRT Wiki. One via an Code Injection Bug and one via an Account on miwifi.com
https://openwrt.org/toh/xiaomi/mini#quick_openwrt_installation

- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
autoupdater name is still the same when checked with the lua command.
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
After fresh reset with firstboot and Install of a fresh build it is still the correct mac address as seen on the device.
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [n/a] should map to their respective radio
    - [n/a] should show activity
device has still only one LED for power status
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [n/a] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`