### PR TITLE
Increase ROOTFS size when GLUON_DEBUG is set

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -54,6 +54,7 @@ end
 if envtrue.GLUON_DEBUG then
 	config 'CONFIG_DEBUG=y'
 	config 'CONFIG_NO_STRIP=y'
+	config 'CONFIG_TARGET_ROOTFS_PARTSIZE=500'
 	config '# CONFIG_USE_STRIP is not set'
 	config '# CONFIG_USE_SSTRIP is not set'
 end


### PR DESCRIPTION
this increases the size of the ROOTFS to 500MB when GLUON_DEBUG is set such that development tools can be included. Thanks to blocktron who prepared the patch.