### PR TITLE
ipq40xx-generic: add alias for Aruba Instant On AP11

### DIFF
--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -25,6 +25,7 @@ defaults {
 
 device('aruba-ap-303', 'aruba_ap-303', {
 	factory = false,
+	aliases = {'aruba-instant-on-ap11'},
 })
 
 


### PR DESCRIPTION
The Aruba Instant On AP11 is the Aruba AP-303 with a stripped-down firmware.

Add an alias for the device to remove confusion about the different naming.