### PR TITLE
ramips-mt7620: add support for TP-Link Archer C2 v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -300,6 +300,10 @@ ramips-mt7620
 
   - WT3020AD/F/H
 
+* TP-Link  
+
+  - Archer C2 v1
+
 * Xiaomi
 
   - MiWiFi Mini

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -61,7 +61,7 @@ elseif platform.match('mpc85xx', 'p1020', {'aerohive,hiveap-330'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('mpc85xx', 'p1020', {'ocedo,panda'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')
-elseif platform.match('ramips', 'mt7620', {'miwifi-mini'}) then
+elseif platform.match('ramips', 'mt7620', {'miwifi-mini', 'tplink,c2-v1'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ramips', 'mt7621', {'dir-860l-b1'}) then
   table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -32,6 +32,13 @@ device('nexx-wt3020-8m', 'wt3020-8M', {
 })
 
 
+-- TP-Link
+
+device('tp-link-archer-c2-v1', 'tplink_c2-v1', {
+        factory = false,
+})
+
+
 -- Xiaomi
 
 device('xiaomi-miwifi-mini', 'miwifi-mini', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [no] webinterface
  - [x] tftp: as described in the OpenWRT Wiki here https://openwrt.org/toh/tp-link/archer_c2_ac750
  - [no] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds (only one)
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [n/a] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`