### PR TITLE
docs: supported_devices: fix small typo

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -300,7 +300,7 @@ ramips-mt7620
 
   - WT3020AD/F/H
 
-# Xiaomi
+* Xiaomi
 
   - MiWiFi Mini
 


### PR DESCRIPTION
Just saw a small typo i made in the Xiaomi Mi Wifi Mini PR. This PR Corrects this.