### PR TITLE
ramips-mt7620: add support for TP-Link Archer C20i

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -303,6 +303,7 @@ ramips-mt7620
 * TP-Link  
 
   - Archer C2 v1
+  - Archer C20i
   - Archer C50 v1
 
 * Xiaomi

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -61,7 +61,7 @@ elseif platform.match('mpc85xx', 'p1020', {'aerohive,hiveap-330'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('mpc85xx', 'p1020', {'ocedo,panda'}) then
   table.insert(try_files, 1, '/sys/class/net/eth1/address')
-elseif platform.match('ramips', 'mt7620', {'miwifi-mini', 'tplink,c2-v1', 'c50'}) then
+elseif platform.match('ramips', 'mt7620', {'miwifi-mini', 'tplink,c2-v1', 'c20i', 'c50'}) then
   table.insert(try_files, 1, '/sys/class/net/eth0/address')
 elseif platform.match('ramips', 'mt7621', {'dir-860l-b1'}) then
   table.insert(try_files, 1, '/sys/class/ieee80211/phy1/macaddress')

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -43,6 +43,8 @@ device('tp-link-archer-c2-v1', 'tplink_c2-v1', {
         factory = false,
 })
 
+device('tp-link-archer-c20i', 'ArcherC20i')
+
 device('tp-link-archer-c50', 'ArcherC50v1', {
         factory = '-squashfs-factory' .. tplink_region_suffix,
 })


### PR DESCRIPTION
- [x]  must be flashable from vendor firmware
  
  - [x]  webinterface
  - [x]  tftp
  - [no]  other

- [x]  must support upgrade mechanism
  
  - [x]  must have working sysupgrade

- [x]  must keep/forget configuration (if applicable)
  _think `sysupgrade [-n]` or `firstboot`_
  - [?] must have working autoupdate
_usually means: gluon profile name must match image name_

- [x]  wps button must return device into config mode

- [x]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)

- wired network
  
  - [x]  should support all network ports on the device
  - [x]  must have correct port assignment (WAN/LAN)

- wifi (if applicable)
  
  - [x]  association with AP must be possible on all radios
  - [x]  association with 802.11s mesh must be working on all radios
  - [x]  ap/mesh mode must work in parallel on all radios

- led mapping
  
  - power/sys led (_critical, because led definitions are setup on firstboot only_)

- [x]  lit while the device is on
- [x]  should display config mode blink sequence
  (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds

- [x]  should map to their respective radio
- [x]  should show activity
  - switchport leds

- [x]  should map to their respective port (or switch, if only one led present)
- [x]  should show link state and activity

- outdoor devices only
  
  - [n/a]  added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
~