### PR TITLE
ramips-mt76x8: add support for TP-Link TL-WA801ND v5

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -300,7 +300,7 @@ ramips-mt7620
 
   - WT3020AD/F/H
 
-* TP-Link  
+* TP-Link
 
   - Archer C2 v1
   - Archer C20i
@@ -350,6 +350,7 @@ ramips-mt76x8
 * TP-Link
 
   - TL-MR3420 v5
+  - TL-WA801ND v5
   - TL-WR841N v13
   - TL-WR902AC v3
   - Archer C50 v3

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -36,6 +36,13 @@ device('tp-link-tl-mr3420-v5', 'tplink_tl-mr3420-v5', {
 	},
 })
 
+device('tp-link-tl-wa801nd-v5', 'tplink_tl-wa801nd-v5', {
+	factory = false,
+	extra_images = {
+		{'-squashfs-tftp-recovery', '-bootloader', '.bin'},
+	},
+})
+
 device('tp-link-tl-wr841n-v13', 'tl-wr841n-v13', {
 	factory = false,
 	extra_images = {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface: does not work on v5 and will brick the device according to owrt wiki
  - [x] tftp: place renamed bootloader image (tp_recovery.bin) at tftp root, reachable at 192.168.0.66. Put device into tftp recovery by pressing reset button while booting until lock LED turns on. Device pulls firmware, flashes it and restarts. (see https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=ce31bdc20c3f2eb387a84c277dff76324a8e39c7)
  - [ ] other: none
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable): sysupgrade w/ and w/o -n tested
  - [x] must have working autoupdate: checked device name: `tp-link-tl-wa801nd-v5`
- [x] reset/wps/phone button must return device into config mode: reset button does the trick
- [x] primary mac should match address on device label (or packaging)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN): only one WAN port
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- no outdoor devices

Running test device: http://[2001:678:6e3:1110:724f:57ff:fe86:4c72]/cgi-bin/status

Not beautiful, but no functional impact: The lock LED (green/red) at the front stays red whenever the device is running. If there are objections I can look further into this, but I would need some help with that, at least pointing me into the right direction.

Fixes #1906