### PR TITLE
ramips-mt7621: add support for Netgear EX6150

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -324,6 +324,7 @@ ramips-mt7621
 
 * NETGEAR
 
+  - EX6150
   - R6220
 
 * Ubiquiti

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -12,6 +12,10 @@ device('d-link-dir-860l-b1', 'dir-860l-b1')
 
 -- Netgear
 
+device('netgear-ex6150', 'netgear_ex6150', {
+        factory_ext = '.chk',
+})
+
 device('netgear-r6220', 'r6220', {
 	factory_ext = '.img',
 })


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [x] webinterface: webinterface was available under http://192.168.1.250/
  - [ ] tftp
  - [ ] other: <specify>
- [ ] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name* model name: *netgear-ex6150*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN): device has only one LAN-port
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`