### PR TITLE
ath79-generic: add support for GL-iNet GL-AR300M-Lite

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -39,11 +39,11 @@ ar71xx-generic
 
 * GL.iNet
 
+  - 6408A
+  - 6416A
   - GL-AR150
   - GL-AR300M
   - GL-AR750
-  - GL.iNet 6408A (v1)
-  - GL.iNet 6416A (v1)
 
 * Linksys
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -192,7 +192,11 @@ ath79-generic
   - WiFi pro 1750i
   - WiFi pro 1750x
 
-  * OCEDO
+* GL.iNet
+
+  - GL-AR300M-Lite
+
+* OCEDO
 
   - Raccoon
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -37,13 +37,13 @@ ar71xx-generic
   - DIR-505 (A1, A2)
   - DIR-825 (B1)
 
-* GL Innovations
+* GL.iNet
 
   - GL-AR150
   - GL-AR300M
   - GL-AR750
-  - GL-iNet 6408A (v1)
-  - GL-iNet 6416A (v1)
+  - GL.iNet 6408A (v1)
+  - GL.iNet 6416A (v1)
 
 * Linksys
 
@@ -294,7 +294,7 @@ mpc85xx-p1020
 ramips-mt7620
 -------------
 
-* GL Innovations
+* GL.iNet
 
   - GL-MT300A
   - GL-MT300N

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -102,7 +102,7 @@ device('d-link-dir-825-rev-b1', 'dir-825-b1', {
 })
 
 
--- GL Innovations
+-- GL.iNet
 
 device('gl-inet-6408a-v1', 'gl-inet-6408A-v1')
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -46,6 +46,12 @@ device('devolo-wifi-pro-1750x', 'devolo_dvl1750x', {
 	factory = false,
 })
 
+-- GL.iNet
+
+device('gl.inet-gl-ar300m-lite', 'glinet_gl-ar300m-lite', {
+    factory = false,
+})
+
 -- OCEDO
 
 device('ocedo-raccoon', 'ocedo_raccoon', {

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -6,7 +6,7 @@ device('asus-rt-ac51u', 'rt-ac51u', {
 })
 
 
--- GL Innovations
+-- GL.iNet
 
 device('gl-mt300a', 'gl-mt300a', {
 	factory = false,


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity