### PR TITLE
ramips-mt76x8: add support for TP-Link TL-MR3020 v3

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -351,6 +351,7 @@ ramips-mt76x8
 
 * TP-Link
 
+  - TL-MR3020 v3
   - TL-MR3420 v5
   - TL-WA801ND v5
   - TL-WR841N v13

--- a/modules
+++ b/modules
@@ -2,7 +2,7 @@ GLUON_FEEDS='packages routing gluon'
 
 OPENWRT_REPO=https://git.openwrt.org/openwrt/openwrt.git
 OPENWRT_BRANCH=openwrt-19.07
-OPENWRT_COMMIT=a229907150e01d8c32293cc0a48630e7c4f0cb00
+OPENWRT_COMMIT=aed6632d31ff5d29045dc904dedc840d902aad97
 
 PACKAGES_PACKAGES_REPO=https://github.com/openwrt/packages.git
 PACKAGES_PACKAGES_BRANCH=openwrt-19.07

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -29,6 +29,13 @@ device('tp-link-archer-c50-v4', 'tplink_c50-v4', {
 	factory = false,
 })
 
+device('tp-link-tl-mr3020-v3', 'tplink_tl-mr3020-v3', {
+	factory = false,
+	extra_images = {
+		{'-squashfs-tftp-recovery', '-bootloader', '.bin'},
+	},
+})
+
 device('tp-link-tl-mr3420-v5', 'tplink_tl-mr3420-v5', {
 	factory = false,
 	extra_images = {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface: untested - it's reported as broken for other mt76x8-based TP-Link devices
  - [x] tftp: place renamed bootloader image (tp_recovery.bin) at tftp root, reachable at 192.168.0.225. Put device into tftp recovery by pressing reset/wps button while booting until 3g/wan led starts flashing. Device pulls firmware, flashes it and restarts. (see https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=6bbb2202551be394fead2efd99eb946f846fc63d)
  - [ ] other: none
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable): tested with sysupgrade w/ and w/o -n
  - [x] must have working autoupdate: verified profile name: tp-link-tl-mr3020-v3
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN): only one WAN port
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led
    - [x] lit while the device is on
    - [x] should display config mode blink sequence
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- no outdoor device

running test device: http://[2001:678:6e3:1110:ae84:c6ff:fe6b:4edc]/cgi-bin/status