### PR TITLE
release: Gluon v2019.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ the future development of Gluon.
 
 Please refrain from using the `master` branch for anything else but development purposes!
 Use the most recent release instead. You can list all releases by running `git tag`
-and switch to one by running `git checkout v2019.1.1 && make update`.
+and switch to one by running `git checkout v2019.1.2 && make update`.
 
 If you're using the autoupdater, do not autoupdate nodes with anything but releases.
 If you upgrade using random master commits the nodes *will break* eventually.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -74,6 +74,7 @@ Several Freifunk communities in Germany use Gluon as the foundation of their Fre
    :caption: Releases
    :maxdepth: 1
 
+   releases/v2019.1.2
    releases/v2019.1.1
    releases/v2019.1
    releases/v2018.2.4

--- a/docs/releases/v2019.1.2.rst
+++ b/docs/releases/v2019.1.2.rst
@@ -1,0 +1,58 @@
+Gluon 2019.1.2
+##############
+
+Bugfixes
+********
+
+* Fixes a buffer-overflow vulnerability in libubox, a core component of OpenWrt
+  (CVE-2020-7248)
+
+* Fixes a vulnerability in the OpenWrt package manager (opkg). By using this vulnerability,
+  an attacker could bypass the integrity check of the package artifacts. (CVE-2020-7982)
+
+Other Changes
+*************
+
+* Linux kernel has been updated to either
+
+  - 4.9.211 (ar71xx, brcm2708, mpc85xx) or
+  - 4.14.167 (ipq40xx, ipq806x, mvebu, ramips, sunxi, x86).
+
+Known issues
+************
+
+* Out of memory situations with high client count on ath9k.
+  (`#1768 <https://github.com/freifunk-gluon/gluon/issues/1768>`_)
+
+* The integration of the BATMAN_V routing algorithm is incomplete.
+
+   - | Mesh neighbors don't appear on the status page. (`#1726 <https://github.com/freifunk-gluon/gluon/issues/1726>`_)
+     | Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new throughput
+     | metric.
+
+   - | Throughput values are not correctly acquired for different interface types.
+     | (`#1728 <https://github.com/freifunk-gluon/gluon/issues/1728>`_)
+     | This affects virtual interface types like bridges and VXLAN.
+
+* Default TX power on many Ubiquiti devices is too high, correct offsets are unknown
+  (`#94 <https://github.com/freifunk-gluon/gluon/issues/94>`_)
+
+  Reducing the TX power in the Advanced Settings is recommended.
+
+* The MAC address of the WAN interface is modified even when Mesh-on-WAN is disabled
+  (`#496 <https://github.com/freifunk-gluon/gluon/issues/496>`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when promiscuous mode is
+  disallowed).
+
+* Inconsistent respondd API (`#522 <https://github.com/freifunk-gluon/gluon/issues/522>`_)
+
+  The current API is inconsistent and will be replaced eventually. The old API will still be supported for a while.
+
+* Frequent reboots due to out-of-memory or high load due to memory pressure on weak hardware especially in larger
+  meshes (`#1243 <https://github.com/freifunk-gluon/gluon/issues/1243>`_)
+
+  Optimizations in Gluon 2018.1 have significantly improved memory usage.
+  There are still known bugs leading to unreasonably high load that we hope to
+  solve in future releases.
+

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2019.1.1
+-- This is an example site configuration for Gluon v2019.1.2
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -8,7 +8,7 @@ Gluon's releases are managed using `Git tags`_. If you are just getting
 started with Gluon we recommend to use the latest stable release of Gluon.
 
 Take a look at the `list of gluon releases`_ and notice the latest release,
-e.g. *v2019.1.1*. Always get Gluon using git and don't try to download it
+e.g. *v2019.1.2*. Always get Gluon using git and don't try to download it
 as a Zip archive as the archive will be missing version information.
 
 Please keep in mind that there is no "default Gluon" build; a site configuration
@@ -44,7 +44,7 @@ Building the images
 -------------------
 
 To build Gluon, first check out the repository. Replace *RELEASE* with the
-version you'd like to checkout, e.g. *v2019.1.1*.
+version you'd like to checkout, e.g. *v2019.1.2*.
 
 ::
 


### PR DESCRIPTION
Two security vulnerabilities were announced in OpenWrt last friday (CVE-2020-7982 & CVE-2020-7248).

While Gluon seems to be mostly unaffected in it's core components, there's still a possibility of being remotely exploitable, depending on the communities selected package set.