### PR TITLE
brcm2708-bcm2710: add manifest_alias for raspberry-pi-3-model-b-rev-1.2

### DIFF
--- a/targets/brcm2708-bcm2710
+++ b/targets/brcm2708-bcm2710
@@ -1,3 +1,7 @@
 include 'brcm2708.inc'
 
-device('raspberry-pi-3', 'rpi-3')
+device('raspberry-pi-3', 'rpi-3', {
+	manifest_aliases = {
+		'raspberry-pi-3-model-b-rev-1.2',
+	},
+})


### PR DESCRIPTION
It's the same Device as the others so it is still broken because of not working mesh on wifi but this rev is missing an alias so an nightly build could not update itself.

> autoupdater: warning: no matching firmware found (model raspberry-pi-3-model-b-rev-1.2)