### PR TITLE
POE on LAN, not on WAN

### DIFF
--- a/docs/features/configmode.rst
+++ b/docs/features/configmode.rst
@@ -26,7 +26,7 @@ In general, Config Mode will be offered on the LAN ports. However, there
 are two practical exceptions:
 
 * Devices with just one network port will run Config Mode on that port.
-* Devices with PoE on the WAN port will run Config Mode on the WAN port instead.
+* Devices with PoE on the LAN port will run Config Mode on the WAN port instead.
 
 
 Accessing Config Mode


### PR DESCRIPTION
Devices with PoE on the **LAN** port will run Config Mode on the WAN port instead.

(This my first pull request, I may make some mistakes commiting this request. Also, to me it's unclear to change this for all affected releases)