### PR TITLE
scripts: do not create gluon_base entry in feeds.conf

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -229,3 +229,7 @@ GLUON_OUTPUTDIR
 
 GLUON_SITEDIR
   Path to the site configuration. Defaults to ``site``.
+
+FOREIGN_BUILD
+  If defined it changes the build-framework into a more generic mode, which will not necessarily 
+  generate a Gluon compatible firmware.

--- a/scripts/feeds.sh
+++ b/scripts/feeds.sh
@@ -11,7 +11,7 @@ rm -rf openwrt/feeds
 rm -rf openwrt/package/feeds
 
 (
-	echo 'src-link gluon_base ../../package'
+	[ -n "${FOREIGN_BUILD}" ] || echo 'src-link gluon_base ../../package'
 	for feed in $FEEDS; do
 		echo "src-link $feed ../../packages/$feed"
 	done


### PR DESCRIPTION
We started to reuse some work of your framework in our framework, so we like to give something back, which finally makes contributing patches directly more easy.

The gluon-script "feeds.sh" creates by default a "gluon_base" entry in the feeds.conf
of OpenWrt. This links to the gluon-base packages directory and causes an error message
during build, as this directory does not exist in our non-gluon firmware.
Add a test for definiton of a "FOREIGN_BUILD" variable to the feeds.sh script, which
will no add the mentioned line to the feeds.conf, when defined.

This PR is taken from https://github.com/freifunk-berlin/firmware/commit/013a01b0c5bb34b4c46e1839f70cd07787379377