### PR TITLE
Dockerfile: Install squashfs-tools

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -9,6 +9,7 @@ RUN apt update && apt install -y --no-install-recommends \
     build-essential \
     gawk \
     unzip \
+    squashfs-tools \
     libncurses5-dev \
     zlib1g-dev \
     libssl-dev \


### PR DESCRIPTION
Building Gluon 2020.1 failed due to the lack of the binary
mksquashfs-lzma. This occurred while building ar71xx-tiny.