### PR TITLE
gluon-client-bridge: add WPA3 Enhanced Open client radio support

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -42,10 +42,14 @@
     -- Wireless channel.
     channel = 1,
 
-    -- ESSID used for client network.
+    -- ESSIDs used for client network.
     ap = {
-      ssid = 'alpha-centauri.freifunk.net',
+      -- ssid = 'alpha-centauri.freifunk.net', (optional - SSID for open client network)
       -- disabled = true, -- (optional)
+
+      -- Configuration for a non-backward compatible OWE network below.
+      -- owe_ssid = 'owe.alpha-centauri.freifunk.net', -- (optional - SSID for OWE client network)
+      -- owe_transition_mode = true, -- (optional - enables transition-mode - requires ssid as well as owe_ssid)
     },
 
     mesh = {

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -130,8 +130,15 @@ wifi24 \: optional
     This will only affect new installations.
     Upgrades will not change the disabled state.
 
-    ``ap`` requires a single parameter, a string, named ``ssid`` which sets the
-    interface's ESSID. This is the WiFi the clients connect to.
+    ``ap`` holds the client network configuration.
+    To create an unencrypted client network, a string named ``ssid`` which sets the
+    interface's ESSID is required. This is the wireless network clients connect to.
+    For an OWE secured network, the ``owe_ssid`` string has to be set. It sets the
+    SSID for the opportunistically encrypted wireless network, to which compatible
+    clients can connect to.
+    To utilize the OWE transition mode, ``owe_transition_mode`` has to be set to true.
+    Note that for the transition mode to work, both ``ssid`` as well as ``owe_ssid``
+    have to be enabled.
 
     ``mesh`` requires a single parameter, a string, named ``id`` which sets the
     mesh id, also visible as an open WiFi in some network managers. Usually you
@@ -147,6 +154,8 @@ wifi24 \: optional
          channel = 11,
          ap = {
            ssid = 'alpha-centauri.freifunk.net',
+           owe_ssid = 'owe.alpha-centauri.freifunk.net',
+           owe_transition_mode = true,  
          },
          mesh = {
            id = 'ueH3uXjdp',

--- a/package/gluon-client-bridge/check_site.lua
+++ b/package/gluon-client-bridge/check_site.lua
@@ -9,7 +9,13 @@ need_string_match(in_domain({'next_node', 'ip6'}), '^[%x:]+$', false)
 
 for _, config in ipairs({'wifi24', 'wifi5'}) do
 	if need_table({config, 'ap'}, nil, false) then
-		need_string_match(in_domain({config, 'ap', 'ssid'}), '^' .. ('.?'):rep(32) .. '$')
 		need_boolean({config, 'ap', 'disabled'}, false)
+		if need_boolean({config, 'ap', 'owe_transition_mode'}, false) then
+			need_string_match(in_domain({config, 'ap', 'ssid'}), '^' .. ('.?'):rep(32) .. '$')
+			need_string_match(in_domain({config, 'ap', 'owe_ssid'}), '^' .. ('.?'):rep(32) .. '$')
+		else
+			need_string_match(in_domain({config, 'ap', 'ssid'}), '^' .. ('.?'):rep(32) .. '$', false)
+			need_string_match(in_domain({config, 'ap', 'owe_ssid'}), '^' .. ('.?'):rep(32) .. '$', false)
+		end
 	end
 end

--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
@@ -1,6 +1,7 @@
 #!/usr/bin/lua
 
 local util = require 'gluon.util'
+local platform = require 'gluon.platform'
 
 local uci = require('simple-uci').cursor()
 
@@ -13,9 +14,7 @@ local function is_disabled(config, name)
 	return config.disabled(false)
 end
 
-util.foreach_radio(uci, function(radio, index, config)
-	local radio_name = radio['.name']
-
+local function configure_ap(radio, index, config, radio_name)
 	local name = 'client_' .. radio_name
 	local suffix = radio_name:match('^radio(%d+)$')
 
@@ -24,12 +23,9 @@ util.foreach_radio(uci, function(radio, index, config)
 
 	uci:delete('wireless', name)
 
-	if not ap() then
-		return
-	end
-
 	local macaddr = util.get_wlan_mac(uci, radio, index, 1)
-	if not macaddr then
+
+	if not ap() or not ap.ssid() or not macaddr then
 		return
 	end
 
@@ -42,6 +38,84 @@ util.foreach_radio(uci, function(radio, index, config)
 		ifname = suffix and 'client' .. suffix,
 		disabled = disabled or false,
 	})
+end
+
+local function configure_owe(radio, index, config, radio_name)
+	local name = 'owe_' .. radio_name
+	local suffix = radio_name:match('^radio(%d+)$')
+
+	local ap = config.ap
+
+	local disabled = is_disabled(ap, 'client_' .. radio_name)
+
+	uci:delete('wireless', name)
+
+	-- Don't configure OWE in case our device
+	-- can't do MFP, as it's mandatory for OWE.
+	if not platform.device_supports_mfp(uci) then
+		return
+	end
+
+	local macaddr = util.get_wlan_mac(uci, radio, index, 3)
+
+	if not ap() or not ap.owe_ssid() or not macaddr then
+		return
+	end
+
+	uci:section('wireless', 'wifi-iface', name, {
+		device = radio_name,
+		network = 'client',
+		mode = 'ap',
+		ssid = ap.owe_ssid(),
+		macaddr = macaddr,
+		ifname = suffix and 'owe' .. suffix,
+		disabled = disabled or false,
+		encryption = 'owe',
+		ieee80211w = 2,
+	})
+end
+
+local function configure_owe_transition_mode(config, radio_name)
+	local ap = config.ap
+
+	-- Don't configure OWE in case our device
+	-- can't do MFP, as it's mandatory for OWE.
+	if not platform.device_supports_mfp(uci) then
+		return
+	end
+
+	if not ap() or not ap.owe_transition_mode() then
+		return
+	end
+
+	local name_client = 'client_' .. radio_name
+	local name_owe = 'owe_' .. radio_name
+
+	local ssid_client = uci:get('wireless', name_client, 'ssid')
+	local ssid_owe = uci:get('wireless', name_owe, 'ssid')
+
+	local macaddr_client = uci:get('wireless', name_client, 'macaddr')
+	local macaddr_owe = uci:get('wireless', name_owe, 'macaddr')
+
+	if not ssid_client or not ssid_owe or not macaddr_client or not macaddr_owe then
+		return
+	end
+
+	uci:set('wireless', name_client, 'owe_transition_ssid', ssid_owe)
+	uci:set('wireless', name_client, 'owe_transition_bssid', macaddr_owe)
+
+	uci:set('wireless', name_owe, 'owe_transition_ssid', ssid_client)
+	uci:set('wireless', name_owe, 'owe_transition_bssid', macaddr_client)
+	uci:set('wireless', name_owe, 'hidden', '1')
+end
+
+util.foreach_radio(uci, function(radio, index, config)
+	local radio_name = radio['.name']
+
+	configure_ap(radio, index, config, radio_name)
+
+	configure_owe(radio, index, config, radio_name)
+	configure_owe_transition_mode(config, radio_name)
 end)
 
 uci:save('wireless')

--- a/package/gluon-respondd/src/respondd-statistics.c
+++ b/package/gluon-respondd/src/respondd-statistics.c
@@ -239,7 +239,7 @@ static void count_iface_stations(size_t *wifi24, size_t *wifi5, const char *ifna
 	}
 }
 
-static void count_stations(size_t *wifi24, size_t *wifi5) {
+static void count_stations(size_t *wifi24, size_t *wifi5, size_t *owe24, size_t owe5) {
 	struct uci_context *ctx = uci_alloc_context();
 	if (!ctx)
 		return;
@@ -269,6 +269,9 @@ static void count_stations(size_t *wifi24, size_t *wifi5) {
 		if (!ifname)
 			continue;
 
+		if (strstr(ifname, "owe") == ifname)
+			count_iface_stations(owe24, owe5, ifname);
+
 		count_iface_stations(wifi24, wifi5, ifname);
 	}
 
@@ -277,15 +280,19 @@ static void count_stations(size_t *wifi24, size_t *wifi5) {
 }
 
 static struct json_object * get_clients(void) {
-	size_t wifi24 = 0, wifi5 = 0;
+	size_t wifi24 = 0, wifi5 = 0, owe24 = 0, owe5 = 0;
 
-	count_stations(&wifi24, &wifi5);
+	count_stations(&wifi24, &wifi5, &owe24, &owe5);
 
 	struct json_object *ret = json_object_new_object();
 
 	json_object_object_add(ret, "wifi", json_object_new_int(wifi24 + wifi5));
 	json_object_object_add(ret, "wifi24", json_object_new_int(wifi24));
 	json_object_object_add(ret, "wifi5", json_object_new_int(wifi5));
+
+	json_object_object_add(ret, "owe", json_object_new_int(owe24 + owe5));
+	json_object_object_add(ret, "owe24", json_object_new_int(owe24));
+	json_object_object_add(ret, "owe5", json_object_new_int(owe5));
 
 	return ret;
 }


### PR DESCRIPTION
This PR adds support for an additional WPA3 Enhanced Open Clients radio.

Enhanced Open provides an encrypted connection, leading to data transferred between the node and client device being protected against passive packet sniffing. It also makes use of mandatory MFP, eliminating deauthentication attacks.

Enahnced Open is fully supported on Android 10, so adoption will most likely increase in the next 1-3 years. 

On the AP side, OWE is (due to enforced MFP) supported on the following chipsets:

 * ath9k (exceptions apply for early draft-N chips)
 * ath10k
 * mt76

Blocked by #1876 