### PR TITLE
add common WiFi packages to relevant targets

### DIFF
--- a/targets/x86.inc
+++ b/targets/x86.inc
@@ -34,5 +34,11 @@ packages {
 	'kmod-usb-serial',
 	'kmod-ath10k',
 	'ath10k-firmware-qca9887',
+	'ath10k-firmware-qca9888',
 	'ath10k-firmware-qca988x',
+	'ath10k-firmware-qca9984',
+	'kmod-mt76x0e',
+	'kmod-mt76x2',
+	'kmod-mt7603',
+	'kmod-mt7615e',
 }


### PR DESCRIPTION
This commit adds packages for supporting common wireless adapters for Raspberry Pi and x86 platforms.

People often want to attach USB adapters to such platforms (whether or not this is a rational thing to do). Currently the packages have to installed after the initial boot process, which breaks Gluons initialization.

As those platforms have enough storage, include common USB adapter driver packages by default. Also extend the list of PCIe driver packages on x86 to include drivers and firmware for more WiFi cards available on the market.

This PR is not yet compile nor run-tested (as i do not own such adapters). So feel free to provide your experiences.