### PR TITLE
ipq40xx-generic: add support for EnGenius ENS620EXT

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -223,6 +223,10 @@ ipq40xx-generic
   - FRITZ!Box 4040 [#avmflash]_
   - FRITZ!Repeater 1200 [#eva_ramboot]_
 
+* EnGenius
+
+  - ENS620EXT
+
 * GL.iNet
 
   - GL-B1300

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -47,6 +47,9 @@ function M.is_outdoor_device()
 
 	elseif M.match('ath79', 'generic', {'devolo,dvl1750x'}) then
 		return true
+
+	elseif M.match('ipq40xx', 'generic', {'engenius,ens620ext'}) then
+		return true
 	end
 
 	return false

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -43,6 +43,17 @@ device('avm-fritz-repeater-1200', 'avm_fritzrepeater-1200', {
 })
 
 
+-- EnGenius
+
+device('engenius-ens620ext', 'engenius_ens620ext', {
+	factory = false,
+	extra_images = {
+		{'-squashfs-factory_30', '-factory_fw30', '.bin'},
+		{'-squashfs-factory_35', '-factory_fw35', '.bin'},
+	},
+})
+
+
 -- GL.iNet
 
 device('gl.inet-gl-b1300', 'glinet_gl-b1300', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [x] webinterface: there are two factory images. you need to choose depending on the currently installed vendor firmware.
  - [ ] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*

```
root@ffka-lr-naturbursche:~# lua -e 'print(require("platform_info").get_image_name())'
engenius-ens620ext
```

- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes): matches mac of 2.4HGz wifi (3 mac addresses, lan/2.4/5, on label)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present)
    - [x] should show link state and activity
- outdoor devices only
  - [x] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

As I wrote above, there are two different factory images because the format changes with vendor firmware 3.5.
I could not find a similar case for current devices so my proposal: ~~Use image for versions below 3.5 as the default since the ap should come preinstalled with this version. Offer the other one as "other" image.~~ Let's offer both factory images as "other" images to avoid confusion.