### PR TITLE
lantiq-xway: add support for NETGEAR DGN3500B

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -274,6 +274,10 @@ lantiq-xway
   - FRITZ!Box 7330 [#avmflash]_ [#lan_as_wan]_
   - FRITZ!Box 7330 SL [#avmflash]_ [#lan_as_wan]_
 
+* NETGEAR
+
+  - DGN3500B [#lan_as_wan]_
+
 mpc85xx-generic
 ---------------
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -8,6 +8,7 @@ if sysconfig.primary_mac then
 end
 
 
+local json = require 'jsonc'
 local platform = require 'gluon.platform'
 local util = require 'gluon.util'
 
@@ -28,6 +29,15 @@ end
 
 local function phy(index)
 	return sysfs('/sys/class/ieee80211/phy%d/macaddress', index)
+end
+
+local function board(iface)
+	return function()
+		local data = json.load('/etc/board.json')
+		if data and data.network and data.network[iface] then
+			return data.network[iface].macaddr
+		end
+	end
 end
 
 
@@ -109,6 +119,11 @@ local primary_addrs = {
 		}},
 		{'ramips', 'mt7621', {
 			'dir-860l-b1',
+		}},
+	}},
+	{board('lan'), {
+		{'lantiq', 'xway', {
+			'netgear,dgn3500b',
 		}},
 	}},
 	-- phy0 default

--- a/targets/lantiq-xway
+++ b/targets/lantiq-xway
@@ -6,3 +6,7 @@ device('avm-fritz-box-7320', 'avm_fritz7320', {
 	factory = false,
 	aliases = {'avm-fritz-box-7330', 'avm-fritz-box-7330-sl'},
 })
+
+device('netgear-dgn3500b', 'netgear_dgn3500b', {
+	factory_ext = '.img',
+})


### PR DESCRIPTION
not a great device, but someone had it laying around.

**TODO: the primary mac should be read from /sys/class/net/eth0.1/address which is currently not working, maybe someone has a clue?**

- [X] must be flashable from vendor firmware
  - [X] webinterface
  - [ ] tftp
  - [X] other: tftp via serial
- [X] must support upgrade mechanism
  - [X] must have working sysupgrade
    - [X] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [X] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [X] reset/wps/phone button must return device into config mode
- [ ] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [X] association with AP must be possible on all radios
  - [X] association with 802.11s mesh must be working on all radios 
  - [X] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [X] lit while the device is on
    - [X] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [X] should map to their respective radio
    - [X] should show activity
  - switchport leds
    - [X] should map to their respective port (or switch, if only one led present) 
    - [X] should show link state and activity
- outdoor devices only
  - [-] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
