### PR TITLE
ath79-generic: add support for GL.iNet GL-AR750S

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -196,6 +196,7 @@ ath79-generic
 * GL.iNet
 
   - GL-AR300M-Lite
+  - GL-AR750S
 
 * OCEDO
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -82,6 +82,7 @@ local primary_addrs = {
 			'hiveap-121',
 		}},
 		{'ath79', 'generic', {
+			'glinet,gl-ar750s-nor',
 			'ocedo,raccoon',
 		}},
 		{'ipq40xx', 'generic', {

--- a/patches/openwrt/0009-ath79-enable-GL-AR750S-NOR-variant-from-master.patch
+++ b/patches/openwrt/0009-ath79-enable-GL-AR750S-NOR-variant-from-master.patch
@@ -1,0 +1,72 @@
+From 0d5a95cac5aada71108e2178e0ec5b2a6efdc415 Mon Sep 17 00:00:00 2001
+From: Jan Alexander <jan@nalx.net>
+Date: Tue, 31 Mar 2020 21:50:28 +0200
+Subject: [PATCH] ath79: enable GL-AR750S NOR variant from master
+
+---
+ target/linux/ath79/base-files/etc/board.d/02_network          | 2 +-
+ .../ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata | 2 +-
+ target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dts           | 4 ++--
+ target/linux/ath79/image/generic.mk                           | 4 ++--
+ 4 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/target/linux/ath79/base-files/etc/board.d/02_network b/target/linux/ath79/base-files/etc/board.d/02_network
+index 8edd4e6c2e..2d2d4e33af 100755
+--- a/target/linux/ath79/base-files/etc/board.d/02_network
++++ b/target/linux/ath79/base-files/etc/board.d/02_network
+@@ -140,7 +140,7 @@ ath79_setup_interfaces()
+ 	etactica,eg200)
+ 		ucidef_set_interface_lan "eth0" "dhcp"
+ 		;;
+-	glinet,gl-ar750s)
++	glinet,gl-ar750s-nor)
+ 		ucidef_add_switch "switch0" \
+ 			"0@eth0" "2:lan:2" "3:lan:1" "1:wan"
+ 		;;
+diff --git a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index d93e6dcd71..c917f38211 100644
+--- a/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ath79/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -117,7 +117,7 @@ case "$FIRMWARE" in
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +1)
+ 		;;
+-	glinet,gl-ar750s)
++	glinet,gl-ar750s-nor)
+ 		ath10kcal_extract "art" 20480 2116
+ 		ath10kcal_patch_mac $(macaddr_add $(mtd_get_mac_binary art 0) +1)
+ 		;;
+diff --git a/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dts b/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dts
+index 0145a24fba..ebecb8cc77 100644
+--- a/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dts
++++ b/target/linux/ath79/dts/qca9563_glinet_gl-ar750s.dts
+@@ -7,8 +7,8 @@
+ #include "qca956x.dtsi"
+ 
+ / {
+-	compatible = "glinet,gl-ar750s", "qca,qca9563";
+-	model = "GL.iNet GL-AR750S";
++	compatible = "glinet,gl-ar750s-nor", "qca,qca9563";
++	model = "GL.iNet GL-AR750S (NOR)";
+ 
+ 	chosen {
+ 		bootargs = "console=ttyS0,115200n8";
+diff --git a/target/linux/ath79/image/generic.mk b/target/linux/ath79/image/generic.mk
+index 55053be34f..892ef10f87 100644
+--- a/target/linux/ath79/image/generic.mk
++++ b/target/linux/ath79/image/generic.mk
+@@ -403,9 +403,9 @@ define Device/glinet_gl-ar750s
+   DEVICE_TITLE := GL.iNet GL-AR750S
+   DEVICE_PACKAGES := kmod-usb2 kmod-ath10k-ct ath10k-firmware-qca9887-ct block-mount
+   IMAGE_SIZE := 16000k
+-  SUPPORTED_DEVICES += gl-ar750s
++  SUPPORTED_DEVICES += gl-ar750s glinet,gl-ar750s-nor
+ endef
+-#TARGET_DEVICES += glinet_gl-ar750s
++TARGET_DEVICES += glinet_gl-ar750s
+ 
+ define Device/glinet_gl-x750
+   ATH_SOC := qca9531
+-- 
+2.25.1
+

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -6,6 +6,14 @@ local ATH10K_PACKAGES_QCA9880 = {
 	'-ath10k-firmware-qca988x-ct',
 }
 
+local ATH10K_PACKAGES_QCA9887 = {
+	'kmod-ath10k',
+	'-kmod-ath10k-ct',
+	'-kmod-ath10k-ct-smallbuffers',
+	'ath10k-firmware-qca9887',
+	'-ath10k-firmware-qca9887-ct',
+}
+
 local ATH10K_PACKAGES_QCA9888 = {
 	'kmod-ath10k',
 	'-kmod-ath10k-ct',
@@ -52,6 +60,11 @@ device('gl.inet-gl-ar300m-lite', 'glinet_gl-ar300m-lite', {
 	factory = false,
 })
 
+device('gl.inet-gl-ar750s-nor', 'glinet_gl-ar750s', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9887,
+})
+
 -- OCEDO
 
 device('ocedo-raccoon', 'ocedo_raccoon', {
@@ -63,4 +76,3 @@ device('ocedo-raccoon', 'ocedo_raccoon', {
 device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })
-


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface: accepts only nand firmware. nand support comes with kernel 4.19 (next openwrt release)
  - [ ] tftp
  - [x] other: flash nor firmware from u-boot webinterface: reboot with reset button pressed and lan cable plugged in. 5G led will blink 5 times. then 2G led will turn on. release reset button and connect to u-boot web at http://192.168.1.1/index.html. upload sysupgrade image.
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
```
root@ffka-lr-minimesh:~# lua -e 'print(require("platform_info").get_image_name())'
gl.inet-gl-ar750s-nor
```
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds: device has only power and radio leds
    - n/a should map to their respective port (or switch, if only one led present) 
    - n/a should show link state and activity
- outdoor devices only
  - n/a added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

Running test device: http://[2001:678:6e3:1110:9683:c4ff:fe00:a7da]/cgi-bin/status