### PR TITLE
gluon-autoupdater: stop dropbear before stopping the network

### DIFF
--- a/package/gluon-autoupdater/files/usr/lib/autoupdater/abort.d/15start-dropbear
+++ b/package/gluon-autoupdater/files/usr/lib/autoupdater/abort.d/15start-dropbear
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. /lib/gluon/autoupdater/lib.sh
+
+start_enabled dropbear

--- a/package/gluon-autoupdater/files/usr/lib/autoupdater/upgrade.d/05stop-dropbear
+++ b/package/gluon-autoupdater/files/usr/lib/autoupdater/upgrade.d/05stop-dropbear
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. /lib/gluon/autoupdater/lib.sh
+
+stop dropbear


### PR DESCRIPTION
Before active SSH sessions would get stuck, when the network was
suddenly stopped. If we instead stop dropbear before that and allow it
to terminate SSH sessions cleanly we improve the user experience.

Fixes #1957

Still untested.