### PR TITLE
build: add class-packages for targets without devices

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -85,6 +85,7 @@ files["package/**/luasrc/lib/gluon/ebtables/*"] = {
 
 files["targets/*"] = {
 	read_globals = {
+		"class",
 		"config",
 		"defaults",
 		"device",

--- a/scripts/target_config_lib.lua
+++ b/scripts/target_config_lib.lua
@@ -31,11 +31,20 @@ END_MAKE
 		]], lib.escape(image)))
 	end
 
-	lib.include('generic')
-	for pkg in string.gmatch(extra_packages, '%S+') do
-		lib.packages {pkg}
+	local function handle_target_pkgs(pkgs)
+		local packages = string.gmatch(pkgs, '%S+')
+		for pkg in packages do
+			lib.packages {pkg}
+		end
 	end
+
+	lib.include('generic')
+	handle_target_pkgs(extra_packages)
 	lib.include(target)
+
+	if lib.target_class ~= nil then
+		handle_target_pkgs(class_packages[lib.target_class])
+	end
 
 	lib.check_devices()
 

--- a/scripts/target_lib.lua
+++ b/scripts/target_lib.lua
@@ -23,6 +23,7 @@ assert(env.GLUON_DEPRECATED)
 
 M.site_code = assert(assert(dofile('scripts/site_config.lua')('site.conf')).site_code)
 M.target_packages = {}
+M.target_class = nil
 M.configs = {}
 M.devices = {}
 M.images = {}
@@ -151,6 +152,10 @@ end
 
 function F.config(...)
 	M.configs[string.format(...)] = 2
+end
+
+function F.class(target_class)
+	M.target_class = target_class
 end
 
 function F.packages(pkgs)

--- a/targets/x86.inc
+++ b/targets/x86.inc
@@ -1,6 +1,8 @@
 config 'CONFIG_VDI_IMAGES=y'
 config 'CONFIG_VMDK_IMAGES=y'
 
+class 'standard'
+
 packages {
 	'kmod-3c59x',
 	'kmod-8139cp',


### PR DESCRIPTION
When adding device classes, targets without devices such as x86 were not
handled. As site and feature packages are included on such a per-device
decision, x86 images ended up without most packages.

Include a class setting for a target and include the class-packages
target-wide when this setting is configured.

Fixes 9c52365077be ("build: introduce device classes")