### PR TITLE
CI: Add test stage

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 indent_style = tab
 charset = utf-8
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/contrib/ci/Jenkinsfile
+++ b/contrib/ci/Jenkinsfile
@@ -34,6 +34,23 @@ pipeline {
 				sh 'make update'
 				sh 'test -d /dl_cache && ln -s /dl_cache openwrt/dl || true'
 				sh 'make -j$(nproc) V=s'
+				stash includes: '**/output/images/factory/*-x86-64.img.gz', name: 'gluon-x86-64-factory'
+			}
+		}
+		stage('test') {
+			agent { label 'gluon-docker-v2' }
+			environment {
+				TMUX = "notmux"
+			}
+			steps {
+				unstash 'gluon-x86-64-factory'
+				sh label: 'Unpack image', script: 'gunzip -cd ./output/images/factory/*x86-64*.img.gz > ./image.img'
+				sh label: 'Print python environment', script: 'python3 -m pip freeze'
+				script {
+					for (f in findFiles(glob: '**/tests/*.py')) {
+						sh label: "Test ${f.name}", script: "python3 tests/${f.name} --use-tmp-workdir"
+					}
+				}
 			}
 		}
 	}
@@ -49,4 +66,5 @@ pipeline {
  can notify lemoer, that you have updated your node.
 
  - gluon-docker-v1: add shellcheck binary to the build environment
+ - gluon-docker-v2: add qemu-testlab testing, requires KVM virtualization support
 */

--- a/contrib/ci/Jenkinsfile
+++ b/contrib/ci/Jenkinsfile
@@ -11,12 +11,14 @@ pipeline {
 				stage('lint-lua') {
 					agent { label 'gluon-docker' }
 					steps {
+						sh label: 'Identify runner', script: 'echo $SLAVE_NAME'
 						sh 'make lint-lua'
 					}
 				}
 				stage('lint-sh') {
 					agent { label 'gluon-docker-v1' }
 					steps {
+						sh label: 'Identify runner', script: 'echo $SLAVE_NAME'
 						sh 'make lint-sh'
 					}
 				}
@@ -25,12 +27,14 @@ pipeline {
 		stage('docs') {
 			agent { label 'gluon-docker' }
 			steps {
+				sh label: 'Identify runner', script: 'echo $SLAVE_NAME'
 				sh 'make -C docs html'
 			}
 		}
 		stage('build') {
 			agent { label 'gluon-docker' }
 			steps {
+				sh label: 'Identify runner', script: 'echo $SLAVE_NAME'
 				sh 'make update'
 				sh 'test -d /dl_cache && ln -s /dl_cache openwrt/dl || true'
 				sh 'make -j$(nproc) V=s'
@@ -43,6 +47,7 @@ pipeline {
 				TMUX = "notmux"
 			}
 			steps {
+				sh label: 'Identify runner', script: 'echo $SLAVE_NAME'
 				unstash 'gluon-x86-64-factory'
 				sh label: 'Unpack image', script: 'gunzip -cd ./output/images/factory/*x86-64*.img.gz > ./image.img'
 				sh label: 'Print python environment', script: 'python3 -m pip freeze'

--- a/contrib/ci/jenkins-community-slave/Dockerfile
+++ b/contrib/ci/jenkins-community-slave/Dockerfile
@@ -5,8 +5,8 @@ USER root
 # this is needed to install default-jre-headless in debian slim images
 RUN mkdir -p /usr/share/man/man1
  
-RUN apt-get update && apt-get install -y default-jre-headless curl python3 python3-pip python3-sphinx git
-RUN pip3 install jenkins-webapi sphinx_rtd_theme
+RUN apt-get update && apt-get install -y default-jre-headless curl git netcat-openbsd python3 python3-pip qemu-system-x86 iproute2 openssh-client
+RUN python3 -m pip install jenkins-webapi sphinx sphinx_rtd_theme gluon-qemu-testlab==0.0.5
  
 # Get docker-compose in the agent container
 RUN mkdir -p /home/jenkins

--- a/contrib/ci/jenkins-community-slave/README.md
+++ b/contrib/ci/jenkins-community-slave/README.md
@@ -1,7 +1,11 @@
 # Gluon CI using Jenkins
 
 ## Requirements
-- Only a host with docker.
+- Linux system
+  - with docker installed
+  - with Hardware Virtualisation (KVM Support)
+    - Verify using: `lscpu | grep vmx`
+    - If machine is virtualized host needs to load `kvm_intel` with `nested=1` option and cpuflags need to include `vmx`
 
 ## Architecture
 
@@ -19,9 +23,11 @@ docker build -t gluon-jenkins .
 mkdir /var/cache/openwrt_dl_cache/
 chown 1000:1000 /var/cache/openwrt_dl_cache
 docker run --detach --restart always \
-    -e "SLAVE_NAME=whoareyou" \
-    -e "SLAVE_SECRET=changeme" \
-    -v /var/cache/openwrt_dl_cache/:/dl_cache
+    --env "SLAVE_NAME=whoareyou" \
+    --env "SLAVE_SECRET=changeme" \
+    --device /dev/kvm:/dev/kvm \
+    --volume /var/cache/openwrt_dl_cache/:/dl_cache \
+    gluon-jenkins
 ```
 4. Check whether the instance is running correctly:
    - Your node should appear [here](https://build.ffh.zone/label/gluon-docker/).

--- a/tests/test_gluon-reconfigure.py
+++ b/tests/test_gluon-reconfigure.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+import sys
+from pynet import *
+
+a = Node()
+
+start()
+
+a.dbg(a.succeed("gluon-reconfigure"))
+
+finish()

--- a/tests/test_respondd.py
+++ b/tests/test_respondd.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python36
+import sys
+from pynet import *
+import asyncio
+import time
+import json
+
+a = Node()
+b = Node()
+
+connect(a, b)
+
+start()
+
+b.wait_until_succeeds("ping -c 5 node1")
+
+
+def query_neighbor_info(request):
+    response = b.wait_until_succeeds(
+        f"gluon-neighbour-info -d ff02::2:1001 -p 1001 -r {request} -i vx_eth2_mesh -c 2"
+    )
+
+    # build json array line by line
+    ret = [json.loads(l) for l in response.split("\n")]
+
+    b.dbg(f"{request.lower()}:\n{json.dumps(ret, indent=4)}")
+    return ret
+
+
+neighbours = query_neighbor_info("neighbours")
+
+vx_eth2_mesh_addr_a = a.succeed("cat /sys/class/net/vx_eth2_mesh/address")
+vx_eth2_mesh_addr_b = b.succeed("cat /sys/class/net/vx_eth2_mesh/address")
+
+res0 = neighbours[0]["batadv"]
+res1 = neighbours[1]["batadv"]
+if vx_eth2_mesh_addr_a in res0:
+    res = res0
+else:
+    res = res1
+
+batadv_neighbours = res[vx_eth2_mesh_addr_a]["neighbours"]
+
+if vx_eth2_mesh_addr_b in batadv_neighbours:
+    print("Node 1 was successfully found in neighbours of node 2.")
+else:
+    print("ERROR: Node 1 was not found in neighbours of node 2.")
+    exit(1)
+
+finish()


### PR DESCRIPTION
This is a preview for QEMU/KVM based testing of Gluon images using https://github.com/lemoer/pynet.

We're still in the process of finding a good structure to define test cases and do proper partioning of the QEMU driver, the DSL and the test cases.

The test cases should be part of the Gluon repository, while the QEMU driver and DSL should reside in the pynet package, which is due to go upstream to pypi with some proper versioning.

We introduce a new `gluon-docker-v2` label, that marks nodes that have updated to the latest Docker image. This change requires runners to have acces to `/dev/kvm` and mount it into the container. 