### PR TITLE
github: build-test all targets using GitHub actions

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -1,0 +1,310 @@
+
+# Update this file after adding/removing/renaming a target by running
+# `make list-targets BROKEN=1 | ./contrib/actions/generate-actions.py > ./.github/workflows/build-gluon.yml`
+
+name: Build Gluon
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+
+  ar71xx-generic:
+    name: ar71xx-generic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ar71xx-generic
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ar71xx-tiny:
+    name: ar71xx-tiny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ar71xx-tiny
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ar71xx-nand:
+    name: ar71xx-nand
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ar71xx-nand
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ath79-generic:
+    name: ath79-generic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ath79-generic
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  brcm2708-bcm2708:
+    name: brcm2708-bcm2708
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh brcm2708-bcm2708
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  brcm2708-bcm2709:
+    name: brcm2708-bcm2709
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh brcm2708-bcm2709
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ipq40xx-generic:
+    name: ipq40xx-generic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ipq40xx-generic
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ipq806x-generic:
+    name: ipq806x-generic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ipq806x-generic
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  lantiq-xrx200:
+    name: lantiq-xrx200
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh lantiq-xrx200
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  lantiq-xway:
+    name: lantiq-xway
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh lantiq-xway
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  mpc85xx-generic:
+    name: mpc85xx-generic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh mpc85xx-generic
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  mpc85xx-p1020:
+    name: mpc85xx-p1020
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh mpc85xx-p1020
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ramips-mt7620:
+    name: ramips-mt7620
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ramips-mt7620
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ramips-mt7621:
+    name: ramips-mt7621
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ramips-mt7621
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ramips-mt76x8:
+    name: ramips-mt76x8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ramips-mt76x8
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ramips-rt305x:
+    name: ramips-rt305x
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ramips-rt305x
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  sunxi-cortexa7:
+    name: sunxi-cortexa7
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh sunxi-cortexa7
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  x86-generic:
+    name: x86-generic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh x86-generic
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  x86-geode:
+    name: x86-geode
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh x86-geode
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  x86-64:
+    name: x86-64
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh x86-64
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  ar71xx-mikrotik:
+    name: ar71xx-mikrotik
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh ar71xx-mikrotik
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  brcm2708-bcm2710:
+    name: brcm2708-bcm2710
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh brcm2708-bcm2710
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+
+  mvebu-cortexa9:
+    name: mvebu-cortexa9
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh mvebu-cortexa9
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+

--- a/contrib/actions/generate-actions.py
+++ b/contrib/actions/generate-actions.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+import sys
+
+ACTIONS_HEAD = """
+# Update this file after adding/removing/renaming a target by running
+# `make list-targets BROKEN=1 | ./contrib/actions/generate-actions.py > ./.github/workflows/build-gluon.yml`
+
+name: Build Gluon
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+"""
+
+ACTIONS_TARGET="""
+  {target_name}:
+    name: {target_name}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Build
+        run: bash contrib/actions/run-build.sh {target_name}
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: output
+          path: output
+"""
+
+output = ACTIONS_HEAD
+
+for target in sys.stdin:
+	output += ACTIONS_TARGET.format(target_name=target.strip())
+
+print(output)

--- a/contrib/actions/run-build.sh
+++ b/contrib/actions/run-build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+sudo apt install git subversion build-essential python gawk unzip libncurses5-dev zlib1g-dev libssl-dev wget time
+
+export BROKEN=1
+export GLUON_DEPRECATED=1
+export GLUON_SITEDIR="contrib/ci/minimal-site"
+export GLUON_TARGET=$1
+
+make update
+make -j2
+

--- a/modules
+++ b/modules
@@ -1,6 +1,6 @@
 GLUON_FEEDS='packages routing gluon'
 
-OPENWRT_REPO=https://git.openwrt.org/openwrt/openwrt.git
+OPENWRT_REPO=https://github.com/openwrt/openwrt.git
 OPENWRT_BRANCH=openwrt-19.07
 OPENWRT_COMMIT=81264ebb51991aa2d17489852854e3b5ec3f514d
 


### PR DESCRIPTION
This PR enables build-testing all targets using GitHub actions.

GitHub provides runners for public projects free of charge. This way, we are able to build-test all Targets simultaneously, which allows to have a PR built this way in under 2 hours.

The Goal of this PR is not to remove the existing Jenkins CI, as a lock-in to GitHub is not desirable. However we are not able to gather enough resources to host this functionality ourselves.

Demo runs can be found here: https://github.com/blocktrron/gluon/actions