### PR TITLE
gluon-respondd: allow queries from extra_prefix6

### DIFF
--- a/package/gluon-respondd/luasrc/lib/gluon/upgrade/400-respondd-firewall
+++ b/package/gluon-respondd/luasrc/lib/gluon/upgrade/400-respondd-firewall
@@ -25,6 +25,7 @@ uci:section('firewall', 'rule', 'client_respondd', {
 	target = 'ACCEPT',
 })
 
+-- Allow respondd-access from within the mesh
 uci:section('firewall', 'rule',  'mesh_respondd_ll', {
 	name = 'mesh_respondd_ll',
 	src = 'mesh',
@@ -42,5 +43,20 @@ uci:section('firewall', 'rule',  'mesh_respondd_siteprefix', {
 	proto = 'udp',
 	target = 'ACCEPT',
 })
+
+uci:delete_all('firewall', 'rule', function(rule)
+	return rule['.name']:find('^mesh_respondd_extraprefix')
+end)
+
+for idx, prefix in ipairs(site.extra_prefixes6({})) do
+	uci:section('firewall', 'rule',  'mesh_respondd_extraprefix' .. idx, {
+		name = 'mesh_respondd_extraprefix' .. idx,
+		src = 'mesh',
+		src_ip = prefix,
+		dest_port = '1001',
+		proto = 'udp',
+		target = 'ACCEPT',
+	})
+end
 
 uci:save('firewall')


### PR DESCRIPTION
Fixes #1959

Would probably a good idea to backport this fix.