### PR TITLE
Add gluon-logging package

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -32,6 +32,7 @@ files["package/**/check_site.lua"] = {
 		"need_chanlist",
 		"need_domain_name",
 		"need_number",
+		"need_number_range",
 		"need_one_of",
 		"need_string",
 		"need_string_array",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,6 +65,7 @@ Several Freifunk communities in Germany use Gluon as the foundation of their Fre
    package/gluon-ebtables-limit-arp
    package/gluon-ebtables-source-filter
    package/gluon-hoodselector
+   package/gluon-logging
    package/gluon-mesh-batman-adv
    package/gluon-mesh-wireless-sae
    package/gluon-radv-filterd

--- a/docs/package/gluon-logging.rst
+++ b/docs/package/gluon-logging.rst
@@ -1,0 +1,37 @@
+gluon-logging
+=============
+
+The *gluon-logging* package allows to configure a remote syslog server that
+will receive the systems log output that is also visible when calling ``logread``
+from a terminal.
+
+It supports both IPv4 and IPv6 endpoints over UDP and TCP.
+
+Note: The syslog mechanism is incapable of providing a complete log as network
+access is required to send out log messages and ``logd`` does not buffer and resend
+older log messages even though they might be available in ``logread``.
+
+This package conflicts with ``gluon-web-logging`` as it will overwrite the
+user-given syslog server on every upgrade.
+
+site.conf
+---------
+
+syslog.ip : required
+    - Destination address of the remote syslog server
+
+syslog.port : optional
+    - Destination port of the remote syslog server
+    - Defaults to 514
+
+syslog.proto : optional
+    - Protocol to transport syslog frames in, can be either ``tcp`` or ``udp``
+    - Defaults to UDP
+
+Example::
+
+  syslog = {
+    ip = "2001:db8::1",
+    port = 514,
+    proto = "udp",
+  },

--- a/package/gluon-logging/Makefile
+++ b/package/gluon-logging/Makefile
@@ -1,0 +1,15 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-logging
+PKG_VERSION:=1
+
+include ../gluon.mk
+
+define Package/gluon-logging
+  TITLE:=Configure remote syslog from site.conf
+  DEPENDS:=+gluon-core
+  CONFLICTS:=gluon-web-logging
+endef
+
+$(eval $(call BuildPackageGluon,gluon-logging))
+

--- a/package/gluon-logging/check_site.lua
+++ b/package/gluon-logging/check_site.lua
@@ -1,0 +1,3 @@
+need_string({'syslog', 'ip'}, true)
+need_number_range({'syslog', 'port'}, 1, 65535, false)
+need_one_of({'syslog', 'proto'}, {'tcp', 'udp'}, false)

--- a/package/gluon-logging/luasrc/lib/gluon/upgrade/040-syslog
+++ b/package/gluon-logging/luasrc/lib/gluon/upgrade/040-syslog
@@ -1,0 +1,19 @@
+#!/usr/bin/lua
+local site = require('gluon.site')
+local uci = require('simple-uci').cursor()
+
+local system = uci:get_first('system', 'system')
+
+if not site.syslog.ip() then
+	uci:delete('system', system, 'log_remote')
+	uci:delete('system', system, 'log_ip')
+	uci:delete('system', system, 'log_port')
+	uci:delete('system', system, 'log_proto')
+else
+	uci:set('system', system, 'log_remote', 1)
+	uci:set('system', system, 'log_ip', site.syslog.ip())
+	uci:set('system', system, 'log_port', site.syslog.port(514))
+	uci:set('system', system, 'log_proto', site.syslog.proto('udp'))
+end
+
+uci:save('system')

--- a/scripts/check_site.lua
+++ b/scripts/check_site.lua
@@ -289,6 +289,19 @@ function M.need_number(path, required)
 	return need_type(path, 'number', required, 'be a number')
 end
 
+function M.need_number_range(path, min, max, required)
+	local val = need_type(path, 'number', required)
+	if not val then
+		return nil
+	end
+
+	if val < min or val > max then
+		var_error(path, val, "be in range [" .. min .. ", " .. max .. "]")
+	end
+
+	return val
+end
+
 function M.need_boolean(path, required)
 	return need_type(path, 'boolean', required, 'be a boolean')
 end


### PR DESCRIPTION
Allows configuration of remote syslog from site.conf.

Conflicts with `gluon-web-logging` as only one of them can control the remote syslog destination.

Resolves #1845. <s>Untested.</s>