### PR TITLE
x86-geode: add target class

### DIFF
--- a/targets/x86-geode
+++ b/targets/x86-geode
@@ -1,3 +1,5 @@
+class 'standard'
+
 packages {
 	'kmod-3c59x',
 	'kmod-8139cp',


### PR DESCRIPTION
x86-geode does not include the common x86 target-settings. Thus we need
to specify the device class in order to build images with all necessary
packages included.