### PR TITLE
ci: add chmod step to resolve permissions on openwrt dl cache

### DIFF
--- a/contrib/ci/jenkins-community-slave/README.md
+++ b/contrib/ci/jenkins-community-slave/README.md
@@ -17,6 +17,7 @@ git clone https://github.com/freifunk-gluon/gluon/
 cd gluon/contrib/ci/jenkins-community-slave/
 docker build -t gluon-jenkins .
 mkdir /var/cache/openwrt_dl_cache/
+chown 1000:1000 /var/cache/openwrt_dl_cache
 docker run --detach --restart always \
     -e "SLAVE_NAME=whoareyou" \
     -e "SLAVE_SECRET=changeme" \


### PR DESCRIPTION
The gluon build user (`uid=1000(gluon) gid=1000(gluon) groups=1000(gluon)`) is unprivileged in the container which is why mounting the directory with `:rw` is not sufficient, we need a matching UID/GID or chmod 0777. I think the latter is worse.

