### PR TITLE
docs: examples: remove haveged from GLUON_SITE_PACKAGES

### DIFF
--- a/docs/multidomain-site-example/site.mk
+++ b/docs/multidomain-site-example/site.mk
@@ -29,7 +29,7 @@ GLUON_MULTIDOMAIN=1
 #		chosen feature flags
 
 
-GLUON_SITE_PACKAGES := haveged iwinfo
+GLUON_SITE_PACKAGES := iwinfo
 
 ##	DEFAULT_GLUON_RELEASE
 #		version string to use for images

--- a/docs/site-example/site.mk
+++ b/docs/site-example/site.mk
@@ -23,7 +23,7 @@ GLUON_FEATURES := \
 #		selection that would be enabled by default or due to the
 #		chosen feature flags
 
-GLUON_SITE_PACKAGES := haveged iwinfo
+GLUON_SITE_PACKAGES := iwinfo
 
 ##	DEFAULT_GLUON_RELEASE
 #		version string to use for images

--- a/package/gluon-autoupdater/files/usr/lib/autoupdater/abort.d/90gluon-autoupdater
+++ b/package/gluon-autoupdater/files/usr/lib/autoupdater/abort.d/90gluon-autoupdater
@@ -4,6 +4,6 @@
 
 
 start_enabled cron
-start_enabled haveged
+start_enabled urngd
 start_enabled micrond
 start_enabled sysntpd

--- a/package/gluon-autoupdater/files/usr/lib/autoupdater/download.d/10gluon-autoupdater
+++ b/package/gluon-autoupdater/files/usr/lib/autoupdater/download.d/10gluon-autoupdater
@@ -4,6 +4,6 @@
 
 
 stop cron
-stop haveged
+stop urngd
 stop micrond
 stop sysntpd

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S13haveged
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S13haveged
@@ -1,5 +1,0 @@
-#!/bin/sh /etc/rc.common
-
-if [ -x /etc/init.d/haveged ] && /etc/init.d/haveged enabled; then
-	. /etc/init.d/haveged
-fi

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S13urngd
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S13urngd
@@ -1,0 +1,5 @@
+#!/bin/sh /etc/rc.common
+
+if [ -x /etc/init.d/urngd ] && /etc/init.d/urngd enabled; then
+	. /etc/init.d/urngd
+fi


### PR DESCRIPTION
OpenWRT 19.07 enables urngd by default, so haveged is redundant.