### PR TITLE
github: actions: only build certain branches

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -5,6 +5,10 @@
 name: Build Gluon
 on:
   push:
+    branches:
+      - master
+      - next
+      - v20*
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/contrib/actions/generate-actions.py
+++ b/contrib/actions/generate-actions.py
@@ -9,6 +9,10 @@ ACTIONS_HEAD = """
 name: Build Gluon
 on:
   push:
+    branches:
+      - master
+      - next
+      - v20*
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
This enables build-testing only on master as well as next and release branches.

Pull requests done from source branches of this repository are still built.
Previously, those builds were redundant.