### PR TITLE
gluon-web-autoupdater: use human-readable names as branch labels, sort by label

### DIFF
--- a/package/gluon-web-autoupdater/luasrc/lib/gluon/config-mode/model/admin/autoupdater.lua
+++ b/package/gluon-web-autoupdater/luasrc/lib/gluon/config-mode/model/admin/autoupdater.lua
@@ -22,11 +22,18 @@ function o:write(data)
 end
 
 o = s:option(ListValue, "branch", translate("Branch"))
-uci:foreach("autoupdater", "branch",
-	function (section)
-		o:value(section[".name"])
-	end
-)
+
+local branches = {}
+uci:foreach("autoupdater", "branch", function(branch)
+	table.insert(branches, branch)
+end)
+table.sort(branches, function(a, b)
+	return a.name < b.name
+end)
+for _, branch in ipairs(branches) do
+	o:value(branch[".name"], branch.name)
+end
+
 o.default = uci:get("autoupdater", autoupdater, "branch")
 function o:write(data)
 	uci:set("autoupdater", autoupdater, "branch", data)


### PR DESCRIPTION
Use the value of the `name` site.conf field as label (it was
accidentally unused before).

Our site.conf currently doesn't define a specific order for the branch
entries. To avoid changing branch orders, sort entries by this label.

Fixes: #1961