### PR TITLE
targets/ath79-generic: add archer-D50 v1

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -109,6 +109,7 @@ local primary_addrs = {
 			'glinet,gl-ar750s-nor',
 			'ocedo,raccoon',
 			'tplink,archer-c2-v3',
+			'tplink,archer-d50-v1',
 		}},
 		{'brcm2708'},
 		{'ipq40xx', 'generic', {

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -91,3 +91,9 @@ device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 })
 
 device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
+
+device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+	broken = true, -- 64M ath9k + ath10k & power LED not working
+})


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [x] tftp
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] **primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)**
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
   - [ ]  **should display config mode blink sequence** <-- NOT Working
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity