### PR TITLE
targets/ramips-mt76x8: add support for Cudy WR1000

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -354,6 +354,10 @@ ramips-mt7621
 ramips-mt76x8
 -------------
 
+* Cudy
+
+  - WR1000 (v1)
+
 * GL.iNet
 
   - GL-MT300N v2

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -1,3 +1,8 @@
+-- Cudy
+
+device('cudy-wr1000', 'cudy_wr1000')
+
+
 -- GL.iNet
 
 device('gl-mt300n-v2', 'gl-mt300n-v2', {


### PR DESCRIPTION
* [x]  must be flashable from vendor firmware

  * [x]  flashing via web works
 
* [x]  must support upgrade mechanism
      
  * [x]  must have working sysupgrade <-- just tested once, looked fine.
        
    * [x]  must keep/forget configuration (if applicable)
      _think `sysupgrade [-n]` or `firstboot`_
  * [x]  must have working autoupdate
    _usually means: gluon profile name must match image name_

* [x]  reset/wps/phone button must return device into config mode

* [x]  primary mac should match address on device label (or packaging) 

* wired network
      
  * [x]  should support all network ports on the device
  * [x]  must have correct port assignment (WAN/LAN)

* wifi (if applicable)
      
  * [x]  association with AP must be possible on all radios
  * [x]  association with 802.11s mesh must be working on all radios
  * [x]  ap/mesh mode must work in parallel on all radios

* led mapping
      
  * power/sys led (_critical, because led definitions are setup on firstboot only_)
          _Power LED Does never blink, maybe hardwired_
        
    * [x]  lit while the device is on
  *   [x]  **should display config mode blink sequence** <-- Not entirely sure, as power led never blinks, but the WPS LED does it's job during config mode
  * radio leds
        
    * [x]  should map to their respective radio
    * [x]  should show activity
  * switchport leds
        
    * [x]  should map to their respective port (or switch, if only one led present)
    * [x]  should show link state and activity

---------------------
https://hannover.freifunk.net/karte/#/en/map/b44bd6224ebc