### PR TITLE
scripts: move output files instead of copy

### DIFF
--- a/scripts/copy_output.lua
+++ b/scripts/copy_output.lua
@@ -36,20 +36,22 @@ local function clean(image, name)
 	lib.exec {'rm', '-f', dir..'/'..file}
 end
 
-for _, image in ipairs(lib.images) do
-	clean(image, image.image)
+for _, images in pairs(lib.images) do
+	for _, image in ipairs(images) do
+		clean(image, image.image)
 
-	local destdir, destname = image:dest_name(image.image)
-	local source = string.format('openwrt/bin/targets/%s/openwrt-%s-%s%s%s',
-		bindir, openwrt_target, image.name, image.in_suffix, image.extension)
+		local destdir, destname = image:dest_name(image.image)
+		local source = string.format('openwrt/bin/targets/%s/openwrt-%s-%s%s%s',
+			bindir, openwrt_target, image.name, image.in_suffix, image.extension)
 
-	lib.exec {'cp', source, destdir..'/'..destname}
+		lib.exec {'cp', source, destdir..'/'..destname}
 
-	for _, alias in ipairs(image.aliases) do
-		clean(image, alias)
+		for _, alias in ipairs(image.aliases) do
+			clean(image, alias)
 
-		local _, aliasname = image:dest_name(alias)
-		lib.exec {'ln', '-s', destname, destdir..'/'..aliasname}
+			local _, aliasname = image:dest_name(alias)
+			lib.exec {'ln', '-s', destname, destdir..'/'..aliasname}
+		end
 	end
 end
 

--- a/scripts/copy_output.lua
+++ b/scripts/copy_output.lua
@@ -31,6 +31,12 @@ mkdir(env.GLUON_IMAGEDIR..'/other')
 lib.include(target)
 
 
+local function image_source(image)
+	return string.format(
+		'openwrt/bin/targets/%s/openwrt-%s-%s%s%s',
+		bindir, openwrt_target, image.name, image.in_suffix, image.extension)
+end
+
 local function clean(image, name)
 	local dir, file = image:dest_name(name, '\0', '\0')
 	lib.exec {'rm', '-f', dir..'/'..file}
@@ -41,8 +47,7 @@ for _, images in pairs(lib.images) do
 		clean(image, image.image)
 
 		local destdir, destname = image:dest_name(image.image)
-		local source = string.format('openwrt/bin/targets/%s/openwrt-%s-%s%s%s',
-			bindir, openwrt_target, image.name, image.in_suffix, image.extension)
+		local source = image_source(image)
 
 		lib.exec {'cp', source, destdir..'/'..destname}
 
@@ -52,6 +57,11 @@ for _, images in pairs(lib.images) do
 			local _, aliasname = image:dest_name(alias)
 			lib.exec {'ln', '-s', destname, destdir..'/'..aliasname}
 		end
+	end
+
+	for _, image in ipairs(images) do
+		local source = image_source(image)
+		lib.exec {'rm', '-f', source}
 	end
 end
 

--- a/scripts/generate_manifest.lua
+++ b/scripts/generate_manifest.lua
@@ -48,8 +48,10 @@ local function generate(image)
 	end
 end
 
-for _, image in ipairs(lib.images) do
-	if image.subdir == 'sysupgrade' then
-		generate(image)
+for _, images in pairs(lib.images) do
+	for _, image in ipairs(images) do
+		if image.subdir == 'sysupgrade' then
+			generate(image)
+		end
 	end
 end

--- a/scripts/target_lib.lua
+++ b/scripts/target_lib.lua
@@ -143,7 +143,9 @@ local image_mt = {
 }
 
 local function add_image(image)
-	table.insert(M.images, setmetatable(image, image_mt))
+	local device = image.image
+	M.images[device] = M.images[device] or {}
+	table.insert(M.images[device], setmetatable(image, image_mt))
 end
 
 function F.try_config(...)


### PR DESCRIPTION
Moving images instead of copying them saves some disk space and there is probably no reason to keep the images in the OpenWrt buildroot.

Additionally the hope is that this will save enough disk space to have ar71xx-generic build through GitHub Actions.