### PR TITLE
kernel: backport slub prefetch fix from v4.19

### DIFF
--- a/patches/openwrt/0010-kernel-backport-slub-prefetch-fix-from-v4.19.patch
+++ b/patches/openwrt/0010-kernel-backport-slub-prefetch-fix-from-v4.19.patch
@@ -1,0 +1,63 @@
+From: Matthias Schiffer <mschiffer@universe-factory.net>
+Date: Sat, 25 Apr 2020 19:27:34 +0200
+Subject: kernel: backport slub prefetch fix from v4.19
+
+This patch fixes a regression introduced in kernel v4.14. While the
+commit message only mentions a performance penalty, the issue is
+suspected to be the cause of spurious data bus errors on MIPS CPUs
+(ar71xx target).
+
+Signed-off-by: Matthias Schiffer <mschiffer@universe-factory.net>
+
+diff --git a/target/linux/generic/backport-4.14/190-v4.19-mm-slub-restore-the-original-intention-of-prefetch_f.patch b/target/linux/generic/backport-4.14/190-v4.19-mm-slub-restore-the-original-intention-of-prefetch_f.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..06bea3e8fd36b3d9f1e9f14c6928aebc315db19c
+--- /dev/null
++++ b/target/linux/generic/backport-4.14/190-v4.19-mm-slub-restore-the-original-intention-of-prefetch_f.patch
+@@ -0,0 +1,46 @@
++From 0882ff9190e3bc51e2d78c3aadd7c690eeaa91d5 Mon Sep 17 00:00:00 2001
++Message-Id: <0882ff9190e3bc51e2d78c3aadd7c690eeaa91d5.1587834219.git.mschiffer@universe-factory.net>
++From: Vlastimil Babka <vbabka@suse.cz>
++Date: Fri, 17 Aug 2018 15:44:44 -0700
++Subject: [PATCH] mm, slub: restore the original intention of
++ prefetch_freepointer()
++
++In SLUB, prefetch_freepointer() is used when allocating an object from
++cache's freelist, to make sure the next object in the list is cache-hot,
++since it's probable it will be allocated soon.
++
++Commit 2482ddec670f ("mm: add SLUB free list pointer obfuscation") has
++unintentionally changed the prefetch in a way where the prefetch is
++turned to a real fetch, and only the next->next pointer is prefetched.
++In case there is not a stream of allocations that would benefit from
++prefetching, the extra real fetch might add a useless cache miss to the
++allocation.  Restore the previous behavior.
++
++Link: http://lkml.kernel.org/r/20180809085245.22448-1-vbabka@suse.cz
++Fixes: 2482ddec670f ("mm: add SLUB free list pointer obfuscation")
++Signed-off-by: Vlastimil Babka <vbabka@suse.cz>
++Acked-by: Kees Cook <keescook@chromium.org>
++Cc: Daniel Micay <danielmicay@gmail.com>
++Cc: Eric Dumazet <edumazet@google.com>
++Cc: Christoph Lameter <cl@linux.com>
++Cc: Pekka Enberg <penberg@kernel.org>
++Cc: David Rientjes <rientjes@google.com>
++Cc: Joonsoo Kim <iamjoonsoo.kim@lge.com>
++Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
++Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>
++---
++ mm/slub.c | 3 +--
++ 1 file changed, 1 insertion(+), 2 deletions(-)
++
++--- a/mm/slub.c
+++++ b/mm/slub.c
++@@ -269,8 +269,7 @@ static inline void *get_freepointer(stru
++ 
++ static void prefetch_freepointer(const struct kmem_cache *s, void *object)
++ {
++-	if (object)
++-		prefetch(freelist_dereference(s, object + s->offset));
+++	prefetch(object + s->offset);
++ }
++ 
++ static inline void *get_freepointer_safe(struct kmem_cache *s, void *object)


### PR DESCRIPTION
This patch fixes a regression introduced in kernel v4.14. While the
commit message only mentions a performance penalty, the issue is
suspected to be the cause of spurious data bus errors on MIPS CPUs
(ar71xx target).

Fixes: #1982

My test device has completed more than 350M cycles of the test program posted in #1982 without issues. Needs more testing on a wider variety of hardware.