### PR TITLE
lantiq-xway: remove support for AVM FRITZ!Box 7320 7330 7330SL

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -271,9 +271,6 @@ lantiq-xway
 * AVM
 
   - FRITZ!Box 7312 [#avmflash]_
-  - FRITZ!Box 7320 [#avmflash]_ [#lan_as_wan]_
-  - FRITZ!Box 7330 [#avmflash]_ [#lan_as_wan]_
-  - FRITZ!Box 7330 SL [#avmflash]_ [#lan_as_wan]_
 
 * NETGEAR
 

--- a/targets/lantiq-xway
+++ b/targets/lantiq-xway
@@ -2,11 +2,6 @@ device('avm-fritz-box-7312', 'avm_fritz7312', {
 	factory = false,
 })
 
-device('avm-fritz-box-7320', 'avm_fritz7320', {
-	factory = false,
-	aliases = {'avm-fritz-box-7330', 'avm-fritz-box-7330-sl'},
-})
-
 device('netgear-dgn3500b', 'netgear_dgn3500b', {
 	factory_ext = '.img',
 })


### PR DESCRIPTION
This device has broken Ethernet on both ports.

Remove support for those devices. for now, as there was no feedback from
the original author.

Closes #1943