### PR TITLE
ath79-generic: add support for Ubiquiti Nanostation AC (WA)

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -54,6 +54,7 @@ function M.is_outdoor_device()
 	elseif M.match('ath79', 'generic', {
 		'devolo,dvl1750x',
 		'tplink,cpe220-v3',
+		'ubnt,nanostation-ac',
 	}) then
 		return true
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -78,3 +78,10 @@ device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 })
 
 device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
+
+-- Ubiquiti
+
+device('ubiquiti-nanostation-ac', 'ubnt_nanostation-ac', {
+	broken = true, -- 64M RAM ath9k + ath10k
+	packages = ATH10K_PACKAGES_QCA9880,
+})


### PR DESCRIPTION
* [x]  must be flashable from vendor firmware
  * [ ]  webinterface (not tested)
  * [ ]  tftp
  * [x]  other: https://openwrt.org/toh/ubiquiti/ubiquiti_nanostation_ac#installation
* [x]  must support upgrade mechanism
  * [x]  must have working sysupgrade
      * [x]  must keep/forget configuration (if applicable)
      _think `sysupgrade [-n]` or `firstboot`_
  * [ ]  must have working autoupdate
    _usually means: gluon profile name must match image name_
* [ ]  reset/wps/phone button must return device into config mode (not tested)
* [x]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
* wired network
  * [x]  should support all network ports on the device
  * [ ]  must have correct port assignment (WAN/LAN) - (no, need help)
* wifi (if applicable)
  * [x]  association with AP must be possible on all radios
  * [x]  association with 802.11s mesh must be working on all radios
  * [x]  ap/mesh mode must work in parallel on all radios
* led mapping
  * power/sys led (_critical, because led definitions are setup on firstboot only_)
      * [x]  lit while the device is on
    * [ ]  should display config mode blink sequence (not tested)
      (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  * radio leds
      * [x]  should map to their respective radio
    * [x]  should show activity
  * switchport leds
      * [x]  should map to their respective port (or switch, if only one led present)
    * [x]  should show link state and activity
* outdoor devices only
  * [x]  added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

