### PR TITLE
docs: add Aruba AP-303 and Instant On AP11 to supported devices list

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -221,6 +221,11 @@ brcm2708-bcm2709
 ipq40xx-generic
 ---------------
 
+* Aruba
+
+  - AP-303
+  - Instant On AP11
+
 * AVM
 
   - FRITZ!Box 4040 [#avmflash]_


### PR DESCRIPTION
I notices these two are missing in the docs.