### PR TITLE
tests: add batctl tpmeter test case

### DIFF
--- a/tests/test_batctl_tpmeter.py
+++ b/tests/test_batctl_tpmeter.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+import sys
+from pynet import *
+import asyncio
+import time
+
+a = Node()
+b = Node()
+
+connect(a, b)
+
+start()
+
+b.wait_until_succeeds("ping -c 5 node1")
+
+addr = a.succeed('cat /sys/class/net/primary0/address')
+result = b.succeed(f'batctl tp {addr}')
+
+print(result)
+
+finish()
+

--- a/tests/test_respondd.py
+++ b/tests/test_respondd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python36
+#!/usr/bin/env python3
 import sys
 from pynet import *
 import asyncio


### PR DESCRIPTION
In https://github.com/freifunk-gluon/gluon/commit/a070e688498b7ab79cba5c9e8126d2a787a92f68 batman-adv was updated to emit correct exit codes when running tpmeter, which should make this test case work.

cc @lemoer 