### PR TITLE
generic: disable urngd by default (v2020.1.x)

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -65,6 +65,7 @@ packages {
 	'-odhcpd-ipv6only',
 	'-ppp',
 	'-ppp-mod-pppoe',
+	'-urngd',
 	'-wpad-mini',
 	'-wpad-basic',
 	'gluon-core',


### PR DESCRIPTION
We already recommend the use of haveged, making urngd redundant. To avoid
incompatible site changes in v2020.1.x, disabled urngd for now.

As proposed in https://github.com/freifunk-gluon/gluon/pull/2001#issuecomment-622031073