### PR TITLE
 targets/lantiq-xrx200: added device Arcadyan VGV7510KW22 aka o2 Box 6431

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -103,6 +103,9 @@ local primary_addrs = {
 		{'ipq806x', 'generic', {
 			'netgear,r7800',
 		}},
+		{'lantiq', 'xrx200', {
+			'arcadyan,vgv7510kw22-nor',
+		}},
 		{'lantiq', 'xway', {
 			'netgear,dgn3500b',
 		}},

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -11,9 +11,12 @@ end
 local platform = require 'gluon.platform'
 local site = require 'gluon.site'
 
+local json = require 'jsonc'
 local uci = require('simple-uci').cursor()
 local unistd = require 'posix.unistd'
 
+local board_data = json.load('/etc/board.json')
+local network_data = (board_data or {}).network
 
 local function iface_exists(ifaces)
 	if not ifaces then return nil end
@@ -26,8 +29,8 @@ local function iface_exists(ifaces)
 end
 
 
-local lan_ifname = iface_exists(uci:get('network', 'lan', 'ifname'))
-local wan_ifname = iface_exists(uci:get('network', 'wan', 'ifname'))
+local lan_ifname = iface_exists((network_data.lan or {}).ifname)
+local wan_ifname = iface_exists((network_data.wan or {}).ifname)
 
 if platform.match('ar71xx', 'generic', {
 	'cpe210',

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -45,6 +45,16 @@ if platform.match('ar71xx', 'generic', {
 	'unifiac-pro',
 }) then
 	lan_ifname, wan_ifname = wan_ifname, lan_ifname
+elseif platform.match('lantiq') then
+	local switch_data = board_data.switch or {}
+	local switch0_data = switch_data.switch0 or {}
+	local roles_data = switch0_data.roles or {}
+	for _, role_data in ipairs(roles_data) do
+		if role_data.role == 'wan' then
+			wan_ifname = iface_exists(role_data.device)
+			break
+		end
+	end
 end
 
 if wan_ifname and lan_ifname then

--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -11,6 +11,11 @@ device('avm-fritz-box-7412', 'avm_fritz7412', {
 	factory = false,
 })
 
+device('arcadyan-vgv7510kw22', 'arcadyan_vgv7510kw22-nor', {
+	factory = false,
+	aliases = {'o2-box-6431'},
+})
+
 -- TP-Link
 
   -- CAVEAT: These devices don't have a dedicated WAN port.


### PR DESCRIPTION
Can't yet answer all questions but wanted to get this started to get feedback and gradually push this when I have time and the skills to do so.

The device is already in usage as a node (https://map.ffmuc.net/#!/en/map/1883bfbda4c8) and now after seeing it "works" I wanted to contribute by bringing this upstream.

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp
  - [x] other: serial (some people connect the serial without opening the case) in combination with tftp worked for me (updated openwrt wiki for this device: https://openwrt.org/toh/arcadyan/vgv7510kw22)  but there are also reports that people got it working without using the serial port.
- [ ] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [ ] must have working autoupdate
    *usually means: gluon profile name must match image name* (I guess an alias which has the right name is also okay as the openwrt image is called different than the output of the get_image_name() function)
- [x] reset/wps/phone button must return device into config mode (reset and wps buttons work)
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [ ] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN)
  - This is a tricky one as already on OpenWRT it seems like my WAN port was broken. It could be that this is due to me opening the case not very carefully or an already damaged WAN port from before as I didn't test the router beforehand. Via vlan I mapped one of the LAN ports to the WAN port.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [ ] should show activity (if i remember correctly this was triggered by `phy0radio` which didn't work which seems to be an issue not just for me [https://openwrt.org/docs/guide-user/base-system/led_configuration#wifi_activity_triggers] so I switched to `phy0tx` manually)
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity