### PR TITLE
RFC: add x86-legacy subtarget

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -412,6 +412,27 @@ jobs:
           name: x86-geode_output
           path: output
 
+  x86-legacy:
+    name: x86-legacy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: sudo contrib/actions/install-dependencies.sh
+      - name: Build
+        run: contrib/actions/run-build.sh x86-legacy
+      - name: Archive build logs
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v1
+        with:
+          name: x86-legacy_logs
+          path: openwrt/logs
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: x86-legacy_output
+          path: output
+
   x86-64:
     name: x86-64
     runs-on: ubuntu-latest

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -19,6 +19,7 @@ $(eval $(call GluonTarget,ramips,rt305x))
 $(eval $(call GluonTarget,sunxi,cortexa7))
 $(eval $(call GluonTarget,x86,generic))
 $(eval $(call GluonTarget,x86,geode))
+$(eval $(call GluonTarget,x86,legacy))
 $(eval $(call GluonTarget,x86,64))
 
 

--- a/targets/x86-legacy
+++ b/targets/x86-legacy
@@ -1,0 +1,10 @@
+include 'x86.inc'
+
+packages {
+        '-kmod-gpio-nct5104d',
+        '-kmod-leds-gpio',
+        '-kmod-leds-apu2',
+}
+
+factory_image('x86-legacy', 'combined-squashfs', '.img.gz')
+sysupgrade_image('x86-legacy', 'combined-squashfs', '.img.gz')


### PR DESCRIPTION
As x86-generic is compiled to pentium4 (and newer) there is a need for
a subtarget for older devices. The x86-legacy subtarget is set to
compile to pentium (and newer) and should support even very old devics.

Comments welcome.

Closes: #2009 