### PR TITLE
Look up primary MAC address through board.json for LAN/WAN

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -12,6 +12,8 @@ local json = require 'jsonc'
 local platform = require 'gluon.platform'
 local util = require 'gluon.util'
 
+local board_data = json.load('/etc/board.json')
+local network_data = (board_data or {}).network
 
 local function sysfs(...)
 	local path = string.format(...)
@@ -33,9 +35,9 @@ end
 
 local function board(iface)
 	return function()
-		local data = json.load('/etc/board.json')
-		if data and data.network and data.network[iface] then
-			return data.network[iface].macaddr
+		local ifdata = network_data[iface] or {}
+		if ifdata.macaddr then
+			return ifdata.macaddr
 		end
 	end
 end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -15,27 +15,33 @@ local util = require 'gluon.util'
 local board_data = json.load('/etc/board.json')
 local network_data = (board_data or {}).network
 
-local function sysfs(...)
-	local path = string.format(...)
-	return function()
-		local addr = util.readfile(path)
-		if addr then
-			return util.trim(addr)
-		end
+local function read(...)
+	local addr = util.readfile(string.format(...))
+	if addr then
+		return util.trim(addr)
 	end
 end
 
-local function eth(index)
-	return sysfs('/sys/class/net/eth%d/address', index)
+local function get_netdev_addr(ifname)
+	return read('/sys/class/net/%s/address', ifname)
+end
+
+
+local function netdev(ifname)
+	return function()
+		return get_netdev_addr(ifname)
+	end
 end
 
 local function phy(index)
-	return sysfs('/sys/class/ieee80211/phy%d/macaddress', index)
+	return function()
+		return read('/sys/class/ieee80211/phy%d/macaddress', index)
+	end
 end
 
-local function board(iface)
+local function interface(name)
 	return function()
-		local ifdata = network_data[iface] or {}
+		local ifdata = network_data[name] or {}
 		if ifdata.macaddr then
 			return ifdata.macaddr
 		end
@@ -45,7 +51,7 @@ end
 
 -- Entries are matched in the order they are listed
 local primary_addrs = {
-	{eth(0), {
+	{netdev('eth0'), {
 		{'x86'},
 		{'brcm2708'},
 		{'ar71xx', 'generic', {
@@ -99,7 +105,7 @@ local primary_addrs = {
 			'miwifi-mini', 'tplink,c2-v1', 'c20-v1', 'c20i', 'c50',
 		}},
 	}},
-	{eth(1), {
+	{netdev('eth0'), {
 		{'ar71xx', 'generic', {
 			'archer-c5',
 			'archer-c58-v1',
@@ -124,7 +130,7 @@ local primary_addrs = {
 			'dir-860l-b1',
 		}},
 	}},
-	{board('lan'), {
+	{interface('lan'), {
 		{'lantiq', 'xway', {
 			'netgear,dgn3500b',
 		}},
@@ -139,7 +145,7 @@ local primary_addrs = {
 		{}, -- matches everything
 	}},
 	-- eth0 fallback when phy0 does not exist
-	{eth(0), {
+	{netdev('eth0'), {
 		{}, -- matches everything
 	}},
 }

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -57,14 +57,13 @@ end
 
 -- Entries are matched in the order they are listed
 local primary_addrs = {
-	{netdev('eth0'), {
-		{'x86'},
-		{'brcm2708'},
+	{interface('lan'), {
 		{'ar71xx', 'generic', {
-			'a40',
-			'a60',
-			'archer-c25-v1',
-			'archer-c60-v2',
+			'archer-c5',
+			'archer-c58-v1',
+			'archer-c59-v1',
+			'archer-c60-v1',
+			'archer-c7',
 			'archer-c7-v4',
 			'archer-c7-v5',
 			'carambola2',
@@ -77,11 +76,9 @@ local primary_addrs = {
 			'mr1750v2',
 			'om2p',
 			'om2pv2',
-			'om2pv4',
 			'om2p-hs',
 			'om2p-hsv2',
 			'om2p-hsv3',
-			'om2p-hsv4',
 			'om2p-lc',
 			'om5p',
 			'om5p-an',
@@ -99,31 +96,44 @@ local primary_addrs = {
 			'glinet,gl-ar750s-nor',
 			'ocedo,raccoon',
 		}},
+		{'brcm2708'},
 		{'ipq40xx', 'generic', {
 			'avm,fritzbox-4040',
+		}},
+		{'ipq806x', 'generic', {
+			'netgear,r7800',
+		}},
+		{'lantiq', 'xway', {
+			'netgear,dgn3500b',
+		}},
+		{'ramips', 'mt7620', {
+			'c20-v1',
+			'c20i',
+			'c50',
+			'tplink,c2-v1',
+		}},
+		{'x86'},
+	}},
+	{interface('wan'), {
+		{'ar71xx', 'generic', {
+			'a40',
+			'a60',
+			'archer-c25-v1',
+			'archer-c60-v2',
+			'om2pv4',
+			'om2p-hsv4',
+		}},
+		{'ipq40xx', 'generic', {
+			'linksys,ea6350v3',
 			'openmesh,a42',
 			'openmesh,a62',
 		}},
 		{'mpc85xx', 'p1020', {
 			'aerohive,hiveap-330',
+			'ocedo,panda',
 		}},
 		{'ramips', 'mt7620', {
-			'miwifi-mini', 'tplink,c2-v1', 'c20-v1', 'c20i', 'c50',
-		}},
-	}},
-	{netdev('eth0'), {
-		{'ar71xx', 'generic', {
-			'archer-c5',
-			'archer-c58-v1',
-			'archer-c59-v1',
-			'archer-c60-v1',
-			'archer-c7',
-		}},
-		{'ipq806x', 'generic', {
-			'netgear,r7800',
-		}},
-		{'mpc85xx', 'p1020', {
-			'ocedo,panda',
+			'miwifi-mini',
 		}},
 	}},
 	{phy(1), {
@@ -134,16 +144,6 @@ local primary_addrs = {
 		}},
 		{'ramips', 'mt7621', {
 			'dir-860l-b1',
-		}},
-	}},
-	{interface('lan'), {
-		{'lantiq', 'xway', {
-			'netgear,dgn3500b',
-		}},
-	}},
-	{board('wan'), {
-		{'ipq40xx', 'generic', {
-			'linksys,ea6350v3',
 		}},
 	}},
 	-- phy0 default

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -26,6 +26,10 @@ local function get_netdev_addr(ifname)
 	return read('/sys/class/net/%s/address', ifname)
 end
 
+local function strip_vlan(ifname)
+	return (ifname:gsub('%..*', ''))
+end
+
 
 local function netdev(ifname)
 	return function()
@@ -44,6 +48,8 @@ local function interface(name)
 		local ifdata = network_data[name] or {}
 		if ifdata.macaddr then
 			return ifdata.macaddr
+		elseif ifdata.ifname then
+			return get_netdev_addr(strip_vlan(ifdata.ifname))
 		end
 	end
 end


### PR DESCRIPTION
In #2008, some confusion was caused by the fact that eth0/eth1 MAC addresses can be overridden by *board.json* after Gluon's upgrade scripts run, making `eth()` return the wrong address.

Clean this up by always looking up logical interface names through board.json, thus avoiding future confusion.