### PR TITLE
gluon-mesh-batman-adv: do not override WAN MAC address with VXLAN

### DIFF
--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/330-gluon-mesh-batman-adv-mac-addresses
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/330-gluon-mesh-batman-adv-mac-addresses
@@ -1,10 +1,15 @@
 #!/usr/bin/lua
 
+local site = require 'gluon.site'
 local util = require 'gluon.util'
 local uci = require('simple-uci').cursor()
 
 
 -- fix up potentially duplicate MAC addresses (for meshing)
-uci:set('network', 'wan', 'macaddr', util.generate_mac(0))
+if not site.mesh.vxlan(true) then
+	uci:set('network', 'wan', 'macaddr', util.generate_mac(0))
+else
+	uci:delete('network', 'wan', 'macaddr')
+end
 uci:set('network', 'mesh_lan', 'macaddr', util.generate_mac(4))
 uci:save('network')


### PR DESCRIPTION
As a partial fix to #496, do not touch the MAC address of the WAN interface when using VXLANs (as only the MAC address of the VXLAN interface matters to batman-adv).

A downside of this change is that it will modify the WAN MAC address of existing Gluon setups, but this seems much cleaner than the alternatives...