### PR TITLE
build: ignore deactivated feeds

### DIFF
--- a/scripts/default_feeds.sh
+++ b/scripts/default_feeds.sh
@@ -1,1 +1,2 @@
-DEFAULT_FEEDS="$(awk '{print $2}' openwrt/feeds.conf.default)"
+# list feeds which don't start with #
+DEFAULT_FEEDS="$(awk '!/^#/ {print $2}' openwrt/feeds.conf.default)"


### PR DESCRIPTION
The OpenWrt feeds.conf.defaults contains some feeds that are commented out and not active. 
But this feeds are returned by the default_feeds.sh script anyway. Limit the script to only return
active feeds, by filtering out lines starting with '#'.

