### PR TITLE
x86: enable /dev/mem

### DIFF
--- a/targets/x86.inc
+++ b/targets/x86.inc
@@ -1,5 +1,6 @@
 config 'CONFIG_VDI_IMAGES=y'
 config 'CONFIG_VMDK_IMAGES=y'
+config 'CONFIG_KERNEL_DEVMEM=y'
 
 packages {
 	'kmod-3c59x',


### PR DESCRIPTION
PC Engine APU Boards are quite popular and it would be nice if we could update the BIOS directly in Gluon. In general this is already possible via flashrom but for it to work `CONFIG_KERNEL_DEVMEM` has to be enabled.