### PR TITLE
gluon-core: add support for configuring the beacon interval

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -119,6 +119,10 @@ regdom \: optional
 wifi24 \: optional
     WLAN configuration for 2.4 GHz devices.
     ``channel`` must be set to a valid wireless channel for your radio.
+    ``beacon_interval`` can be specified to set a custom beacon interval in
+    time units (TU). A time unit is equivalent to 1024 microseconds.
+    If not set, the default value of 100 TU (=102.4 ms) is used.
+
 
     There are currently two interface types available. You may choose to
     configure any subset of them:

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -32,6 +32,7 @@ local supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000}
 for _, config in ipairs({'wifi24', 'wifi5'}) do
 	if need_table({config}, nil, false) then
 		need_string(in_site({'regdom'})) -- regdom is only required when wifi24 or wifi5 is configured
+		need_number({config, 'beacon_interval'}, false)
 
 		if config == "wifi24" then
 			local channels = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -191,6 +191,7 @@ wireless.foreach_radio(uci, function(radio, index, config)
 
 	local channel = get_channel(radio, config)
 	local htmode = get_htmode(radio)
+	local beacon_interval = config.beacon_interval()
 
 	uci:delete('wireless', radio_name, 'disabled')
 
@@ -225,6 +226,8 @@ wireless.foreach_radio(uci, function(radio, index, config)
 			configure_mesh_wireless(radio, index, config)
 		end
 	end
+
+	uci:set('wireless', radio_name, 'beacon_int', beacon_interval)
 
 	fixup_wan(radio, index)
 end)


### PR DESCRIPTION
This adds support for the beacon interval to be set on a per-band base.
This has the potential to reduce the amount of airtime used up for
sending beacon frames.