### PR TITLE
docs: enhance OWE documentation

### DIFF
--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -47,9 +47,21 @@
       -- ssid = 'alpha-centauri.freifunk.net', (optional - SSID for open client network)
       -- disabled = true, -- (optional)
 
-      -- Configuration for a non-backward compatible OWE network below.
-      -- owe_ssid = 'owe.alpha-centauri.freifunk.net', -- (optional - SSID for OWE client network)
-      -- owe_transition_mode = true, -- (optional - enables transition-mode - requires ssid as well as owe_ssid)
+      -- `owe_ssid` sets the SSID for OWE client network and
+      -- `owe_transition_mode` enables transition-mode, both settings are
+      -- optional, the transition-mode requires `ssid` as well as `owe_ssid` set.
+      -- Note: some devices cannot connect with transition mode enabled
+      -- There are two backward compatible configurations possible: 
+      
+      -- 1. a (mostly) backward compatible OWE network, where those clients
+      --    that are able automatically connect to the OWE SSID:
+      -- owe_ssid = 'owe.alpha-centauri.freifunk.net', 
+      -- owe_transition_mode = true,
+
+      -- 2. a securely backward compatible OWE network, where you have to
+      --    manually choose the SSID you want to connnect to:
+      -- owe_ssid = 'owe.alpha-centauri.freifunk.net',
+      -- owe_transition_mode = false, -- (default)
     },
 
     mesh = {

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -130,15 +130,18 @@ wifi24 \: optional
     This will only affect new installations.
     Upgrades will not change the disabled state.
 
-    ``ap`` holds the client network configuration.
-    To create an unencrypted client network, a string named ``ssid`` which sets the
-    interface's ESSID is required. This is the wireless network clients connect to.
-    For an OWE secured network, the ``owe_ssid`` string has to be set. It sets the
-    SSID for the opportunistically encrypted wireless network, to which compatible
-    clients can connect to.
-    To utilize the OWE transition mode, ``owe_transition_mode`` has to be set to true.
-    Note that for the transition mode to work, both ``ssid`` as well as ``owe_ssid``
-    have to be enabled.
+    ``ap`` holds the client network configuration. To create an unencrypted
+    client network, a string named ``ssid`` which sets the interface's ESSID is
+    required. This is the wireless network clients connect to. For an OWE
+    secured network, the ``owe_ssid`` string has to be set which sets the SSID
+    for the opportunistically encrypted wireless network (to which compatible
+    clients can connect to) and the ``wireless-encryption-wpa3`` feature has to
+    be added to ``GLUON_FEATURES_standard`` in ``site.mk`` (which will enable it
+    only for non-tiny devices). To utilize the OWE transition mode,
+    ``owe_transition_mode`` has to be set to true. Note that for the transition
+    mode to work, both ``ssid`` as well as ``owe_ssid`` have to be enabled. Also
+    note that some devices get problems connecting, when transition mode is
+    enabled.
 
     ``mesh`` requires a single parameter, a string, named ``id`` which sets the
     mesh id, also visible as an open WiFi in some network managers. Usually you


### PR DESCRIPTION
This adds a better hint how to configure an OWE network in the example site.conf and adds a hint to the `wireless-encryption-wpa3` package in the documentation