### PR TITLE
jenkins-community-slave: fix slave.py HTTPS warnings

### DIFF
--- a/contrib/ci/jenkins-community-slave/slave.py
+++ b/contrib/ci/jenkins-community-slave/slave.py
@@ -2,7 +2,6 @@ from jenkins import Jenkins, JenkinsError, NodeLaunchMethod
 import os
 import signal
 import sys
-import urllib.request
 import subprocess
 import shutil
 import requests
@@ -34,8 +33,9 @@ def slave_download(target):
     if os.path.isfile(slave_jar):
         os.remove(slave_jar)
 
-    loader = urllib.request.URLopener()
-    loader.retrieve(os.environ['JENKINS_URL'] + '/jnlpJars/slave.jar', '/var/lib/jenkins/slave.jar')
+    r = requests.get(os.environ['JENKINS_URL'] + '/jnlpJars/slave.jar')
+    with open('/var/lib/jenkins/slave.jar', 'wb') as f:
+        f.write(r.content)
 
 def slave_run(slave_jar, jnlp_url):
     params = [ 'java', '-jar', slave_jar, '-jnlpUrl', jnlp_url ]

--- a/contrib/ci/jenkins-community-slave/slave.py
+++ b/contrib/ci/jenkins-community-slave/slave.py
@@ -70,7 +70,7 @@ if os.environ.get('SLAVE_SECRET') is None:
 
 def master_ready(url):
     try:
-        r = requests.head(url, verify=False, timeout=None)
+        r = requests.head(url, timeout=None)
         return r.status_code == requests.codes.ok
     except:
         return False


### PR DESCRIPTION
I don't have access to a slave setup, so I could test this only superficially.

Fixes: #1997