### PR TITLE
gluon-wireless-encryption-wpa3: switch to hostapd-wolfssl

### DIFF
--- a/package/gluon-wireless-encryption/Makefile
+++ b/package/gluon-wireless-encryption/Makefile
@@ -6,7 +6,7 @@ PKG_RELEASE:=1
 include ../gluon.mk
 
 define Package/gluon-wireless-encryption-wpa3
-  DEPENDS:=+hostapd-openssl
+  DEPENDS:=+hostapd-wolfssl
   TITLE:=Package for supporting WPA3 encrypted wireless networks
 endef
 


### PR DESCRIPTION
This switches hostapd variant used for SAE and OWE from hostapd-openssl
to hostapd-wolfssl.

The bug shich one broke the wolfssl implementation was resolved upstream
with commit 631c437a91c2 ("hostapd: backport wolfssl bignum fixes").
This particular commit also got backported to OpenWrt 19.07.

The Image size is reduced by around 600KB.