### PR TITLE
Fix tunnel interface detection in respondd nodeinfo

### DIFF
--- a/package/libgluonutil/src/libgluonutil.h
+++ b/package/libgluonutil/src/libgluonutil.h
@@ -27,6 +27,7 @@
 #ifndef _LIBGLUON_LIBGLUON_H_
 #define _LIBGLUON_LIBGLUON_H_
 
+#include <net/if.h>
 #include <netinet/in.h>
 #include <stdbool.h>
 
@@ -34,7 +35,18 @@
 char * gluonutil_read_line(const char *filename);
 char * gluonutil_get_sysconfig(const char *key);
 char * gluonutil_get_node_id(void);
+
+enum gluonutil_interface_type {
+	GLUONUTIL_INTERFACE_TYPE_UNKNOWN,
+	GLUONUTIL_INTERFACE_TYPE_WIRED,
+	GLUONUTIL_INTERFACE_TYPE_WIRELESS,
+	GLUONUTIL_INTERFACE_TYPE_TUNNEL,
+};
+
+void gluonutil_get_interface_lower(char out[IF_NAMESIZE], const char *ifname);
 char * gluonutil_get_interface_address(const char *ifname);
+enum gluonutil_interface_type gluonutil_get_interface_type(const char *ifname);
+
 bool gluonutil_get_node_prefix6(struct in6_addr *prefix);
 
 struct json_object * gluonutil_wrap_string(const char *str);


### PR DESCRIPTION
As noted in #1783, Wireguard and L2TP interfaces are not correctly detected as tunnels in our current respondd nodeinfo providers. To fix this, use the DEVTYPE value of the interface `uevent` as an additional data source. I did not check my code in an actual tunneldigger or wireguard setup (as I don't have access to one), but I checked the DEVTYPE of l2tpeth interfaces created using `ip l2tp`, and looked at the wireguard kernel code.

To avoid code duplication between the batadv and babel providers, this function is implemented in libgluonutil. A helper to get the base interface of VLAN/VXLAN/... interfaces  is added as well.

The first patch of this series is some cleanup of the link-local address function in the mesh-babel code. The mesh-babel changes are compile-tested only - a test in an actual Babel setup would be highly appreciated (but I guess I can try to build something myself if necessary).