### PR TITLE
actions: build documentation

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,20 @@
+name: Build Documentation
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  build-documentation:
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Install Dependencies
+        run: sudo pip3 install sphinx-rtd-theme
+      - name: Build documentation
+        run: make -C docs html
+      - name: Archive build output
+        uses: actions/upload-artifact@v1
+        with:
+          name: docs_output
+          path: docs/_build/html


### PR DESCRIPTION
This adds a new workflow for building the Gluon documentation.

In contrast to the existing build workflow, the documentation
is built for every branch, as it only takes around two minutes
to render the HTML documentation.