### PR TITLE
Fix /etc/config/network commit for outdoor mode change, and related fixes

### DIFF
--- a/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
+++ b/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
@@ -25,5 +25,5 @@ return function(form, uci)
 		end
 	end
 
-	return {'gluon', 'wireless'}
+	return {'gluon', 'network', 'wireless'}
 end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -162,12 +162,13 @@ local function fixup_wan(radio, index)
 	uci:set('wireless', name, 'macaddr', macaddr)
 end
 
-local function configure_mesh_wireless(radio, index, config)
+local function configure_mesh_wireless(radio, index, config, disabled)
 	local radio_name = radio['.name']
 	local suffix = radio_name:match('^radio(%d+)$')
 
 	configure_mesh(config.mesh(), radio, index, suffix,
 		first_non_nil(
+			disabled,
 			is_disabled('mesh_' .. radio_name),
 			config.mesh.disabled(false)
 		)
@@ -215,7 +216,7 @@ wireless.foreach_radio(uci, function(radio, index, config)
 			util.add_to_set(hostapd_options, 'country3=0x4f')
 			uci:set_list('wireless', radio_name, 'hostapd_options', hostapd_options)
 
-			uci:delete('wireless', 'mesh_' .. radio_name)
+			configure_mesh_wireless(radio, index, config, true)
 		else
 			uci:delete('wireless', radio_name, 'channels')
 

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -71,14 +71,13 @@ uci:foreach('wireless', 'wifi-device', function(config)
 		return out
 	end
 
-	local function filter_active_interfaces(interfaces)
-		local out = false
+	local function has_active_interfaces(interfaces)
 		for _, interface in ipairs(interfaces) do
 			if not uci:get_bool('wireless', interface .. '_' .. radio, 'disabled') then
-				out = true
+				return true
 			end
 		end
-		return out
+		return false
 	end
 
 	local function vif_option(name, interfaces, msg)
@@ -89,7 +88,7 @@ uci:foreach('wireless', 'wifi-device', function(config)
 		end
 
 		local o = p:option(Flag, radio .. '_' .. name .. '_enabled', msg)
-		o.default = filter_active_interfaces(existing_interfaces)
+		o.default = has_active_interfaces(existing_interfaces)
 
 		function o:write(data)
 			for _, interface in ipairs(existing_interfaces) do

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -181,6 +181,7 @@ end
 function f:write()
 	uci:commit('gluon')
 	os.execute('/lib/gluon/upgrade/200-wireless')
+	uci:commit('network')
 	uci:commit('wireless')
 end
 

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -47,13 +47,18 @@ f:section(Section, nil, translate(
 ))
 
 
+local mesh_vifs_5ghz = {}
+
+
 uci:foreach('wireless', 'wifi-device', function(config)
 	local radio = config['.name']
 
+	local is_5ghz = false
 	local title
 	if config.hwmode == '11g' or config.hwmode == '11ng' then
 		title = translate("2.4GHz WLAN")
 	elseif config.hwmode == '11a' or config.hwmode == '11na' then
+		is_5ghz = true
 		title = translate("5GHz WLAN")
 	else
 		return
@@ -95,10 +100,16 @@ uci:foreach('wireless', 'wifi-device', function(config)
 				uci:set('wireless', interface .. '_' .. radio, 'disabled', not data)
 			end
 		end
+
+		return o
 	end
 
 	vif_option('client', {'client', 'owe'}, translate('Enable client network (access point)'))
-	vif_option('mesh', {'mesh'}, translate("Enable mesh network (802.11s)"))
+
+	local mesh_vif = vif_option('mesh', {'mesh'}, translate("Enable mesh network (802.11s)"))
+	if is_5ghz then
+		table.insert(mesh_vifs_5ghz, mesh_vif)
+	end
 
 	local phy = wireless.find_phy(config)
 	if not phy then
@@ -141,6 +152,10 @@ if has_5ghz_radio() then
 
 	local outdoor = r:option(Flag, 'outdoor', translate("Node will be installed outdoors"))
 	outdoor.default = uci:get_bool('gluon', 'wireless', 'outdoor')
+
+	for _, mesh_vif in ipairs(mesh_vifs_5ghz) do
+		mesh_vif:depends(outdoor, false)
+	end
 
 	function outdoor:write(data)
 		uci:set('gluon', 'wireless', 'outdoor', data)


### PR DESCRIPTION
When looking into #2048 (fixed by the first commit of this PR), I noticed another issue in the outdoor mode setting: The advanced WLAN config page required an additional reload to update the mesh iface option visibility after changing the outdoor mode setting. This is fixed by the subsequent commits.

Fixes:  #2048