### PR TITLE
lantiq-xrx200: add support for AVM Fritz!Box 3370

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -270,6 +270,7 @@ lantiq-xrx200
 
 * AVM
 
+  - FRITZ!Box 3370 (Hynix Nand, Micron Nand) [#lan_as_wan]_
   - FRITZ!Box 7360 (v1, v2) [#avmflash]_ [#lan_as_wan]_
   - FRITZ!Box 7360 SL [#avmflash]_ [#lan_as_wan]_
   - FRITZ!Box 7362 SL [#eva_ramboot]_ [#lan_as_wan]_

--- a/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
+++ b/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
@@ -25,5 +25,5 @@ return function(form, uci)
 		end
 	end
 
-	return {'gluon', 'wireless'}
+	return {'gluon', 'network', 'wireless'}
 end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -162,12 +162,13 @@ local function fixup_wan(radio, index)
 	uci:set('wireless', name, 'macaddr', macaddr)
 end
 
-local function configure_mesh_wireless(radio, index, config)
+local function configure_mesh_wireless(radio, index, config, disabled)
 	local radio_name = radio['.name']
 	local suffix = radio_name:match('^radio(%d+)$')
 
 	configure_mesh(config.mesh(), radio, index, suffix,
 		first_non_nil(
+			disabled,
 			is_disabled('mesh_' .. radio_name),
 			config.mesh.disabled(false)
 		)
@@ -215,7 +216,7 @@ wireless.foreach_radio(uci, function(radio, index, config)
 			util.add_to_set(hostapd_options, 'country3=0x4f')
 			uci:set_list('wireless', radio_name, 'hostapd_options', hostapd_options)
 
-			uci:delete('wireless', 'mesh_' .. radio_name)
+			configure_mesh_wireless(radio, index, config, true)
 		else
 			uci:delete('wireless', radio_name, 'channels')
 

--- a/package/gluon-setup-mode/files/etc/hotplug.d/button/50-gluon-setup-mode
+++ b/package/gluon-setup-mode/files/etc/hotplug.d/button/50-gluon-setup-mode
@@ -12,7 +12,8 @@ wait_setup_mode() {
 }
 
 
-if [ "$BUTTON" = wps ] || [ "$BUTTON" = reset ] || [ "$BUTTON" = phone ]; then
+if [ "$BUTTON" = wps ] || [ "$BUTTON" = reset ] ||
+	[ "$BUTTON" = phone ] || [ "$BUTTON" = power ]; then
 	case "$ACTION" in
 		pressed)
 			wait_setup_mode &

--- a/patches/openwrt/0010-lantiq-xrx200-show_LAN_activity_on_AVM_3370.patch
+++ b/patches/openwrt/0010-lantiq-xrx200-show_LAN_activity_on_AVM_3370.patch
@@ -1,0 +1,24 @@
+From: D. Gathmann <dzsoftware@posteo.org>
+Date: Sat, 06 Jun 2020 14:37:07 +0200
+Subject: lantiq: show LAN activity on AVM Fritzbox 3370
+
+This patch changes system.led_lan.trigger to 'netdev' for Fritzbox 3370.
+This will configure the LED to show both status and activity on the LAN ports,
+as demanded by gluon's Device Integration Checklist.
+
+Signed-off-by: D. Gathmann <dzsoftware@posteo.org>
+
+diff --git a/target/linux/lantiq/base-files/etc/board.d/01_leds b/target/linux/lantiq/base-files/etc/board.d/01_leds
+index e89de97fbe..3d7d1dc6db 100755
+--- a/target/linux/lantiq/base-files/etc/board.d/01_leds
++++ b/target/linux/lantiq/base-files/etc/board.d/01_leds
+@@ -55,7 +55,7 @@ netgear,dm200)
+ 	;;
+ avm,fritz3370-rev2-hynix|\
+ avm,fritz3370-rev2-micron)
+-	ucidef_set_led_switch "lan" "LAN" "fritz3370:green:lan" "switch0" "0x17"
++	ucidef_set_led_netdev "lan" "LAN" "fritz3370:green:lan" "eth0"
+ 	;;
+ zyxel,p-2812hnu-f1|\
+ zyxel,p-2812hnu-f3)
+

--- a/scripts/target_config_check.lua
+++ b/scripts/target_config_check.lua
@@ -9,18 +9,26 @@ local function fail(msg)
 	io.stderr:write(' * ', msg, '\n')
 end
 
-local function match_config(f)
-	for line in io.lines('openwrt/.config') do
-		if f(line) then
-			return true
-		end
+local function match_config(expected, actual)
+	if expected == actual then
+		return true
+	end
+
+	if expected:gsub('=m$', '=y') == actual then
+		return true
 	end
 
 	return false
 end
 
 local function check_config(config)
-	return match_config(function(line) return line == config end)
+	for line in io.lines('openwrt/.config') do
+		if match_config(config, line) then
+			return true
+		end
+	end
+
+	return false
 end
 
 

--- a/scripts/target_config_lib.lua
+++ b/scripts/target_config_lib.lua
@@ -139,6 +139,7 @@ lib.check_devices()
 if not lib.opkg then
 	lib.config('SIGNED_PACKAGES', false)
 	lib.config('CLEAN_IPKG', true)
+	lib.config('ALL_NONSHARED', false)
 	lib.packages {'-opkg'}
 end
 

--- a/targets/generic
+++ b/targets/generic
@@ -40,7 +40,7 @@ config('PACKAGE_kmod-jool', false) -- fails to build
 config('BUSYBOX_CUSTOM', true)
 config('BUSYBOX_CONFIG_FEATURE_PREFER_IPV4_ADDRESS', false)
 
-config('PACKAGE_ATH_DEBUG', true)
+try_config('PACKAGE_ATH_DEBUG', true)
 
 try_config('TARGET_SQUASHFS_BLOCK_SIZE', 256)
 

--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -1,3 +1,21 @@
+-- AVM
+
+device('avm-fritz-box-3370-rev-2-hynix-nand', 'avm_fritz3370-rev2-hynix', {
+        factory = false,
+        extra_images = {
+               {'-squashfs-eva-filesystem', '-eva-filesystem', '.bin'},
+               {'-squashfs-eva-kernel', '-eva-kernel', '.bin'},
+        },
+})
+
+device('avm-fritz-box-3370-rev-2-micron-nand', 'avm_fritz3370-rev2-micron', {
+        factory = false,
+        extra_images = {
+               {'-squashfs-eva-filesystem', '-eva-filesystem', '.bin'},
+               {'-squashfs-eva-kernel', '-eva-kernel', '.bin'},
+        },
+})
+
 device('avm-fritz-box-7360-sl', 'avm_fritz7360sl', {
 	factory = false,
 	aliases = {'avm-fritz-box-7360-v1', 'avm-fritz-box-7360-v2'},


### PR DESCRIPTION
Based on Dark4MD's patch (https://github.com/freifunk-gluon/gluon/commit/2360924e4a43754b5a3c24e5797d94c6a9451a7f).
Further changes, might need discussion: 
1. Long press (>3s) the power button to get to setup mode. There is the problem of incidentally powering off the device by releasing the button too soon. But this shouldn't cause real damage (except for the loss of time), because the operator was planning to shut down the device anyway.
And the opposite problem of incidentally putting the device into setup mode, when the intention was to switch it off.
2. Patch to show LAN activity on LED, but IMHO that's not an important feature.
3. Don't know the reason for the ordering of LAN ports, so didn't change anything there (https://github.com/dzzinstant/gluon/issues/4), probably not relevant for gluon?

The flashing process is a bit more involved than for other AVM devices, see hints in follow-up to this message.

### Device Integration Checklist
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: ftp [EVA bootloader, separate images for kernel and filesystem partitions] -> https://github.com/dzzinstant/gluon/issues/3
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
  _usually means: gluon profile name must match image name_
  ```
  :~# lua -e 'print(require("platform_info").get_image_name())'
  avm-fritz-box-3370-rev-2-hynix-nand
  ```
- [ ] reset/wps/phone button must return device into config mode [no such button => use 'power' button instead] -> https://github.com/dzzinstant/gluon/commit/7ba5577eac5146fc8df3b669cd3c10a96e0ad0a1
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN) [numbering of LAN ports is mixed up, does that matter?] -> https://github.com/dzzinstant/gluon/issues/4
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity [shows only state, maybe apply patch to also show activity] -> https://github.com/dzzinstant/gluon/commit/84fe9fc1a0d9642b84f7bda9077f4b8038a1dfc4
- outdoor devices only
  ( ) added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

**Additional / device-specific**
- [x] wan-radio/private wlan [can be enabled in parallel with client + mesh wlan]
- [ ] 'WLAN' button enables/disables radio -> https://github.com/openwrt/openwrt/pull/3042
- [ ] also works in the 5 Ghz band [3370 only has a single radio for both bands]
  - [x] association with AP must be possible
  - [x] association with 802.11s mesh must be working (only indoor mode)
  - [x] ap/mesh mode must work in parallel (only indoor mode)
  - [ ] outdoor mode with DFS [basically works, but some clients cause false radar detections]

Successfully tested on:
```
$ grep "^HW.*Revision\s\|^bootloader\|NAND device:" support\ FRITZ.Box\ WLAN\ 3370*.txt 
HWRevision	175
HWSubRevision	2
bootloaderVersion	1.1186
[    1.560000] NAND device: Manufacturer ID: 0x20, Chip ID: 0xdc (ST Micro NAND04GW3B2DN6), 512MiB, page size: 2048, OOB size: 64
```
(using the `..-hynix-nand-..` images; there was no automatic reboot after 30s)