### PR TITLE
build: target_config_lib: do not build unused packages for targets without opkg

### DIFF
--- a/scripts/target_config_lib.lua
+++ b/scripts/target_config_lib.lua
@@ -139,6 +139,7 @@ lib.check_devices()
 if not lib.opkg then
 	lib.config('SIGNED_PACKAGES', false)
 	lib.config('CLEAN_IPKG', true)
+	lib.config('ALL_NONSHARED', false)
 	lib.packages {'-opkg'}
 end
 

--- a/targets/generic
+++ b/targets/generic
@@ -40,7 +40,7 @@ config('PACKAGE_kmod-jool', false) -- fails to build
 config('BUSYBOX_CUSTOM', true)
 config('BUSYBOX_CONFIG_FEATURE_PREFER_IPV4_ADDRESS', false)
 
-config('PACKAGE_ATH_DEBUG', true)
+try_config('PACKAGE_ATH_DEBUG', true)
 
 try_config('TARGET_SQUASHFS_BLOCK_SIZE', 256)
 


### PR DESCRIPTION
Normally, we build all nonshared packages (which includes all kernel
modules) to generate an opkg feed for later package installations by
users. On targets without opkg, this just wastes time - disable it.

This also reduced the size of the base kernel by a lot, as interfaces only needed by optional modules can be removed as well - saving more than 64KB on ar71xx-tiny!

This is something I wanted for some time now, and with #2037 it's finally easily possible.
I propose we also backport this to v2020.2.x.