### PR TITLE
mac80211: rt2800: enable MFP support unconditionally

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -66,7 +66,7 @@ end
 
 function M.device_supports_wpa3()
 	-- rt2x00 crashes when enabling WPA3 personal / OWE VAP
-	if M.match('ramips', 'rt305x') or M.match('ramips', 'mt7620') then
+	if M.match('ramips', 'rt305x') then
 		return false
 	end
 

--- a/patches/openwrt/0012-mac80211-rt2800-enable-MFP-support-unconditionally.patch
+++ b/patches/openwrt/0012-mac80211-rt2800-enable-MFP-support-unconditionally.patch
@@ -1,0 +1,62 @@
+From: Rui Salvaterra <rsalvaterra@gmail.com>
+Date: Mon, 25 May 2020 14:49:07 +0100
+Subject: mac80211: rt2800: enable MFP support unconditionally
+
+This gives us WPA3 support out of the box without having to manually disable
+hardware crypto. The driver will fall back to software crypto if the connection
+requires management frame protection.
+
+Signed-off-by: Daniel Golle <daniel@makrotopia.org>
+[apply to openwrt-1907]
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/package/kernel/mac80211/patches/rt2x00/080-rt2800-enable-MFP-support-unconditionally.patch b/package/kernel/mac80211/patches/rt2x00/080-rt2800-enable-MFP-support-unconditionally.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..1d55b2756c365a13b2315e874809e2397fb35855
+--- /dev/null
++++ b/package/kernel/mac80211/patches/rt2x00/080-rt2800-enable-MFP-support-unconditionally.patch
+@@ -0,0 +1,44 @@
++From b6b15e20421fefae9f78274f9fef80bc97bf5d5c Mon Sep 17 00:00:00 2001
++From: Rui Salvaterra <rsalvaterra@gmail.com>
++Date: Mon, 25 May 2020 14:49:07 +0100
++Subject: [PATCH] rt2800: enable MFP support unconditionally
++
++This gives us WPA3 support out of the box without having to manually disable
++hardware crypto. The driver will fall back to software crypto if the connection
++requires management frame protection.
++
++Suggested-by: Stanislaw Gruszka <stf_xl@wp.pl>
++Signed-off-by: Rui Salvaterra <rsalvaterra@gmail.com>
++Acked-by: Stanislaw Gruszka <stf_xl@wp.pl>
++Signed-off-by: Kalle Valo <kvalo@codeaurora.org>
++Link: https://lore.kernel.org/r/20200525134906.1672-1-rsalvaterra@gmail.com
++---
++ drivers/net/wireless/ralink/rt2x00/rt2800lib.c | 4 +---
++ drivers/net/wireless/ralink/rt2x00/rt2x00mac.c | 3 ++-
++ 2 files changed, 3 insertions(+), 4 deletions(-)
++
++--- a/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
+++++ b/drivers/net/wireless/ralink/rt2x00/rt2800lib.c
++@@ -9985,9 +9985,7 @@ static int rt2800_probe_hw_mode(struct r
++ 	if (!rt2x00_is_usb(rt2x00dev))
++ 		ieee80211_hw_set(rt2x00dev->hw, HOST_BROADCAST_PS_BUFFERING);
++ 
++-	/* Set MFP if HW crypto is disabled. */
++-	if (rt2800_hwcrypt_disabled(rt2x00dev))
++-		ieee80211_hw_set(rt2x00dev->hw, MFP_CAPABLE);
+++	ieee80211_hw_set(rt2x00dev->hw, MFP_CAPABLE);
++ 
++ 	SET_IEEE80211_DEV(rt2x00dev->hw, rt2x00dev->dev);
++ 	SET_IEEE80211_PERM_ADDR(rt2x00dev->hw,
++--- a/drivers/net/wireless/ralink/rt2x00/rt2x00mac.c
+++++ b/drivers/net/wireless/ralink/rt2x00/rt2x00mac.c
++@@ -459,7 +459,8 @@ int rt2x00mac_set_key(struct ieee80211_h
++ 	if (!test_bit(DEVICE_STATE_PRESENT, &rt2x00dev->flags))
++ 		return 0;
++ 
++-	if (!rt2x00_has_cap_hw_crypto(rt2x00dev))
+++	/* The hardware can't do MFP */
+++	if (!rt2x00_has_cap_hw_crypto(rt2x00dev) || (sta && sta->mfp))
++ 		return -EOPNOTSUPP;
++ 
++ 	/*


### PR DESCRIPTION
With this backported patch, rt2x00 will automatically fall back to software crypto in case MFP is used on the link.

Enable WPA3 features for the mt7620 target, as WPA3-SAE as well as OWE are working now.

This might also be possible for the rt305x subtarget, however I'm not in the possession of such a device. 