### PR TITLE
Enable 5GHz mesh interfaces when disabling outdoor mode, fix default status from site.conf

### DIFF
--- a/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
+++ b/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
@@ -21,6 +21,24 @@ return function(form, uci)
 		if data ~= outdoor_mode then
 			uci:set('gluon', 'wireless', 'outdoor', data)
 			uci:save('gluon')
+
+			if data == false then
+				local mesh_ifaces_5ghz = {}
+				uci:foreach('wireless', 'wifi-device', function(config)
+					if config.hwmode ~= '11a' and config.hwmode ~= '11na' then
+						return
+					end
+
+					local radio_name = config['.name']
+					local mesh_iface = 'mesh_' .. radio_name
+					table.insert(mesh_ifaces_5ghz, mesh_iface)
+				end)
+				for _, mesh_iface in ipairs(mesh_ifaces_5ghz) do
+					uci:delete('wireless', mesh_iface)
+				end
+				uci:save('wireless')
+			end
+
 			os.execute('/lib/gluon/upgrade/200-wireless')
 		end
 	end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -85,7 +85,7 @@ local function is_disabled(name)
 	if uci:get('wireless', name) then
 		return uci:get_bool('wireless', name, 'disabled')
 	else
-		return false
+		return nil
 	end
 end
 

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -1,5 +1,6 @@
 local iwinfo = require 'iwinfo'
 local uci = require("simple-uci").cursor()
+local site = require 'gluon.site'
 local wireless = require 'gluon.wireless'
 
 
@@ -155,6 +156,9 @@ if has_5ghz_radio() then
 
 	for _, mesh_vif in ipairs(mesh_vifs_5ghz) do
 		mesh_vif:depends(outdoor, false)
+		if outdoor.default then
+			mesh_vif.default = not site.wifi5.mesh.disabled(false)
+		end
 	end
 
 	function outdoor:write(data)


### PR DESCRIPTION
In both places where the outdoor mode can be disabled, we would leave the mesh interfaces disabled by default after #2049. This is a problem for the wizard in particular, as there is no way to enable the mesh interfaces at all without switching to the advanced settings.

While fixing this, I also noticed that we were ignoring the `disabled` site.conf flag for mesh interfaces since Gluon v2017.1... This is fixed as well.

Fixes: #2053

Completely untested so far, @rotanid please test! I'll give it a few test runs tomorrow.