### PR TITLE
gluon-mesh-batman-adv: do not delete bat0 during hardif teardown

### DIFF
--- a/package/gluon-mesh-batman-adv/files/lib/gluon/core/mesh/teardown.d/70-gluon-mesh-batman-adv
+++ b/package/gluon-mesh-batman-adv/files/lib/gluon/core/mesh/teardown.d/70-gluon-mesh-batman-adv
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 lock /var/lock/gluon_bat0.lock
-batctl interface del "$IFNAME" 2>/dev/null
+batctl interface -M del "$IFNAME" 2>/dev/null
 lock -u /var/lock/gluon_bat0.lock


### PR DESCRIPTION
With very bad timing, it is possible that the teardown script of a
gluon_mesh interface runs when bat0 was just created, but primary0 is not
yet added to it. Although there is no hardif to remove in this case,
bat0 will still be deleted, because there is no hardif in bat0.

Disable the interface removal logic by passing `-M` to `batctl interface`.

This was reported by @rotanid and @mbaumga