### PR TITLE
Replace GLUON_BRANCH with GLUON_AUTOUPDATER_BRANCH and GLUON_AUTOUPDATER_ENABLED

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,14 @@ GLUON_RELEASE ?= $(error GLUON_RELEASE not set. GLUON_RELEASE can be set in site
 
 GLUON_DEPRECATED ?= $(error GLUON_DEPRECATED not set. Please consult the documentation)
 
+ifneq ($(GLUON_BRANCH),)
+  $(warning *** Warning: GLUON_BRANCH has been deprecated, please set GLUON_AUTOUPDATER_BRANCH and GLUON_AUTOUPDATER_ENABLED instead.)
+  GLUON_AUTOUPDATER_BRANCH ?= $(GLUON_BRANCH)
+  GLUON_AUTOUPDATER_ENABLED ?= 1
+endif
+
+GLUON_AUTOUPDATER_ENABLED ?= 0
+
 # initialize (possibly already user set) directory variables
 GLUON_TMPDIR ?= tmp
 GLUON_OUTPUTDIR ?= output
@@ -58,7 +66,7 @@ endef
 GLUON_VARS = \
 	GLUON_RELEASE GLUON_REGION GLUON_MULTIDOMAIN GLUON_AUTOREMOVE GLUON_DEBUG GLUON_MINIFY GLUON_DEPRECATED \
 	GLUON_DEVICES GLUON_TARGETSDIR GLUON_PATCHESDIR GLUON_TMPDIR GLUON_IMAGEDIR GLUON_PACKAGEDIR GLUON_DEBUGDIR \
-	GLUON_SITEDIR GLUON_RELEASE GLUON_BRANCH GLUON_LANGS GLUON_BASE_FEEDS \
+	GLUON_SITEDIR GLUON_RELEASE GLUON_AUTOUPDATER_BRANCH GLUON_AUTOUPDATER_ENABLED GLUON_LANGS GLUON_BASE_FEEDS \
 	GLUON_TARGET BOARD SUBTARGET
 
 unexport $(GLUON_VARS)
@@ -185,23 +193,23 @@ dirclean: FORCE
 
 manifest: $(LUA) FORCE
 	@
-	[ '$(GLUON_BRANCH)' ] || (echo 'Please set GLUON_BRANCH to create a manifest.'; false)
+	[ '$(GLUON_AUTOUPDATER_BRANCH)' ] || (echo 'Please set GLUON_AUTOUPDATER_BRANCH to create a manifest.'; false)
 	echo '$(GLUON_PRIORITY)' | grep -qE '^([0-9]*\.)?[0-9]+$$' || (echo 'Please specify a numeric value for GLUON_PRIORITY to create a manifest.'; false)
 	$(CheckExternal)
 
 	(
 		export $(GLUON_ENV)
-		echo 'BRANCH=$(GLUON_BRANCH)'
+		echo 'BRANCH=$(GLUON_AUTOUPDATER_BRANCH)'
 		echo "DATE=$$($(LUA) scripts/rfc3339date.lua)"
 		echo 'PRIORITY=$(GLUON_PRIORITY)'
 		echo
 		for target in $(GLUON_TARGETS); do
 			$(LUA) scripts/generate_manifest.lua "$$target"
 		done
-	) > 'tmp/$(GLUON_BRANCH).manifest.tmp'
+	) > 'tmp/$(GLUON_AUTOUPDATER_BRANCH).manifest.tmp'
 
 	mkdir -p '$(GLUON_IMAGEDIR)/sysupgrade'
-	mv 'tmp/$(GLUON_BRANCH).manifest.tmp' '$(GLUON_IMAGEDIR)/sysupgrade/$(GLUON_BRANCH).manifest'
+	mv 'tmp/$(GLUON_AUTOUPDATER_BRANCH).manifest.tmp' '$(GLUON_IMAGEDIR)/sysupgrade/$(GLUON_AUTOUPDATER_BRANCH).manifest'
 
 FORCE: ;
 

--- a/docs/features/autoupdater.rst
+++ b/docs/features/autoupdater.rst
@@ -7,8 +7,11 @@ Building Images
 ---------------
 
 By default, the autoupdater is disabled (as it is usually not helpful to have unexpected updates
-during development), but it can be enabled by setting the variable GLUON_BRANCH when building
-to override the default branch set in the site configuration.
+during development), but it can be enabled by setting the variable ``GLUON_AUTOUPDATER_ENABLED`` to ``1`` when building.
+It is also possible to override the default branch during build using the variable ``GLUON_AUTOUPDATER_BRANCH``.
+
+If a default branch is set neither in *site.conf* nor via ``GLUON_AUTOUPDATER_BRANCH``, the default branch is
+implementation-defined. Currently, the branch with the first name in alphabetical order is chosen.
 
 A manifest file for the updater can be generated with `make manifest`. A signing script (using
 ``ecdsautils``) can be found in the `contrib` directory. When creating the manifest, the
@@ -32,15 +35,16 @@ Automated nightly builds
 
 A fully automated nightly build could use the following commands:
 
-::
+.. code-block:: sh
 
     git pull
-    (git -C site pull)
+    # git -C site pull
     make update
     make clean GLUON_TARGET=ar71xx-generic
     NUM_CORES_PLUS_ONE=$(expr $(nproc) + 1)
-    make -j$NUM_CORES_PLUS_ONE GLUON_TARGET=ar71xx-generic GLUON_BRANCH=experimental GLUON_RELEASE=$GLUON_RELEASE
-    make manifest GLUON_BRANCH=experimental GLUON_RELEASE=$GLUON_RELEASE
+    make -j$NUM_CORES_PLUS_ONE GLUON_TARGET=ar71xx-generic GLUON_RELEASE=$GLUON_RELEASE \
+        GLUON_AUTOUPDATER_BRANCH=experimental GLUON_AUTOUPDATER_ENABLED=1
+    make manifest GLUON_RELEASE=$GLUON_RELEASE GLUON_AUTOUPDATER_BRANCH=experimental
     contrib/sign.sh $SECRETKEY output/images/sysupgrade/experimental.manifest
 
     rm -rf /where/to/put/this/experimental

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -164,7 +164,8 @@
   },
 
   autoupdater = {
-    -- Default branch. Don't forget to set GLUON_BRANCH when building!
+    -- Default branch (optional), can be overridden by setting GLUON_AUTOUPDATER_BRANCH when building.
+    -- Set GLUON_AUTOUPDATER_ENABLED to enable the autoupdater by default for newly installed nodes.
     branch = 'stable',
 
     -- List of branches. You may define multiple branches.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -171,10 +171,12 @@ usually be set on the command line or in ``site.mk``.
 Common variables
 ................
 
-GLUON_BRANCH
-  Sets the default branch of the autoupdater. If unset, the autoupdater is disabled
-  by default. For the ``make manifest`` command, GLUON_BRANCH defines the branch to
-  generate a manifest for.
+GLUON_AUTOUPDATER_BRANCH
+  Overrides the default branch of the autoupdater set in ``site.conf``. For the ``make manifest`` command,
+  ``GLUON_AUTOUPDATER_BRANCH`` defines the branch to generate a manifest for.
+
+GLUON_AUTOUPDATER_ENABLED
+  Set to ``1`` to enable the autoupdater by default for newly installed nodes.
 
 GLUON_DEPRECATED
   Controls whether images for deprecated devices should be built. The following
@@ -225,7 +227,7 @@ GLUON_DEBUG
   similar tools. Requires a device or target with at least 16 MB of flash space, e.g. `x86-64`. Unset by default.
 
 GLUON_MINIFY
-  Setting ``GLUON_MINIFY=0`` will omit the minification of scripts during the build process. By 
+  Setting ``GLUON_MINIFY=0`` will omit the minification of scripts during the build process. By
   default the flag is set to ``1``. Disabling the flag is handy if human readable scripts on the
   devices are desired for development purposes. Be aware that this will increase the size of the
   resulting images and is therefore not suitable for devices with small flash chips.

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -418,12 +418,16 @@ poe_passthrough \: optional
 autoupdater \: package
     Configuration for the autoupdater feature of Gluon.
 
+    Specifying a default branch in *site.conf* is optional. See
+    :doc:`../features/autoupdater` for information how to change the behaviour
+    of the autoupdater during image build.
+
     The mirrors are checked in random order until the manifest could be downloaded
     successfully or all mirrors have been tried.
     ::
 
       autoupdater = {
-        branch = 'stable',
+        branch = 'stable', -- optional
         branches = {
           stable = {
             name = 'stable',

--- a/package/gluon-autoupdater/Config.in
+++ b/package/gluon-autoupdater/Config.in
@@ -1,0 +1,10 @@
+if PACKAGE_gluon-autoupdater
+
+config GLUON_AUTOUPDATER_BRANCH
+	string "Autoupdater branch"
+	default ""
+
+config GLUON_AUTOUPDATER_ENABLED
+	bool "Enable autoupdater by default"
+
+endif

--- a/package/gluon-autoupdater/Makefile
+++ b/package/gluon-autoupdater/Makefile
@@ -3,7 +3,7 @@ include $(TOPDIR)/rules.mk
 PKG_NAME:=gluon-autoupdater
 PKG_VERSION:=4
 
-PKG_CONFIG_DEPENDS := CONFIG_GLUON_BRANCH
+PKG_CONFIG_DEPENDS := CONFIG_GLUON_AUTOUPDATER_BRANCH CONFIG_GLUON_AUTOUPDATER_ENABLED
 
 include ../gluon.mk
 
@@ -13,19 +13,19 @@ define Package/gluon-autoupdater
 endef
 
 define Package/gluon-autoupdater/config
-config GLUON_BRANCH
-	string "Gluon autoupdater branch"
-	depends on PACKAGE_gluon-autoupdater
-	default ""
+	source "$(SOURCE)/Config.in"
 endef
 
 define Package/gluon-autoupdater/install
 	$(Gluon/Build/Install)
 
-ifneq ($(CONFIG_GLUON_BRANCH),"")
 	$(INSTALL_DIR) $(1)/lib/gluon/autoupdater
-	echo '$(call qstrip,$(CONFIG_GLUON_BRANCH))' > $(1)/lib/gluon/autoupdater/default_branch
-endif
+  ifneq ($(CONFIG_GLUON_AUTOUPDATER_BRANCH),"")
+	echo '$(call qstrip,$(CONFIG_GLUON_AUTOUPDATER_BRANCH))' > $(1)/lib/gluon/autoupdater/default_branch
+  endif
+  ifneq ($(CONFIG_GLUON_AUTOUPDATER_ENABLED),)
+	touch $(1)/lib/gluon/autoupdater/default_enabled
+  endif
 endef
 
 $(eval $(call BuildPackageGluon,gluon-autoupdater))

--- a/package/gluon-autoupdater/check_site.lua
+++ b/package/gluon-autoupdater/check_site.lua
@@ -1,4 +1,4 @@
-need_string(in_site({'autoupdater', 'branch'}))
+need_string(in_site({'autoupdater', 'branch'}), false)
 
 need_table({'autoupdater', 'branches'}, function(branch)
 	need_alphanumeric_key(branch)

--- a/package/gluon-autoupdater/luasrc/lib/gluon/upgrade/500-autoupdater
+++ b/package/gluon-autoupdater/luasrc/lib/gluon/upgrade/500-autoupdater
@@ -5,6 +5,8 @@ local uci = require('simple-uci').cursor()
 local unistd = require 'posix.unistd'
 
 
+local min_branch
+
 for name, config in pairs(site.autoupdater.branches()) do
 	uci:delete('autoupdater', name)
 	uci:section('autoupdater', 'branch', name, {
@@ -13,16 +15,24 @@ for name, config in pairs(site.autoupdater.branches()) do
 		good_signatures = config.good_signatures,
 		pubkey = config.pubkeys,
 	})
+
+	if not min_branch or (name < min_branch) then
+		min_branch = name
+	end
 end
 
 if not uci:get('autoupdater', 'settings') then
 	local enabled = unistd.access('/lib/gluon/autoupdater/default_enabled') ~= nil
 
-	local branch = site.autoupdater.branch()
+	local branch = site.autoupdater.branch(min_branch)
 	local f = io.open('/lib/gluon/autoupdater/default_branch')
 	if f then
 		branch = f:read('*line')
 		f:close()
+	end
+
+	if not branch then
+		enabled = false
 	end
 
 	uci:section('autoupdater', 'autoupdater', 'settings', {

--- a/package/gluon-autoupdater/luasrc/lib/gluon/upgrade/500-autoupdater
+++ b/package/gluon-autoupdater/luasrc/lib/gluon/upgrade/500-autoupdater
@@ -2,6 +2,7 @@
 
 local site = require 'gluon.site'
 local uci = require('simple-uci').cursor()
+local unistd = require 'posix.unistd'
 
 
 for name, config in pairs(site.autoupdater.branches()) do
@@ -15,12 +16,11 @@ for name, config in pairs(site.autoupdater.branches()) do
 end
 
 if not uci:get('autoupdater', 'settings') then
-	local enabled = false
-	local branch = site.autoupdater.branch()
+	local enabled = unistd.access('/lib/gluon/autoupdater/default_enabled') ~= nil
 
+	local branch = site.autoupdater.branch()
 	local f = io.open('/lib/gluon/autoupdater/default_branch')
 	if f then
-		enabled = true
 		branch = f:read('*line')
 		f:close()
 	end

--- a/targets/generic
+++ b/targets/generic
@@ -3,7 +3,9 @@ assert(env.GLUON_LANGS)
 
 config('GLUON_SITEDIR', env.GLUON_SITEDIR)
 config('GLUON_RELEASE', env.GLUON_RELEASE)
-try_config('GLUON_BRANCH', env.GLUON_BRANCH or '')
+
+try_config('GLUON_AUTOUPDATER_BRANCH', env.GLUON_BRANCH)
+try_config('GLUON_AUTOUPDATER_ENABLED', env.GLUON_BRANCH ~= '')
 
 for lang in string.gmatch(env.GLUON_LANGS, '%S+') do
 	try_config('GLUON_WEB_LANG_' .. lang, true)

--- a/targets/generic
+++ b/targets/generic
@@ -4,8 +4,8 @@ assert(env.GLUON_LANGS)
 config('GLUON_SITEDIR', env.GLUON_SITEDIR)
 config('GLUON_RELEASE', env.GLUON_RELEASE)
 
-try_config('GLUON_AUTOUPDATER_BRANCH', env.GLUON_BRANCH)
-try_config('GLUON_AUTOUPDATER_ENABLED', env.GLUON_BRANCH ~= '')
+try_config('GLUON_AUTOUPDATER_BRANCH', env.GLUON_AUTOUPDATER_BRANCH)
+try_config('GLUON_AUTOUPDATER_ENABLED', istrue(env.GLUON_AUTOUPDATER_ENABLED))
 
 for lang in string.gmatch(env.GLUON_LANGS, '%S+') do
 	try_config('GLUON_WEB_LANG_' .. lang, true)


### PR DESCRIPTION
The old setting is still supported, but will emit a deprecation warning.

Also, make the branch setting in `site.conf` optional.

Closes: #1236