### PR TITLE
gluon-web: don't display outdoor mode on preserve_channels

### DIFF
--- a/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
+++ b/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
@@ -1,8 +1,14 @@
 return function(form, uci)
 	local platform = require 'gluon.platform'
+	local wireless = require 'gluon.wireless'
 
 	if not (platform.is_outdoor_device() and platform.device_uses_11a(uci)) then
 		-- only visible on wizard for outdoor devices
+		return
+	end
+
+	if wireless.preserve_channels(uci) then
+		-- Don't show if channel should be preserved
 		return
 	end
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -54,7 +54,7 @@ end
 
 local function get_channel(radio, config)
 	local channel
-	if uci:get_first('gluon-core', 'wireless', 'preserve_channels') then
+	if wireless.preserve_channels(uci) then
 		-- preserved channel always wins
 		channel = radio.channel
 	elseif  (radio.hwmode == '11a' or radio.hwmode == '11na') and is_outdoor() then

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -96,4 +96,8 @@ function M.foreach_radio(uci, f)
 	end
 end
 
+function M.preserve_channels(uci)
+	return uci:get_first('gluon-core', 'wireless', 'preserve_channels')
+end
+
 return M

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -142,7 +142,7 @@ uci:foreach('wireless', 'wifi-device', function(config)
 end)
 
 
-if has_5ghz_radio() then
+if has_5ghz_radio() and not wireless.preserve_channels(uci) then
 	local r = f:section(Section, translate("Outdoor Installation"), translate(
 		"Configuring the node for outdoor use tunes the 5 GHz radio to a frequency "
 		.. "and transmission power that conforms with the local regulatory requirements. "


### PR DESCRIPTION
This will hide the outdoor mode setting on compatible devices in case
the defined channels should be preserved.

Otherwise a user might be under the impression their device is compliant
with out door operation when in reality it still uses prohibited
channels.