### PR TITLE
openwrt: backport DFS fixes

### DIFF
--- a/patches/openwrt/0014-mac80211-create-channel-list-for-fixed-channel-operation.patch
+++ b/patches/openwrt/0014-mac80211-create-channel-list-for-fixed-channel-operation.patch
@@ -1,0 +1,28 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 4 Jul 2020 13:20:02 +0200
+Subject: mac80211: create channel list for fixed channel operation
+
+Currently a device which has a DFS channel selected using the UCI
+channel setting might switch to a non-DFS channel in case no chanlist is
+provided (UCI setting "channels") when the radio detects a DFS event.
+
+Automatically add a chanlist consisting of the configured channel when
+the device does not operate in auto-channel mode and no chanlist set to
+circumvent this issue.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+index 634aadcee949bd1c3ad9963d01d9eb444250aa0b..49e51618ab71e197f27ec0581470e81056f1e8b7 100644
+--- a/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
++++ b/package/kernel/mac80211/files/lib/netifd/wireless/mac80211.sh
+@@ -100,6 +100,9 @@ mac80211_hostapd_setup_base() {
+ 	json_get_vars noscan ht_coex
+ 	json_get_values ht_capab_list ht_capab tx_burst
+ 
++	[ "$auto_channel" = 0 ] && [ -z "$channel_list" ] && \
++		channel_list="$channel"
++
+ 	set_default noscan 0
+ 
+ 	[ "$noscan" -gt 0 ] && hostapd_noscan=1

--- a/patches/openwrt/0015-hostapd-enter-DFS-state-if-no-available-channel-is-found.patch
+++ b/patches/openwrt/0015-hostapd-enter-DFS-state-if-no-available-channel-is-found.patch
@@ -1,0 +1,47 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 4 Jul 2020 13:20:07 +0200
+Subject: hostapd: enter DFS state if no available channel is found
+
+Previously hostapd would not stop transmitting when a DFS event was
+detected and no available channel to switch to was available.
+
+Disable and re-enable the interface to enter DFS state. This way, TX
+does not happen until the kernel notifies hostapd about the NOP
+expiring.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/package/network/services/hostapd/patches/800-dfs-enter-DFS-state-if-no-available-channel-is-found.patch b/package/network/services/hostapd/patches/800-dfs-enter-DFS-state-if-no-available-channel-is-found.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..59e903f06ae66208517c2d620b4cd128f41f25c1
+--- /dev/null
++++ b/package/network/services/hostapd/patches/800-dfs-enter-DFS-state-if-no-available-channel-is-found.patch
+@@ -0,0 +1,28 @@
++From cefc52e6b93731c713f1bba1cb5e7e92105b758b Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Fri, 3 Jul 2020 23:00:34 +0200
++Subject: [PATCH] dfs: enter DFS state if no available channel is found
++
++Previously hostapd would not stop transmitting when a DFS event was
++detected and no available channel to switch to was available.
++
++Disable and re-enable the interface to enter DFS state. This way, TX
++does not happen until the kernel notifies hostapd about the NOP
++expiring.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ src/ap/dfs.c | 11 +++++++++--
++ 1 file changed, 9 insertions(+), 2 deletions(-)
++
++--- a/src/ap/dfs.c
+++++ b/src/ap/dfs.c
++@@ -930,6 +930,8 @@ static int hostapd_dfs_start_channel_swi
++ 			wpa_printf(MSG_INFO,
++ 				   "%s: no DFS channels left, waiting for NOP to finish",
++ 				   __func__);
+++			hostapd_disable_iface(iface);
+++			hostapd_enable_iface(iface);
++ 			return err;
++ 		}
++ 


### PR DESCRIPTION
This backports two fixes related to operation on DFS-required
channels.

When a DFS-required channel was selected as the regular
(non-outdoor-mode) 5 GHz channel, hostapd would switch to a non-DFS
channel as OpenWrt did not pass a chanlist of allowed ACS channels.

When hostapd is given a single channel for the chanlist or there's no
available channel left (all allowed channels are in the no-occupancy
period), hostapd prints "no DFS channels left, waiting for NOP to
finish" to the syslog but never stopped transmitting on this channel,
still sending out beacon frames and allowing client data transfer.