### PR TITLE
actions: cache OpenWrt DL folder

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -18,10 +18,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ar71xx-generic-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ar71xx-generic
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -39,10 +50,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ar71xx-tiny-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ar71xx-tiny
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -60,10 +82,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ar71xx-nand-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ar71xx-nand
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -81,10 +114,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ath79-generic-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ath79-generic
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -102,10 +146,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-brcm2708-bcm2708-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh brcm2708-bcm2708
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -123,10 +178,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-brcm2708-bcm2709-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh brcm2708-bcm2709
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -144,10 +210,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ipq40xx-generic-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ipq40xx-generic
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -165,10 +242,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ipq806x-generic-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ipq806x-generic
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -186,10 +274,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-lantiq-xrx200-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh lantiq-xrx200
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -207,10 +306,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-lantiq-xway-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh lantiq-xway
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -228,10 +338,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-mpc85xx-generic-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh mpc85xx-generic
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -249,10 +370,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-mpc85xx-p1020-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh mpc85xx-p1020
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -270,10 +402,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ramips-mt7620-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ramips-mt7620
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -291,10 +434,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ramips-mt7621-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ramips-mt7621
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -312,10 +466,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ramips-mt76x8-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ramips-mt76x8
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -333,10 +498,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ramips-rt305x-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ramips-rt305x
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -354,10 +530,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-sunxi-cortexa7-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh sunxi-cortexa7
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -375,10 +562,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-x86-generic-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh x86-generic
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -396,10 +594,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-x86-geode-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh x86-geode
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -417,10 +626,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-x86-legacy-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh x86-legacy
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -438,10 +658,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-x86-64-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh x86-64
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -459,10 +690,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-ar71xx-mikrotik-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ar71xx-mikrotik
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -480,10 +722,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-brcm2708-bcm2710-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh brcm2708-bcm2710
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -501,10 +754,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-mvebu-cortexa9-${{ hashFiles('modules') }}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh mvebu-cortexa9
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1

--- a/contrib/actions/generate-actions.py
+++ b/contrib/actions/generate-actions.py
@@ -24,10 +24,21 @@ ACTIONS_TARGET="""
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - uses: actions/cache@v2
+        id: cache-dl
+        with:
+          path: dl_target
+          key: openwrt-dl-{target_name}-${{{{ hashFiles('modules') }}}}
+      - name: Prepare download cache
+        if: steps.cache-dl.outputs.cache-hit == 'true'
+        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh {target_name}
+      - name: Create cache to save
+        if: steps.cache-dl.outputs.cache-hit != 'true'
+        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{{{ !cancelled() }}}}
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
This adds the ability to cache OpenWrt dependencies on a per-target
base. Artifacts over 10MB are excluded, as GitHub imposes a limit of 5G
of available space per repository cache. This affects mostly
linux(-firmware) and gcc / gdb.

The goal is to reduce the total amount of requests necessary to fetch
dependencies.