### PR TITLE
gluon-status-page: add wireless client count

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -142,7 +142,13 @@
 					<tr><th><%:RAM%></th><td><%= statistics('memory', 'memory') %></td></tr>
 					<tr><th><%:Filesystem%></th><td><%= statistics('rootfs_usage', 'percent') %></td></tr>
 					<tr><th><%:Gateway%></th><td><%= statistics('gateway') %><br /><%= statistics('gateway_nexthop', 'neighbour') %></td></tr>
-					<tr><th><%:Clients%></th><td><%= statistics('clients/total') %></td></tr>
+				</table>
+
+				<h3><%:Clients%></h3>
+				<table>
+					<tr><th><%:Total%></th><td><%= statistics('clients/total') %></td></tr>
+					<tr><th><%:Wireless 2.4 GHz%></th><td><%= statistics('clients/wifi24') %></td></tr>
+					<tr><th><%:Wireless 5 GHz%></th><td><%= statistics('clients/wifi5') %></td></tr>
 				</table>
 
 				<h3><%:Traffic%></h3>

--- a/package/gluon-status-page/i18n/de.po
+++ b/package/gluon-status-page/i18n/de.po
@@ -55,9 +55,6 @@ msgstr "Weitergeleitet"
 msgid "Gateway"
 msgstr "Gateway"
 
-msgid "Gateway Nexthop"
-msgstr "Gateway Nexthop"
-
 msgid "IP address"
 msgstr "IP-Adresse"
 
@@ -106,6 +103,9 @@ msgstr "Site"
 msgid "Status"
 msgstr "Status"
 
+msgid "Total"
+msgstr "Gesamt"
+
 msgid "Traffic"
 msgstr ""
 
@@ -114,6 +114,12 @@ msgstr "Gesendet"
 
 msgid "Uptime"
 msgstr "Laufzeit"
+
+msgid "Wireless 2.4 GHz"
+msgstr ""
+
+msgid "Wireless 5 GHz"
+msgstr ""
 
 msgid "connected"
 msgstr "verbunden"
@@ -126,3 +132,6 @@ msgstr "aktiviert"
 
 msgid "not connected"
 msgstr "nicht verbunden"
+
+#~ msgid "Gateway Nexthop"
+#~ msgstr "Gateway Nexthop"

--- a/package/gluon-status-page/i18n/gluon-status-page.pot
+++ b/package/gluon-status-page/i18n/gluon-status-page.pot
@@ -46,9 +46,6 @@ msgstr ""
 msgid "Gateway"
 msgstr ""
 
-msgid "Gateway Nexthop"
-msgstr ""
-
 msgid "IP address"
 msgstr ""
 
@@ -97,6 +94,9 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
+msgid "Total"
+msgstr ""
+
 msgid "Traffic"
 msgstr ""
 
@@ -104,6 +104,12 @@ msgid "Transmitted"
 msgstr ""
 
 msgid "Uptime"
+msgstr ""
+
+msgid "Wireless 2.4 GHz"
+msgstr ""
+
+msgid "Wireless 5 GHz"
 msgstr ""
 
 msgid "connected"


### PR DESCRIPTION
This adds the wireless client count for 2.4GHz and 5 GHz radios to the status page.

Previously, only the total client count advertised by the mesh protocol was visible.