### PR TITLE
lantiq-xrx200: remove modem packages from image

### DIFF
--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -1,3 +1,17 @@
+packages {
+	'-ltq-vdsl-vr9-vectoring-fw-installer',
+	'-kmod-ltq-vdsl-vr9-mei',
+	'-kmod-ltq-vdsl-vr9',
+	'-kmod-ltq-atm-vr9',
+	'-kmod-ltq-ptm-vr9',
+	'-kmod-ltq-deu-vr9',
+	'-ltq-vdsl-app',
+	'-dsl-vrx200-firmware-xdsl-a',
+	'-dsl-vrx200-firmware-xdsl-b-patch',
+	'-ppp-mod-pppoa',
+}
+
+
 device('avm-fritz-box-7360-sl', 'avm_fritz7360sl', {
 	factory = false,
 	aliases = {'avm-fritz-box-7360-v1', 'avm-fritz-box-7360-v2'},


### PR DESCRIPTION
The packages necessary to get the DSL modem working increase the
squashfs size by around 1MB.

Remove them from Gluon, as this functionality is not supported.