### PR TITLE
docs: fix small typos and use common used notation

### DIFF
--- a/docs/dev/build.rst
+++ b/docs/dev/build.rst
@@ -23,7 +23,7 @@ GLUON_SITE_FEED
     List of site feeds; defined in file *modules* in site config
 
 \*_REPO, \*_BRANCH, \*_COMMIT
-    Git repository URL, branch and and
+    Git repository URL, branch and
     commit ID of the feeds to use. The branch name may be omitted; the default
     branch will be used in this case.
 
@@ -79,7 +79,7 @@ patch.sh
     - updating all git submodules
 
     This solution with a temporary clone ensures that the timestamps of checked
-    out files are not changed by any intermedidate patch steps, but only when
+    out files are not changed by any intermediate patch steps, but only when
     updating the checkout with the final result. This avoids triggering unnecessary
     rebuilds.
 

--- a/docs/dev/debugging.rst
+++ b/docs/dev/debugging.rst
@@ -7,7 +7,7 @@ Debugging
 Kernel Oops
 -----------
 
-Sometimes a running Linux kernel detects an error during runtime that canot
+Sometimes a running Linux kernel detects an error during runtime that can't
 be corrected.
 This usually generates a stack trace that points to the location in the code
 that caused the oops.

--- a/docs/dev/packages.rst
+++ b/docs/dev/packages.rst
@@ -85,7 +85,7 @@ packages when certain combinations of flags are set.
 Feature definitions use Lua syntax. The function *feature* has two arguments:
 
 * A logical expression composed of feature flag names (each prefixed with an underscore before the opening
-  quotation mark), logical operators (*and*, *or*, *not*) and parantheses
+  quotation mark), logical operators (*and*, *or*, *not*) and parentheses
 * A table with settings that are applied when the logical expression is
   satisfied:
 

--- a/docs/dev/wan.rst
+++ b/docs/dev/wan.rst
@@ -13,7 +13,7 @@ the mesh's DNS servers and use these for all other name resolution.
 
 If the device does not feature a WAN port, the LAN port is configured as WAN port.
 In case such a device has multiple LAN ports, all these can be used as WAN.
-Devices, which feature a "hybrid" port (labled as WAN/LAN), this port is used as WAN.
+Devices, which feature a "hybrid" port (labelled as WAN/LAN), this port is used as WAN.
 
 This behavior can be reversed using the ``single_as_lan`` site.conf option.
 

--- a/docs/features/vpn.rst
+++ b/docs/features/vpn.rst
@@ -47,7 +47,7 @@ The resulting firmware will allow users to choose between secure (encrypted) and
 .. image:: fastd_mode.gif
 
 **Unix socket:**
-To confirm whether the correct cipher is being used, fastds unix
+To confirm whether the correct cipher is being used, fastd's unix
 socket can be interrogated, after installing for example `socat`.
 
 ::

--- a/docs/package/gluon-hoodselector.rst
+++ b/docs/package/gluon-hoodselector.rst
@@ -66,7 +66,7 @@ and others which contain shapes.
 
 * **default domain**
 
-The default domain doesn’t hold any shapes and represents the inverted area of
+The default domain doesn't hold any shapes and represents the inverted area of
 all other shapes held by other domains with geo coordinates. It will only be
 entered if a node could not be matched to a geo domain. A suggested approach is
 to define the "old" network as default domain and gradually migrate nodes from

--- a/docs/releases/v2015.1.rst
+++ b/docs/releases/v2015.1.rst
@@ -19,7 +19,7 @@ ar71xx-generic
 
   - DIR-615 (C1)
 
-* GL-Inet
+* GL.iNet
 
   - 6408A (v1)
   - 6416A (v1)

--- a/docs/releases/v2018.2.1.rst
+++ b/docs/releases/v2018.2.1.rst
@@ -21,7 +21,7 @@ ramips-mt7620
 ramips-mt76x8
 ^^^^^^^^^^^^^
 
-* Gl.iNet
+* GL.iNet
 
   - MT300N (v2) [#noibss]_
 

--- a/docs/releases/v2020.1.1.rst
+++ b/docs/releases/v2020.1.1.rst
@@ -10,7 +10,7 @@ Bugfixes
 - Fixed non-working LEDs on TP-Link Archer C5 v1 and Archer C7 v2 after an upgrade to Gluon 2020.1.
 
 - Fixed an issue which leads to AVM FRITZ!WLAN Repeater 450E devices being stuck in failsafe mode
-  ater an upgrade to Gluon 2020.1.
+  after an upgrade to Gluon 2020.1.
 
 Other changes
 -------------

--- a/docs/releases/v2020.1.2.rst
+++ b/docs/releases/v2020.1.2.rst
@@ -37,7 +37,7 @@ Other changes
 Internals
 ---------
 
-- OpenWrt 19.07 introduced the urgnd entropy daemon that serves the same function as the haveged service, which we have been recommending. To not have two redundant entropy daemons in this release we remove urngd in favor of haveged in the v2020.1 release series.
+- OpenWrt 19.07 introduced the urngd entropy daemon that serves the same function as the haveged service, which we have been recommending. To not have two redundant entropy daemons in this release we remove urngd in favor of haveged in the v2020.1 release series.
 
 Known issues
 ------------

--- a/docs/releases/v2020.2.rst
+++ b/docs/releases/v2020.2.rst
@@ -129,7 +129,7 @@ Bugfixes
 
 - Disabling outdoor mode and enabling meshing in the config mode can now be performed in a single step.
 
-- Fixed section visiblity with enabled outdoor mode in config mode.
+- Fixed section visibility with enabled outdoor mode in config mode.
 
 
 Site changes

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -176,7 +176,7 @@ wifi24 \: optional
 .. _user-site-wifi5:
 
 wifi5 \: optional
-    Same as `wifi24` but for the 5Ghz radio.
+    Same as `wifi24` but for the 5 GHz radio.
 
     Additionally a range of channels that are safe to use outsides on the 5 GHz band can
     be set up through ``outdoor_chanlist``, which allows for a space-separated list of
@@ -326,7 +326,7 @@ mesh_vpn
     implementation.
 
     **Note:** It may be interesting to include the package *gluon-iptables-clamp-mss-to-pmtu*
-    in the build when using *gluon-mesh-babel* to work around icmp blackholes on the internet.
+    in the build when using *gluon-mesh-babel* to work around ICMP blackholes on the internet.
 
     ::
 


### PR DESCRIPTION
Just some very minor fixes.