### PR TITLE
build: check for unsynced feeds before build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,13 +114,6 @@ define CheckTarget
 	fi
 endef
 
-define CheckExternal
-	if [ ! -d openwrt ]; then
-		echo "You don't seem to have obtained the external repositories needed by Gluon; please call \`make update\` first!"
-		exit 1
-	fi
-endef
-
 define CheckSite
 	if ! GLUON_SITEDIR='$(GLUON_SITEDIR)' GLUON_SITE_CONFIG='$(1).conf' $(LUA) -e 'assert(dofile("scripts/site_config.lua")(os.getenv("GLUON_SITE_CONFIG")))'; then
 		echo 'Your site configuration ($(1).conf) did not pass validation'
@@ -147,7 +140,7 @@ LUA := openwrt/staging_dir/hostpkg/bin/lua
 $(LUA):
 	+@
 
-	$(CheckExternal)
+	scripts/module_check.sh
 
 	[ -e openwrt/.config ] || $(OPENWRTMAKE) defconfig
 	$(OPENWRTMAKE) tools/install
@@ -157,7 +150,7 @@ $(LUA):
 config: $(LUA) FORCE
 	+@
 
-	$(CheckExternal)
+	scripts/module_check.sh
 	$(CheckTarget)
 	$(foreach conf,site $(patsubst $(GLUON_SITEDIR)/%.conf,%,$(wildcard $(GLUON_SITEDIR)/domains/*.conf)),\
 		$(call CheckSite,$(conf)); \
@@ -187,7 +180,7 @@ manifest: $(LUA) FORCE
 	@
 	[ '$(GLUON_BRANCH)' ] || (echo 'Please set GLUON_BRANCH to create a manifest.'; false)
 	echo '$(GLUON_PRIORITY)' | grep -qE '^([0-9]*\.)?[0-9]+$$' || (echo 'Please specify a numeric value for GLUON_PRIORITY to create a manifest.'; false)
-	$(CheckExternal)
+	scripts/module_check.sh
 
 	(
 		export $(GLUON_ENV)

--- a/scripts/module_check.sh
+++ b/scripts/module_check.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -e
+
+. scripts/modules.sh
+
+GLUONDIR="$(pwd)"
+
+if [ ! -d "$GLUONDIR/openwrt" ]; then
+	echo "You don't seem to have obtained the external repositories needed by Gluon; please call \`make update\` first!"
+	exit 1
+fi
+
+need_sync=false
+
+for module in $GLUON_MODULES; do
+	var=$(echo "$module" | tr '[:lower:]/' '[:upper:]_')
+	eval 'commit_expected=${'"${var}"'_COMMIT}'
+
+	prefix=invalid
+	cd "$GLUONDIR/$module" 2>/dev/null && prefix="$(git rev-parse --show-prefix 2>/dev/null)"
+	if [ "$prefix" ]; then
+		echo "*** No Git repository found at '$module'."
+		need_sync=true
+		continue
+	fi
+
+	commit_actual="$(git rev-parse heads/base 2>/dev/null)"
+	if [ -z "$commit_actual" ]; then
+		echo "*** No base branch found at '$module'."
+		need_sync=true
+		continue
+	fi
+
+	if [ "$commit_expected" != "$commit_actual" ]; then
+		echo "*** base branch at '$module' did not match module file (expected: ${commit_expected}, actual: ${commit_actual})"
+		need_sync=true
+		continue
+	fi
+
+	# Use git status instead of git diff -q, as the latter doesn't
+	# check for untracked files
+	if [ "$(git status --porcelain 2>/dev/null | wc -l)" -ne 0 ]; then
+		echo "*** Module '$module' has uncommitted changes:"
+		git status --short
+	fi
+done
+
+if $need_sync; then
+	echo
+	# shellcheck disable=SC2016
+	echo 'Run `make update` to sync dependencies.'
+	echo
+fi


### PR DESCRIPTION
Forgetting to `make update` or leaving uncommitted changes in the
repositories managed by Gluon is a recurring cause of confusion, even
for experienced developers. Let's print an obvious warning message in
this case.