### PR TITLE
scripts/target_lib.lua: print a meaningful error message for missing site_code

### DIFF
--- a/scripts/target_lib.lua
+++ b/scripts/target_lib.lua
@@ -21,7 +21,9 @@ assert(env.GLUON_RELEASE)
 assert(env.GLUON_DEPRECATED)
 
 
-M.site_code = assert(assert(dofile('scripts/site_config.lua')('site.conf')).site_code)
+M.site_code = assert(
+	dofile('scripts/site_config.lua')('site.conf').site_code, 'site_code missing in site.conf'
+)
 M.target_packages = {}
 M.configs = {}
 M.devices = {}


### PR DESCRIPTION
site_code is evaluated early during config generation, so a site.conf
without site_code would hit this assertion that just printed 'Assertion
failed'. Add a proper error message to tell users what went wrong.

The inner assert() is removed, as it should never be hit (as site.conf
syntax will have already been validated when this script runs), and it
doesn't add anything (even without the assert, the attempt to index a
nil value would throw an error).