### PR TITLE
gluon-mesh-wireless-sae: switch to wpa-supplicant-mesh-wolfssl

### DIFF
--- a/package/gluon-mesh-wireless-sae/Makefile
+++ b/package/gluon-mesh-wireless-sae/Makefile
@@ -7,7 +7,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-wireless-sae
   TITLE:=Encryption of 802.11s Mesh Links through SAE
-  DEPENDS:=+gluon-core +wpa-supplicant-openssl
+  DEPENDS:=+gluon-core +wpa-supplicant-mesh-wolfssl
 endef
 
 $(eval $(call BuildPackageGluon,gluon-mesh-wireless-sae))


### PR DESCRIPTION
In #2042 we're switch our hostapd variant to wolfSSL. I've tested the functionality of the `gluon-mesh-wireless-sae` package.

I've reported my success in https://github.com/freifunk-gluon/gluon/pull/2042#issuecomment-674456189.