### PR TITLE
gluon-ebtables-filter-multicast: allow respondd queries

### DIFF
--- a/package/gluon-ebtables-filter-multicast/luasrc/lib/gluon/ebtables/110-mcast-allow-respondd
+++ b/package/gluon-ebtables-filter-multicast/luasrc/lib/gluon/ebtables/110-mcast-allow-respondd
@@ -1,0 +1,1 @@
+rule 'MULTICAST_OUT -p IPv6 --ip6-protocol udp --ip6-destination-port 1001 --ip6-dst ff05::2:1001 -j RETURN'


### PR DESCRIPTION
This allows running a respondd querier and map server behind a Gluon
node.

For instance at Freifunk Lübeck we now moved the map server
behind a Gluon VM and removed batman-adv and fastd from the
map server VM to reduce the maintenance work.

Increased multicast overhead should be minimal / non existent, as it is
unlikely to accidentally have respondd queriers running behind a Gluon
node.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>