### PR TITLE
docs: fixes for v2020.2 release notes

### DIFF
--- a/docs/releases/v2020.2.rst
+++ b/docs/releases/v2020.2.rst
@@ -173,8 +173,9 @@ Build system
 Known issues
 ------------
 
-* Out of memory situations with high client count on ath9k.
-  (`#1768 <https://github.com/freifunk-gluon/gluon/issues/1768>`_)
+* Upgrading EdgeRouter-X from versions before v2020.1.x may lead to a soft-bricked state due to bad blocks on the
+  NAND flash which the NAND driver before this release does not handle well.
+  (`#1937 <https://github.com/freifunk-gluon/gluon/issues/1937>`_)
 
 * The integration of the BATMAN_V routing algorithm is incomplete.
 
@@ -189,3 +190,9 @@ Known issues
   (`#94 <https://github.com/freifunk-gluon/gluon/issues/94>`_)
 
   Reducing the TX power in the Advanced Settings is recommended.
+
+* In configurations not using VXLAN, the MAC address of the WAN interface is modified even when Mesh-on-WAN is disabled
+  (`#496 <https://github.com/freifunk-gluon/gluon/issues/496>`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when promiscuous mode is
+  disallowed).


### PR DESCRIPTION
we forgot issues marked as known issue in the last release's release notes, forgot to mention the issue with upgrades for ER-X and can remove an issue that seems to be obsolete starting with v2020.1