### PR TITLE
ar71xx-generic: Add support for GL-iNet Microuter (GL-USB150)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -44,6 +44,7 @@ ar71xx-generic
   - GL-AR150
   - GL-AR300M
   - GL-AR750
+  - GL-USB150 (Microuter)
 
 * Linksys
 

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -126,6 +126,10 @@ device('gl.inet-gl-ar750', 'gl-ar750', {
 	packages = ATH10K_PACKAGES_QCA9887,
 })
 
+device('gl.inet-gl-usb150', 'gl-usb150', {
+	factory = false,
+})
+
 
 -- Linksys by Cisco
 


### PR DESCRIPTION
A small, USB powered wifi router from GL-iNet, with network-over-USB support. Handy for Gluon development on-the-go.

https://openwrt.org/toh/hwdata/gl.inet/gl.inet_gl-usb150
https://www.gl-inet.com/products/gl-usb150/

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp
  - [x] other: ssh
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name* -> checked that Lua platform info matched
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN) -> USB-Ethernet: WAN, no LAN
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [ ] should map to their respective port (or switch, if only one led present) -> N/A
    - [ ] should show link state and activity -> N/A
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua` -> N/A