### PR TITLE
ramips-mt7620: add support for Netgear EX3700/EX3800

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -111,6 +111,7 @@ local primary_addrs = {
 			'c20i',
 			'c50',
 			'tplink,c2-v1',
+			'ex3700'
 		}},
 		{'x86'},
 	}},

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -20,6 +20,14 @@ device('gl-mt750', 'gl-mt750', {
 	factory = false,
 })
 
+-- Netgear
+
+device('netgear-ex3700', 'ex3700-ex3800', {
+	aliases = {'netgear-ex3800',
+		'netgear-ex3700-ex3800',
+	},
+	factory_ext = '.chk',
+})
 
 -- Nexx
 


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] other: nmrpflash
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)  *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate *usually means: gluon profile name must match image name*
- [x] wps button must return device into config mode
- [x] primary mac should match address on device label (or packaging)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence (https://gluon.readthedocs.io/en/latest/features/configmode.html)
 