### PR TITLE
treewide: rename local_client zone

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
@@ -51,9 +51,9 @@ uci:section('firewall', 'zone', 'drop', {
 	forward = 'DROP',
 })
 
-local networks = uci:get_list('firewall', 'local_client', 'network')
+local networks = uci:get_list('firewall', 'loc_client', 'network')
 util.add_to_set(networks, 'local_node')
-uci:set_list('firewall', 'local_client', 'network', networks)
+uci:set_list('firewall', 'loc_client', 'network', networks)
 
 
 local dnsmasq = uci:get_first('dhcp', 'dnsmasq')

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/300-firewall-rules
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/300-firewall-rules
@@ -18,7 +18,7 @@ end
 
 uci:foreach('firewall', 'zone', reject_input_on_wan)
 
-for _, zone in ipairs({'mesh', 'local_client', 'wired_mesh'}) do
+for _, zone in ipairs({'mesh', 'loc_client', 'wired_mesh'}) do
 	-- Other packages assign interfaces to these zones
 	uci:section('firewall', 'zone', zone, {
 		name = zone,
@@ -57,8 +57,14 @@ for _, zone in ipairs({'mesh', 'local_client', 'wired_mesh'}) do
 	uci:delete('firewall', zone .. '_ICMPv6_out')
 end
 
-uci:section('firewall', 'rule', 'local_client_ICMPv4_in', {
-	src = 'local_client',
+-- ToDo Remove in v2022.x
+uci:delete('firewall', 'local_client')
+uci:delete('firewall', 'local_client_ssh')
+uci:delete('firewall', 'local_client_ICMPv4_in')
+uci:delete('firewall', 'local_client_ICMPv6_in')
+
+uci:section('firewall', 'rule', 'loc_client_ICMPv4_in', {
+	src = 'loc_client',
 	proto = 'icmp',
 	icmp_type = {
 		'echo-request',
@@ -67,9 +73,8 @@ uci:section('firewall', 'rule', 'local_client_ICMPv4_in', {
 	target = 'ACCEPT',
 })
 
-
 -- allow inbound SSH from anywhere
-for _, zone in ipairs({ 'wan', 'local_client', 'mesh' }) do
+for _, zone in ipairs({ 'wan', 'loc_client', 'mesh' }) do
 	uci:section('firewall', 'rule', zone .. '_ssh', {
 		name =  zone .. '_ssh',
 		src = zone,

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/820-dns-config
@@ -18,7 +18,7 @@ uci:delete('firewall', 'client_dns')
 if dns.servers then
 	-- allow inbound traffic for dns from client zone
 	uci:section('firewall', 'rule', 'client_dns', {
-		src = 'local_client',
+		src = 'loc_client',
 		dest_port = '53',
 		proto = 'tcpudp',
 		target = 'ACCEPT',

--- a/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/310-gluon-mesh-babel-firewall
+++ b/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/310-gluon-mesh-babel-firewall
@@ -23,18 +23,18 @@ uci:section('firewall', 'zone', 'mmfd', {
 
 -- forwardings and respective rules
 uci:section('firewall', 'forwarding', 'fcc', {
-	src = 'local_client',
-	dest = 'local_client',
+	src = 'loc_client',
+	dest = 'loc_client',
 })
 
 uci:section('firewall', 'forwarding', 'fcm', {
-	src = 'local_client',
+	src = 'loc_client',
 	dest = 'mesh',
 })
 
 uci:section('firewall', 'forwarding', 'fmc', {
 	src = 'mesh',
-	dest = 'local_client',
+	dest = 'loc_client',
 })
 
 uci:section('firewall', 'forwarding', 'fmm', {
@@ -44,11 +44,11 @@ uci:section('firewall', 'forwarding', 'fmm', {
 
 uci:section('firewall', 'forwarding', 'flc', {
 	src = 'l3roamd',
-	dest = 'local_client',
+	dest = 'loc_client',
 })
 
 uci:section('firewall', 'forwarding', 'fcl', {
-	src = 'local_client',
+	src = 'loc_client',
 	dest = 'l3roamd',
 })
 

--- a/package/gluon-respondd/luasrc/lib/gluon/upgrade/400-respondd-firewall
+++ b/package/gluon-respondd/luasrc/lib/gluon/upgrade/400-respondd-firewall
@@ -18,7 +18,7 @@ uci:section('firewall', 'rule', 'wan_respondd', {
 -- Allow respondd-access for local clients
 uci:section('firewall', 'rule', 'client_respondd', {
 	name = 'client_respondd',
-	src = 'local_client',
+	src = 'loc_client',
 	src_ip = 'fe80::/64',
 	dest_port = '1001',
 	proto = 'udp',

--- a/package/gluon-status-page/luasrc/lib/gluon/upgrade/500-status-page
+++ b/package/gluon-status-page/luasrc/lib/gluon/upgrade/500-status-page
@@ -27,7 +27,7 @@ uci:section('uhttpd', 'uhttpd', 'main', {
 uci:save('uhttpd')
 
 
-for _, zone in ipairs({'mesh', 'local_client'}) do
+for _, zone in ipairs({'mesh', 'loc_client'}) do
 	uci:section('firewall', 'rule', zone .. '_http', {
 		src = zone,
 		dest_port = '80',
@@ -35,4 +35,8 @@ for _, zone in ipairs({'mesh', 'local_client'}) do
 		target = 'ACCEPT',
 	})
 end
+
+-- ToDo remove in v2022.x
+uci:delete('firewall', 'local_client_http')
+
 uci:save('firewall')


### PR DESCRIPTION
This renames the local_client zone to loc_client, as local_clint exceeds
the maximum zone length allowed for firewall3, which is 11 bytes.

This worked previously due to firewall3 using unsafe string operations.
Now creation of the chain fails (latest OpenWrt master).