### PR TITLE
ar71xx-generic: remove USB package for builds of d-link-dir-825-rev-b1

### DIFF
--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -101,6 +101,7 @@ device('d-link-dir-825-rev-b1', 'dir-825-b1', {
 	profile = 'DIR825B1',
 	factory = false,
 	class = 'tiny', -- Only 6M of usable Firmware space
+	packages = { '-kmod-usb-core', '-kmod-usb2', '-kmod-usb-ledtrig-usbport' },
 })
 
 


### PR DESCRIPTION
without removing the USB packages i couldn't add any custom package to this device, i'm not sure where we draw the line here so i'm just proposing this change, not directly committing it

EDIT: build tested now