### PR TITLE
clean up old cleanup code lines

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/300-gluon-client-bridge-network
@@ -40,9 +40,6 @@ uci:section('network', 'interface', 'client', {
 
 uci:save('network')
 
--- TODO: remove this line and the next in 2019. Firewall zones have been renamed in 2017.
-uci:delete('firewall', 'client')
-
 uci:section('firewall', 'zone', 'drop', {
 	name = 'drop',
 	network = {'client'},
@@ -60,10 +57,6 @@ local dnsmasq = uci:get_first('dhcp', 'dnsmasq')
 uci:set('dhcp', dnsmasq, 'boguspriv', false)
 uci:set('dhcp', dnsmasq, 'localise_queries', false)
 uci:set('dhcp', dnsmasq, 'rebind_protection', false)
-
--- TODO: remove this line and the next two in 2019 the zones were removed in 2017
-uci:delete('dhcp', 'client')
-uci:delete('firewall', 'local_node')
 
 uci:section('dhcp', 'dhcp', 'local_client', {
 	interface = 'client',

--- a/package/gluon-core/files/lib/gluon/upgrade/100-core-reset-sysctl
+++ b/package/gluon-core/files/lib/gluon/upgrade/100-core-reset-sysctl
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-# This script can be removed after Gluon v2018.2
-
-# Check for a random line that always was in /etc/sysctl.conf
-if grep -qxF 'net.ipv4.ip_forward=1' /etc/sysctl.conf; then
-	echo '# Defaults are configured in /etc/sysctl.d/* and can be customized in this file' >/etc/sysctl.conf
-fi

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/300-firewall-rules
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/300-firewall-rules
@@ -52,9 +52,6 @@ for _, zone in ipairs({'mesh', 'loc_client', 'wired_mesh'}) do
 		family = 'ipv6',
 		target = 'ACCEPT',
 	})
-
-	-- Can be removed soon: was never in a release
-	uci:delete('firewall', zone .. '_ICMPv6_out')
 end
 
 -- ToDo Remove in v2022.x


### PR DESCRIPTION
this PR removes parts of two files, which were marked as "can be removed" a few years ago, one of which even wasn't part of any Gluon release.
also, it removes a single file marked as deletable a while ago.