### PR TITLE
github: remove GitHub actions cache

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -18,21 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ar71xx-generic-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ar71xx-generic
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -50,21 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ar71xx-tiny-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ar71xx-tiny
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -82,21 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ar71xx-nand-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ar71xx-nand
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -114,21 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ath79-generic-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ath79-generic
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -146,21 +102,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-brcm2708-bcm2708-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh brcm2708-bcm2708
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -178,21 +123,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-brcm2708-bcm2709-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh brcm2708-bcm2709
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -210,21 +144,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ipq40xx-generic-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ipq40xx-generic
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -242,21 +165,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ipq806x-generic-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ipq806x-generic
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -274,21 +186,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-lantiq-xrx200-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh lantiq-xrx200
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -306,21 +207,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-lantiq-xway-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh lantiq-xway
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -338,21 +228,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-mpc85xx-generic-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh mpc85xx-generic
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -370,21 +249,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-mpc85xx-p1020-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh mpc85xx-p1020
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -402,21 +270,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ramips-mt7620-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ramips-mt7620
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -434,21 +291,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ramips-mt7621-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ramips-mt7621
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -466,21 +312,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ramips-mt76x8-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ramips-mt76x8
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -498,21 +333,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ramips-rt305x-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ramips-rt305x
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -530,21 +354,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-sunxi-cortexa7-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh sunxi-cortexa7
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -562,21 +375,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-x86-generic-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh x86-generic
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -594,21 +396,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-x86-geode-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh x86-geode
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -626,21 +417,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-x86-legacy-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh x86-legacy
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -658,21 +438,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-x86-64-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh x86-64
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -690,21 +459,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-ar71xx-mikrotik-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh ar71xx-mikrotik
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -722,21 +480,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-brcm2708-bcm2710-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh brcm2708-bcm2710
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1
@@ -754,21 +501,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-mvebu-cortexa9-${{ hashFiles('modules') }}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh mvebu-cortexa9
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v1

--- a/contrib/actions/generate-actions.py
+++ b/contrib/actions/generate-actions.py
@@ -24,21 +24,10 @@ ACTIONS_TARGET="""
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions/cache@v2
-        id: cache-dl
-        with:
-          path: dl_target
-          key: openwrt-dl-{target_name}-${{{{ hashFiles('modules') }}}}
-      - name: Prepare download cache
-        if: steps.cache-dl.outputs.cache-hit == 'true'
-        run: mkdir -p openwrt/dl; mv dl_target/* openwrt/dl/; ls openwrt/dl
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
       - name: Build
         run: contrib/actions/run-build.sh {target_name}
-      - name: Create cache to save
-        if: steps.cache-dl.outputs.cache-hit != 'true'
-        run: mkdir dl_target; mv openwrt/dl/* dl_target/; find dl_target/ -size +20M -delete
       - name: Archive build logs
         if: ${{{{ !cancelled() }}}}
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
The performance benefit the cache brought was due to a broken sources
CDN mirror handling in OpenWrt.

The cache brings no measurable performance benefit. Disable it to slim
down the pipeline steps.