### PR TITLE
ipq40xx-generic: add support for AVM FRITZBox 7530

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -230,6 +230,7 @@ ipq40xx-generic
 * AVM
 
   - FRITZ!Box 4040 [#avmflash]_
+  - FRITZ!Box 7530 [#eva_ramboot]_
   - FRITZ!Repeater 1200 [#eva_ramboot]_
 
 * EnGenius

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -38,6 +38,10 @@ device('avm-fritz-box-4040', 'avm_fritzbox-4040', {
 	},
 })
 
+device('avm-fritz-box-7530', 'avm_fritzbox-7530', {
+	factory = false,
+})
+
 device('avm-fritz-repeater-1200', 'avm_fritzrepeater-1200', {
 	factory = false,
 })


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: EVA
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes) No primary MAC on device
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`