### PR TITLE
ar71xx-generic: only create manifest alias for Rocket M5

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -108,9 +108,9 @@ ar71xx-generic
   - Nanostation M2/M5  [#device-class-tiny]_
   - Nanostation M2/M5 XW
   - Picostation M2  [#device-class-tiny]_
-  - Rocket M2/M5
-  - Rocket M2/M5 Ti
-  - Rocket M2/M5 XW
+  - Rocket M2
+  - Rocket M2 Ti
+  - Rocket M2 XW
   - UniFi AC Mesh
   - UniFi AC Mesh Pro
   - UniFi AP

--- a/targets/ar71xx-generic
+++ b/targets/ar71xx-generic
@@ -427,10 +427,8 @@ device('ubiquiti-bullet-m', 'ubnt-bullet-m', {
 })
 
 device('ubiquiti-rocket-m', 'ubnt-rocket-m', {
-	aliases = {
-		'ubiquiti-rocket-m2',
-		'ubiquiti-rocket-m5',
-	},
+	aliases = {'ubiquiti-rocket-m2'},
+	manifest_aliases = {'ubiquiti-rocket-m5'},
 })
 
 device('ubiquiti-nanostation-m', 'ubnt-nano-m', {


### PR DESCRIPTION
This follow up the discussion done in #2070 by not  creating a symlink
for the Rocket M5. Images for the Rocket M2 can still be flashed on a
Rocket M5.

This change will prevent the Rocket M5 from appearing in Firmware
selectors. Existing devices will still receive updates, as the device
name is still referenced for the device name expected by the M5.

Closes #2070