### PR TITLE
ath79: migrate OCEDO Koala from ar71xx

### DIFF
--- a/package/gluon-core/files/lib/gluon/core/migration/create_led_config.sh
+++ b/package/gluon-core/files/lib/gluon/core/migration/create_led_config.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+CFG=/etc/board.json
+
+. /lib/functions/config-generate.sh
+
+json_init
+json_load "$(cat ${CFG})"
+
+umask 077
+
+keys=
+
+json_get_keys keys led
+for key in $keys; do generate_led $key; done

--- a/package/gluon-core/files/lib/gluon/core/migration/create_led_config.sh
+++ b/package/gluon-core/files/lib/gluon/core/migration/create_led_config.sh
@@ -2,7 +2,7 @@
 
 CFG=/etc/board.json
 
-. /lib/functions/config-generate.sh
+. /bin/config_generate source-only
 
 json_init
 json_load "$(cat ${CFG})"

--- a/package/gluon-core/files/lib/upgrade/keep.d/gluon
+++ b/package/gluon-core/files/lib/upgrade/keep.d/gluon
@@ -1,1 +1,2 @@
 /lib/gluon/core/sysconfig/
+/lib/gluon/core/migration/flags

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/002-ath79-migration
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/002-ath79-migration
@@ -10,6 +10,7 @@ local migration_name = 'ar71xx-ath79'
 
 local migration_target_config = {
 	-- {DEVICE, ETH_SWAP}
+	{'ocedo,koala', false}
 }
 
 -- Create a list for use with platform matching

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/002-ath79-migration
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/002-ath79-migration
@@ -1,0 +1,98 @@
+#!/usr/bin/lua
+
+local platform = require 'gluon.platform'
+local sysconfig = require 'gluon.sysconfig'
+local migration = require 'gluon.migration'
+
+local uci = require('simple-uci').cursor()
+
+local migration_name = 'ar71xx-ath79'
+
+local migration_target_config = {
+	-- {DEVICE, ETH_SWAP}
+}
+
+-- Create a list for use with platform matching
+local migration_targets = {}
+for _, v in ipairs(migration_target_config) do
+	table.insert(migration_targets, v[0])
+end
+
+-- Check if device is a migration target
+if not platform.match('ath79', 'generic', migration_targets) then
+    return
+end
+
+-- Check if this is an initial installation
+if not sysconfig.gluon_version then
+    os.execute('touch /lib/gluon/core/migrations/ar71xx-ath79')
+    return
+end
+
+-- Check if migration has already been done
+if migration.is_migration_done(migration_name) then
+    return
+end
+
+-- Reinit board.json
+migration.reinit_board_json()
+
+migration.reinit_led_config(uci)
+
+local function sysconfig_ifname_swap(input_ifnames)
+	local output_ifnames = {}
+	for v in input_ifnames:gmatch('%S+') do
+		if string.match(v, 'eth0') then
+			table.insert(output_ifnames, v:gsub('eth0', 'eth1'))
+		elseif string.match(v, 'eth1') then
+			table.insert(output_ifnames, v:gsub('eth1', 'eth0'))
+		end
+	end
+
+	return table.concat(output_ifnames, ' ')
+end
+
+-- For devices with embedded FE switch, eth0 and eth1
+-- have been swapped.
+local function perform_eth_swap()
+	-- Modify running config
+	uci:foreach('network', 'interface', function(iface)
+		local interfaces = uci:get_list('network', iface['.name'], 'ifname')
+		if interfaces == nil then return end
+
+		local new_interfaces = {}
+
+		for _, v in ipairs(interfaces) do
+			if string.match(v, 'eth0') then
+				table.insert(new_interfaces, v:gsub('eth0', 'eth1'))
+			elseif string.match(v, 'eth1') then
+				table.insert(new_interfaces, v:gsub('eth1', 'eth0'))
+			end
+		end
+
+		uci:set_list('network', iface['.name'], 'ifname', new_interfaces)
+	end)
+	uci:save('network')
+
+	-- Modify Gluons port assignment. Important for setup-mode.
+	sysconfig.lan_ifname = sysconfig_ifname_swap(sysconfig.lan_ifname)
+	sysconfig.wan_ifname = sysconfig_ifname_swap(sysconfig.wan_ifname)
+end
+
+local function board_requires_eth_swap()
+	local board_name = platform.get_board_name()
+	for _, v in ipairs(migration_target_config) do
+		if board_name == v[0] and v[1] then
+			return true
+		end
+	end
+	return false
+end
+
+-- Perform eth swap
+if board_requires_eth_swap() then
+	perform_eth_swap()
+end
+
+-- Flag migration done
+migration.flag_migration_done(migration_name)

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -80,7 +80,6 @@ local primary_addrs = {
 			'archer-c7-v4',
 			'archer-c7-v5',
 			'carambola2',
-			'koala',
 			'mr600',
 			'mr600v2',
 			'mr900',
@@ -107,6 +106,7 @@ local primary_addrs = {
 		}},
 		{'ath79', 'generic', {
 			'glinet,gl-ar750s-nor',
+			'ocedo,koala',
 			'ocedo,raccoon',
 			'tplink,archer-c2-v3',
 			'tplink,archer-d50-v1',

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/migration.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/migration.lua
@@ -1,0 +1,37 @@
+local unistd = require 'posix.unistd'
+
+
+local M = {}
+
+function M.get_migration_flag_path(migration_name)
+	return '/lib/gluon/core/migration/flags' .. migration_name
+end
+
+function M.is_migration_done(migration_name)
+	return unistd.access(M.get_migration_flag_path(migration_name))
+end
+
+function M.flag_migration_done(migration_name)
+	os.execute(M.get_migration_flag_path(migration_name))
+end
+
+function M.reinit_led_config(uci)
+	-- Remove LED configuration
+	uci:foreach('system', 'rssid', function(config)
+		uci:delete('system', config['.name'])
+	end)
+	uci:foreach('system', 'led', function(config)
+		uci:delete('system', config['.name'])
+	end)
+	uci:save('led')
+
+	-- Create LED configuration
+	os.execute('/lib/gluon/core/migration/create_led_config.sh')
+end
+
+function M.reinit_board_json()
+	os.execute('rm /etc/board.json')
+	os.execute('board_detect')
+end
+
+return M

--- a/patches/openwrt/0005-base-files-allow-sourcing-of-config_generate.patch
+++ b/patches/openwrt/0005-base-files-allow-sourcing-of-config_generate.patch
@@ -1,0 +1,17 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sun, 27 Jun 2021 12:33:36 +0200
+Subject: base-files: allow sourcing of config_generate
+
+diff --git a/package/base-files/files/bin/config_generate b/package/base-files/files/bin/config_generate
+index 0dca5549e8a91749217d959b543a16f1258b0af0..cc838d25e8acfa7cc0652c9801de795e497d3033 100755
+--- a/package/base-files/files/bin/config_generate
++++ b/package/base-files/files/bin/config_generate
+@@ -5,7 +5,7 @@ CFG=/etc/board.json
+ . /usr/share/libubox/jshn.sh
+ 
+ [ -s $CFG ] || /bin/board_detect || exit 1
+-[ -s /etc/config/network -a -s /etc/config/system ] && exit 0
++[ "$1" != "source-only" ] && [ -s /etc/config/network -a -s /etc/config/system ] && exit 0
+ 
+ generate_bridge() {
+ 	local name=$1

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -62,6 +62,11 @@ device('gl.inet-gl-ar300m-lite', 'glinet_gl-ar300m-lite', {
 
 -- OCEDO
 
+device('ocedo-koala', 'ocedo_koala', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('ocedo-raccoon', 'ocedo_raccoon', {
 	factory = false,
 })


### PR DESCRIPTION
This provides the basic migration procedures necessary for most boards to be ported from ar71xx to ath79.

Handling of the WiFi path migration is handled upstream. We handle recreation of LED configuration, which will not be preserved.

Additionally, there's already a the necessary migration for devices where the GMAC iterator is swapped for ath79 when compared to ar71xx. This is not the case for the board in question.