### PR TITLE
build: improve refreshing patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,13 @@ update-patches: FORCE
 	scripts/update-patches.sh
 	scripts/patch.sh
 
+refresh-patches: FORCE
+	@
+	export $(GLUON_ENV)
+	scripts/update.sh
+	scripts/patch.sh
+	scripts/update-patches.sh
+
 update-feeds: FORCE
 	@$(GLUON_ENV) scripts/feeds.sh
 

--- a/scripts/update-patches.sh
+++ b/scripts/update-patches.sh
@@ -21,6 +21,7 @@ for module in $GLUON_MODULES; do
 	for commit in $(git rev-list --reverse --no-merges base..patched); do
 		(( ++n ))
 		mkdir -p "${GLUON_PATCHESDIR}/$module"
+		echo "Updating: $(git log --format=%s -n 1 "$commit")"
 		git -c core.abbrev=40 show --pretty=format:'From: %an <%ae>%nDate: %aD%nSubject: %B' --no-renames --binary "$commit" > "${GLUON_PATCHESDIR}/$module/$(printf '%04u' "$n")-$(git show -s --pretty=format:%f "$commit").patch"
 	done
 done


### PR DESCRIPTION
This PR adds a new `refresh-patches` step to the project Makefile which allows to apply and update all patches to feeds and OpenWrt without installing feed packages to the OpenWrt buildsystem.

This reduces the time necessary for refreshing patches when updating feeds or the OpenWrt base.

This PR will also print the commit title for every patch created when updating patches. This was previously only done when applying    patches.