### PR TITLE
mt76: mt7603: add additional EEPROM chip ID

### DIFF
--- a/patches/openwrt/0017-mt76-mt7603-add-additional-EEPROM-chip-ID.patch
+++ b/patches/openwrt/0017-mt76-mt7603-add-additional-EEPROM-chip-ID.patch
@@ -1,0 +1,46 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 15 Oct 2020 22:42:54 +0200
+Subject: mt76: mt7603: add additional EEPROM chip ID
+
+Some newer MT7628 based routers (notably the TP-Link Archer C50 v4) are
+shipped with a chip-id of 0x7600 in the on-flash EEPROM. Add this as a
+possible valid ID.
+
+Ref: https://bugs.openwrt.org/index.php?do=details&task_id=2781
+
+Suggested-by: Ron Asimi <ron.asimi@gmail.com>
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/package/kernel/mt76/patches/002-mt76-mt7603-add-additional-EEPROM-chip-ID.patch b/package/kernel/mt76/patches/002-mt76-mt7603-add-additional-EEPROM-chip-ID.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..c749aa403f5940c19e5f580f461874b708b41f66
+--- /dev/null
++++ b/package/kernel/mt76/patches/002-mt76-mt7603-add-additional-EEPROM-chip-ID.patch
+@@ -0,0 +1,27 @@
++From 6b51340cdc32b1ba75163faaa8592feaeb4bddec Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Sat, 10 Oct 2020 00:36:02 +0200
++Subject: [PATCH] mt76: mt7603: add additional EEPROM chip ID
++
++Some newer MT7628 based routers (notably the TP-Link Archer C50 v4) are
++shipped with a chip-id of 0x7600 in the on-flash EEPROM. Add this as a
++possible valid ID.
++
++Ref: https://bugs.openwrt.org/index.php?do=details&task_id=2781
++
++Suggested-by: Ron Asimi <ron.asimi@gmail.com>
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ mt7603/eeprom.c | 1 +
++ 1 file changed, 1 insertion(+)
++
++--- a/mt7603/eeprom.c
+++++ b/mt7603/eeprom.c
++@@ -136,6 +136,7 @@ static int mt7603_check_eeprom(struct mt
++ 	switch (val) {
++ 	case 0x7628:
++ 	case 0x7603:
+++	case 0x7600:
++ 		return 0;
++ 	default:
++ 		return -EINVAL;


### PR DESCRIPTION
Some newer MT7628 based routers (notably the TP-Link Archer C50 v4) are
shipped with a chip-id of 0x7600 in the on-flash EEPROM. Add this as a
possible valid ID.

This fixes unstable WiFi on some units of the TP-Link Archer C50 v4.