### PR TITLE
ar71xx-generic: add support for TP-Link CPE210 v3.20

### DIFF
--- a/patches/openwrt/0027-kernel-mtd-add-support-for-EN25QH64-in-spi-nor.c.patch
+++ b/patches/openwrt/0027-kernel-mtd-add-support-for-EN25QH64-in-spi-nor.c.patch
@@ -1,0 +1,44 @@
+From: Roger Pueyo Centelles <roger.pueyo@guifi.net>
+Date: Mon, 24 Dec 2018 15:39:32 +0100
+Subject: kernel: mtd: add support for EN25QH64 in spi-nor.c
+
+The Eon EN25QH64 is a 64 Mbit SPI NOR flash memory chip. Its 32, 128 and
+256 Mbits siblings are supported upstream but this particular size wasn't.
+This commit includes patches for kernels 4.14 and 4.19.
+
+Tested on a COMFAST CF-E120A v3 (ath79).
+
+Signed-off-by: Roger Pueyo Centelles <roger.pueyo@guifi.net>
+
+diff --git a/target/linux/generic/pending-4.14/479-mtd-spi-nor-add-eon-en25qh64.patch b/target/linux/generic/pending-4.14/479-mtd-spi-nor-add-eon-en25qh64.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..c290a784d045576b6f145d489ed4580477ee7829
+--- /dev/null
++++ b/target/linux/generic/pending-4.14/479-mtd-spi-nor-add-eon-en25qh64.patch
+@@ -0,0 +1,10 @@
++--- a/drivers/mtd/spi-nor/spi-nor.c
+++++ b/drivers/mtd/spi-nor/spi-nor.c
++@@ -956,6 +956,7 @@ static const struct flash_info spi_nor_i
++ 	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
++ 	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
++ 	{ "en25qh32",   INFO(0x1c7016, 0, 64 * 1024,   64, 0) },
+++	{ "en25qh64",   INFO(0x1c7017, 0, 64 * 1024,   128, 0) },
++ 	{ "en25qh128",  INFO(0x1c7018, 0, 64 * 1024,  256, 0) },
++ 	{ "en25qh256",  INFO(0x1c7019, 0, 64 * 1024,  512, 0) },
++ 	{ "en25s64",	INFO(0x1c3817, 0, 64 * 1024,  128, SECT_4K) },
+diff --git a/target/linux/generic/pending-4.19/479-mtd-spi-nor-add-eon-en25qh64.patch b/target/linux/generic/pending-4.19/479-mtd-spi-nor-add-eon-en25qh64.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..6bb77547332d6d9dc2944f45edc5d170fdfdc7aa
+--- /dev/null
++++ b/target/linux/generic/pending-4.19/479-mtd-spi-nor-add-eon-en25qh64.patch
+@@ -0,0 +1,10 @@
++--- a/drivers/mtd/spi-nor/spi-nor.c
+++++ b/drivers/mtd/spi-nor/spi-nor.c
++@@ -996,6 +996,7 @@ static const struct flash_info spi_nor_i
++ 	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
++ 	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
++ 	{ "en25qh32",   INFO(0x1c7016, 0, 64 * 1024,   64, 0) },
+++	{ "en25qh64",   INFO(0x1c7017, 0, 64 * 1024,   128, 0) },
++ 	{ "en25qh128",  INFO(0x1c7018, 0, 64 * 1024,  256, 0) },
++ 	{ "en25qh256",  INFO(0x1c7019, 0, 64 * 1024,  512, 0) },
++ 	{ "en25s64",	INFO(0x1c3817, 0, 64 * 1024,  128, SECT_4K) },

--- a/patches/openwrt/0028-tplink-safeloader-expand-support-list-for-TP-Link-CPE210-v3.patch
+++ b/patches/openwrt/0028-tplink-safeloader-expand-support-list-for-TP-Link-CPE210-v3.patch
@@ -1,0 +1,37 @@
+From: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+Date: Wed, 8 Jul 2020 11:08:17 +0200
+Subject: tplink-safeloader: expand support list for TP-Link CPE210 v3
+
+This adds new strings to the support list for the TP-Link CPE210 v3
+that are supposed to work with the existing setup.
+
+Without it, the factory image won't be accepted by the vendor UI on
+these newer revisions.
+
+Tested on a CPE210 v3.20 (EU).
+
+Ref: https://forum.openwrt.org/t/build-for-cpe210-v3-20/68000
+
+Signed-off-by: Adrian Schmutzler <freifunk@adrianschmutzler.de>
+
+diff --git a/tools/firmware-utils/src/tplink-safeloader.c b/tools/firmware-utils/src/tplink-safeloader.c
+index de15faf6796c993efc6c2a36b22bb1e978e3be90..4f762d82e3d6073591958fa30af993da66dd10ec 100644
+--- a/tools/firmware-utils/src/tplink-safeloader.c
++++ b/tools/firmware-utils/src/tplink-safeloader.c
+@@ -205,8 +205,15 @@ static struct device_info boards[] = {
+ 			"SupportList:\r\n"
+ 			"CPE210(TP-LINK|EU|N300-2|45550000):3.0\r\n"
+ 			"CPE210(TP-LINK|UN|N300-2|00000000):3.0\r\n"
++			"CPE210(TP-LINK|US|N300-2|55530000):3.0\r\n"
+ 			"CPE210(TP-LINK|UN|N300-2):3.0\r\n"
+-			"CPE210(TP-LINK|EU|N300-2):3.0\r\n",
++			"CPE210(TP-LINK|EU|N300-2):3.0\r\n"
++			"CPE210(TP-LINK|EU|N300-2|45550000):3.1\r\n"
++			"CPE210(TP-LINK|UN|N300-2|00000000):3.1\r\n"
++			"CPE210(TP-LINK|US|N300-2|55530000):3.1\r\n"
++			"CPE210(TP-LINK|EU|N300-2|45550000):3.20\r\n"
++			"CPE210(TP-LINK|UN|N300-2|00000000):3.20\r\n"
++			"CPE210(TP-LINK|US|N300-2|55530000):3.20\r\n",
+ 		.support_trail = '\xff',
+ 		.soft_ver = NULL,
+ 

--- a/patches/openwrt/0029-Backport-en25qh64-from-4.14-to-4.9.patch
+++ b/patches/openwrt/0029-Backport-en25qh64-from-4.14-to-4.9.patch
@@ -1,0 +1,22 @@
+From: Chris Fiege <chris@tinyhost.de>
+Date: Wed, 14 Oct 2020 21:47:56 +0200
+Subject: HACK: Backport en25qh64 from 4.14 to 4.9
+
+diff --git a/target/linux/generic/pending-4.9/476-mtd-spi-nor-add-eon-en25q128.patch b/target/linux/generic/pending-4.9/476-mtd-spi-nor-add-eon-en25q128.patch
+index ac1fda51593af87fe9bd5a5a3bb433e1f098a740..9a9371165369442143a04e74c100db4d589b99d0 100644
+--- a/target/linux/generic/pending-4.9/476-mtd-spi-nor-add-eon-en25q128.patch
++++ b/target/linux/generic/pending-4.9/476-mtd-spi-nor-add-eon-en25q128.patch
+@@ -8,11 +8,12 @@ Signed-off-by: Piotr Dymacz <pepe2k@gmail.com>
+ 
+ --- a/drivers/mtd/spi-nor/spi-nor.c
+ +++ b/drivers/mtd/spi-nor/spi-nor.c
+-@@ -954,6 +954,7 @@ static const struct flash_info spi_nor_i
++@@ -954,6 +954,8 @@ static const struct flash_info spi_nor_i
+  	{ "en25q32b",   INFO(0x1c3016, 0, 64 * 1024,   64, 0) },
+  	{ "en25p64",    INFO(0x1c2017, 0, 64 * 1024,  128, 0) },
+  	{ "en25q64",    INFO(0x1c3017, 0, 64 * 1024,  128, SECT_4K) },
+ +	{ "en25q128",   INFO(0x1c3018, 0, 64 * 1024,  256, SECT_4K) },
+++	{ "en25qh64",   INFO(0x1c7017, 0, 64 * 1024,   128, 0) },
+  	{ "en25qh128",  INFO(0x1c7018, 0, 64 * 1024,  256, 0) },
+  	{ "en25qh256",  INFO(0x1c7019, 0, 64 * 1024,  512, 0) },
+  	{ "en25s64",	INFO(0x1c3817, 0, 64 * 1024,  128, SECT_4K) },


### PR DESCRIPTION
This pull request backports changes from OpenWrt into the v2019.1.x maintainance branch that allow us to use the CPE210 v3.2.

The PR contains two parts:
a) Allow the SPI-NOR driver to bind for the NOR used inside the CPE210 V3.2. This change was made for 4.19 and 4.14 in OpenWRT upstream. This patch packports the crucial change from there to 4.9 (that is used for ar71xx-generic in v2019.1.x).
The upstream commit was:
https://github.com/openwrt/openwrt/commit/359f5e539036db4f7ac69a6d1c3fb7fe70266ffd

b) Add the needed sugar to the TP-Link safeloader.
The upstream commit was:
https://github.com/openwrt/openwrt/commit/4a2380a1e778a8f8e0bfb0a00f2996ed0aab58d8

I hope this kind of backporting of Upstream Changes to older branches is OK. This way this hardware can be supported in all the communities that still rely on v2019.1.x to be maintained a bit longer.

This PR replaces the following PRs done by Parabol1337:
https://github.com/freifunk-gluon/gluon/pull/2123
https://github.com/freifunk-gluon/gluon/pull/2124 (This one is still open but can be closed now.)

Also Parabol1337 has tested this changes on his CPE210 v3.2.