### PR TITLE
ramips-mt7620: use manifest alias for EX3700/EX3800

### DIFF
--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -25,8 +25,8 @@ device('gl-mt750', 'gl-mt750', {
 device('netgear-ex3700', 'ex3700-ex3800', {
 	aliases = {
 		'netgear-ex3800',
-		'netgear-ex3700-ex3800',
 	},
+	manifest_aliases = {'netgear-ex3700-ex3800'},
 	factory_ext = '.chk',
 })
 


### PR DESCRIPTION
Use a manifest alias for the autoupdater image string of the Netgear
EX3700 / EX3800. This way, no unnecessary symlink is created and the
autoupdater functionality is preserved.