### PR TITLE
ath79-generic: add support TP-Link Archer C2 v3

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -95,6 +95,7 @@ local primary_addrs = {
 		{'ath79', 'generic', {
 			'glinet,gl-ar750s-nor',
 			'ocedo,raccoon',
+			'tplink,archer-c2-v3',
 		}},
 		{'brcm2708'},
 		{'ipq40xx', 'generic', {

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -73,6 +73,13 @@ device('ocedo-raccoon', 'ocedo_raccoon', {
 
 -- TP-Link
 
+device('tp-link-archer-c2-v3', 'tplink_archer-c2-v3', {
+	packages = ATH10K_PACKAGES_QCA9887,
+	class = 'tiny',
+	broken = true,  -- 64M ath9k + ath10k
+
+})
+
 device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })


### PR DESCRIPTION
https://openwrt.org/toh/tp-link/tp-link_archer_c2_ac900

64M RAM, guess we'll mark it as TINY/BROKEN.


- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
    ```
    # lua -e 'print(require("platform_info").get_image_name())'
    tp-link-archer-c2-v3
    ```
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- <s>outdoor devices only</s>
  - [ ] <s>added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`</s>