### PR TITLE
docs: fix simple typo, notifiy -> notify

### DIFF
--- a/contrib/ci/jenkins-community-slave/README.md
+++ b/contrib/ci/jenkins-community-slave/README.md
@@ -35,7 +35,7 @@ docker run --detach --restart always \
    - Your node should appear [here](https://build.ffh.zone/label/gluon-docker/).
    - When clicking on it, Jenkins should state "Agent is connected." like here: 
 ![Screenshot from 2019-09-24 01-00-52](https://user-images.githubusercontent.com/601153/65469209-dac6c180-de66-11e9-9d62-0d1c3b6b940b.png)
-5. **Your docker container needs to be rebuilt, when the build dependencies of gluon change. As soon as build dependencies have changed, the build dependency api level has to be raised.** After you rebuilt your docker container, notifiy @lemoer, so he can bump the versioning number.
+5. **Your docker container needs to be rebuilt, when the build dependencies of gluon change. As soon as build dependencies have changed, the build dependency api level has to be raised.** After you rebuilt your docker container, notify @lemoer, so he can bump the versioning number.
 
 ## Backoff
 - If @lemoer is not reachable, please be patient at first if possible. Otherwise contact info@hannover.freifunk.net or join the channel `#freifunkh` on hackint.


### PR DESCRIPTION
There is a small typo in contrib/ci/jenkins-community-slave/README.md.

Should read `notify` rather than `notifiy`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md