### PR TITLE
Generalize proto "gluon_wired.sh"

### DIFF
--- a/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
+++ b/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
@@ -8,6 +8,7 @@ proto_gluon_wired_init_config() {
         proto_config_add_boolean transitive
         proto_config_add_int index
         proto_config_add_boolean vxlan
+        proto_config_add_string vxpeer6addr
 }
 
 xor2() {
@@ -15,8 +16,24 @@ xor2() {
         echo -n "${1:1:1}" | tr '0123456789abcdef' '23016745ab89efcd'
 }
 
+is_layer3_device () {
+        local addrlen="$(cat "/sys/class/net/$1/addr_len")"
+        test "$addrlen" -eq 0
+}
+
 # shellcheck disable=SC2086
 interface_linklocal() {
+        if is_layer3_device "$1"; then
+                if ! ubus call network.interface dump | \
+                     jsonfilter -e "@.interface[@.l3_device='$1']['ipv6-address'][*].address" | \
+                     grep -e '^fe[89ab][0-9a-f]' -m 1; then
+                        proto_notify_error "$config" "MISSING_LL_ADDR_ON_LOWER_IFACE"
+                        proto_block_restart "$config"
+                        exit 1
+                fi
+                return
+        fi
+
         local macaddr="$(ubus call network.device status '{"name": "'"$1"'"}' | jsonfilter -e '@.macaddr')"
         local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
 
@@ -29,11 +46,12 @@ proto_gluon_wired_setup() {
 
         local meshif="$config"
 
-        local transitive index vxlan
-        json_get_vars transitive index vxlan
+        local transitive index vxlan vxpeer6addr
+        json_get_vars transitive index vxlan vxpeer6addr
 
         # default args
         [ -z "$vxlan" ] && vxlan=1
+        [ -z "$vxpeer6addr" ] && vxpeer6addr='ff02::15c'
 
         proto_init_update "$ifname" 1
         proto_send_update "$config"
@@ -46,8 +64,9 @@ proto_gluon_wired_setup() {
                 [ -n "$index" ] && json_add_string macaddr "$(lua -e "print(require('gluon.util').generate_mac($index))")"
                 json_add_string proto 'vxlan6'
                 json_add_string tunlink "$config"
+                # ip6addr (the lower interface ip6) is used by the vxlan.sh proto
                 json_add_string ip6addr "$(interface_linklocal "$ifname")"
-                json_add_string peer6addr 'ff02::15c'
+                json_add_string peer6addr "$vxpeer6addr"
                 json_add_int vid "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')"
                 json_add_boolean rxcsum '0'
                 json_add_boolean txcsum '0'

--- a/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
+++ b/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
@@ -7,6 +7,7 @@ init_proto "$@"
 proto_gluon_wired_init_config() {
         proto_config_add_boolean transitive
         proto_config_add_int index
+        proto_config_add_boolean vxlan
 }
 
 xor2() {
@@ -28,15 +29,16 @@ proto_gluon_wired_setup() {
 
         local meshif="$config"
 
-        local vxlan="$(lua -e 'print(require("gluon.site").mesh.vxlan(true))')"
+        local transitive index vxlan
+        json_get_vars transitive index vxlan
 
-        local transitive index
-        json_get_vars transitive index
+        # default args
+        [ -z "$vxlan" ] && vxlan=1
 
         proto_init_update "$ifname" 1
         proto_send_update "$config"
 
-        if [ "$vxlan" = 'true' ]; then
+        if [ "$vxlan" -eq 1 ]; then
                 meshif="vx_$config"
 
                 json_init

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/210-interface-wan
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/210-interface-wan
@@ -7,6 +7,7 @@ uci:section('network', 'interface', 'mesh_wan', {
 	ifname = 'br-wan',
 	proto  = 'gluon_wired',
 	index  = 0,
+	vxlan  = site.mesh.vxlan(true),
 })
 
 local enable = site.mesh_on_wan(false)

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/220-interface-lan
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/220-interface-lan
@@ -15,6 +15,7 @@ uci:section('network', 'interface', 'mesh_lan', {
 	igmp_snooping = false,
 	proto         = 'gluon_wired',
 	index         = 4,
+	vxlan         = site.mesh.vxlan(true),
 })
 
 if sysconfig.lan_ifname:match(' ') then


### PR DESCRIPTION
These are two small patches to allow using the `gluon_wired.sh` proto for the `mesh_vpn` interface.

This works for layer 2 and layer 3 vpns:
- In case of a layer 2 vpn, this just adds the `gluon_mesh.sh` proto as before.
- In case of a layer 3 vpn, creates an intermediate vxlan interface on top of the interface before applying the `gluon_mesh.sh` proto.

Furthermore an additional setting `vxpeer6addr` is added to the gluon_wired.sh proto, which is only used, if a vxlan layer is added. It can be used to control the peer address of vxlan.

This is preparatory to support wireguard in a clean way. 