### PR TITLE
packages: introduce syslog function in gluon.util

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -1,5 +1,6 @@
 local bit = require 'bit'
 local posix_glob = require 'posix.glob'
+local posix_syslog = require 'posix.syslog'
 local hash = require 'hash'
 local sysconfig = require 'gluon.sysconfig'
 local site = require 'gluon.site'
@@ -177,6 +178,14 @@ function M.get_uptime()
 		return nil
 	end
 	return tonumber(uptime_file:match('^[^ ]+'))
+end
+
+function M.log(message, verbose)
+	if verbose then
+		io.stdout:write(message .. '\n')
+	end
+
+	posix_syslog.syslog(posix_syslog.LOG_INFO, message)
 end
 
 return M

--- a/package/gluon-hoodselector/luasrc/usr/lib/lua/hoodselector/util.lua
+++ b/package/gluon-hoodselector/luasrc/usr/lib/lua/hoodselector/util.lua
@@ -3,13 +3,7 @@ local math_polygon = require('math-polygon')
 local json = require ('jsonc')
 local uci = require('simple-uci').cursor()
 local site = require ('gluon.site')
-local logger = require('posix.syslog')
 local M = {}
-
-function M.log(msg)
-	io.stdout:write(msg..'\n')
-	logger.openlog(msg, logger.LOG_PID)
-end
 
 function M.get_domains()
 	local list = {}
@@ -68,7 +62,7 @@ end
 function M.set_domain_config(domain)
 	if uci:get('gluon', 'core', 'domain') ~= domain.domain_code then
 		os.execute(string.format("exec gluon-switch-domain --no-reboot '%s'", domain.domain_code))
-		M.log('Set domain "'..domain.domain.domain_names[domain.domain_code]..'"')
+		util.log('Set domain "' .. domain.domain.domain_names[domain.domain_code] .. '"', true)
 		return true
 	end
 	return false

--- a/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
+++ b/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
@@ -1,6 +1,7 @@
 #!/usr/bin/lua
 
 local bit = require('bit')
+local util = require ('gluon.util')
 local unistd = require('posix.unistd')
 local fcntl = require('posix.fcntl')
 local hoodutil = require('hoodselector.util')
@@ -10,7 +11,7 @@ local lockfile = '/var/lock/hoodselector.lock'
 local lockfd, err = fcntl.open(lockfile, bit.bor(fcntl.O_WRONLY, fcntl.O_CREAT), 384) -- mode 0600
 
 if not lockfd then
-	hoodutil.log(err, '\n')
+	util.log(err, true)
 	os.exit(1)
 end
 
@@ -40,7 +41,7 @@ if geo.lat ~= nil and geo.lon ~= nil then
 	local geo_base_domain = hoodutil.get_domain_by_geo(jdomains, geo)
 	if geo_base_domain ~= nil then
 		if hoodutil.set_domain_config(geo_base_domain) then
-			hoodutil.log('Domain set by geolocation mode.\n')
+			util.log('Domain set by geolocation mode.', true)
 		end
 		return
 	end


### PR DESCRIPTION
This commit introduces a simple function for writing to the syslog and replaces the custom function used by gluon-hoodselector.