### PR TITLE
actions: run tasks based on set of modified paths

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,8 +1,14 @@
 name: Build Documentation
 on:
   push:
+    paths:
+      - 'docs/**'
+      - '.github/workflows/build-docs.yml'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'docs**/'
+      - '.github/workflows/build-docs.yml'
 jobs:
   build-documentation:
     name: docs

--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -9,8 +9,24 @@ on:
       - master
       - next
       - v20*
+    paths:
+      - "modules"
+      - "Makefile"
+      - "scripts/**"
+      - "package/**"
+      - "patches/**"
+      - "targets/**"
+      - ".github/workflows/build-gluon.yml"
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "modules"
+      - "Makefile"
+      - "scripts/**"
+      - "package/**"
+      - "patches/**"
+      - "targets/**"
+      - ".github/workflows/build-gluon.yml"
 jobs:
   build_firmware:
     strategy:

--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -1,8 +1,17 @@
+---
 name: Check patches
 on:
   push:
+    paths:
+      - 'modules'
+      - 'patches/**'
+      - '.github/workflows/check-patches.yml'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'modules'
+      - 'patches/**'
+      - '.github/workflows/check-patches.yml'
 jobs:
   check-patches:
     name: Check patches

--- a/contrib/actions/generate-actions.py
+++ b/contrib/actions/generate-actions.py
@@ -13,8 +13,24 @@ on:
       - master
       - next
       - v20*
+    paths:
+      - "modules"
+      - "Makefile"
+      - "scripts/**"
+      - "package/**"
+      - "patches/**"
+      - "targets/**"
+      - ".github/workflows/build-gluon.yml"
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - "modules"
+      - "Makefile"
+      - "scripts/**"
+      - "package/**"
+      - "patches/**"
+      - "targets/**"
+      - ".github/workflows/build-gluon.yml"
 jobs:
   build_firmware:
     strategy:


### PR DESCRIPTION
Builds are often unnecessarily queuing up, so this is basically what I had in mind in #2004 ported to actions.