### PR TITLE
gluon-core: use OpenWrt label-mac as fallback

### DIFF
--- a/package/gluon-core/files/lib/gluon/label_mac.sh
+++ b/package/gluon-core/files/lib/gluon/label_mac.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+. /lib/functions/system.sh
+
+get_mac_label

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -54,6 +54,19 @@ local function interface(name)
 	end
 end
 
+local function label_mac()
+	return function()
+		local mac = util.exec('/lib/gluon/label_mac.sh')
+
+		if mac == nil then return nil end
+
+		mac = util.trim(mac)
+		if string.len(mac) ~= 17 then return nil end
+
+		return mac
+	end
+end
+
 
 -- Entries are matched in the order they are listed
 local primary_addrs = {
@@ -147,6 +160,10 @@ local primary_addrs = {
 		{'ramips', 'mt7621', {
 			'dir-860l-b1',
 		}},
+	}},
+	-- label-mac-device default
+	{label_mac(), {
+		{}, -- matches everything
 	}},
 	-- phy0 default
 	{phy(0), {


### PR DESCRIPTION
This adds the OpenWrt label-mac device selection as the most preferred
fallback.

While this is only used on OpenWrt 19.07 for backports, we can also use
the label-mac device when backporting device support. This way, we have
to deal with less device-sepcific code downstream.

Signed-off-by: David Bauer <mail@david-bauer.net>