### PR TITLE
gluon-config-mode-core: serve config mode in normal mode

### DIFF
--- a/package/gluon-config-mode-core/files/etc/init.d/gluon-config-mode
+++ b/package/gluon-config-mode-core/files/etc/init.d/gluon-config-mode
@@ -1,0 +1,14 @@
+#!/bin/sh /etc/rc.common
+
+START=50
+
+USE_PROCD=1
+
+UHTTPD_BIN="/usr/sbin/uhttpd"
+
+start_service() {
+	procd_open_instance
+	procd_set_param respawn
+	procd_set_param command "$UHTTPD_BIN" -f -h /lib/gluon/config-mode/www -x /cgi-bin -A 1 -R -p 127.0.0.1:81
+	procd_close_instance
+}

--- a/package/gluon-config-mode-core/files/usr/lib/autoupdater/abort.d/70gluon-config-mode
+++ b/package/gluon-config-mode-core/files/usr/lib/autoupdater/abort.d/70gluon-config-mode
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. /lib/gluon/autoupdater/lib.sh
+
+
+start_enabled gluon-config-mode

--- a/package/gluon-config-mode-core/files/usr/lib/autoupdater/download.d/30gluon-config-mode
+++ b/package/gluon-config-mode-core/files/usr/lib/autoupdater/download.d/30gluon-config-mode
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. /lib/gluon/autoupdater/lib.sh
+
+
+stop gluon-config-mode


### PR DESCRIPTION
This commit starts a second uhttpd instance bound to localhost:81 which
serves the config mode during normal runtime. This is useful to change
settings via ssh port forwarding:

    ssh routername -L 12345:127.0.0.1:81

Then you can access the config mode on your computer using
http://localhost:12345/.