### PR TITLE
gluon-respondd: fix crash on 64bit archs (+ one unrelated issue)

### DIFF
--- a/package/gluon-respondd/src/respondd-statistics.c
+++ b/package/gluon-respondd/src/respondd-statistics.c
@@ -239,7 +239,7 @@ static void count_iface_stations(size_t *wifi24, size_t *wifi5, const char *ifna
 	}
 }
 
-static void count_stations(size_t *wifi24, size_t *wifi5, size_t *owe24, size_t owe5) {
+static void count_stations(size_t *wifi24, size_t *wifi5, size_t *owe24, size_t *owe5) {
 	struct uci_context *ctx = uci_alloc_context();
 	if (!ctx)
 		return;

--- a/package/libgluonutil/src/libgluonutil.h
+++ b/package/libgluonutil/src/libgluonutil.h
@@ -54,6 +54,7 @@ struct json_object * gluonutil_wrap_and_free_string(char *str);
 
 bool gluonutil_has_domains(void);
 char * gluonutil_get_domain(void);
+char * gluonutil_get_primary_domain(void);
 struct json_object * gluonutil_load_site_config(void);
 
 #endif /* _LIBGLUON_LIBGLUON_H_ */


### PR DESCRIPTION
Fix two issues (that should have been obvious if anyone were looking at compiler warnings...)

The first issue causes a crash on 64bit archs in multidomain setups. The second issue is harmless.

Affects Gluon next, master and v2020.2.x.

Closes #2173 