### PR TITLE
gluon-web-private-wifi: define ifname for WAN radio

### DIFF
--- a/package/gluon-private-wifi/Makefile
+++ b/package/gluon-private-wifi/Makefile
@@ -1,0 +1,13 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-private-wifi
+PKG_VERSION:=1
+
+include ../gluon.mk
+
+define Package/gluon-private-wifi
+  TITLE:=Provides a virtual access point for the nodes WAN network 
+  DEPENDS:=+gluon-core
+endef
+
+$(eval $(call BuildPackageGluon,gluon-private-wifi))

--- a/package/gluon-private-wifi/luasrc/lib/gluon/upgrade/325-gluon-private-wifi
+++ b/package/gluon-private-wifi/luasrc/lib/gluon/upgrade/325-gluon-private-wifi
@@ -1,0 +1,18 @@
+#!/usr/bin/lua
+
+local uci = require("simple-uci").cursor()
+local wireless = require 'gluon.wireless'
+
+wireless.foreach_radio(uci, function(radio)
+	local radio_name = radio['.name']
+	local suffix = radio_name:match('^radio(%d+)$')
+	local name   = "wan_" .. radio_name
+
+	if not uci:get('wireless', name, 'device') then
+		return
+	end
+
+	uci:set('wireless', name, 'ifname', suffix and 'wan' .. suffix)
+end)
+
+uci:save('wireless')

--- a/package/gluon-web-private-wifi/Makefile
+++ b/package/gluon-web-private-wifi/Makefile
@@ -7,7 +7,7 @@ PKG_RELEASE:=1
 include ../gluon.mk
 
 define Package/gluon-web-private-wifi
-  DEPENDS:=+gluon-web-admin
+  DEPENDS:=+gluon-web-admin +gluon-private-wifi
   TITLE:=UI for activating a private WLAN
 endef
 

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
@@ -49,6 +49,7 @@ mfp.default = uci:get('wireless', primary_iface, 'ieee80211w') or "0"
 function f:write()
 	wireless.foreach_radio(uci, function(radio, index)
 		local radio_name = radio['.name']
+		local suffix = radio_name:match('^radio(%d+)$')
 		local name   = "wan_" .. radio_name
 
 		if enabled.data then
@@ -62,6 +63,7 @@ function f:write()
 				ssid       = ssid.data,
 				key        = key.data,
 				macaddr    = macaddr,
+				ifname     = suffix and 'wan' .. suffix,
 				disabled   = false,
 			})
 


### PR DESCRIPTION
Set the ifname for the WAN radio (Private WLAN) to wanX, X being the
radio index.

All other radios created by Gluon already have their ifname defined
following this pattern.

Signed-off-by: David Bauer <mail@david-bauer.net>