### PR TITLE
build: add support for multiple mmodule sources

### DIFF
--- a/modules
+++ b/modules
@@ -1,14 +1,14 @@
 GLUON_FEEDS='packages routing gluon'
 
-OPENWRT_REPO=https://github.com/openwrt/openwrt.git
+OPENWRT_REPO='https://github.com/openwrt/openwrt.git https://git.openwrt.org/openwrt/openwrt.git'
 OPENWRT_BRANCH=openwrt-19.07
 OPENWRT_COMMIT=a7a207e18bf7fa04f265bb95cbe6fa91561fbfe8
 
-PACKAGES_PACKAGES_REPO=https://github.com/openwrt/packages.git
+PACKAGES_PACKAGES_REPO='https://github.com/openwrt/packages.git https://git.openwrt.org/feed/packages.git'
 PACKAGES_PACKAGES_BRANCH=openwrt-19.07
 PACKAGES_PACKAGES_COMMIT=2974079d3db786fe5da00c10f1d80e79b0112093
 
-PACKAGES_ROUTING_REPO=https://github.com/openwrt-routing/packages.git
+PACKAGES_ROUTING_REPO='https://github.com/openwrt-routing/packages.git https://git.openwrt.org/feed/routing.git'
 PACKAGES_ROUTING_BRANCH=openwrt-19.07
 PACKAGES_ROUTING_COMMIT=02b4dbfcb7b8f8b566940847d22d5a6f229d2e66
 

--- a/modules
+++ b/modules
@@ -12,5 +12,5 @@ PACKAGES_ROUTING_REPO='https://github.com/openwrt-routing/packages.git https://g
 PACKAGES_ROUTING_BRANCH=openwrt-19.07
 PACKAGES_ROUTING_COMMIT=02b4dbfcb7b8f8b566940847d22d5a6f229d2e66
 
-PACKAGES_GLUON_REPO=https://github.com/freifunk-gluon/packages.git
+PACKAGES_GLUON_REPO='https://github.com/freifunk-gluon/packages.git https://gh6.ring0.space/freifunk-gluon/packages.git'
 PACKAGES_GLUON_COMMIT=12e41d0ff07ec54bbd67a31ab50d12ca04f2238c


### PR DESCRIPTION
This PR adds support for multiple module sources to Gluon. This allows a module to be obtained from a different git source in case it cannot be obtained from the primary source. It preserves full backwards compatibility for existing module files contained in site repositories.

## Motivation

### Module availability

As it became [apparent](https://github.com/openwrt/openwrt/pull/3701#issuecomment-770882601) that the availability of the OpenWrt GitHub mirror is not guaranteed and not under full control of the project, a way to ensure Gluon can be built even if such a situation occurs should be provided. As git.openwrt.org is under full control of the project, this is a suitable source.

On the other hand Gluon makes extensive usage of the GitHub actions service. As it was discovered multiple times in the past, git.openwrt.org has a rate limit which we frequently hit when using the Actions CI, forcing us to switch to the GitHub mirror in the first place. With this PR, this is not an issue, as the clone happens primarily from GitHub and only falls back to git.openwrt.org in case the GitHub mirror is not available.

### Building Gluon in IPv6 only environments

The git.openwrt.org server is IPv6 capable and all modules apart from Gluons packages feed can be obtained from there. Add a GitHub IPv6 mirror service as a fallback source for the Gluon packages feed in order to support building Gluon in IPv6 only environments

I yet have to verify the last part, as Gluon downloads it's sources from a lot of different sources. In theory, the IPv6 sources mirror is capable and should serve as a fallback in case the primary source for a package does not support IPv6. I'll do a test build on an IPv6 only machine in the coming days.