### PR TITLE
gluon-mesh-batman-adv: Use source routing for br-client

### DIFF
--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/320-gluon-mesh-batman-adv-client-bridge
@@ -14,7 +14,7 @@ uci:section('network', 'interface', 'client', {
 	proto = 'dhcpv6',
 	reqprefix = 'no',
 	peerdns = not site.dns.servers(),
-	sourcefilter = false,
+	sourcefilter = true,
 	keep_ra_dnslifetime = true,
 	robustness = 9,
 	query_interval = 2000,


### PR DESCRIPTION
Router advertisement servers advertise prefixes together with a default
router in layer 2 networks. There may be multiple router advertisement
servers in one layer 2 network. Each of those router advertisement
servers can advertise different prefixes and a different default router.

A client can accept multiple of the advertised prefixes at the same
time. If it does that, it installs an address in each of the advertised
prefixes. It also has to install default routes from the router
advertisements. Since default routers are sometimes not able to
forward ip packets from arbitrary source addresses, the client should
install routes to all default routers and use the correct one depending
on which of the installed addresses it is sending from.

This can be addressed using source based routing. The odhcpv6 script
already attempts to implement this. The setting is named
"sourcefilter". In this commit, we enable it.

	Note, that the following examples show output of ip-full.
	I am not sure, whether the "from" part is acutally shown by
	ip-tiny.

	Before this commit:

	root@platzhalter-525400123457:/# ip -6 route show default
	default via fe80::8ae6:40ff:feba:a099 dev br-client proto static metric 512 pref medium

	After this commit:

	root@platzhalter-525400123457:/# ip -6 route show default
	default from 2001:678:978:199::/64 via fe80::8ae6:40ff:feba:1099 dev br-client proto static metric 512 pref medium
	default from 2a02:790:ff:799::/64 via fe80::8ae6:40ff:feba:1099 dev br-client proto static metric 512 pref medium
	default from 2a02:790:ff:899::/64 via fe80::8ae6:40ff:feba:1099 dev br-client proto static metric 512 pref medium
	default from 2a02:790:ff:999::/64 via fe80::8ae6:40ff:feba:1099 dev br-client proto static metric 512 pref medium
	default from 2a02:790:ff:1099::/64 via fe80::8ae6:40ff:feba:1099 dev br-client proto static metric 512 pref medium
	default from fdca:ffee:8:99::/64 via fe80::8ae6:40ff:feba:1099 dev br-client proto static metric 512 pref medium

Fixes #2180
Tested-By: Leonardo Mörlein <git@irrelefant.net>