### PR TITLE
gluon-neighbour-info: end before timeout

### DIFF
--- a/package/gluon-neighbour-info/src/gluon-neighbour-info.c
+++ b/package/gluon-neighbour-info/src/gluon-neighbour-info.c
@@ -44,7 +44,8 @@ void usage() {
 	puts("  -t <sec>         timeout in seconds (default: 3)");
 	puts("  -s <event>       output as server-sent events of type <event>");
 	puts("                   or without type if <event> is the empty string");
-	puts("  -c <count>       only wait for at most <count> replies");
+	puts("  -c <count>       only wait for at most <count> replies (default: 1");
+	puts("                   if -l is not given for unicast destination addresses)");
 	puts("  -l               after timeout (or <count> replies if -c is given),");
 	puts("                   send another request and loop forever");
 	puts("  -h               this help\n");
@@ -230,6 +231,10 @@ int main(int argc, char **argv) {
 			perror("setsockopt");
 			exit(EXIT_FAILURE);
 		}
+	}
+
+	if (!loop && !IN6_IS_ADDR_MULTICAST(&client_addr.sin6_addr)) {
+		max_count=1;
 	}
 
 	if (sse) {


### PR DESCRIPTION
This is has been compiled and tested.

Results of `time ./gluon-neighbour-info -s neighbour -d ff02::2:1001 -p 1001 -r nodeinfo`
before and after:

`real	0m3,013s`
and
`real	0m0,168s`

> End the process after one result in case  is not given.
> Reduces singleshot execution time from timeout seconds to around 150ms.
> 
> resolves #2184