### PR TITLE
contrib/actions: use apt-get instead of apt

### DIFF
--- a/contrib/actions/install-dependencies.sh
+++ b/contrib/actions/install-dependencies.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-apt update
-apt install git subversion build-essential python gawk unzip libncurses5-dev zlib1g-dev libssl-dev wget time
-apt clean
+apt-get -y update
+apt-get -y install git subversion build-essential python gawk unzip libncurses5-dev zlib1g-dev libssl-dev wget time
+apt-get -y clean
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
apt does not have a stable CLI interface. Don't use it in scripts.