### PR TITLE
WIP: Add Aruba AP-105

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -185,6 +185,10 @@ ar71xx-tiny [#deprecated]_ [#device-class-tiny]_
 ath79-generic
 --------------
 
+* Aruba
+  
+  - AP-105
+
 * devolo
 
   - WiFi pro 1200e [#lan_as_wan]_

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -91,3 +91,10 @@ device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 })
 
 device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
+
+-- Aruba
+
+device('aruba-ap-105', 'aruba_ap-105', {
+	factory = false,
+})
+


### PR DESCRIPTION
Add support for Aruba AP-105 devices supported by [OpenWRT](https://openwrt.org/toh/aruba/aruba_ap-105)

Integration checklist

- [X] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [X] other: An external flashing tool is required to overwritte the boot loader
- [ ] must support upgrade mechanism
  - [ ] must have working sysupgrade
    - [ ] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [ ] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [X] reset/wps/phone button must return device into config mode: Depends on the revision of the device. Some revision have not a reset button.
- [X] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [ ] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [ ] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only: it's an indoor device
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
