### PR TITLE
 contrib/Dockerfile: use apt-get instead of apt

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,6 +1,7 @@
 FROM debian:buster-slim
 
-RUN apt update && apt install -y --no-install-recommends \
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     file \
     git \


### PR DESCRIPTION
* apt is meant for user interactive usage. apt does not guarantee a stable CLI.
* set DEBIAN_FRONTEND=noninteractive to tell apt-get that no user interaction is wanted