### PR TITLE
gluon-status-page: add role to status-page

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -126,6 +126,9 @@
 							<%- end %>
 						</dd>
 					<%- end %>
+					<% if nodeinfo.system.role then -%>
+						<dt><%:Role%></dt><dd><%| nodeinfo.system.role %></dd>
+					<%- end %>
 					<% if nodeinfo.software.autoupdater then -%>
 						<dt><%:Automatic updates%></dt><dd><%| enabled(nodeinfo.software.autoupdater.enabled) %><%|
 							nodeinfo.software.autoupdater.enabled and

--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -4,6 +4,7 @@
 	local util = require 'gluon.util'
 
 	local translations = {}
+	local site_i18n = i18n 'gluon-site'
 
 	local function _(v)
 		translations[v] = translate(v)
@@ -127,7 +128,7 @@
 						</dd>
 					<%- end %>
 					<% if nodeinfo.system.role then -%>
-						<dt><%:Role%></dt><dd><%| nodeinfo.system.role %></dd>
+						<dt><%:Role%></dt><dd><%| site_i18n._translate('gluon-web-node-role:role:' .. nodeinfo.system.role) %></dd>
 					<%- end %>
 					<% if nodeinfo.software.autoupdater then -%>
 						<dt><%:Automatic updates%></dt><dd><%| enabled(nodeinfo.software.autoupdater.enabled) %><%|

--- a/package/gluon-status-page/i18n/de.po
+++ b/package/gluon-status-page/i18n/de.po
@@ -97,6 +97,9 @@ msgstr "RAM"
 msgid "Received"
 msgstr "Empfangen"
 
+msgid "Role"
+msgstr "Rolle"
+
 msgid "Site"
 msgstr "Site"
 

--- a/package/gluon-status-page/i18n/gluon-status-page.pot
+++ b/package/gluon-status-page/i18n/gluon-status-page.pot
@@ -88,6 +88,9 @@ msgstr ""
 msgid "Received"
 msgstr ""
 
+msgid "Role"
+msgstr ""
+
 msgid "Site"
 msgstr ""
 

--- a/package/gluon-status-page/i18n/ru.README
+++ b/package/gluon-status-page/i18n/ru.README
@@ -18,6 +18,7 @@ if we ever add Russion to gluon-web, the following strings can be reused:
 "Clients": "Клиенты",
 "Transmitted": "Передано",
 "Received": "Получено",
+"Role": "Роль",
 "Forwarded": "Переправленно",
 "Day": "День",
 "Days": "Дней",


### PR DESCRIPTION
Implements the next open crumb of #1415.