### PR TITLE
gluon-{config,web}-*: show "save & apply" button during runtime

### DIFF
--- a/package/gluon-config-mode-core/i18n/de.po
+++ b/package/gluon-config-mode-core/i18n/de.po
@@ -13,6 +13,9 @@ msgstr ""
 msgid "Save & restart"
 msgstr "Speichern & Neustarten"
 
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"
+
 msgid "Welcome!"
 msgstr "Willkommen!"
 

--- a/package/gluon-config-mode-core/i18n/fr.po
+++ b/package/gluon-config-mode-core/i18n/fr.po
@@ -13,6 +13,9 @@ msgstr ""
 msgid "Save & restart"
 msgstr "Enregistrer & Redémarer"
 
+msgid "Save & apply"
+msgstr "Enregistrer & Appliquer"
+
 msgid "Welcome!"
 msgstr "Bienvenue!"
 

--- a/package/gluon-config-mode-core/i18n/gluon-config-mode-core.pot
+++ b/package/gluon-config-mode-core/i18n/gluon-config-mode-core.pot
@@ -4,6 +4,9 @@ msgstr "Content-Type: text/plain; charset=UTF-8"
 msgid "Save & restart"
 msgstr ""
 
+msgid "Save & apply"
+msgstr ""
+
 msgid "Welcome!"
 msgstr ""
 

--- a/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
+++ b/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
@@ -54,7 +54,7 @@ return function(form, uci)
 	function o:write(data)
 		if data ~= selected_domain then
 			domain_changed = true
-			uci:set('gluon', 'core', 'domain', data)
+			uci:set('gluon', 'core', 'switch_domain', data)
 		end
 	end
 

--- a/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
+++ b/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
@@ -32,5 +32,11 @@ return function(form, uci)
 		pretty_hostname.set(uci, data or default_hostname)
 	end
 
-	return {'system'}
+	local function reload_hostname()
+		local hostname_file = io.open('/proc/sys/kernel/hostname', 'w')
+		hostname_file:write(o.data or default_hostname)
+		hostname_file:close()
+	end
+
+	return {'system', reload_hostname}
 end

--- a/package/gluon-web-admin/i18n/de.po
+++ b/package/gluon-web-admin/i18n/de.po
@@ -133,3 +133,6 @@ msgstr "Hier kannst du ein manuelles Firmwareupdate durchführen."
 msgid "You can provide your SSH keys here (one per line):"
 msgstr ""
 "Hier hast du die Möglichkeit, SSH-Keys zu hinterlegen (einen pro Zeile):"
+
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"

--- a/package/gluon-web-admin/i18n/fr.po
+++ b/package/gluon-web-admin/i18n/fr.po
@@ -133,3 +133,6 @@ msgstr "Ici vous pouvez changer manuellement votre firmware."
 
 msgid "You can provide your SSH keys here (one per line):"
 msgstr "Ici vous pouvez entrer vos clés SSH (une par ligne):"
+
+msgid "Save & apply"
+msgstr "Enregistrer & Appliquer"

--- a/package/gluon-web-admin/i18n/gluon-web-admin.pot
+++ b/package/gluon-web-admin/i18n/gluon-web-admin.pot
@@ -115,3 +115,6 @@ msgstr ""
 
 msgid "You can provide your SSH keys here (one per line):"
 msgstr ""
+
+msgid "Save & apply"
+msgstr ""

--- a/package/gluon-web-admin/luasrc/lib/gluon/config-mode/model/admin/remote.lua
+++ b/package/gluon-web-admin/luasrc/lib/gluon/config-mode/model/admin/remote.lua
@@ -18,6 +18,11 @@ local unistd = require 'posix.unistd'
 local wait = require 'posix.sys.wait'
 
 local f_keys = Form(translate("SSH keys"), translate("You can provide your SSH keys here (one per line):"), 'keys')
+
+if not util.in_setup_mode() then
+	f_keys.submit = translate('Save & apply')
+end
+
 local s = f_keys:section(Section)
 local keys = s:option(TextValue, "keys")
 keys.wrap = "off"
@@ -32,6 +37,10 @@ function keys:write(value)
 		f:close()
 	else
 		unistd.unlink("/etc/dropbear/authorized_keys")
+	end
+
+	if not util.in_setup_mode() then
+		util.reconfigure_asynchronously()
 	end
 end
 
@@ -56,6 +65,10 @@ local f_password = Form(translate("Password"), translate(
 	), 'password'
 )
 f_password.reset = false
+
+if not util.in_setup_mode() then
+	f_password.submit = translate('Save & apply')
+end
 
 s = f_password:section(Section)
 
@@ -125,6 +138,10 @@ function f_password:write()
 		-- We don't check the return code here as the error 'password for root is already locked' is normal...
 		os.execute('passwd -l root >/dev/null')
 		f_password.message = translate("Password removed.")
+	end
+
+	if not util.in_setup_mode() then
+		util.reconfigure_asynchronously()
 	end
 end
 

--- a/package/gluon-web-autoupdater/i18n/de.po
+++ b/package/gluon-web-autoupdater/i18n/de.po
@@ -18,3 +18,6 @@ msgstr "Branch"
 
 msgid "Enable"
 msgstr "Aktivieren"
+
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"

--- a/package/gluon-web-autoupdater/i18n/fr.po
+++ b/package/gluon-web-autoupdater/i18n/fr.po
@@ -18,3 +18,6 @@ msgstr "Branche"
 
 msgid "Enable"
 msgstr "Activer"
+
+msgid "Save & apply"
+msgstr "Enregistrer & Appliquer"

--- a/package/gluon-web-autoupdater/i18n/gluon-web-autoupdater.pot
+++ b/package/gluon-web-autoupdater/i18n/gluon-web-autoupdater.pot
@@ -9,3 +9,6 @@ msgstr ""
 
 msgid "Enable"
 msgstr ""
+
+msgid "Save & apply"
+msgstr ""

--- a/package/gluon-web-autoupdater/luasrc/lib/gluon/config-mode/model/admin/autoupdater.lua
+++ b/package/gluon-web-autoupdater/luasrc/lib/gluon/config-mode/model/admin/autoupdater.lua
@@ -10,8 +10,14 @@ You may obtain a copy of the License at
 
 local uci = require("simple-uci").cursor()
 local autoupdater = uci:get_first("autoupdater", "autoupdater")
+local util = require 'gluon.util'
 
 local f = Form(translate("Automatic updates"))
+
+if not util.in_setup_mode() then
+	f.submit = translate('Save & apply')
+end
+
 local s = f:section(Section)
 local o
 
@@ -41,6 +47,10 @@ end
 
 function f:write()
 	uci:commit("autoupdater")
+
+	if not util.in_setup_mode() then
+		util.reconfigure_asynchronously()
+	end
 end
 
 return f

--- a/package/gluon-web-logging/i18n/de.po
+++ b/package/gluon-web-logging/i18n/de.po
@@ -22,3 +22,6 @@ msgstr "Logging"
 
 msgid "Port"
 msgstr ""
+
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"

--- a/package/gluon-web-logging/i18n/gluon-web-logging.pot
+++ b/package/gluon-web-logging/i18n/gluon-web-logging.pot
@@ -18,3 +18,6 @@ msgstr ""
 
 msgid "Port"
 msgstr ""
+
+msgid "Save & apply"
+msgstr ""

--- a/package/gluon-web-logging/luasrc/lib/gluon/config-mode/model/admin/logging.lua
+++ b/package/gluon-web-logging/luasrc/lib/gluon/config-mode/model/admin/logging.lua
@@ -1,11 +1,17 @@
 local uci = require('simple-uci').cursor()
 local system = uci:get_first('system', 'system')
+local util = require 'gluon.util'
 
 local f = Form(translate('Logging'), translate(
 	"If you want to use a remote syslog server, you can set it up here. "
 	.. "Please keep in mind that the data is not encrypted, which may cause "
 	.. "individual-related data to be transmitted unencrypted over the internet."
 ))
+
+if not util.in_setup_mode() then
+	f.submit = translate('Save & apply')
+end
+
 local s = f:section(Section)
 
 local enable = s:option(Flag, 'log_remote', translate('Enable'))
@@ -36,6 +42,10 @@ end
 
 function f:write()
 	uci:commit('system')
+
+	if not util.in_setup_mode() then
+		util.reconfigure_asynchronously()
+	end
 end
 
 return f

--- a/package/gluon-web-mesh-vpn-fastd/i18n/de.po
+++ b/package/gluon-web-mesh-vpn-fastd/i18n/de.po
@@ -36,3 +36,6 @@ msgstr "Hohe Geschwindigkeit"
 
 msgid "Security mode"
 msgstr "Hohe Sicherheit"
+
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"

--- a/package/gluon-web-mesh-vpn-fastd/i18n/fr.po
+++ b/package/gluon-web-mesh-vpn-fastd/i18n/fr.po
@@ -36,3 +36,6 @@ msgstr "Mode performance"
 
 msgid "Security mode"
 msgstr "Mode sécurité"
+
+msgid "Save & apply"
+msgstr "Enregistrer & Appliquer"

--- a/package/gluon-web-mesh-vpn-fastd/i18n/gluon-web-mesh-vpn-fastd.pot
+++ b/package/gluon-web-mesh-vpn-fastd/i18n/gluon-web-mesh-vpn-fastd.pot
@@ -21,3 +21,6 @@ msgstr ""
 
 msgid "Security mode"
 msgstr ""
+
+msgid "Save & apply"
+msgstr ""

--- a/package/gluon-web-mesh-vpn-fastd/luasrc/lib/gluon/config-mode/model/admin/mesh_vpn_fastd.lua
+++ b/package/gluon-web-mesh-vpn-fastd/luasrc/lib/gluon/config-mode/model/admin/mesh_vpn_fastd.lua
@@ -3,6 +3,10 @@ local util = require 'gluon.util'
 
 local f = Form(translate('Mesh VPN'))
 
+if not util.in_setup_mode() then
+	f.submit = translate('Save & apply')
+end
+
 local s = f:section(Section)
 
 local mode = s:option(Value, 'mode')
@@ -37,6 +41,10 @@ function mode:write(data)
 
 	uci:save('fastd')
 	uci:commit('fastd')
+
+	if not util.in_setup_mode() then
+		util.reconfigure_asynchronously()
+	end
 end
 
 return f

--- a/package/gluon-web-model/i18n/de.po
+++ b/package/gluon-web-model/i18n/de.po
@@ -15,3 +15,6 @@ msgstr "Zurücksetzen"
 
 msgid "Save"
 msgstr "Speichern"
+
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"

--- a/package/gluon-web-model/i18n/fr.po
+++ b/package/gluon-web-model/i18n/fr.po
@@ -15,3 +15,6 @@ msgstr "Remise à zéro"
 
 msgid "Save"
 msgstr "Soumettre"
+
+msgid "Save & apply"
+msgstr "Enregistrer & Appliquer"

--- a/package/gluon-web-model/i18n/gluon-web-model.pot
+++ b/package/gluon-web-model/i18n/gluon-web-model.pot
@@ -6,3 +6,6 @@ msgstr ""
 
 msgid "Save"
 msgstr ""
+
+msgid "Save & apply"
+msgstr ""

--- a/package/gluon-web-network/i18n/de.po
+++ b/package/gluon-web-network/i18n/de.po
@@ -60,3 +60,6 @@ msgstr "Statische DNS-Server"
 
 msgid "WAN connection"
 msgstr "WAN-Verbindung"
+
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"

--- a/package/gluon-web-network/i18n/fr.po
+++ b/package/gluon-web-network/i18n/fr.po
@@ -60,3 +60,6 @@ msgstr "Adresse DNS statique"
 
 msgid "WAN connection"
 msgstr "Connexion WAN"
+
+msgid "Save & apply"
+msgstr "Enregistrer & Appliquer"

--- a/package/gluon-web-network/i18n/gluon-web-network.pot
+++ b/package/gluon-web-network/i18n/gluon-web-network.pot
@@ -51,3 +51,6 @@ msgstr ""
 
 msgid "WAN connection"
 msgstr ""
+
+msgid "Save & apply"
+msgstr ""

--- a/package/gluon-web-network/luasrc/lib/gluon/config-mode/model/admin/network.lua
+++ b/package/gluon-web-network/luasrc/lib/gluon/config-mode/model/admin/network.lua
@@ -18,6 +18,10 @@ local dns_static = uci:get_first("gluon-wan-dnsmasq", "static")
 
 local f = Form(translate("WAN connection"))
 
+if not util.in_setup_mode() then
+	f.submit = translate('Save & apply')
+end
+
 local s = f:section(Section)
 
 local ipv4 = s:option(ListValue, "ipv4", translate("IPv4"))
@@ -163,6 +167,10 @@ function f:write()
 
 	uci:commit("network")
 	uci:commit('system')
+
+	if not util.in_setup_mode() then
+		util.reconfigure_asynchronously()
+	end
 end
 
 return f

--- a/package/gluon-web-node-role/i18n/de.po
+++ b/package/gluon-web-node-role/i18n/de.po
@@ -25,3 +25,6 @@ msgstr "Verwendungszweck"
 
 msgid "Role"
 msgstr "Rolle"
+
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"

--- a/package/gluon-web-node-role/i18n/fr.po
+++ b/package/gluon-web-node-role/i18n/fr.po
@@ -25,3 +25,6 @@ msgstr "Rôle du nœud"
 
 msgid "Role"
 msgstr "Rôle"
+
+msgid "Save & apply"
+msgstr "Enregistrer & Appliquer"

--- a/package/gluon-web-node-role/i18n/gluon-web-node-role.pot
+++ b/package/gluon-web-node-role/i18n/gluon-web-node-role.pot
@@ -12,3 +12,6 @@ msgstr ""
 
 msgid "Role"
 msgstr ""
+
+msgid "Save & apply"
+msgstr ""

--- a/package/gluon-web-node-role/luasrc/lib/gluon/config-mode/model/admin/noderole.lua
+++ b/package/gluon-web-node-role/luasrc/lib/gluon/config-mode/model/admin/noderole.lua
@@ -2,12 +2,17 @@ local f, s, o
 local site = require 'gluon.site'
 local site_i18n = i18n 'gluon-site'
 local uci = require("simple-uci").cursor()
+local util = require 'gluon.util'
 local config = 'gluon-node-info'
 
 -- where to read the configuration from
 local role = uci:get(config, uci:get_first(config, "system"), "role")
 
 f = Form(translate("Node role"))
+
+if not util.in_setup_mode() then
+	f.submit = translate('Save & apply')
+end
 
 s = f:section(Section, nil, translate(
 	"If this node has a special role within the mesh network you can specify this role here. "
@@ -24,6 +29,10 @@ end
 function o:write(data)
 	uci:set(config, uci:get_first(config, "system"), "role", data)
 	uci:commit(config)
+
+	if not util.in_setup_mode() then
+		util.reconfigure_asynchronously()
+	end
 end
 
 return f

--- a/package/gluon-web-private-wifi/i18n/de.po
+++ b/package/gluon-web-private-wifi/i18n/de.po
@@ -60,3 +60,6 @@ msgstr ""
 "Funktionalität ist völlig unabhängig von den Mesh-Funktionen des Knotens. "
 "Beachte, dass du nicht gleichzeitig das Meshen über den WAN-Port aktiviert "
 "haben solltest."
+
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"

--- a/package/gluon-web-private-wifi/i18n/fr.po
+++ b/package/gluon-web-private-wifi/i18n/fr.po
@@ -59,3 +59,6 @@ msgstr ""
 "Fi séparé. Cette fonction est complètement indépendante de les fonctions de "
 "MESH. Il ne faut pas activer la fonction de MESH et de Wi-Fi privé en même "
 "temps."
+
+msgid "Save & apply"
+msgstr "Enregistrer & Appliquer"

--- a/package/gluon-web-private-wifi/i18n/gluon-web-private-wifi.pot
+++ b/package/gluon-web-private-wifi/i18n/gluon-web-private-wifi.pot
@@ -46,3 +46,6 @@ msgid ""
 "the mesh functionality. Please note that the private WLAN and meshing on the "
 "WAN interface should not be enabled at the same time."
 msgstr ""
+
+msgid "Save & apply"
+msgstr ""

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
@@ -1,11 +1,16 @@
 local uci = require("simple-uci").cursor()
 local platform = require 'gluon.platform'
 local wireless = require 'gluon.wireless'
+local util = require 'gluon.util'
 
 -- where to read the configuration from
 local primary_iface = 'wan_radio0'
 
 local f = Form(translate("Private WLAN"))
+
+if not util.in_setup_mode() then
+	f.submit = translate('Save & apply')
+end
 
 local s = f:section(Section, nil, translate(
 	'Your node can additionally extend your private network by bridging the WAN interface '
@@ -77,6 +82,10 @@ function f:write()
 	end)
 
 	uci:commit('wireless')
+
+	if not util.in_setup_mode() then
+		util.reconfigure_asynchronously()
+	end
 end
 
 return f

--- a/package/gluon-web-wifi-config/i18n/de.po
+++ b/package/gluon-web-wifi-config/i18n/de.po
@@ -77,3 +77,6 @@ msgstr ""
 "werden. Wenn möglich, ist in den Werten der Sendeleistung der Antennengewinn "
 "enthalten; diese Werte sind allerdings für viele Geräte nicht verfügbar oder "
 "fehlerhaft."
+
+msgid "Save & apply"
+msgstr "Speichern & Anwenden"

--- a/package/gluon-web-wifi-config/i18n/fr.po
+++ b/package/gluon-web-wifi-config/i18n/fr.po
@@ -71,3 +71,6 @@ msgstr ""
 "d'émmission se votre Wi-Fi. Prenez note que les valeurs fournies pour la "
 "puissance de transmission prennent en compte les gains fournis par "
 "l'antenne, et que ces valeurs ne sont pas toujours disponibles ou exactes."
+
+msgid "Save & apply"
+msgstr "Enregistrer & Appliquer"

--- a/package/gluon-web-wifi-config/i18n/gluon-web-wifi-config.pot
+++ b/package/gluon-web-wifi-config/i18n/gluon-web-wifi-config.pot
@@ -47,3 +47,6 @@ msgid ""
 "values include the antenna gain where available, but there are many devices "
 "for which the gain is unavailable or inaccurate."
 msgstr ""
+
+msgid "Save & apply"
+msgstr ""

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -1,6 +1,7 @@
 local iwinfo = require 'iwinfo'
 local uci = require("simple-uci").cursor()
 local site = require 'gluon.site'
+local util = require 'gluon.util'
 local wireless = require 'gluon.wireless'
 
 
@@ -37,6 +38,10 @@ local function has_5ghz_radio()
 end
 
 local f = Form(translate("WLAN"))
+
+if not util.in_setup_mode() then
+	f.submit = translate('Save & apply')
+end
 
 f:section(Section, nil, translate(
 	"You can enable or disable your node's client and mesh network "
@@ -201,6 +206,10 @@ function f:write()
 	os.execute('/lib/gluon/upgrade/200-wireless')
 	uci:commit('network')
 	uci:commit('wireless')
+
+	if not util.in_setup_mode() then
+		util.reconfigure_asynchronously()
+	end
 end
 
 return f


### PR DESCRIPTION
If the user has left the setup mode and starts a uhttpd instance to
serve the config mode during normal runtime of the gluon node, this
change is helpful. Instead of the "Save" or "Save & reboot" button,
now a "Save & apply" button is presented. If this button is pressed,
"gluon-reload" including a "gluon-reconfigure" is invoked internally
causing the node to regenerate and reload its configuration
immediately.

Currently such an uhttpd instance is not running by default, but a
user can start such an instance manually and access it via ssh port
forwarding.

---
Before:
![Screenshot from 2021-04-23 00-52-35](https://user-images.githubusercontent.com/601153/115794423-4455db80-a3ce-11eb-9e4c-76f06261749c.png)

After:
![Screenshot from 2021-04-23 00-53-46](https://user-images.githubusercontent.com/601153/115794514-64859a80-a3ce-11eb-91f9-6cf7fead38eb.png)

---

Tested:
- Changing hostname works.
- Changing domain works.
- Changing password works.
- Disabling/enabling vpn works.
- Enabling/disabling mesh on wan works. 