### PR TITLE
gluon-mesh-batman-adv: reenable batman-adv multicast optimizations

### DIFF
--- a/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
+++ b/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
@@ -47,7 +47,6 @@ proto_gluon_bat0_setup() {
 
 	batctl orig_interval 5000
 	batctl hop_penalty "$(lookup_uci 'gluon.mesh_batman_adv.hop_penalty' 15)"
-	batctl multicast_mode 0
 
 	case "$gw_mode" in
 		server)


### PR DESCRIPTION
With batman-adv 2020.4 and the according backports to batman-adv v2019.2
several more bugs were found and fixed regarding the batman-adv
multicast optimizations feature.

Also a "wakeup-call" feature was added to the Linux bridge IGMP/MLD
snooping code in Gluon to work around issues with Android devices.

With batman-adv now at v2019.2, multicast-to-multi-unicasts conversion
is supported, too. Which means that even if there are a few outdated nodes
these and all other recipients will be served multicast packets via unicast,
too, as long as the sum of receiving nodes does not exceed the multicast
fanout setting (default: 16). If is exceeded, then batman-adv will revert
back to broadcast flooding automatically.

Long story short, with all these extra measures in place, let's reenable
the batman-adv multicast optimizations to reduce the layer 2 overhead
and in preparation for multicast applications in the future.

The default is enabled for this feature anyway, so removing the
"batctl multicast_mode 0" overwrite is sufficient.

Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>