### PR TITLE
web-admin: fix firmware partition name

### DIFF
--- a/package/gluon-web-admin/luasrc/lib/gluon/config-mode/controller/admin/upgrade.lua
+++ b/package/gluon-web-admin/luasrc/lib/gluon/config-mode/controller/admin/upgrade.lua
@@ -72,7 +72,7 @@ local function action_upgrade(http, renderer)
 		if unistd.access("/proc/mtd") then
 			for l in io.lines("/proc/mtd") do
 				local s, n = l:match('^[^%s]+%s+([^%s]+)%s+[^%s]+%s+"([^%s]+)"')
-				if n == "linux" then
+				if n == "firmware" then
 					size = tonumber(s, 16)
 					break
 				end


### PR DESCRIPTION
The rudimentary flash size determination function expects the partition
for the devices firmware to be called "linux" while it is (since quite
some time) "firmware".

Fix this error to display available flash size as well as more useful
error message in case the uploaded firmware image exceeds the flash
space.

Signed-off-by: David Bauer <mail@david-bauer.net>

![Screenshot from 2021-05-01 03-14-22](https://user-images.githubusercontent.com/16539439/116766568-76e58100-aa2b-11eb-96b5-5e41ccca617d.png)
