### PR TITLE
actions: build gluon for next sub-branches

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
       - master
-      - next
+      - next*
       - v20*
     paths:
       - "modules"

--- a/contrib/actions/generate-actions.py
+++ b/contrib/actions/generate-actions.py
@@ -11,7 +11,7 @@ on:
   push:
     branches:
       - master
-      - next
+      - next*
       - v20*
     paths:
       - "modules"


### PR DESCRIPTION
Currently we do not perform CI firmware builds on the next-2102 branch.

Build Gluon for all branches starting with "next" to increase the
coverage of our build tests.

Signed-off-by: David Bauer <mail@david-bauer.net>