### PR TITLE
gluon-ebtables-filter-multicast: relax IPv6 multicast firewall rules

### DIFF
--- a/package/gluon-ebtables-filter-multicast/luasrc/lib/gluon/ebtables/355-mcast-drop
+++ b/package/gluon-ebtables-filter-multicast/luasrc/lib/gluon/ebtables/355-mcast-drop
@@ -1,1 +1,3 @@
+rule ('MULTICAST_OUT -p IPv6 --ip6-dst ff02::1/128 -j DROP')
+rule ('MULTICAST_OUT -p IPv6 --ip6-dst ff00::/8 -j mark --set-mark 0x4 --mark-target RETURN')
 rule ('MULTICAST_OUT -j DROP')

--- a/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
+++ b/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
@@ -47,6 +47,7 @@ proto_gluon_bat0_setup() {
 
 	batctl orig_interval 5000
 	batctl hop_penalty "$(lookup_uci 'gluon.mesh_batman_adv.hop_penalty' 15)"
+	batctl noflood_mark 0x4/0x4
 
 	case "$gw_mode" in
 		server)

--- a/patches/packages/routing/0003-batman-adv-Introduce-no-noflood-mark.patch
+++ b/patches/packages/routing/0003-batman-adv-Introduce-no-noflood-mark.patch
@@ -1,0 +1,187 @@
+From: Linus Lüssing <linus.luessing@c0d3.blue>
+Date: Sat, 1 May 2021 22:19:03 +0200
+Subject: batman-adv: Introduce no noflood mark
+
+This mark prevents a multicast packet being flooded through the whole
+mesh. The advantage of marking certain multicast packets via e.g.
+ebtables instead of dropping is then the following:
+
+This allows an administrator to let specific multicast packets pass as
+long as they are forwarded to a limited number of nodes only and are
+therefore creating no burdon to unrelated nodes.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+
+diff --git a/batman-adv/patches/0034-batman-adv-Introduce-no-noflood-mark.patch b/batman-adv/patches/0034-batman-adv-Introduce-no-noflood-mark.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..2ccb6da270acf41e56f9a37801e23301e592b112
+--- /dev/null
++++ b/batman-adv/patches/0034-batman-adv-Introduce-no-noflood-mark.patch
+@@ -0,0 +1,167 @@
++From 25b21382238c783298c0d8defc8c739126c1b54d Mon Sep 17 00:00:00 2001
++From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
++Date: Sat, 31 Mar 2018 03:36:19 +0200
++Subject: [PATCH] batman-adv: Introduce no noflood mark
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++This mark prevents a multicast packet being flooded through the whole
++mesh. The advantage of marking certain multicast packets via e.g.
++ebtables instead of dropping is then the following:
++
++This allows an administrator to let specific multicast packets pass as
++long as they are forwarded to a limited number of nodes only and are
++therefore creating no burdon to unrelated nodes.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++---
++
++https://www.open-mesh.org/projects/batman-adv/wiki/Noflood-broadcast-prevention
++
++Changelog v2:
++
++* rebased to master
++* sysfs -> netlink
++---
++ include/uapi/linux/batman_adv.h | 12 ++++++++++++
++ net/batman-adv/netlink.c        | 22 ++++++++++++++++++++++
++ net/batman-adv/soft-interface.c | 20 ++++++++++++++++++++
++ net/batman-adv/types.h          | 12 ++++++++++++
++ 4 files changed, 66 insertions(+)
++
++diff --git a/include/uapi/linux/batman_adv.h b/include/uapi/linux/batman_adv.h
++index 67f46367..6fabb7aa 100644
++--- a/include/uapi/linux/batman_adv.h
+++++ b/include/uapi/linux/batman_adv.h
++@@ -480,6 +480,18 @@ enum batadv_nl_attrs {
++ 	 */
++ 	BATADV_ATTR_MULTICAST_FANOUT,
++ 
+++	/**
+++	 * @BATADV_ATTR_NOFLOOD_MARK: the noflood mark which allows to tag
+++	 *  frames which should never be broadcast flooded through the mesh.
+++	 */
+++	BATADV_ATTR_NOFLOOD_MARK,
+++
+++	/**
+++	 * @BATADV_ATTR_NOFLOOD_MASK: the noflood (bit)mask which allows to tag
+++	 *  frames which should never be broadcast flooded through the mesh.
+++	 */
+++	BATADV_ATTR_NOFLOOD_MASK,
+++
++ 	/* add attributes above here, update the policy in netlink.c */
++ 
++ 	/**
++diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
++index e1978bc5..3d2c147a 100644
++--- a/net/batman-adv/netlink.c
+++++ b/net/batman-adv/netlink.c
++@@ -134,6 +134,8 @@ static const struct nla_policy batadv_netlink_policy[NUM_BATADV_ATTR] = {
++ 	[BATADV_ATTR_AP_ISOLATION_ENABLED]	= { .type = NLA_U8 },
++ 	[BATADV_ATTR_ISOLATION_MARK]		= { .type = NLA_U32 },
++ 	[BATADV_ATTR_ISOLATION_MASK]		= { .type = NLA_U32 },
+++	[BATADV_ATTR_NOFLOOD_MARK]		= { .type = NLA_U32 },
+++	[BATADV_ATTR_NOFLOOD_MASK]		= { .type = NLA_U32 },
++ 	[BATADV_ATTR_BONDING_ENABLED]		= { .type = NLA_U8 },
++ 	[BATADV_ATTR_BRIDGE_LOOP_AVOIDANCE_ENABLED]	= { .type = NLA_U8 },
++ 	[BATADV_ATTR_DISTRIBUTED_ARP_TABLE_ENABLED]	= { .type = NLA_U8 },
++@@ -286,6 +288,14 @@ static int batadv_netlink_mesh_fill(struct sk_buff *msg,
++ 			bat_priv->isolation_mark_mask))
++ 		goto nla_put_failure;
++ 
+++	if (nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MARK,
+++			bat_priv->noflood_mark))
+++		goto nla_put_failure;
+++
+++	if (nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MASK,
+++			bat_priv->noflood_mark_mask))
+++		goto nla_put_failure;
+++
++ 	if (nla_put_u8(msg, BATADV_ATTR_BONDING_ENABLED,
++ 		       !!atomic_read(&bat_priv->bonding)))
++ 		goto nla_put_failure;
++@@ -466,6 +476,18 @@ static int batadv_netlink_set_mesh(struct sk_buff *skb, struct genl_info *info)
++ 		bat_priv->isolation_mark_mask = nla_get_u32(attr);
++ 	}
++ 
+++	if (info->attrs[BATADV_ATTR_NOFLOOD_MARK]) {
+++		attr = info->attrs[BATADV_ATTR_NOFLOOD_MARK];
+++
+++		bat_priv->noflood_mark = nla_get_u32(attr);
+++	}
+++
+++	if (info->attrs[BATADV_ATTR_NOFLOOD_MASK]) {
+++		attr = info->attrs[BATADV_ATTR_NOFLOOD_MASK];
+++
+++		bat_priv->noflood_mark_mask = nla_get_u32(attr);
+++	}
+++
++ 	if (info->attrs[BATADV_ATTR_BONDING_ENABLED]) {
++ 		attr = info->attrs[BATADV_ATTR_BONDING_ENABLED];
++ 
++diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
++index c99facdb..4e71b9f3 100644
++--- a/net/batman-adv/soft-interface.c
+++++ b/net/batman-adv/soft-interface.c
++@@ -176,6 +176,23 @@ static void batadv_interface_set_rx_mode(struct net_device *dev)
++ {
++ }
++ 
+++/**
+++ * batadv_send_skb_has_noflood_mark() - check if packet has a noflood mark
+++ * @bat_priv: the bat priv with all the soft interface information
+++ * @skb: the packet to check
+++ *
+++ * Return: True if the skb's mark matches a configured noflood mark and
+++ * noflood mark mask. False otherwise.
+++ */
+++static bool
+++batadv_skb_has_noflood_mark(struct batadv_priv *bat_priv, struct sk_buff *skb)
+++{
+++	u32 match_mark = skb->mark & bat_priv->noflood_mark_mask;
+++
+++	return bat_priv->noflood_mark_mask &&
+++	       match_mark == bat_priv->noflood_mark;
+++}
+++
++ static netdev_tx_t batadv_interface_tx(struct sk_buff *skb,
++ 				       struct net_device *soft_iface)
++ {
++@@ -326,6 +343,9 @@ static netdev_tx_t batadv_interface_tx(struct sk_buff *skb,
++ 		if (batadv_dat_snoop_outgoing_arp_request(bat_priv, skb))
++ 			brd_delay = msecs_to_jiffies(ARP_REQ_DELAY);
++ 
+++		if (batadv_skb_has_noflood_mark(bat_priv, skb))
+++			goto dropped;
+++
++ 		if (batadv_skb_head_push(skb, sizeof(*bcast_packet)) < 0)
++ 			goto dropped;
++ 
++diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
++index c0ded822..09c877fa 100644
++--- a/net/batman-adv/types.h
+++++ b/net/batman-adv/types.h
++@@ -1599,6 +1599,18 @@ struct batadv_priv {
++ 	 */
++ 	u32 isolation_mark_mask;
++ 
+++	/**
+++	 * @noflood_mark: the skb->mark value used to allow directed targeting
+++	 *  only
+++	 */
+++	u32 noflood_mark;
+++
+++	/**
+++	 * @noflood_mark_mask: bitmask identifying the bits in skb->mark to be
+++	 *  used for the noflood mark
+++	 */
+++	u32 noflood_mark_mask;
+++
++ 	/** @bcast_seqno: last sent broadcast packet sequence number */
++ 	atomic_t bcast_seqno;
++ 
++-- 
++2.31.0
++

--- a/patches/packages/routing/0004-batctl-Add-noflood_mark-command.patch
+++ b/patches/packages/routing/0004-batctl-Add-noflood_mark-command.patch
@@ -1,0 +1,287 @@
+From: Linus Lüssing <linus.luessing@c0d3.blue>
+Date: Sat, 1 May 2021 22:19:41 +0200
+Subject: batctl: Add noflood_mark command
+
+Adds support for the new 'noflood_mark' setting in batman-adv.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+
+diff --git a/batctl/patches/0012-batctl-Add-noflood_mark-command.patch b/batctl/patches/0012-batctl-Add-noflood_mark-command.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..296f3c51b79333a8e96c340d151ba00b8f457120
+--- /dev/null
++++ b/batctl/patches/0012-batctl-Add-noflood_mark-command.patch
+@@ -0,0 +1,273 @@
++From c14abebbeb4af76600cd6eb508e5e4e38a436b2f Mon Sep 17 00:00:00 2001
++From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
++Date: Fri, 26 Apr 2019 19:27:38 +0200
++Subject: [PATCH] batctl: Add noflood_mark command
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++Adds support for the new 'noflood_mark' setting in batman-adv.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++---
++Changelog v3:
++* changed command from a noflood tri-state option
++  to a value/mask one similar to the isolation mark
++* noflood.c -> noflood_mark.c
++
++Changelog v2:
++* added noflood.c
++---
++ Makefile       |   1 +
++ README.rst     |  15 ++++++
++ batman_adv.h   |  12 +++++
++ man/batctl.8   |  23 ++++++++
++ noflood_mark.c | 141 +++++++++++++++++++++++++++++++++++++++++++++++++
++ 5 files changed, 192 insertions(+)
++ create mode 100644 noflood_mark.c
++
++diff --git a/Makefile b/Makefile
++index e3747a2..686de7e 100755
++--- a/Makefile
+++++ b/Makefile
++@@ -61,6 +61,7 @@ $(eval $(call add_command,multicast_mode,y))
++ $(eval $(call add_command,nc_nodes,y))
++ $(eval $(call add_command,neighbors,y))
++ $(eval $(call add_command,network_coding,y))
+++$(eval $(call add_command,noflood_mark,y))
++ $(eval $(call add_command,orig_interval,y))
++ $(eval $(call add_command,originators,y))
++ $(eval $(call add_command,ping,y))
++diff --git a/README.rst b/README.rst
++index 128f539..bc937d2 100644
++--- a/README.rst
+++++ b/README.rst
++@@ -582,6 +582,21 @@ Usage::
++ * Example 4: ``batctl mark 0x0f``
++ 
++ 
+++batctl noflood_mark
+++=======================
+++
+++display or modify noflood_mark setting
+++
+++Usage::
+++
+++  batctl noflood_mark|nf $value[/0x$mask]
+++
+++* Example 1: ``batctl nf 0x00000001/0xffffffff``
+++* Example 2: ``batctl nf 0x00040000/0xffff0000``
+++* Example 3: ``batctl nf 16``
+++* Example 4: ``batctl nf 0x0f``
+++
+++
++ batctl translocal
++ =================
++ 
++diff --git a/batman_adv.h b/batman_adv.h
++index 67f4636..6fabb7a 100644
++--- a/batman_adv.h
+++++ b/batman_adv.h
++@@ -480,6 +480,18 @@ enum batadv_nl_attrs {
++ 	 */
++ 	BATADV_ATTR_MULTICAST_FANOUT,
++ 
+++	/**
+++	 * @BATADV_ATTR_NOFLOOD_MARK: the noflood mark which allows to tag
+++	 *  frames which should never be broadcast flooded through the mesh.
+++	 */
+++	BATADV_ATTR_NOFLOOD_MARK,
+++
+++	/**
+++	 * @BATADV_ATTR_NOFLOOD_MASK: the noflood (bit)mask which allows to tag
+++	 *  frames which should never be broadcast flooded through the mesh.
+++	 */
+++	BATADV_ATTR_NOFLOOD_MASK,
+++
++ 	/* add attributes above here, update the policy in netlink.c */
++ 
++ 	/**
++diff --git a/man/batctl.8 b/man/batctl.8
++index d42b682..5489c2e 100644
++--- a/man/batctl.8
+++++ b/man/batctl.8
++@@ -124,6 +124,29 @@ If no parameter is given the current multicast fanout setting is displayed. Othe
++ the multicast fanout. The multicast fanout defines the maximum number of packet copies that may be generated for a
++ multicast-to-unicast conversion. Once this limit is exceeded distribution will fall back to broadcast.
++ .br
+++.IP "\fBnoflood_mark\fP|\fBnf\fP"
+++If no parameter is given the current noflood mark value is displayed.
+++Otherwise the parameter is used to set or unset the noflood mark. The
+++noflood mark allows to prevent broadcast flooding of a frame which
+++was previously tagged via netfilter for instance. batman-adv will
+++then only forward a frame into the mesh if destined to a limited
+++number of destination nodes and drop the frame otherwise.
+++.br
+++The input is supposed to be of the form $value/$mask, where $value can be any
+++32bit long integer (expressed in decimal or hex base) and $mask is a generic
+++bitmask (expressed in hex base) that selects the bits to take into consideration
+++from $value. It is also possible to enter the input using only $value and in
+++this case the full bitmask is used by default.
+++
+++.br
+++.br
+++Example 1: 0x00000001/0xffffffff
+++.br
+++Example 2: 0x00040000/0xffff0000
+++.br
+++Example 3: 16 or 0x0F
+++.br
+++.br
++ .IP "\fBloglevel\fP|\fBll\fP [\fBlevel\fP[ \fBlevel\fP[ \fBlevel\fP]] \fB...\fP]"
++ If no parameter is given the current log level settings are displayed otherwise the parameter(s) is/are used to set the log
++ level. Level 'none' disables all verbose logging. Level 'batman' enables messages related to routing / flooding / broadcasting.
++diff --git a/noflood_mark.c b/noflood_mark.c
++new file mode 100644
++index 0000000..e89205c
++--- /dev/null
+++++ b/noflood_mark.c
++@@ -0,0 +1,141 @@
+++// SPDX-License-Identifier: GPL-2.0
+++/* Copyright (C) 2009-2019  B.A.T.M.A.N. contributors:
+++ *
+++ * Antonio Quartulli <a@unstable.cc>
+++ * Linus Lüssing <linus.luessing@c0d3.blue>
+++ *
+++ * License-Filename: LICENSES/preferred/GPL-2.0
+++ */
+++
+++#include <errno.h>
+++#include <stddef.h>
+++#include <stdint.h>
+++#include <string.h>
+++
+++#include "main.h"
+++#include "sys.h"
+++
+++static struct noflood_mark_data {
+++	uint32_t noflood_mark;
+++	uint32_t noflood_mask;
+++} noflood_mark;
+++
+++static int parse_noflood_mark(struct state *state, int argc, char *argv[])
+++{
+++	struct settings_data *settings = state->cmd->arg;
+++	struct noflood_mark_data *data = settings->data;
+++	char *mask_ptr;
+++	char buff[256];
+++	uint32_t mark;
+++	uint32_t mask;
+++	char *endptr;
+++
+++	if (argc != 2) {
+++		fprintf(stderr, "Error - incorrect number of arguments (expected 1)\n");
+++		return -EINVAL;
+++	}
+++
+++	strncpy(buff, argv[1], sizeof(buff));
+++	buff[sizeof(buff) - 1] = '\0';
+++
+++	/* parse the mask if it has been specified, otherwise assume the mask is
+++	 * the biggest possible
+++	 */
+++	mask = 0xFFFFFFFF;
+++	mask_ptr = strchr(buff, '/');
+++	if (mask_ptr) {
+++		*mask_ptr = '\0';
+++		mask_ptr++;
+++
+++		/* the mask must be entered in hex base as it is going to be a
+++		 * bitmask and not a prefix length
+++		 */
+++		mask = strtoul(mask_ptr, &endptr, 16);
+++		if (!endptr || *endptr != '\0')
+++			goto inval_format;
+++	}
+++
+++	/* the mark can be entered in any base */
+++	mark = strtoul(buff, &endptr, 0);
+++	if (!endptr || *endptr != '\0')
+++		goto inval_format;
+++
+++	data->noflood_mask = mask;
+++	/* erase bits not covered by the mask */
+++	data->noflood_mark = mark & mask;
+++
+++	return 0;
+++
+++inval_format:
+++	fprintf(stderr, "Error - incorrect number of arguments (expected 1)\n");
+++	fprintf(stderr, "The following formats for mark(/mask) are allowed:\n");
+++	fprintf(stderr, " * 0x12345678\n");
+++	fprintf(stderr, " * 0x12345678/0xabcdef09\n");
+++	return -EINVAL;
+++}
+++
+++static int print_noflood_mark(struct nl_msg *msg, void *arg)
+++{
+++	struct nlattr *attrs[BATADV_ATTR_MAX + 1];
+++	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+++	struct genlmsghdr *ghdr;
+++	int *result = arg;
+++
+++	if (!genlmsg_valid_hdr(nlh, 0))
+++		return NL_OK;
+++
+++	ghdr = nlmsg_data(nlh);
+++
+++	if (nla_parse(attrs, BATADV_ATTR_MAX, genlmsg_attrdata(ghdr, 0),
+++		      genlmsg_len(ghdr), batadv_netlink_policy)) {
+++		return NL_OK;
+++	}
+++
+++	if (!attrs[BATADV_ATTR_NOFLOOD_MARK] ||
+++	    !attrs[BATADV_ATTR_NOFLOOD_MASK])
+++		return NL_OK;
+++
+++	printf("0x%08x/0x%08x\n",
+++	       nla_get_u32(attrs[BATADV_ATTR_NOFLOOD_MARK]),
+++	       nla_get_u32(attrs[BATADV_ATTR_NOFLOOD_MASK]));
+++
+++	*result = 0;
+++	return NL_STOP;
+++}
+++
+++static int get_noflood_mark(struct state *state)
+++{
+++	return sys_simple_nlquery(state, BATADV_CMD_GET_MESH,
+++				  NULL, print_noflood_mark);
+++}
+++
+++static int set_attrs_noflood_mark(struct nl_msg *msg, void *arg)
+++{
+++	struct state *state = arg;
+++	struct settings_data *settings = state->cmd->arg;
+++	struct noflood_mark_data *data = settings->data;
+++
+++	nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MARK, data->noflood_mark);
+++	nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MASK, data->noflood_mask);
+++
+++	return 0;
+++}
+++
+++static int set_noflood_mark(struct state *state)
+++{
+++	return sys_simple_nlquery(state, BATADV_CMD_SET_MESH,
+++				  set_attrs_noflood_mark, NULL);
+++}
+++
+++static struct settings_data batctl_settings_noflood_mark = {
+++	.sysfs_name = NULL,
+++	.data = &noflood_mark,
+++	.parse = parse_noflood_mark,
+++	.netlink_get = get_noflood_mark,
+++	.netlink_set = set_noflood_mark,
+++};
+++
+++COMMAND_NAMED(SUBCOMMAND, noflood_mark, "nf", handle_sys_setting,
+++	      COMMAND_FLAG_MESH_IFACE | COMMAND_FLAG_NETLINK,
+++	      &batctl_settings_noflood_mark,
+++	      "[mark]            \tdisplay or modify noflood_mark setting");
++-- 
++2.31.0
++


### PR DESCRIPTION
Allow the transmission of IPv6 multicast packets as long as they are not flooded through the whole mesh.

This is achieved by adding a small "noflood mark" patch to batman-adv. With that multicast packets can be marked by iptables/ip6tables/ebtables as: "Please drop me, batman-adv, if I you'd flood me through the whole mesh."
    
That way it is now possible to send IPv6 packets with a link-local multicast if less than 16 nodes signed up for it (16 = batman-adv multicast fanout default).

This implements the remaining part of #1357.