### PR TITLE
mesh-wireless-sae: drop unused function parameters

### DIFF
--- a/package/gluon-mesh-wireless-sae/luasrc/lib/gluon/upgrade/205-wireless-mesh-sae
+++ b/package/gluon-mesh-wireless-sae/luasrc/lib/gluon/upgrade/205-wireless-mesh-sae
@@ -11,7 +11,7 @@ local function configure_sae(vif)
 	uci:set('wireless', vif, 'key', site.wifi.mesh.sae_passphrase() or hash.md5(site.prefix6()))
 end
 
-wireless.foreach_radio(uci, function(radio, _, _)
+wireless.foreach_radio(uci, function(radio)
 	local radio_name = radio['.name']
 	local vif = 'mesh_' .. radio_name
 	local enable = site.wifi.mesh.sae(false)


### PR DESCRIPTION
Drop these unused parameters in the function description, as only the
first parameter is referenced within the function block.