### PR TITLE
ipq40xx: add support for MikroTik SXTsq 5 ac

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -256,6 +256,10 @@ ipq40xx-generic
 
   - EA6350 (v3)
 
+* MikroTik
+
+  - SXTsq 5 ac
+
 * NETGEAR
 
   - EX6100 (v2)

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -116,6 +116,7 @@ local primary_addrs = {
 			'avm,fritzbox-4040',
 			'plasmacloud,pa1200',
 			'plasmacloud,pa2200',
+			'mikrotik,sxtsq-5-ac',
 		}},
 		{'ipq806x', 'generic', {
 			'netgear,r7800',

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -69,6 +69,9 @@ device('gl.inet-gl-b1300', 'glinet_gl-b1300', {
 
 device('linksys-ea6350v3', 'linksys_ea6350v3')
 
+-- MikroTik
+
+device('mikrotik-sxtsq-5-ac', 'mikrotik_sxtsq-5-ac')
 
 -- NETGEAR
 


### PR DESCRIPTION
The SXTsq 5 AC is a sector antenna with ipq40xx SoC. In particular, the device is ideal to be mounted on the balcony to supply public areas with internet access.

(Still draft since I have no idea of Gluon Firmware ;) )
(I'm just building the hamburg firmware... let see if I will be succesfull)

It fails. :/

```
#
# configuration written to .config
#
make[1]: Leaving directory '/home/nick/Desktop/gluon/openwrt'
Configuration failed:
 * unable to set 'CONFIG_TARGET_DEVICE_PACKAGES_ipq40xx_generic_DEVICE_mikrotik_sxtsq-5-ac="-kmod-ipt-offload -odhcpd-ipv6only -ppp -ppp-mod-pppoe -wpad-mini -wpad-basic -wpad-basic-wolfssl -libustream-wolfssl -ca-bundle gluon-core ip6tables gluon-ebtables-limit-arp gluon-web-wifi-config gluon-config-mode-mesh-vpn hostapd-mini gluon-status-page gluon-ebtables-filter-multicast gluon-web-autoupdater gluon-status-page-mesh-batman-adv gluon-config-mode-domain-select gluon-respondd gluon-web-network gluon-radv-filterd gluon-radvd gluon-config-mode-hostname gluon-mesh-vpn-fastd gluon-web-private-wifi gluon-mesh-batman-adv-15 gluon-ebtables-filter-ra-dhcp gluon-config-mode-autoupdater gluon-autoupdater gluon-config-mode-outdoor gluon-web-admin -gluon-config-mode-geo-location -gluon-config-mode-contact-info gluon-ebtables-source-filter gluon-web-mesh-vpn-fastd iptables iwinfo kmod-ath10k -kmod-ath10k-ct -kmod-ath10k-ct-smallbuffers ath10k-firmware-qca4019 -ath10k-firmware-qca4019-ct"'
 * unable to enable device 'mikrotik_sxtsq-5-ac'
make: *** [Makefile:166: config] Error 1
```