### PR TITLE
gluon-status-page: add mesh protocol to status-page

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -136,6 +136,15 @@
 								string.format(' (%s)', nodeinfo.software.autoupdater.branch)
 						%></dd>
 					<%- end %>
+					<% if nodeinfo.software.babeld or nodeinfo.software['batman-adv'] then -%>
+						<dt><%:Mesh protocol%></dt>
+						<% if nodeinfo.software.babeld then -%>
+						<dd>babel <%| nodeinfo.software.babeld.version %></dd>
+						<%- end %>
+						<% if nodeinfo.software['batman-adv'] then -%>
+						<dd>batman-adv <%| nodeinfo.software['batman-adv'].version %> (compat<%| nodeinfo.software['batman-adv'].compat %>)</dd>
+						<%- end %>
+					<%- end %>
 				</dl>
 			</div>
 			<div class="frame">

--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -139,7 +139,7 @@
 					<% if nodeinfo.software.babeld or nodeinfo.software['batman-adv'] then -%>
 						<dt><%:Mesh protocol%></dt>
 						<% if nodeinfo.software.babeld then -%>
-						<dd>babel <%| nodeinfo.software.babeld.version %></dd>
+						<dd>babeld <%| nodeinfo.software.babeld.version %></dd>
 						<%- end %>
 						<% if nodeinfo.software['batman-adv'] then -%>
 						<dd>batman-adv <%| nodeinfo.software['batman-adv'].version %> (compat<%| nodeinfo.software['batman-adv'].compat %>)</dd>

--- a/package/gluon-status-page/i18n/de.po
+++ b/package/gluon-status-page/i18n/de.po
@@ -70,6 +70,9 @@ msgstr "Systemlast"
 msgid "Location"
 msgstr "Position"
 
+msgid "Mesh protocol"
+msgstr "Mesh-Protokoll"
+
 msgid "Mesh VPN"
 msgstr "Mesh-VPN"
 

--- a/package/gluon-status-page/i18n/gluon-status-page.pot
+++ b/package/gluon-status-page/i18n/gluon-status-page.pot
@@ -61,6 +61,9 @@ msgstr ""
 msgid "Location"
 msgstr ""
 
+msgid "Mesh protocol"
+msgstr ""
+
 msgid "Mesh VPN"
 msgstr ""
 

--- a/package/gluon-status-page/i18n/ru.README
+++ b/package/gluon-status-page/i18n/ru.README
@@ -28,6 +28,7 @@ if we ever add Russion to gluon-web, the following strings can be reused:
 "Packets/s": "Пакетов/c",
 "Statistic": "Статистика",
 "Traffic": "Трафик",
+"Mesh protocol": "Ячеистый протокол"
 "Neighbors": "Соседи",
 "Firmware": "Прошивка",
 "Branch": "Ветка"


### PR DESCRIPTION
This is a draft to show the deployed mesh protocol as well as its version on the routers statuspage.

Its addresses another open point on the agenda of #1415.


An example router can be found at http://lilienstra-e.n.ffh.zone/, or in case our dns misbehaves http://[2001:678:978:114:b64b:d6ff:fe20:2778]/cgi-bin/status .