### PR TITLE
docs: update development basics regarding 'make update'

### DIFF
--- a/docs/dev/basics.rst
+++ b/docs/dev/basics.rst
@@ -52,6 +52,13 @@ and you can try rebasing it onto the new `base` branch yourself and after that c
 Always call `make update-patches` after making changes to a module repository as `make update` will overwrite your
 commits, making `git reflog` the only way to recover them!
 
+Then all is set start the build by calling (probably add -jn):
+
+::
+
+	make all
+
+
 Development Guidelines
 ----------------------
 Lua should be used instead of sh whenever sensible. The following criteria

--- a/docs/dev/basics.rst
+++ b/docs/dev/basics.rst
@@ -37,6 +37,10 @@ rerun
 `make update` also applies the patches that can be found in the directories found in
 `patches`; the resulting branch will be called `patched`, while the commit specified in `modules`
 can be referred to by the branch `base`.
+To separately call `make update` was choosen, to let you decide when to update and reset the external
+repos. This will prevent potential loss of commits during local development and allow building Gluon
+without the need of having an internet connection (for sure the the 3rd-party sources must have been
+downloaded already).
 
 After new patches have been committed on top of the `patched` branch (or existing commits
 since the base commit have been edited or removed), the patch directories can be regenerated


### PR DESCRIPTION
based on #2212  I added some sentences why ```make update``` has to be called explicitly and not by an dependency of ```make all```.