### PR TITLE
gluon-mesh-vpn-core: respondd bandwidth_limit

### DIFF
--- a/package/gluon-mesh-vpn-core/src/Makefile
+++ b/package/gluon-mesh-vpn-core/src/Makefile
@@ -3,4 +3,4 @@ all: respondd.so
 CFLAGS += -Wall -Werror-implicit-function-declaration
 
 respondd.so: respondd.c
-	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -shared -fPIC -D_GNU_SOURCE -o $@ $^ $(LDLIBS) -lgluonutil
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -shared -fPIC -D_GNU_SOURCE -o $@ $^ $(LDLIBS) -lgluonutil -luci


### PR DESCRIPTION
Implements a respondd provider for bandwidth limits using simple-tc.
Due to their static nature, I added the limits to nodeinfo.
This is what the network tree looks like after merging this:

**this was edited**
```
"network": {
  "addresses": [
    "2a02:790:ff:714:b64b:d6ff:fe22:4ebc",
    "2a02:790:ff:914:b64b:d6ff:fe22:4ebc",
    "2a02:790:ff:1014:b64b:d6ff:fe22:4ebc",
    "2001:678:978:114:b64b:d6ff:fe22:4ebc",
    "2a02:790:ff:514:b64b:d6ff:fe22:4ebc",
    "fdca:ffee:8:14:b64b:d6ff:fe22:4ebc",
    "fe80::b64b:d6ff:fe22:4ebc"
  ],
  "mesh": {
    "bat0": {
      "interfaces": {
        "wireless": [
          "b6:4b:d6:22:4e:c0",
          "9a:62:78:2a:dd:59"
        ],
        "tunnel": [
          "9a:62:78:2a:dd:5f"
        ],
        "other": [
          "9a:62:78:2a:dd:5b"
        ]
      }
    }
  },
  "mesh_vpn": {
    "bandwith_limit": {
      "enabled": true,
      "ingress": 5000,
      "egress": 800
    }
  },
  "mac": "b4:4b:d6:22:4e:bc"
},
```


Resolves a part of  #644 .

