### PR TITLE
gluon-status-page: add bandwidth limit

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -64,6 +64,16 @@
 		return v and translate('enabled') or translate('disabled')
 	end
 
+	local function formatBits(bits)
+		local units = {[0]='', 'k', 'M', 'G'}
+
+		local pow = math.floor(math.log(math.max(math.abs(bits), 1)) / math.log(1000))
+		local known_pow = math.min(pow, #units)
+
+		local significand = bits/(1000^known_pow)
+		return string.format('%g %sbit', significand, units[known_pow])
+	end
+
 	local function statistics(key, format)
 		return string.format('<span data-statistics="%s" data-format="%s"></span>', pcdata(key), pcdata(format or 'id'))
 	end
@@ -122,6 +132,17 @@
 							<br /><%| nodeinfo.network.mesh_vpn.provider %>
 							<%- end %>
 						</dd>
+						<% if nodeinfo.network.mesh_vpn.bandwidth_limit.enabled then -%>
+						<dt><%:Bandwidth limit%></dt>
+						<dd>
+							<% if nodeinfo.network.mesh_vpn.bandwidth_limit.egress then -%>
+								▲ <%| formatBits(nodeinfo.network.mesh_vpn.bandwidth_limit.egress*1000) %>/s <%:upstream%><br />
+							<%- end %>
+							<% if nodeinfo.network.mesh_vpn.bandwidth_limit.ingress then -%>
+								▼ <%| formatBits(nodeinfo.network.mesh_vpn.bandwidth_limit.ingress*1000) %>/s <%:downstream%>
+							<%- end %>
+						</dd>
+						<%- end %>
 					<%- end %>
 					<dt><%:Site%></dt><dd><%| site.site_name() %></dd>
 					<% if nodeinfo.system.domain_code then -%>

--- a/package/gluon-status-page/i18n/de.po
+++ b/package/gluon-status-page/i18n/de.po
@@ -28,6 +28,9 @@ msgstr "1 Tag"
 msgid "Automatic updates"
 msgstr "Automatische Updates"
 
+msgid "Bandwidth limit"
+msgstr "Bandbreitenlimit"
+
 msgid "Channel"
 msgstr "Kanal"
 
@@ -42,6 +45,9 @@ msgstr "Entfernung"
 
 msgid "Domain"
 msgstr "Domäne"
+
+msgid "downstream"
+msgstr "Downstream"
 
 msgid "Error"
 msgstr "Fehler"
@@ -123,6 +129,9 @@ msgstr ""
 
 msgid "Transmitted"
 msgstr "Gesendet"
+
+msgid "upstream"
+msgstr "Upstream"
 
 msgid "Uptime"
 msgstr "Laufzeit"

--- a/package/gluon-status-page/i18n/fr.README
+++ b/package/gluon-status-page/i18n/fr.README
@@ -1,0 +1,10 @@
+Draft for french translation, taken from gluon-config-mode-mesh-vpn
+
+msgid ""
+msgstr ""
+
+msgid "downstream"
+msgstr "débit déscendant"
+
+msgid "upstream"
+msgstr "débit ascendant"

--- a/package/gluon-status-page/i18n/gluon-status-page.pot
+++ b/package/gluon-status-page/i18n/gluon-status-page.pot
@@ -19,6 +19,9 @@ msgstr ""
 msgid "Automatic updates"
 msgstr ""
 
+msgid "Bandwidth limit"
+msgstr ""
+
 msgid "Channel"
 msgstr ""
 
@@ -32,6 +35,9 @@ msgid "Distance"
 msgstr ""
 
 msgid "Domain"
+msgstr ""
+
+msgid "downstream"
 msgstr ""
 
 msgid "Error"
@@ -113,6 +119,9 @@ msgid "Traffic"
 msgstr ""
 
 msgid "Transmitted"
+msgstr ""
+
+msgid "upstream"
 msgstr ""
 
 msgid "Uptime"

--- a/package/gluon-status-page/i18n/ru.README
+++ b/package/gluon-status-page/i18n/ru.README
@@ -10,6 +10,7 @@ if we ever add Russion to gluon-web, the following strings can be reused:
 "Primary MAC": "Основной MAC",
 "IP Address": "IP Адрес",
 "Automatic updates": "Автоматические обновления",
+"Bandwidth limit": "Ограничение пропускной способности",
 "Overview": "Обзор",
 "used": "используется",
 "Uptime": "Время работы",


### PR DESCRIPTION
**blocked** by #2216

There will be a bandwidth limit on the statuspage, eventually.

And likewise this might finally resolve #1415 .

This router has the necessary commits applied:
http://meshvpnabstracttest.n.ffh.zone/cgi-bin/status or
http://[2001:678:978:114:b64b:d6ff:fe22:4ebc]/cgi-bin/status

![img](https://aiyionpri.me/shared/2217_bandwidth_limit/first_draft.png)

I implemented a bit-formatting function that looks like this, whether this should go in statuspage or a util file is up to decide.

```lua
local function formatBits(v, factor)
    --to format a value given in kilobits use a factor of 1000
    factor = factor or 1
    units = {'k', 'M', 'G'}
    units[0] = ''

    bits = math.max(0, v*factor)
    pow = math.floor(math.log(bits)/math.log(1000))
    known_pow = math.min(pow, #units)

    bits = bits/1000^known_pow
    return string.format('%s%sbit', bits, units[known_pow])
end
```

This is what it works like:

```console
$ lua demo.lua 
(5000, 1000) -> 	5.0Mbit
(800, 1000) -> 	        800.0kbit
(133742, 1000) -> 	133.742Mbit
(13371337, 1000) -> 	13.371337Gbit
```