### PR TITLE
libgluonutil: free getline

### DIFF
--- a/package/libgluonutil/src/libgluonutil.c
+++ b/package/libgluonutil/src/libgluonutil.c
@@ -196,6 +196,7 @@ enum gluonutil_interface_type gluonutil_get_interface_type(const char *ifname) {
 			break;
 		}
 	}
+	free(line);
 
 	fclose(f);
 	return ret;


### PR DESCRIPTION
We discovered respondds memoryusage to be growing over time in our recent WireGuard tests in hanover.

I built a recent x86 image with `GLUON_DEBUG=1`, ran it using qemu (thanks @lemoer for numerous examples) and installed valgrind.

This is the output:
```console
==8200== 962 bytes in 52 blocks are definitely lost in loss record 14 of 16
==8200==    at 0x407B488: realloc (vg_replace_malloc.c:836)
==8200==    by 0x404813F: getdelim (getdelim.c:38)
==8200==    by 0x40482B8: getline (getline.c:5)
==8200==    by 0x44BD5FD: gluonutil_get_interface_type (in /usr/lib/libgluonutil.so)
==8200==    by 0x44DC3AF: mesh_add_subif (respondd-nodeinfo.c:139)
==8200==    by 0x44DC3AF: get_mesh_subifs (respondd-nodeinfo.c:168)
==8200==    by 0x44DC3AF: get_mesh (respondd-nodeinfo.c:185)
==8200==    by 0x44DC3AF: respondd_provider_nodeinfo (respondd-nodeinfo.c:195)
==8200==    by 0x8049EB9: single_request (in /usr/bin/respondd)
==8200==    by 0x804C248: serve_request (in /usr/bin/respondd)
==8200==    by 0x8049B70: main (in /usr/bin/respondd)
```

And here's the full output for 1 week: https://bpa.st/4LXYM3FPG4B5XTUWC73NHOERCE

There's a not properly freed `getline()` in `gluonutil_get_interface_type` in libgluonutil.

This pr fixes it.