### PR TITLE
gluon-status-page: vpn protocol

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -114,8 +114,14 @@
 					<dt><%:Primary MAC address%></dt><dd><%| nodeinfo.network.mac %></dd>
 					<dt><%:IP address%></dt><dd><%= pcdata(table.concat(sorted(nodeinfo.network.addresses), '\n')):gsub('\n', '<br />') %></dd>
 					<dt><%:Firmware%></dt><dd><%| nodeinfo.software.firmware.release %></dd>
-					<% if nodeinfo.software.fastd then -%>
-						<dt><%:Mesh VPN%></dt><dd><%| enabled(nodeinfo.software.fastd.enabled) %></dd>
+					<% if nodeinfo.network.mesh_vpn then -%>
+						<dt><%:Mesh VPN%></dt>
+						<dd>
+							<%| enabled(nodeinfo.network.mesh_vpn.enabled) %>
+							<% if nodeinfo.network.mesh_vpn.provider then -%>
+							<br /><%| nodeinfo.network.mesh_vpn.provider %>
+							<%- end %>
+						</dd>
 					<%- end %>
 					<dt><%:Site%></dt><dd><%| site.site_name() %></dd>
 					<% if nodeinfo.system.domain_code then -%>


### PR DESCRIPTION
This reimplements the `Mesh VPN`-section on the statuspage in order to close another part of #1415.
Currently the section shows up, if fastd is installed.
Other providers are ignored.

The reimplementation takes whatever vpn-provider is configured as active and shows it below the info whether mesh-vpn is enabled. Both values are provided by respondd since the merge of #2219.

The current implementation is available for feedback on http://meshvpnabstracttest.n.ffh.zone/