### PR TITLE
Simplify save/commit handling of config wizard sections

### DIFF
--- a/package/gluon-config-mode-contact-info/luasrc/lib/gluon/config-mode/wizard/0500-contact-info.lua
+++ b/package/gluon-config-mode-contact-info/luasrc/lib/gluon/config-mode/wizard/0500-contact-info.lua
@@ -21,7 +21,6 @@ return function(form, uci)
 	o.optional = true
 	function o:write(data)
 		uci:set("gluon-node-info", owner, "contact", data)
+		uci:save("gluon-node-info")
 	end
-
-	return {'gluon-node-info'}
 end

--- a/package/gluon-config-mode-core/luasrc/lib/gluon/config-mode/model/gluon-config-mode/wizard.lua
+++ b/package/gluon-config-mode-core/luasrc/lib/gluon/config-mode/model/gluon-config-mode/wizard.lua
@@ -20,6 +20,7 @@ function f:write()
 	local unistd = require 'posix.unistd'
 
 	uci:set("gluon-setup-mode", uci:get_first("gluon-setup-mode", "setup_mode"), "configured", true)
+	uci:save("gluon-setup-mode")
 
 	os.execute('gluon-reconfigure')
 

--- a/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
+++ b/package/gluon-config-mode-domain-select/luasrc/lib/gluon/config-mode/wizard/0200-domain-select.lua
@@ -49,20 +49,8 @@ return function(form, uci)
 		o:value(domain.domain_code, domain.domain_name)
 	end
 
-	local domain_changed = false
-
 	function o:write(data)
-		if data ~= selected_domain then
-			domain_changed = true
-			uci:set('gluon', 'core', 'domain', data)
-		end
+		uci:set('gluon', 'core', 'domain', data)
+		uci:save('gluon')
 	end
-
-	local function reconfigure()
-		if domain_changed then
-			os.execute('gluon-reconfigure')
-		end
-	end
-
-	return {'gluon', reconfigure}
 end

--- a/package/gluon-config-mode-geo-location/luasrc/lib/gluon/config-mode/wizard/0400-geo-location.lua
+++ b/package/gluon-config-mode-geo-location/luasrc/lib/gluon/config-mode/wizard/0400-geo-location.lua
@@ -100,5 +100,7 @@ return function(form, uci)
 		end
 	end
 
-	return {'gluon-node-info'}
+	function s:write()
+		uci:save("gluon-node-info")
+	end
 end

--- a/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
+++ b/package/gluon-config-mode-hostname/luasrc/lib/gluon/config-mode/wizard/0100-hostname.lua
@@ -30,7 +30,6 @@ return function(form, uci)
 
 	function o:write(data)
 		pretty_hostname.set(uci, data or default_hostname)
+		uci:save('system')
 	end
-
-	return {'system'}
 end

--- a/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
+++ b/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
@@ -60,8 +60,5 @@ return function(form, uci)
 
 	function s:write()
 		uci:save('gluon')
-		os.execute('exec /lib/gluon/mesh-vpn/update-config')
 	end
-
-	return {'gluon', 'fastd', 'tunneldigger', 'simple-tc'}
 end

--- a/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
+++ b/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
@@ -58,8 +58,7 @@ return function(form, uci)
 		uci:set("gluon", "mesh_vpn", "limit_egress", data * 1000)
 	end
 
-	function s:handle()
-		Section.handle(s)
+	function s:write()
 		uci:save('gluon')
 		os.execute('exec /lib/gluon/mesh-vpn/update-config')
 	end

--- a/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
+++ b/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
@@ -44,10 +44,6 @@ return function(form, uci)
 				end
 				uci:save('wireless')
 			end
-
-			os.execute('/lib/gluon/upgrade/200-wireless')
 		end
 	end
-
-	return {'gluon', 'network', 'wireless'}
 end


### PR DESCRIPTION
- Add a write() to form sections, so the wizard sections can call `save()` on the UCI cursor themselves
- Always run reconfigure after the wizard. This commits all packages.

This also avoids the `uci_sections()` handling in #2102.