### PR TITLE
ramips-mt76x8: add Xiaomi Mi Router 4A (100M Edition)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -405,6 +405,10 @@ ramips-mt76x8
 
   - VoCore2
 
+* Xiaomi
+
+  - Xiaomi Mi Router 4A (100M Edition)
+
 ramips-rt305x [#deprecated]_  [#device-class-tiny]_
 ---------------------------------------------------
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -130,6 +130,9 @@ local primary_addrs = {
 			'tplink,c2-v1',
 			'ex3700'
 		}},
+		{'ramips', 'mt76x8', {
+			'xiaomi,mir4a-100m',
+		}},
 		{'x86'},
 	}},
 	{interface('wan'), {

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -74,3 +74,10 @@ device('tp-link-tl-wr902ac-v3', 'tplink_tl-wr902ac-v3', {
 device('vocore2', 'vocore2', {
 	factory = false,
 })
+
+
+-- Xiaomi
+
+device('xiaomi-mi-router-4a-100m-edition', 'xiaomi_mir4a-100m', {
+	factory = false,
+})


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other serial: 
INSTALLATION:
1. Connect to the serial port of the router and power it up.
   If you get a prompt asking for boot-mode, go to step 3.
2. Unplug the router after
       > Erasing SPI Flash...
       > raspi_erase: offs:20000 len:10000
   occurs on the serial port. Plug the router back in.
3. At the prompt select option 2 (Load system code then
   write to Flash via TFTP.)
4. Enter 192.168.1.1 as the device IP and 192.168.1.2 as the
   Server-IP.
5. Connect your computer to LAN1 and assign it as 192.168.1.2/24.
6. Rename the sysupgrade image to test.bin and serve it via TFTP.
7. Enter test.bin on the serial console and press enter.
 - [x] other exploit:
https://github.com/acecilia/OpenWRTInvasion
You need to get the "stok" on the same machine that runs the exploit.
And in my case if Windows wont work, try a linux system.

- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [n/a] should map to their respective radio
    - [n/a] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [n/a] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
 
Device is running here: 
https://hannover.freifunk.net/karte/#/de/map/9c9d7effe58a
Already ran 4 days stable but with wrong MAC Address:
https://hannover.freifunk.net/karte/#/de/map/9c9d7effe58b