### PR TITLE
docs: remove dropped hardware from docs

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -237,12 +237,6 @@ ramips-mt76x8
 ramips-rt305x [#deprecated]_  [#device-class-tiny]_
 ---------------------------------------------------
 
-* A5-V11
-
-* D-Link
-
-  - DIR-615 (D1, D2, D3, D4, H1)
-
 * VoCore
 
   - VoCore (8M, 16M)


### PR DESCRIPTION
Fixes commit 89dc6b203d4d ("ramips-rt305x: drop devices with insufficient flash")

Signed-off-by: David Bauer <mail@david-bauer.net>