### PR TITLE
ramips-mt76x8: add Xiaomi Mi Router 4C

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -233,6 +233,7 @@ ramips-mt76x8
 * Xiaomi
 
   - Xiaomi Mi Router 4A (100M Edition)
+  - Xiaomi Mi Router 4C
 
 ramips-rt305x [#deprecated]_  [#device-class-tiny]_
 ---------------------------------------------------

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -81,3 +81,7 @@ device('vocore2', 'vocore_vocore2', {
 device('xiaomi-mi-router-4a-100m-edition', 'xiaomi_mi-router-4a-100m', {
 	factory = false,
 })
+
+device('xiaomi-mi-router-4c', 'xiaomi_mi-router-4c', {
+	factory = false,
+})


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other exploit:
As described here:
https://github.com/acecilia/OpenWRTInvasion
You need to get the "stok" on the same machine that runs the exploit.
And in my case if Windows wont work, try a linux system.
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [n/a] should map to their respective radio
    - [n/a] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [n/a] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
 
Device is running here: 
https://hannover.freifunk.net/karte/#/de/map/64644a263aca