### PR TITLE
ramips-mt7621: add Xiaomi Mi Router 4A (Gigabit Edition)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -199,6 +199,10 @@ ramips-mt7621
 
   - WG3526-16M
   - WG3526-32M
+  
+* Xiaomi
+
+  - Xiaomi Mi Router 4A (Gigabit Edition)
 
 ramips-mt76x8
 -------------

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -29,6 +29,13 @@ device('netgear-wndr3700-v5', 'netgear_wndr3700-v5', {
 })
 
 
+-- Xiaomi
+
+device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {
+	factory = false,
+})
+
+
 -- ZBT
 
 device('zbtlink-zbt-wg3526-16m', 'zbtlink_zbt-wg3526-16m', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other exploit:
As described here:
https://github.com/acecilia/OpenWRTInvasion
You need to get the "stok" on the same machine that runs the exploit.
And in my case if Windows wont work, try a linux system.
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [n/a] should map to their respective radio
    - [n/a] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [n/a] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
 
Device is running here: 
https://hannover.freifunk.net/karte/#/de/map/9c9d7e11b5ea