### PR TITLE
modules: update routing feed URL

### DIFF
--- a/modules
+++ b/modules
@@ -8,7 +8,7 @@ PACKAGES_PACKAGES_REPO=https://github.com/openwrt/packages.git
 PACKAGES_PACKAGES_BRANCH=openwrt-21.02
 PACKAGES_PACKAGES_COMMIT=5fa605a1fa76bc68e3f70122713e592a1b25f068
 
-PACKAGES_ROUTING_REPO=https://github.com/openwrt-routing/packages.git
+PACKAGES_ROUTING_REPO=https://github.com/openwrt/routing.git
 PACKAGES_ROUTING_BRANCH=openwrt-21.02
 PACKAGES_ROUTING_COMMIT=2baff33918c089fd3744c7192f8ae7a29c47a8d7
 


### PR DESCRIPTION
The OpenWrt routing feed was moved to the OpenWrt GitHub org.

Update the URL, as the old one might not work in the future.

Signed-off-by: David Bauer <mail@david-bauer.net>