### PR TITLE
gluon-core: util: check if file exists prior to reading

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -4,6 +4,7 @@ local posix_syslog = require 'posix.syslog'
 local hash = require 'hash'
 local sysconfig = require 'gluon.sysconfig'
 local site = require 'gluon.site'
+local unistd = require 'posix.unistd'
 
 
 local M = {}
@@ -37,6 +38,10 @@ function M.contains(table, value)
 end
 
 function M.file_contains_line(path, value)
+	if not unistd.access(path) then
+		return false
+	end
+
 	for line in io.lines(path) do
 		if line == value then
 			return true


### PR DESCRIPTION
The file_contains_line helper function was not testing whether a file
exists or not prior attempting to read from it.

Add this check to circumvent errors on the private WiFi config in
case the hwflags file is missing.

Reported-by: Tom Herbers <freifunk@tomherbers.de>
Tested-by: Tom Herbers <freifunk@tomherbers.de>
Signed-off-by: David Bauer <mail@david-bauer.net>