### PR TITLE
gluon-status-page: relax nodeinfo query timeout

### DIFF
--- a/package/gluon-status-page/luasrc/lib/gluon/status-page/controller/status-page.lua
+++ b/package/gluon-status-page/luasrc/lib/gluon/status-page/controller/status-page.lua
@@ -61,7 +61,7 @@ local function match(a, b, n)
 end
 
 entry({}, call(function(http, renderer)
-	local nodeinfo = json.parse(util.exec('exec gluon-neighbour-info -d ::1 -p 1001 -t 1 -c 1 -r nodeinfo'))
+	local nodeinfo = json.parse(util.exec('exec gluon-neighbour-info -d ::1 -p 1001 -t 3 -c 1 -r nodeinfo'))
 
 	local node_ip = parse_ip(http:getenv('SERVER_ADDR'))
 	if node_ip and (


### PR DESCRIPTION
It was found that a one second timeout for nodeinfo data may be too low,
so that when a node is otherwise occupied that timeout may be reached
too often.

The nodeinfo query response is also vital to the status-page base
template, so that when it times out, the site will be turned in a broken
state, that it cannot recover from.

Fixes: #2256