### PR TITLE
gluon-core: delete all network device sections

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -74,9 +74,7 @@ uci:delete('network', 'lan')
 uci:delete('network', 'wan')
 
 uci:foreach('network', 'device', function(dev)
-	if dev['type'] ~= 'bridge' then return end
-	if dev['ifname'] ~= 'lan' and dev['ifname'] ~= 'wan' then return end
-
+	-- Delete all default OpenWrt network device sections.
 	uci:delete('network', dev['.name'])
 end)
 


### PR DESCRIPTION
Delete all default network device sections upon first boot.

Only LAN & WAN networks are defined at this point. We are using the
legacy way of definiting bridges via the interface sections ifname
option.

The prior filtering was based upon a single device and didn't take into
consideration that DSA interface names can be named arbitrarily.

Signed-off-by: David Bauer <mail@david-bauer.net>