### PR TITLE
ath79-generic: add support for Siemens WS-AP3610

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -26,6 +26,10 @@ ath79-generic
   - PA300
   - PA300E
 
+* Siemens
+
+  - WS-AP3610
+
 * TP-Link
 
   - Archer C6 (v2)

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -72,6 +72,13 @@ device('plasma-cloud-pa300', 'plasmacloud_pa300')
 
 device('plasma-cloud-pa300e', 'plasmacloud_pa300e')
 
+
+-- Siemens
+
+device('siemens-ws-ap3610', 'siemens_ws-ap3610', {
+	factory = false,
+})
+
 -- TP-Link
 
 device('tp-link-archer-c2-v3', 'tplink_archer-c2-v3', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: CISCO RJ-45 console & tftpboot
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
    ` siemens-ws-ap3610`

- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`