### PR TITLE
ramips-mt76x8: add support for RAVPower RP-WD009

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -227,6 +227,10 @@ ramips-mt76x8
 
   - R6120
 
+* RAVPower
+
+  - RP-WD009
+
 * TP-Link
 
   - Archer C50 (v3)

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -21,6 +21,11 @@ device('netgear-r6120', 'netgear_r6120', {
 })
 
 
+-- RAVPower
+
+device('ravpower-rp-wd009', 'ravpower_rp-wd009')
+
+
 -- TP-Link
 
 device('tp-link-archer-c50-v3', 'tplink_archer-c50-v3', {


### PR DESCRIPTION
- [ ] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: U-Boot recovery Web-UI
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`