### PR TITLE
WIP: lantiq-xrx200: Add support for AVM FRITZ!Box 7430

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -115,6 +115,7 @@ lantiq-xrx200
   - FRITZ!Box 7360 SL [#avmflash]_ [#lan_as_wan]_
   - FRITZ!Box 7362 SL [#eva_ramboot]_ [#lan_as_wan]_
   - FRITZ!Box 7412 [#eva_ramboot]_
+  - FRITZ!Box 7430 [#eva_ramboot]_
 
 lantiq-xway
 -----------

--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -43,6 +43,10 @@ device('avm-fritz-box-7412', 'avm_fritz7412', {
 	factory = false,
 })
 
+device('avm-fritz-box-7430', 'avm_fritz7430', {
+	factory = false,
+})
+
 -- TP-Link
 
   -- CAVEAT: These devices don't have a dedicated WAN port.


### PR DESCRIPTION
- [X] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [X] other: EVA
- [X] must support upgrade mechanism
  - [X] must have working sysupgrade
    - [X] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [X] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [X] reset/wps/phone button must return device into config mode
- [ ] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes) No primary MAC on device
- wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [X] association with AP must be possible on all radios
  - [X] association with 802.11s mesh must be working on all radios 
  - [X] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [X] lit while the device is on
    - [X] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [X] should map to their respective radio
    - [X] should show activity
  - switchport leds
    - [X] should map to their respective port (or switch, if only one led present) 
    - [X] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
