### PR TITLE
WIP: ramips-mt7621: Add support for Xiaomi MiWiFi 3G v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -213,6 +213,7 @@ ramips-mt7621
   
 * Xiaomi
 
+  - Xiaomi MiWiFi 3G (v1)
   - Xiaomi Mi Router 4A (Gigabit Edition)
 
 ramips-mt76x8

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -35,6 +35,10 @@ device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {
 	factory = false,
 })
 
+device('xiaomi-mir3g', 'xiaomi_mir4g', {
+	factory = false,
+})
+
 
 -- ZBT
 


### PR DESCRIPTION
- [X] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [X] other: see-commit: https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=6e283cdc0da25928f8148805ebef7f8f2b769ee8
- [X] must support upgrade mechanism
  - [X] must have working sysupgrade
    - [X] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [X] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [X] reset/wps/phone button must return device into config mode
- [X] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [X] association with AP must be possible on all radios
  - [X] association with 802.11s mesh must be working on all radios 
  - [X] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [X] lit while the device is on
    - [X] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [X] should map to their respective radio
    - [X] should show activity
  - switchport leds
    - [X] should map to their respective port (or switch, if only one led present) 
    - [X] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
