### PR TITLE
contrib/ci/minimal-site: build with owe and wpa3 support

### DIFF
--- a/contrib/ci/minimal-site/site.conf
+++ b/contrib/ci/minimal-site/site.conf
@@ -64,6 +64,8 @@
     outdoor_chanlist = '100-140',
     ap = {
       ssid = 'gluon-ci-ssid',
+      owe_ssid = "owe.gluon-ci-ssid",
+      owe_transition_mode = false,
     },
     mesh = {
       -- Adjust these values!

--- a/docs/site-example/site.mk
+++ b/docs/site-example/site.mk
@@ -17,6 +17,9 @@ GLUON_FEATURES := \
 	web-advanced \
 	web-wizard
 
+GLUON_FEATURES_standard := \
+  wireless-encryption-wpa3
+
 ##	GLUON_SITE_PACKAGES
 #		Specify additional Gluon/OpenWrt packages to include here;
 #		A minus sign may be prepended to remove a packages from the


### PR DESCRIPTION
We saw a kconfig option that had no value set and we assume this is due to crypto (openssl?) in our site. Since this should be a reasonable default these days, let's enable OWE and WPA3 support in the minimal site used in the CI.

> SHA-224/SHA-256 digest algorithm (ARMv8 Crypto Extensions) (CRYPTO_SHA2_ARM64_CE) [N/m/y/?] (NEW) hexa@build:~$ 