### PR TITLE
gluon-core: use uci:delete_all() instead of foreach()+delete()

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -78,9 +78,6 @@ end
 uci:delete('network', 'lan')
 uci:delete('network', 'wan')
 
-uci:foreach('network', 'device', function(dev)
-	-- Delete all default OpenWrt network device sections.
-	uci:delete('network', dev['.name'])
-end)
+uci:delete_all('network', 'device')
 
 uci:save('network')


### PR DESCRIPTION
Currently untested.