### PR TITLE
gluon-mesh-batman-adv: implement checks

### DIFF
--- a/package/gluon-mesh-batman-adv/files/lib/gluon/state/check.d/has_default_gw4
+++ b/package/gluon-mesh-batman-adv/files/lib/gluon/state/check.d/has_default_gw4
@@ -1,0 +1,2 @@
+#!/bin/sh
+out=$(batctl gwl -H 2>/dev/null) && [ -n "$out" ]

--- a/package/gluon-mesh-batman-adv/files/lib/gluon/state/check.d/has_neighbours
+++ b/package/gluon-mesh-batman-adv/files/lib/gluon/state/check.d/has_neighbours
@@ -1,0 +1,2 @@
+#!/bin/sh
+out=$(batctl n -H 2>/dev/null) && [ -n "$out" ]


### PR DESCRIPTION
This is a follow-up on #2245,
that contains the mesh-protocol dependent code that was split off it.