### PR TITLE
ramips-mt76x8: add support for TP-Link RE200 v2

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -210,7 +210,7 @@ ramips-mt7621
 
   - WG3526-16M
   - WG3526-32M
-  
+
 * Xiaomi
 
   - Xiaomi Mi Router 4A (Gigabit Edition)
@@ -239,6 +239,7 @@ ramips-mt76x8
 
   - Archer C50 (v3)
   - Archer C50 (v4)
+  - RE200 (v2)
   - TL-MR3020 (v3)
   - TL-MR3420 (v5)
   - TL-WA801ND (v5)

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -39,6 +39,8 @@ device('tp-link-archer-c50-v4', 'tplink_archer-c50-v4', {
 	factory = false,
 })
 
+device('tp-link-re200-v2', 'tplink_re200-v2')
+
 device('tp-link-tl-mr3020-v3', 'tplink_tl-mr3020-v3', {
 	factory = false,
 	extra_images = {


### PR DESCRIPTION
TP-Link RE200 v2 is a wireless range extender with Ethernet and 2.4G and 5G
WiFi with internal antennas. It's based on MediaTek MT7628AN+MT7610EN.

### Specifications
- MediaTek MT7628AN (580 Mhz)
- 64 MB of RAM
- 8 MB of FLASH
- 2T2R 2.4 GHz and 1T1R 5 GHz
- 1x 10/100 Mbps Ethernet
- UART header on PCB (57600 8n1)
- 8x LED (GPIO-controlled), 2x button

There are 2.4G and 5G LEDs in red and green which are controlled
separately.


### Integration Checklist

- [x] must be flashable from vendor firmware
  - [x] webinterface
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show activity