### PR TITLE
treewide: correctly specify conffiles

### DIFF
--- a/package/gluon-core/Makefile
+++ b/package/gluon-core/Makefile
@@ -27,6 +27,11 @@ config GLUON_MINIFY
 	default y
 endef
 
+define Package/gluon-core/conffiles
+/etc/config/gluon
+/etc/config/gluon-core
+endef
+
 define Package/gluon-core/install
 	$(Gluon/Build/Install)
 

--- a/package/gluon-node-info/Makefile
+++ b/package/gluon-node-info/Makefile
@@ -11,4 +11,8 @@ define Package/gluon-node-info
   DEPENDS:=+gluon-core +libgluonutil
 endef
 
+define Package/gluon-node-info/conffiles
+/etc/config/gluon-node-info
+endef
+
 $(eval $(call BuildPackageGluon,gluon-node-info))

--- a/package/gluon-setup-mode/Makefile
+++ b/package/gluon-setup-mode/Makefile
@@ -17,6 +17,10 @@ define Package/gluon-setup-mode/description
 	Offline mode to perform basic setup in a secure manner.
 endef
 
+define Package/gluon-setup-mode/conffiles
+/etc/config/gluon-setup-mode
+endef
+
 init_links := \
 	K89log \
 	K98boot \

--- a/package/gluon-wan-dnsmasq/Makefile
+++ b/package/gluon-wan-dnsmasq/Makefile
@@ -14,4 +14,8 @@ define Package/gluon-wan-dnsmasq/description
 	Gluon community wifi mesh firmware framework: Support for a secondary DNS server using the WAN interface
 endef
 
+define Package/gluon-wan-dnsmasq/conffiles
+/etc/config/gluon-wan-dnsmasq
+endef
+
 $(eval $(call BuildPackageGluon,gluon-wan-dnsmasq))


### PR DESCRIPTION
Specify conffiles for our packages, so they aren't overwritten during
opkg updates. While this only matters during development, it is
unintended to have different behaviour for opkg update and full firmware
updates.