### PR TITLE
ath79-generic: add support for Joy-IT JT-OR750i

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -17,6 +17,10 @@ ath79-generic
 
   - GL-AR300M-Lite
 
+* Joy-IT
+
+  - JT-OR750i
+
 * OCEDO
 
   - Raccoon

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -60,6 +60,14 @@ device('gl.inet-gl-ar300m-lite', 'glinet_gl-ar300m-lite', {
 	factory = false,
 })
 
+-- JOY-IT
+
+device('joy-it-jt-or750i', 'joyit_jt-or750i', {
+	packages = ATH10K_PACKAGES_QCA9887,
+	factory = false,
+})
+
+
 -- OCEDO
 
 device('ocedo-raccoon', 'ocedo_raccoon', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: Bootloader HTTP
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds - none
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`