### PR TITLE
Add support for tp-link CPE510 V3

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -38,6 +38,7 @@ ath79-generic
 
   - Archer C6 (v2)
   - CPE220 (v3.0)
+  - CPE510 (v3.0)
   - TL-WDR3600 (v1)
   - TL-WDR4300 (v1)
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -30,6 +30,7 @@ function M.is_outdoor_device()
 		'plasmacloud,pa300',
 		'plasmacloud,pa300e',
 		'tplink,cpe220-v3',
+		'tplink,cpe510-v3',
 	}) then
 		return true
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -106,6 +106,7 @@ device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
 })
 
 device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
+device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
 
 device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
 device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')


### PR DESCRIPTION
Fix for #2281 

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [ ] must have working autoupdate
    *usually means: gluon profile name must match image name*
(cannot test this yet but should work)
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [x] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
