### PR TITLE
ath79-generic: add TP-Link TL-WDR3600/4300

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -38,6 +38,8 @@ ath79-generic
 
   - Archer C6 (v2)
   - CPE220 (v3.0)
+  - TL-WDR3600 (v1)
+  - TL-WDR4300 (v1)
 
 ath79-nand
 ----------

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -106,3 +106,6 @@ device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
 })
 
 device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
+
+device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
+device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -99,10 +99,10 @@ device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })
 
-device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
-
 device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,
 	broken = true, -- 64M ath9k + ath10k & power LED not working
 })
+
+device('tp-link-cpe220-v3', 'tplink_cpe220-v3')


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface (untested, but it is unlikely that this broke)
  - [x] tftp
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [ ] association with 802.11s mesh must be working on all radios (untested; both radios are ath9k, so this is likely working fine)
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity

Only WDR3600 was checked, but it can be assumed that the WDR4300 is working fine as well due to the similarity of these two devices.

I have also tested a sysupgrade from Gluon v2019.1.x and haven't found any issues; no special migrations are necessary.