### PR TITLE
ipq40xx: add support for Aruba AP-365 / InstantOn AP17

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -63,7 +63,9 @@ ipq40xx-generic
 * Aruba
 
   - AP-303
+  - AP-365
   - Instant On AP11
+  - Instant On AP17
 
 * AVM
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -34,6 +34,7 @@ function M.is_outdoor_device()
 		return true
 
 	elseif M.match('ipq40xx', 'generic', {
+		'aruba,ap-365',
 		'engenius,ens620ext',
 		'plasmacloud,pa1200',
 	}) then

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -28,6 +28,11 @@ device('aruba-ap-303', 'aruba_ap-303', {
 	aliases = {'aruba-instant-on-ap11'},
 })
 
+device('aruba-ap-365', 'aruba_ap-365', {
+	factory = false,
+	aliases = {'aruba-instant-on-ap17'},
+})
+
 
 -- AVM
 


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: tftpboot with USb attached Serial console (Accessible via service opening)
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    root@bc9fe4c21a3a:/# lua -e 'print(require("platform_info").get_image_name())'
    aruba-ap-365
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds *NONE*
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds *NONE*
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only
  - [x] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`