### PR TITLE
gluon-mesh-babel: implement neighbour check

### DIFF
--- a/package/gluon-mesh-babel/files/lib/gluon/state/check.d/has_neighbours
+++ b/package/gluon-mesh-babel/files/lib/gluon/state/check.d/has_neighbours
@@ -1,0 +1,2 @@
+#!/bin/sh
+out=$(echo dump | nc ::1 33123 | grep "add neighbour" 2>/dev/null) && [ -n "$out" ]


### PR DESCRIPTION
This lacks a check for `has_default_gw4` or the decision, that babel can't give suitable response.

Resolves #2228.