### PR TITLE
ath79-generic: add support for TP-Link EAP225-Outdoor v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -40,6 +40,7 @@ ath79-generic
   - CPE220 (v3.0)
   - CPE510 (v2.0)
   - CPE510 (v3.0)
+  - EAP225-Outdoor (v1)
   - TL-WDR3600 (v1)
   - TL-WDR4300 (v1)
   - WBS210 (v2.0)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -32,6 +32,7 @@ function M.is_outdoor_device()
 		'tplink,cpe220-v3',
 		'tplink,cpe510-v2',
 		'tplink,cpe510-v3',
+		'tplink,eap225-outdoor-v1',
 		'tplink,wbs210-v2',
 	}) then
 		return true

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -109,6 +109,10 @@ device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
 device('tp-link-cpe510-v2', 'tplink_cpe510-v2')
 device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
 
+device('tp-link-eap225-outdoor-v1', 'tplink_eap225-outdoor-v1', {
+       packages = ATH10K_PACKAGES_QCA9888,
+})
+
 device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
 device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
 


### PR DESCRIPTION
Supported Since OpenWRT Commit: [4f86edf477edbc0f20b5a49a69f658fa82158284](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=4f86edf477edbc0f20b5a49a69f658fa82158284)

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: 
      - ssh into target device with recent (>= v1.6.0) firmware
      - run `cliclientd stopcs` on target device
      - upload factory image via web interface.
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
       root@64xxx-60a4b76b1488:~# lua -e 'print(require("platform_info").get_image_name())'
       tp-link-eap225-outdoor-v1
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds _NONE_
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds _NONE_
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only
  - [x] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

cc @blocktrron 