### PR TITLE
ipq40xx: add support for Aruba AP-303H / Instant ON AP11D

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -67,8 +67,10 @@ ipq40xx-generic
 * Aruba
 
   - AP-303
+  - AP-303H
   - AP-365
   - Instant On AP11
+  - Instant On AP11D
   - Instant On AP17
 
 * AVM

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -28,6 +28,11 @@ device('aruba-ap-303', 'aruba_ap-303', {
 	aliases = {'aruba-instant-on-ap11'},
 })
 
+device('aruba-ap-303h', 'aruba_ap-303h', {
+	factory = false,
+	aliases = {'aruba-instant-on-ap11d'},
+})
+
 device('aruba-ap-365', 'aruba_ap-365', {
 	factory = false,
 	aliases = {'aruba-instant-on-ap17'},


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: Console port available. Manufacturer specific cable required.
        Tutorial in OpenWRT commit message https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=c6e972c8772a628a1a2f2e5590d7c6f4acef9ab0
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
        root@Aruba-AP-303H:~# lua -e 'print(require("platform_info").get_image_name())'
        aruba-ap-303h
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present)
    - [x] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- ToDo (upstream):
  - enable PoE pass through on interface E3
        system.poe_passthrough=gpio_switch
        system.poe_passthrough.name='PoE Passthrough'
        system.poe_passthrough.gpio_pin='446'
        system.poe_passthrough.value='0' (0 is active)