### PR TITLE
ramips-mt76x8: add support for GL.iNet microuter-N300

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -235,6 +235,7 @@ ramips-mt76x8
 * GL.iNet
 
   - GL-MT300N (v2)
+  - microuter-N300
   - VIXMINI
 
 * NETGEAR

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -9,6 +9,10 @@ device('gl-mt300n-v2', 'glinet_gl-mt300n-v2', {
 	factory = false,
 })
 
+device('gl.inet-microuter-n300', 'glinet_microuter-n300', {
+	factory = false,
+})
+
 device('gl.inet-vixmini', 'glinet_vixmini', {
 	factory = false,
 })


### PR DESCRIPTION
Supported Since OpenWRT Commit: [b30f2281cce6649567e0194d203f06517d173115](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=b30f2281cce6649567e0194d203f06517d173115)

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp
  - [x] other: bootloader httpd
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
       root@ffrn-9483c409b99c:~# lua -e 'print(require("platform_info").get_image_name())'
       gl.inet-microuter-n300
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds _NONE_
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`