### PR TITLE
gluon-status-page: swap bandwidth limits

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -135,11 +135,11 @@
 						<% if nodeinfo.network.mesh_vpn.bandwidth_limit.enabled then -%>
 						<dt><%:Bandwidth limit%></dt>
 						<dd>
-							<% if nodeinfo.network.mesh_vpn.bandwidth_limit.egress then -%>
-								▲ <%| formatBits(nodeinfo.network.mesh_vpn.bandwidth_limit.egress*1000) %>/s <%:upstream%><br />
-							<%- end %>
 							<% if nodeinfo.network.mesh_vpn.bandwidth_limit.ingress then -%>
 								▼ <%| formatBits(nodeinfo.network.mesh_vpn.bandwidth_limit.ingress*1000) %>/s <%:downstream%>
+							<%- end %>
+							<% if nodeinfo.network.mesh_vpn.bandwidth_limit.egress then -%>
+								▲ <%| formatBits(nodeinfo.network.mesh_vpn.bandwidth_limit.egress*1000) %>/s <%:upstream%><br />
 							<%- end %>
 						</dd>
 						<%- end %>


### PR DESCRIPTION
I fell like showing the Downstream Limit first is what most people would expect. 

Additionally, the ⌛ that would be created is more in line with what these settings are doing. ;)


cc @AiyionPrime (I think I had this comment before, but decided not to pursue it. Well, I guess that has changed now.)