### PR TITLE
ath79-generic: add support for Onion Omega

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -27,7 +27,7 @@ ath79-generic
 
 * Onion
 
-  - Omega
+  - Omega [#modular_ethernet]_
 
 * Plasma Cloud
 
@@ -328,3 +328,10 @@ Footnotes
 
 .. [#lan_as_wan]
   All LAN ports on this device are used as WAN.
+
+.. [#modular_ethernet]
+  These devices follow a modular principle,
+  which means even basic functionality like ethernet is provided by an expansion-board,
+  that may not be bundled with the device itself.
+  Such expansions are recommended for the config mode, but are not strictly necessary,
+  as exposed serial ports may grant sufficient access as well.

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -25,6 +25,10 @@ ath79-generic
 
   - Raccoon
 
+* Onion
+
+  - Omega
+
 * Plasma Cloud
 
   - PA300

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -76,7 +76,7 @@ device('ocedo-raccoon', 'ocedo_raccoon', {
 
 -- Onion
 
--- modular/optional "ethernet expansion board" recommended for setupmode
+-- modular/optional "ethernet expansion board" recommended for config mode
 -- setup via integrated (USB-)tty is possible as well
 device('onion-omega', 'onion_omega')
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -74,6 +74,10 @@ device('ocedo-raccoon', 'ocedo_raccoon', {
 	factory = false,
 })
 
+-- Onion
+
+device('onion-omega', 'onion_omega')
+
 -- Plasma Cloud
 
 device('plasma-cloud-pa300', 'plasmacloud_pa300')

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -76,6 +76,8 @@ device('ocedo-raccoon', 'ocedo_raccoon', {
 
 -- Onion
 
+-- modular/optional "ethernet expansion board" recommended for setupmode
+-- setup via integrated (USB-)tty is possible as well
 device('onion-omega', 'onion_omega')
 
 -- Plasma Cloud


### PR DESCRIPTION
The device appears to be working properly and the latest build is running on [http://[2a02:790:ff:1014:42a3:6bff:fec1:199b]/cgi-bin/status](http://[2a02:790:ff:1014:42a3:6bff:fec1:199b]/cgi-bin/status) in hanover.

_GitHubs IPv6-support appears to suck even more now..._

The device itself has no ethernet-port, but works as intended, when mounted on an expansionboard.

https://github.com/freifunk-gluon/gluon/commit/a44a5dce02de3738944b7ee742e5bc2fa068c939
I'm not sure, what configuration issues the ar71xx-variant had, but cannot confirm them in ath79, yet.
@NeoRaider do you remember, how to reproduce the error, looking at the mentioned commit?

If the removable ethernetport is alone enough to mark the device as broken,
we should add `broken = true, -- no Ethernet` to the device definition.

------

Supported Since OpenWRT Commit: [5cc05358006d592d3712e6565c253762819fe010](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=5cc05358006d592d3712e6565c253762819fe010)

* [x]  must be flashable from vendor firmware (vendor firmware is openwrt ar71xx-based)
  * [x]  webinterface (if luci is installed)
  * [x]  sysupgrade 
  * [x]  tftp 
  * [x]  other: bootloader httpd
* [x]  must support upgrade mechanism
  * [x]  must have working sysupgrade
    * [x]  must keep/forget configuration (if applicable)
      _think `sysupgrade [-n]` or `firstboot`_
  * [x]  must have working autoupdate
    root@mayauplink:~# lua -e 'print(require("platform_info").get_image_name())'
    onion-omega
* [x]  reset/wps/phone button must return device into config mode
* [x]  primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
* wired network _one removable port_
  * [x]  should support all network ports on the device
  * [x]  must have correct port assignment (WAN/LAN)
* wifi (if applicable)
  * [x]  association with AP must be possible on all radios _singleband 2.4GHz_
  * [x]  association with 802.11s mesh must be working on all radios
  * [x]  ap/mesh mode must work in parallel on all radios
* led mapping
  * power/sys led (_critical, because led definitions are setup on firstboot only_)
    * [x]  lit while the device is on 
    * [x]  should display config mode blink sequence
      (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  * radio leds _NONE_
    * [ ]  should map to their respective radio
    * [ ]  should show activity
  * switchport leds _NONE_
    * [ ]  should map to their respective port (or switch, if only one led present)
    * [ ]  should show link state and activity
* outdoor devices only
  * [ ]  added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

------

support was previously dropped in
commit 45c84a117bf8 ("ar71xx: drop target")