### PR TITLE
treewide: clean up site checks for prefix[46] and extra_prefixes6

### DIFF
--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -26,7 +26,9 @@ need_string(in_site({'timezone'}))
 
 need_string_array({'ntp_servers'}, false)
 
+need_string_match(in_domain({'prefix4'}), '^%d+.%d+.%d+.%d+/%d+$', false)
 need_string_match(in_domain({'prefix6'}), '^[%x:]+/64$')
+need_string_array_match(in_domain({'extra_prefixes6'}), '^[%x:]+/%d+$', false)
 
 local supported_rates = {6000, 9000, 12000, 18000, 24000, 36000, 48000, 54000}
 for _, config in ipairs({'wifi24', 'wifi5'}) do

--- a/package/gluon-ebtables-source-filter/check_site.lua
+++ b/package/gluon-ebtables-source-filter/check_site.lua
@@ -1,2 +1,0 @@
-need_string_match(in_domain({'prefix4'}), '^%d+.%d+.%d+.%d+/%d+$', false)
-need_string_array_match(in_domain({'extra_prefixes6'}), '^[%x:]+/%d+$', false)

--- a/package/gluon-l3roamd/check_site.lua
+++ b/package/gluon-l3roamd/check_site.lua
@@ -1,3 +1,1 @@
-need_string_match(in_domain({'prefix6'}), '^[%x:]+/64$', true)
 need_string_match(in_domain({'node_client_prefix6'}), '^[%x:]+/64$', false)
-need_string_match(in_domain({'prefix4'}), '^%d+.%d+.%d+.%d+/%d+$', false)


### PR DESCRIPTION
- Move site check for prefix4 and extra_prefixes6 to gluon-core, so the
  rules don't need to be duplicated in several packages. This also fixes
  gluon-respondd not checking extra_prefixes6 at all when
  gluon-ebtables-source-filter is not installed as well.
- A redundant check for prefix6 is removed from gluon-l3roamd (this was
  already checked by gluon-core)
- A separate check for prefix4 remains in gluon-client-bridge, as the
  setting in mandatory there