### PR TITLE
treewide: remove duplicate i18n translations

### DIFF
--- a/package/gluon-config-mode-geo-location/i18n/de.po
+++ b/package/gluon-config-mode-geo-location/i18n/de.po
@@ -32,9 +32,6 @@ msgstr "Längengrad"
 msgid "Set node position"
 msgstr "Knotenposition setzen"
 
-msgid "Advertise node position"
-msgstr "Knotenposition veröffentlichen"
-
 msgid ""
 "Specifying the altitude is optional; it should only be filled in if an "
 "accurate value is known."

--- a/package/gluon-config-mode-geo-location/i18n/fr.po
+++ b/package/gluon-config-mode-geo-location/i18n/fr.po
@@ -30,9 +30,6 @@ msgstr "Longitude"
 msgid "Set node position"
 msgstr ""
 
-msgid "Advertise node position"
-msgstr ""
-
 msgid ""
 "Specifying the altitude is optional; it should only be filled in if an "
 "accurate value is known."

--- a/package/gluon-web-wifi-config/i18n/de.po
+++ b/package/gluon-web-wifi-config/i18n/de.po
@@ -47,15 +47,6 @@ msgstr "Knoten wird im Außenbereich betrieben"
 msgid "Outdoor Installation"
 msgstr "Outdoor-Installation"
 
-msgid "HT Mode"
-msgstr "HT-Modus"
-
-msgid "Node will be installed outdoors"
-msgstr "Knoten wird im Außenbereich betrieben"
-
-msgid "Outdoor Installation"
-msgstr "Outdoor-Installation"
-
 msgid "Transmission power"
 msgstr "Sendeleistung"
 

--- a/package/gluon-web-wifi-config/i18n/fr.po
+++ b/package/gluon-web-wifi-config/i18n/fr.po
@@ -42,15 +42,6 @@ msgstr ""
 msgid "Outdoor Installation"
 msgstr "Installation extérieure"
 
-msgid "HT Mode"
-msgstr "Mode HT"
-
-msgid "Node will be installed outdoors"
-msgstr ""
-
-msgid "Outdoor Installation"
-msgstr "Installation extérieure"
-
 msgid "Transmission power"
 msgstr "Puissance d'émission"
 


### PR DESCRIPTION
Before this commit, some *.po files contained the same translation
twice within the same file. While this did not led to errors in
gluon yet, it is still invalid. This commit fixes that and removes
the duplicates.