### PR TITLE
ramips-mt7621: add support for Ubiquiti UniFi 6 Lite

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -223,6 +223,7 @@ ramips-mt7621
 
   - EdgeRouter X
   - EdgeRouter X-SFP
+  - UniFi 6 Lite
 
 * ZBT
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -29,6 +29,13 @@ device('netgear-wndr3700-v5', 'netgear_wndr3700-v5', {
 })
 
 
+-- Ubiquiti
+
+device('ubiquiti-unifi-6-lite', 'ubnt_unifi-6-lite', {
+	factory = false,
+})
+
+
 -- Xiaomi
 
 device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: ssh
as described in openwrt commit https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=fb4d7a9680117a00721936c98ce41eeb2dea95c9
```
Installation
------------

1. Connect to the booted device at 192.168.1.20 using username/password
   "ubnt".

2. Update the bootloader environment.

   $ fw_setenv devmode TRUE
   $ fw_setenv boot_openwrt "fdt addr \$(fdtcontroladdr);
     fdt rm /signature; bootubnt"
   $ fw_setenv bootcmd "run boot_openwrt"

3. Transfer the OpenWrt sysupgrade image to the device using SCP.

4. Check the mtd partition number for bs / kernel0 / kernel1

   $ cat /proc/mtd

5. Set the bootselect flag to boot from kernel0

   $ dd if=/dev/zero bs=1 count=1 of=/dev/mtdblock4

6. Write the OpenWrt sysupgrade image to both kernel0 as well as kernel1

   $ dd if=openwrt.bin of=/dev/mtdblock6
   $ dd if=openwrt.bin of=/dev/mtdblock7

7. Reboot the device. It should boot into OpenWrt.
```

- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [n/a] should map to their respective radio
    - [n/a] should show activity
  - switchport leds
    - [n/a] should map to their respective port (or switch, if only one led present) 
    - [n/a] should show link state and activity
- outdoor devices only
  - [n/a] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

Device is running here:
https://hannover.freifunk.net/karte/#/de/map/245a4c1354d4