### PR TITLE
Hide WLAN config on devices without WLAN + related cleanup

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
@@ -1,6 +1,5 @@
 #!/usr/bin/lua
 
-local platform = require 'gluon.platform'
 local wireless = require 'gluon.wireless'
 
 local uci = require('simple-uci').cursor()
@@ -52,7 +51,7 @@ local function configure_owe(radio, index, config, radio_name)
 
 	-- Don't configure OWE in case our device
 	-- can't do MFP, as it's mandatory for OWE.
-	if not platform.device_supports_mfp(uci) then
+	if not wireless.device_supports_mfp(uci) then
 		return
 	end
 
@@ -80,7 +79,7 @@ local function configure_owe_transition_mode(config, radio_name)
 
 	-- Don't configure OWE in case our device
 	-- can't do MFP, as it's mandatory for OWE.
-	if not platform.device_supports_mfp(uci) then
+	if not wireless.device_supports_mfp(uci) then
 		return
 	end
 

--- a/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
+++ b/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
@@ -2,7 +2,7 @@ return function(form, uci)
 	local platform = require 'gluon.platform'
 	local wireless = require 'gluon.wireless'
 
-	if not (platform.is_outdoor_device() and platform.device_uses_11a(uci)) then
+	if not (platform.is_outdoor_device() and wireless.device_uses_11a(uci)) then
 		-- only visible on wizard for outdoor devices
 		return
 	end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/180-outdoors
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/180-outdoors
@@ -13,6 +13,7 @@ end
 
 local sysconfig = require 'gluon.sysconfig'
 local platform = require 'gluon.platform'
+local wireless = require 'gluon.wireless'
 
 local config = site.wifi5.outdoors('preset')
 local outdoor
@@ -22,7 +23,7 @@ if sysconfig.gluon_version then
 	outdoor = false
 elseif config == 'preset' then
 	-- enable outdoor mode through presets on new installs
-	outdoor = platform.is_outdoor_device() and platform.device_uses_11a(uci)
+	outdoor = platform.is_outdoor_device() and wireless.device_uses_11a(uci)
 else
 	-- enable/disable outdoor mode unconditionally on new installs
 	outdoor = config

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -1,7 +1,5 @@
 local platform_info = require 'platform_info'
 local util = require 'gluon.util'
-local wireless = require 'gluon.wireless'
-local unistd = require 'posix.unistd'
 
 
 local M = setmetatable({}, {
@@ -46,43 +44,6 @@ function M.is_outdoor_device()
 	end
 
 	return false
-end
-
-function M.device_supports_wpa3()
-	return unistd.access('/lib/gluon/features/wpa3')
-end
-
-function M.device_supports_mfp(uci)
-	local supports_mfp = true
-
-	if not M.device_supports_wpa3() then
-		return false
-	end
-
-	uci:foreach('wireless', 'wifi-device', function(radio)
-		local phy = wireless.find_phy(radio)
-		local phypath = '/sys/kernel/debug/ieee80211/' .. phy .. '/'
-
-		if not util.file_contains_line(phypath .. 'hwflags', 'MFP_CAPABLE') then
-			supports_mfp = false
-			return false
-		end
-	end)
-
-	return supports_mfp
-end
-
-function M.device_uses_11a(uci)
-	local ret = false
-
-	uci:foreach('wireless', 'wifi-device', function(radio)
-		if radio.hwmode == '11a' or radio.hwmode == '11na' then
-			ret = true
-			return false
-		end
-	end)
-
-	return ret
 end
 
 return M

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -150,6 +150,17 @@ function M.device_supports_mfp(uci)
 	return supports_mfp
 end
 
+function M.device_uses_wlan(uci)
+	local ret = false
+
+	uci:foreach('wireless', 'wifi-device', function()
+		ret = true
+		return false
+	end)
+
+	return ret
+end
+
 function M.device_uses_11a(uci)
 	local ret = false
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -126,4 +126,41 @@ function M.preserve_channels(uci)
 	return uci:get_first('gluon-core', 'wireless', 'preserve_channels')
 end
 
+function M.device_supports_wpa3()
+	return unistd.access('/lib/gluon/features/wpa3')
+end
+
+function M.device_supports_mfp(uci)
+	local supports_mfp = true
+
+	if not M.device_supports_wpa3() then
+		return false
+	end
+
+	uci:foreach('wireless', 'wifi-device', function(radio)
+		local phy = M.find_phy(radio)
+		local phypath = '/sys/kernel/debug/ieee80211/' .. phy .. '/'
+
+		if not util.file_contains_line(phypath .. 'hwflags', 'MFP_CAPABLE') then
+			supports_mfp = false
+			return false
+		end
+	end)
+
+	return supports_mfp
+end
+
+function M.device_uses_11a(uci)
+	local ret = false
+
+	uci:foreach('wireless', 'wifi-device', function(radio)
+		if radio.hwmode == '11a' or radio.hwmode == '11na' then
+			ret = true
+			return false
+		end
+	end)
+
+	return ret
+end
+
 return M

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/controller/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/controller/admin/privatewifi.lua
@@ -1,3 +1,8 @@
+local uci = require("simple-uci").cursor()
+local wireless = require 'gluon.wireless'
+
 package 'gluon-web-private-wifi'
 
-entry({"admin", "privatewifi"}, model("admin/privatewifi"), _("Private WLAN"), 30)
+if wireless.device_uses_wlan(uci) then
+	entry({"admin", "privatewifi"}, model("admin/privatewifi"), _("Private WLAN"), 30)
+end

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
@@ -1,5 +1,4 @@
 local uci = require("simple-uci").cursor()
-local platform = require 'gluon.platform'
 local wireless = require 'gluon.wireless'
 
 -- where to read the configuration from
@@ -30,7 +29,7 @@ key.default = uci:get('wireless', primary_iface, "key")
 local encryption = s:option(ListValue, "encryption", translate("Encryption"))
 encryption:depends(enabled, true)
 encryption:value("psk2", translate("WPA2"))
-if platform.device_supports_wpa3() then
+if wireless.device_supports_wpa3() then
 	encryption:value("psk3-mixed", translate("WPA2 / WPA3"))
 	encryption:value("psk3", translate("WPA3"))
 end
@@ -39,7 +38,7 @@ encryption.default = uci:get('wireless', primary_iface, 'encryption') or "psk2"
 local mfp = s:option(ListValue, "mfp", translate("Management Frame Protection"))
 mfp:depends(enabled, true)
 mfp:value("0", translate("Disabled"))
-if platform.device_supports_mfp(uci) then
+if wireless.device_supports_mfp(uci) then
 	mfp:value("1", translate("Optional"))
 	mfp:value("2", translate("Required"))
 end
@@ -68,7 +67,7 @@ function f:write()
 			})
 
 			-- hostapd-mini won't start in case 802.11w is configured
-			if platform.device_supports_mfp(uci) then
+			if wireless.device_supports_mfp(uci) then
 				uci:set('wireless', name, 'ieee80211w', mfp.data)
 			else
 				uci:delete('wireless', name, 'ieee80211w')

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/controller/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/controller/admin/wifi-config.lua
@@ -1,3 +1,8 @@
+local uci = require("simple-uci").cursor()
+local wireless = require 'gluon.wireless'
+
 package 'gluon-web-wifi-config'
 
-entry({"admin", "wifi-config"}, model("admin/wifi-config"), _("WLAN"), 20)
+if wireless.device_uses_wlan(uci) then
+	entry({"admin", "wifi-config"}, model("admin/wifi-config"), _("WLAN"), 20)
+end

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -24,18 +24,6 @@ local function txpower_list(phy)
 	return new
 end
 
-local function has_5ghz_radio()
-	local result = false
-	uci:foreach('wireless', 'wifi-device', function(config)
-		local radio = config['.name']
-		local hwmode = uci:get('wireless', radio, 'hwmode')
-
-		result = result or (hwmode == '11a' or hwmode == '11na')
-	end)
-
-	return result
-end
-
 local f = Form(translate("WLAN"))
 
 f:section(Section, nil, translate(
@@ -142,7 +130,7 @@ uci:foreach('wireless', 'wifi-device', function(config)
 end)
 
 
-if has_5ghz_radio() and not wireless.preserve_channels(uci) then
+if wireless.device_uses_11a(uci) and not wireless.preserve_channels(uci) then
 	local r = f:section(Section, translate("Outdoor Installation"), translate(
 		"Configuring the node for outdoor use tunes the 5 GHz radio to a frequency "
 		.. "and transmission power that conforms with the local regulatory requirements. "


### PR DESCRIPTION
Implementation for #2311 + cleanup for a few things I noticed. Tested on an x86-64 VM without WLAN and a TL-WDR3600.

One downside of this change is that each time an Advanced Settings page is generated, two additional UCI contexts are created, each parsing `/etc/config/wireless`, as there is no common UCI context for gluon-web controllers. As the node is not under load in config mode, this should be fine - I haven't noticed any performance issues on the TL-WDR3600.