### PR TITLE
x86: don't build ext4 images

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -21,7 +21,8 @@
     "Makefile",
     "patches/**",
     "targets/generic",
-    "targets/targets.mk"
+    "targets/targets.mk",
+    "targets/bcm27xx.inc"
   ],
   "bcm27xx-bcm2709": [
     "targets/bcm27xx-bcm2709",
@@ -29,7 +30,8 @@
     "Makefile",
     "patches/**",
     "targets/generic",
-    "targets/targets.mk"
+    "targets/targets.mk",
+    "targets/bcm27xx.inc"
   ],
   "ipq40xx-generic": [
     "targets/ipq40xx-generic",
@@ -133,7 +135,8 @@
     "Makefile",
     "patches/**",
     "targets/generic",
-    "targets/targets.mk"
+    "targets/targets.mk",
+    "targets/x86.inc"
   ],
   "x86-geode": [
     "targets/x86-geode",
@@ -149,7 +152,8 @@
     "Makefile",
     "patches/**",
     "targets/generic",
-    "targets/targets.mk"
+    "targets/targets.mk",
+    "targets/x86.inc"
   ],
   "x86-64": [
     "targets/x86-64",
@@ -158,6 +162,7 @@
     "patches/**",
     "targets/generic",
     "targets/targets.mk",
+    "targets/x86.inc",
     "contrib/ci/minimal-site/**",
     "package/**"
   ],
@@ -167,7 +172,8 @@
     "Makefile",
     "patches/**",
     "targets/generic",
-    "targets/targets.mk"
+    "targets/targets.mk",
+    "targets/bcm27xx.inc"
   ],
   "mvebu-cortexa9": [
     "targets/mvebu-cortexa9",

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ update-modules: FORCE
 	@scripts/update-modules.sh
 
 update-ci: FORCE
-	@scripts/update-ci.sh
+	@$(GLUON_ENV) scripts/update-ci.sh
 
 GLUON_TARGETS :=
 

--- a/contrib/actions/generate-target-filters.py
+++ b/contrib/actions/generate-target-filters.py
@@ -3,6 +3,8 @@
 # Update target filters using
 #   make update-ci
 
+import re
+import os
 import sys
 import json
 
@@ -23,6 +25,13 @@ extra = [
 
 _filter = dict()
 
+# INCLUDE_PATTERN matches:
+# include '...'
+# include "..."
+# include("...")
+# include('...')
+INCLUDE_PATTERN = "^\\s*include *\\(? *[\"']([^\"']+)[\"']"
+
 # construct filters map from stdin
 for target in sys.stdin:
     target = target.strip()
@@ -30,6 +39,11 @@ for target in sys.stdin:
     _filter[target] = [
         f"targets/{target}"
     ] + common
+
+    target_file = os.path.join(os.environ['GLUON_TARGETSDIR'], target)
+    with open(target_file) as f:
+        includes = re.findall(INCLUDE_PATTERN, f.read(), re.MULTILINE)
+        _filter[target].extend([f"targets/{i}" for i in includes])
 
     if target == "x86-64":
         _filter[target].extend(extra)

--- a/targets/x86.inc
+++ b/targets/x86.inc
@@ -40,6 +40,9 @@ packages {
 	'kmod-mt7615e',
 }
 
+-- We do not use the ext4 images, so we do not want to build them.
+config('TARGET_ROOTFS_EXT4FS', false)
+
 defaults {
 	factory = '-squashfs-combined',
 	factory_ext = {'.img.gz', '.vmdk', '.vdi'},


### PR DESCRIPTION
Since we're discarding the ext4 images anyways, we now stop building 
them as well and save a few seconds of build time.