### PR TITLE
gluon-core: allow overriding gluon-version by .scmversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,11 @@ GLUON_ENV = $(foreach var,$(GLUON_VARS),$(var)=$(call escape,$($(var))))
 show-release:
 	@echo '$(GLUON_RELEASE)'
 
+show-version:
+	@cat .scmversion 2>/dev/null || git describe --always --dirty=+ 2>/dev/null || echo unknown
+
+show-describe:
+	@git describe --always --dirty=+ 2>/dev/null || echo unknown
 
 update: FORCE
 	@

--- a/package/gluon-core/Makefile
+++ b/package/gluon-core/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=gluon-core
 
-GLUON_VERSION = $(shell git describe --always --dirty=+ 2>/dev/null || echo unknown)
+GLUON_VERSION = $(shell cat $(TOPDIR)/../.scmversion 2>/dev/null || git describe --always --dirty=+ 2>/dev/null || echo unknown)
 PKG_VERSION:=$(if $(DUMP),x,$(GLUON_VERSION))
 
 PKG_BUILD_DIR := $(BUILD_DIR)/$(PKG_NAME)


### PR DESCRIPTION
Usually gluon calls "git describe" inside the gluon directory to determine
the gluon-version. While this is sufficient in most cases, it becomes
insufficient if you have a meta build system, which patches gluon before
building gluon.

It is actually insufficient, because if you patch gluon before building
it, the the output of "git describe" would then describe the patched
revision and not the base revision (before patching gluon).

After this commit, you can use .scmversion to avoid this problem. By
writing to .scmversion inside the gluon directory before calling make,
gluon will now use the contents of .scmversion instead of "git describe"
to define the gluon-version. So you can write to .scmversion to define
gluon-version before patching gluon in your meta build system.

To do this, you can do something like this in your meta build system:

    cd gluon
    make show-describe > .scmversion
    # apply your own patches to gluon
    git am < ...
    # make gluon
    make GLUON_TARGET=...

Instead of using the output of "make show-describe" as .scmversion, you
can also use any other useful version description. E.g. you may append
the number of additional patches on top of the base commit of gluon (or
so).

As a side note, inside gluon, you can obtain the version (as before) via:

    root@platzhalter-525400123457:/# cat /lib/gluon/gluon-version
    v2021.1-150-gb39ea759+

    root@platzhalter-525400123457:/# gluon-neighbour-info -r nodeinfo
    {
      ...
      "software": {
        "firmware": {
          "base": "gluon-v2021.1-150-gb39ea759+",
          ...
        }
      }
    }

    root@platzhalter-525400123457:/# opkg info gluon-core | grep ^Version:
    Version: v2021.1-150-gb39ea759+