### PR TITLE
gluon-ebtables-filter-ra-dhcp: disable DHCPv4 filter when gw_mode == 'server'

### DIFF
--- a/package/gluon-ebtables-filter-ra-dhcp/luasrc/lib/gluon/ebtables/200-dir-dhcpv4
+++ b/package/gluon-ebtables-filter-ra-dhcp/luasrc/lib/gluon/ebtables/200-dir-dhcpv4
@@ -1,5 +1,11 @@
-rule 'FORWARD -p IPv4 --ip-protocol udp --ip-destination-port 67 -j OUT_ONLY'
-rule 'OUTPUT -p IPv4 --ip-protocol udp --ip-destination-port 67 -j OUT_ONLY'
+local uci = require('simple-uci').cursor()
 
-rule 'FORWARD -p IPv4 --ip-protocol udp --ip-destination-port 68 -j IN_ONLY'
-rule 'INPUT -p IPv4 --ip-protocol udp --ip-destination-port 68 -j IN_ONLY'
+local gw_mode = uci:get('network', 'gluon_bat0', 'gw_mode')
+
+if gw_mode ~= 'server' then
+	rule 'FORWARD -p IPv4 --ip-protocol udp --ip-destination-port 67 -j OUT_ONLY'
+	rule 'OUTPUT -p IPv4 --ip-protocol udp --ip-destination-port 67 -j OUT_ONLY'
+
+	rule 'FORWARD -p IPv4 --ip-protocol udp --ip-destination-port 68 -j IN_ONLY'
+	rule 'INPUT -p IPv4 --ip-protocol udp --ip-destination-port 68 -j IN_ONLY'
+end


### PR DESCRIPTION
In meshes without VPN or supernodes, it may be desirable to connect a
router providing IPv4 addresses directly to a regular Gluon node. For
this to work, it was necessary to remove the gluon-ebtables-filter-ra-dhcp
package from the node, so the autoupdater also needed to be disabled.

To avoid this, make gluon-ebtables-filter-ra-dhcp disable the DHCPv4
filter rules when gw_mode is set to 'server'.

No solution is provided for RA/DHCPv6, but this seems less pressing for
local meshes, as nodes can already provide working IPv6 connectivity
by themselves through gluon-radvd.