### PR TITLE
ath79-generic: Re-add OpenMesh devices

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -40,7 +40,7 @@ ath79-generic
   - MR600 (v1, v2)
   - MR900 (v1, v2)
   - MR1750 (v1, v2)
-  - OM2P (v1, v2)
+  - OM2P (v1, v2, v4)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -43,6 +43,7 @@ ath79-generic
   - OM2P (v1, v2, v4)
   - OM2P-HS (v1, v2, v3, v4)
   - OM2P-LC
+  - OM5P
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -37,6 +37,7 @@ ath79-generic
 
   - A40
   - A60
+  - MR600 (v1)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -44,7 +44,7 @@ ath79-generic
   - OM2P-HS (v1, v2, v3, v4)
   - OM2P-LC
   - OM5P
-  - OM5P-AC (v1)
+  - OM5P-AC (v1, v2)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -41,7 +41,7 @@ ath79-generic
   - MR900 (v1, v2)
   - MR1750 (v1, v2)
   - OM2P (v1, v2, v4)
-  - OM2P-HS (v1, v2)
+  - OM2P-HS (v1, v2, v3)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -41,7 +41,7 @@ ath79-generic
   - MR900 (v1, v2)
   - MR1750 (v1, v2)
   - OM2P (v1, v2, v4)
-  - OM2P-HS (v1, v2, v3)
+  - OM2P-HS (v1, v2, v3, v4)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -39,6 +39,7 @@ ath79-generic
   - A60
   - MR600 (v1, v2)
   - MR900 (v1, v2)
+  - MR1750 (v1)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -45,6 +45,7 @@ ath79-generic
   - OM2P-LC
   - OM5P
   - OM5P-AC (v1, v2)
+  - OM5P-AN
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -38,7 +38,7 @@ ath79-generic
   - A40
   - A60
   - MR600 (v1, v2)
-  - MR900 (v1)
+  - MR900 (v1, v2)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -42,6 +42,7 @@ ath79-generic
   - MR1750 (v1, v2)
   - OM2P (v1, v2, v4)
   - OM2P-HS (v1, v2, v3, v4)
+  - OM2P-LC
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -44,6 +44,7 @@ ath79-generic
   - OM2P-HS (v1, v2, v3, v4)
   - OM2P-LC
   - OM5P
+  - OM5P-AC (v1)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -39,7 +39,7 @@ ath79-generic
   - A60
   - MR600 (v1, v2)
   - MR900 (v1, v2)
-  - MR1750 (v1)
+  - MR1750 (v1, v2)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -40,7 +40,7 @@ ath79-generic
   - MR600 (v1, v2)
   - MR900 (v1, v2)
   - MR1750 (v1, v2)
-  - OM2P (v1)
+  - OM2P (v1, v2)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -41,6 +41,7 @@ ath79-generic
   - MR900 (v1, v2)
   - MR1750 (v1, v2)
   - OM2P (v1, v2, v4)
+  - OM2P-HS (v1)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -38,6 +38,7 @@ ath79-generic
   - A40
   - A60
   - MR600 (v1, v2)
+  - MR900 (v1)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -33,6 +33,10 @@ ath79-generic
 
   - Omega [#modular_ethernet]_
 
+* OpenMesh
+
+  - A60
+
 * Plasma Cloud
 
   - PA300

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -40,6 +40,7 @@ ath79-generic
   - MR600 (v1, v2)
   - MR900 (v1, v2)
   - MR1750 (v1, v2)
+  - OM2P (v1)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -41,7 +41,7 @@ ath79-generic
   - MR900 (v1, v2)
   - MR1750 (v1, v2)
   - OM2P (v1, v2, v4)
-  - OM2P-HS (v1)
+  - OM2P-HS (v1, v2)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -37,7 +37,7 @@ ath79-generic
 
   - A40
   - A60
-  - MR600 (v1)
+  - MR600 (v1, v2)
 
 * Plasma Cloud
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -35,6 +35,7 @@ ath79-generic
 
 * OpenMesh
 
+  - A40
   - A60
 
 * Plasma Cloud

--- a/patches/openwrt/0005-ath79-Add-support-for-OpenMesh-A60.patch
+++ b/patches/openwrt/0005-ath79-Add-support-for-OpenMesh-A60.patch
@@ -1,0 +1,337 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Mon, 23 Nov 2020 13:41:34 +0100
+Subject: ath79: Add support for OpenMesh A60
+
+Device specifications:
+======================
+
+* Qualcomm/Atheros QCA9558 ver 1 rev 0
+* 720/600/240 MHz (CPU/DDR/AHB)
+* 128 MB of RAM
+* 16 MB of SPI NOR flash
+  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
+* 3T3R 2.4 GHz Wi-Fi (11n)
+* 3T3R 5 GHz Wi-Fi (11ac)
+* multi-color LED (controlled via red/green/blue GPIOs)
+* 1x GPIO-button (reset)
+* external h/w watchdog (enabled by default))
+* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
+* 2x ethernet
+  - eth0
+    + Label: Ethernet 1
+    + AR8035 ethernet PHY (RGMII)
+    + 10/100/1000 Mbps Ethernet
+    + 802.3af POE
+    + used as WAN interface
+  - eth1
+    + Label: Ethernet 2
+    + AR8031 ethernet PHY (SGMII)
+    + 10/100/1000 Mbps Ethernet
+    + used as LAN interface
+* 1x USB
+* internal antennas
+
+Flashing instructions:
+======================
+
+Various methods can be used to install the actual image on the flash.
+Two easy ones are:
+
+ap51-flash
+----------
+
+The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be
+used to transfer the image to the u-boot when the device boots up.
+
+initramfs from TFTP
+-------------------
+
+The serial console must be used to access the u-boot shell during bootup.
+It can then be used to first boot up the initramfs image from a TFTP server
+(here with the IP 192.168.1.21):
+
+   setenv serverip 192.168.1.21
+   setenv ipaddr 192.168.1.1
+   tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr
+
+The actual sysupgrade image can then be transferred (on the LAN port) to the
+device via
+
+  scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/
+
+On the device, the sysupgrade must then be started using
+
+  sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+(cherry picked from commit eaf2e32c12655d7fb58e158086a784393dc6f69a)
+
+diff --git a/package/boot/uboot-envtools/files/ath79 b/package/boot/uboot-envtools/files/ath79
+index abcb99663dfd8e5d1ad0ee757e17972d63c856c7..0791d58b04cd108fcd2190bcf3c39f715f0b511f 100644
+--- a/package/boot/uboot-envtools/files/ath79
++++ b/package/boot/uboot-envtools/files/ath79
+@@ -49,6 +49,7 @@ netgear,wnr2200-16m|\
+ netgear,wnr612-v2|\
+ ocedo,koala|\
+ ocedo,raccoon|\
++openmesh,a60|\
+ openmesh,mr600-v1|\
+ openmesh,mr600-v2|\
+ openmesh,mr900-v1|\
+diff --git a/target/linux/ath79/dts/qca9558_openmesh_a60.dts b/target/linux/ath79/dts/qca9558_openmesh_a60.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..473f055b492f6dffb0c460fd13e7ad9b604373c6
+--- /dev/null
++++ b/target/linux/ath79/dts/qca9558_openmesh_a60.dts
+@@ -0,0 +1,8 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "qca9558_openmesh_a60.dtsi"
++
++/ {
++	compatible = "openmesh,a60", "qca,qca9558";
++	model = "OpenMesh A60";
++};
+diff --git a/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi b/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
+new file mode 100644
+index 0000000000000000000000000000000000000000..9938e5f4c013575c686edce5699f3541942133d3
+--- /dev/null
++++ b/target/linux/ath79/dts/qca9558_openmesh_a60.dtsi
+@@ -0,0 +1,180 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "qca955x.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	chosen {
++		/delete-property/ bootargs;
++	};
++
++	aliases {
++		serial0 = &uart;
++		led-boot = &led_status_green;
++		led-failsafe = &led_status_green;
++		led-running = &led_status_green;
++		led-upgrade = &led_status_green;
++		label-mac-device = &eth0;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		status_blue {
++			label = "blue:status";
++			gpios = <&gpio 13 GPIO_ACTIVE_HIGH>;
++		};
++
++		status_red {
++			label = "red:status";
++			gpios = <&gpio 22 GPIO_ACTIVE_HIGH>;
++		};
++
++		led_status_green: status_green {
++			label = "green:status";
++			gpios = <&gpio 23 GPIO_ACTIVE_HIGH>;
++		};
++	};
++
++	watchdog {
++		compatible = "linux,wdt-gpio";
++		gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
++		hw_algo = "toggle";
++		/* hw_margin_ms is actually 300s but driver limits it to 60s */
++		hw_margin_ms = <60000>;
++		always-running;
++	};
++};
++
++&usb_phy1 {
++	status = "okay";
++};
++
++&usb1 {
++	status = "okay";
++};
++
++&spi {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++
++		/* partitions are passed via bootloader */
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "u-boot";
++				reg = <0x000000 0x040000>;
++				read-only;
++			};
++
++			partition@40000 {
++				label = "u-boot-env";
++				reg = <0x040000 0x010000>;
++			};
++
++			partition@50000 {
++				label = "custom";
++				reg = <0x050000 0x060000>;
++				read-only;
++			};
++
++			partition@b0000 {
++				label = "inactive";
++				reg = <0x0b0000 0x7a0000>;
++			};
++
++			partition@850000 {
++				label = "inactive2";
++				reg = <0x850000 0x7a0000>;
++			};
++
++			art: partition@ff0000 {
++				label = "ART";
++				reg = <0xff0000 0x010000>;
++				read-only;
++			};
++		};
++	};
++};
++
++&mdio0 {
++	status = "okay";
++
++	phy-mask = <0x6>;
++
++	phy1: ethernet-phy@1 {
++		reg = <1>;
++		eee-broken-100tx;
++		eee-broken-1000t;
++	};
++
++	phy2: ethernet-phy@2 {
++		reg = <2>;
++		eee-broken-100tx;
++		eee-broken-1000t;
++		at803x-override-sgmii-link-check;
++	};
++};
++
++&eth0 {
++	status = "okay";
++
++	pll-data = <0x82000101 0x80000101 0x80001313>;
++
++	mtd-mac-address = <&art 0x0>;
++
++	phy-mode = "rgmii-id";
++	phy-handle = <&phy1>;
++
++	gmac-config {
++		device = <&gmac>;
++		rgmii-enabled = <1>;
++		rxd-delay = <3>;
++		rxdv-delay = <3>;
++		txd-delay = <0>;
++		txen-delay = <0>;
++	};
++};
++
++&eth1 {
++	status = "okay";
++
++	pll-data = <0x03000101 0x80000101 0x80001313>;
++
++	mtd-mac-address = <&art 0x6>;
++
++	qca955x-sgmii-fixup;
++
++	phy-handle = <&phy2>;
++};
++
++&wmac {
++	status = "okay";
++
++	mtd-cal-data = <&art 0x1000>;
++	mtd-mac-address = <&art 0x0>;
++	mtd-mac-address-increment = <2>;
++};
++
++&pcie0 {
++	status = "okay";
++};
+diff --git a/target/linux/ath79/generic/base-files/etc/board.d/02_network b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+index d4f53e7dae16b84955d318b9d79b6912ee156bdb..4b83ac7d32fc372cd3b493e8ec427c04e0f2e0d1 100755
+--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
++++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+@@ -172,6 +172,7 @@ ath79_setup_interfaces()
+ 	comfast,cf-e120a-v3|\
+ 	comfast,cf-e314n-v2|\
+ 	compex,wpj531-16m|\
++	openmesh,a60|\
+ 	openmesh,om2p-v4|\
+ 	openmesh,om2p-hs-v4|\
+ 	plasmacloud,pa300|\
+diff --git a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 69735f336070a48ddad76c72c2876bcd775c56a1..b4c8a78a7fe4ba5bd3ca1f9c6e2b5e51e7fd1882 100644
+--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -99,6 +99,7 @@ case "$FIRMWARE" in
+ 		caldata_extract "art" 0x5000 0x844
+ 		ath10k_patch_mac $(mtd_get_mac_binary art 0xc)
+ 		;;
++	openmesh,a60|\
+ 	openmesh,mr1750-v1|\
+ 	openmesh,mr1750-v2|\
+ 	openmesh,om5p-ac-v2)
+diff --git a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+index 1240ef51e88ed2e5d24088746596da085c01ab5c..f7862bb032fbce56be77e9db8ae2e37bf5da30ea 100644
+--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+@@ -65,6 +65,7 @@ platform_do_upgrade() {
+ 	jjplus,ja76pf2)
+ 		redboot_fis_do_upgrade "$1" linux
+ 		;;
++	openmesh,a60|\
+ 	openmesh,mr600-v1|\
+ 	openmesh,mr600-v2|\
+ 	openmesh,mr900-v1|\
+diff --git a/target/linux/ath79/image/generic.mk b/target/linux/ath79/image/generic.mk
+index 304e58980062465ba7955e5fe45dbd6b0097937b..c669eb2cdb3f868c320412801723ceb112b4089f 100644
+--- a/target/linux/ath79/image/generic.mk
++++ b/target/linux/ath79/image/generic.mk
+@@ -1640,6 +1640,16 @@ define Device/openmesh_common_256k
+ 	openmesh-image ce_type=$$$$(OPENMESH_CE_TYPE) | append-metadata
+ endef
+ 
++define Device/openmesh_a60
++  $(Device/openmesh_common_64k)
++  SOC := qca9558
++  DEVICE_MODEL := A60
++  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2
++  OPENMESH_CE_TYPE := A60
++  SUPPORTED_DEVICES += a60
++endef
++TARGET_DEVICES += openmesh_a60
++
+ define Device/openmesh_mr600-v1
+   $(Device/openmesh_common_64k)
+   SOC := ar9344

--- a/patches/openwrt/0006-ath79-Add-support-for-OpenMesh-A40.patch
+++ b/patches/openwrt/0006-ath79-Add-support-for-OpenMesh-A40.patch
@@ -1,0 +1,151 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Mon, 23 Nov 2020 13:41:34 +0100
+Subject: ath79: Add support for OpenMesh A40
+
+Device specifications:
+======================
+
+* Qualcomm/Atheros QCA9558 ver 1 rev 0
+* 720/600/240 MHz (CPU/DDR/AHB)
+* 128 MB of RAM
+* 16 MB of SPI NOR flash
+  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
+* 2T2R 2.4 GHz Wi-Fi (11n)
+* 2T2R 5 GHz Wi-Fi (11ac)
+* multi-color LED (controlled via red/green/blue GPIOs)
+* 1x GPIO-button (reset)
+* external h/w watchdog (enabled by default))
+* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
+* 2x ethernet
+  - eth0
+    + Label: Ethernet 1
+    + AR8035 ethernet PHY (RGMII)
+    + 10/100/1000 Mbps Ethernet
+    + 802.3af POE
+    + used as WAN interface
+  - eth1
+    + Label: Ethernet 2
+    + AR8035 ethernet PHY (SGMII)
+    + 10/100/1000 Mbps Ethernet
+    + used as LAN interface
+* 1x USB
+* internal antennas
+
+Flashing instructions:
+======================
+
+Various methods can be used to install the actual image on the flash.
+Two easy ones are:
+
+ap51-flash
+----------
+
+The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be
+used to transfer the image to the u-boot when the device boots up.
+
+initramfs from TFTP
+-------------------
+
+The serial console must be used to access the u-boot shell during bootup.
+It can then be used to first boot up the initramfs image from a TFTP server
+(here with the IP 192.168.1.21):
+
+   setenv serverip 192.168.1.21
+   setenv ipaddr 192.168.1.1
+   tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr
+
+The actual sysupgrade image can then be transferred (on the LAN port) to the
+device via
+
+  scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/
+
+On the device, the sysupgrade must then be started using
+
+  sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+(cherry picked from commit 9a172797e593c061f6759a37eaeba2956ad8d72f)
+
+diff --git a/package/boot/uboot-envtools/files/ath79 b/package/boot/uboot-envtools/files/ath79
+index 0791d58b04cd108fcd2190bcf3c39f715f0b511f..a37057953bc1e9b7fdf2be02136142d0fc145054 100644
+--- a/package/boot/uboot-envtools/files/ath79
++++ b/package/boot/uboot-envtools/files/ath79
+@@ -49,6 +49,7 @@ netgear,wnr2200-16m|\
+ netgear,wnr612-v2|\
+ ocedo,koala|\
+ ocedo,raccoon|\
++openmesh,a40|\
+ openmesh,a60|\
+ openmesh,mr600-v1|\
+ openmesh,mr600-v2|\
+diff --git a/target/linux/ath79/dts/qca9558_openmesh_a40.dts b/target/linux/ath79/dts/qca9558_openmesh_a40.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..d2b817031a9db6846de0632a64962a0197fa2c6f
+--- /dev/null
++++ b/target/linux/ath79/dts/qca9558_openmesh_a40.dts
+@@ -0,0 +1,8 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "qca9558_openmesh_a60.dtsi"
++
++/ {
++	compatible = "openmesh,a40", "qca,qca9558";
++	model = "OpenMesh A40";
++};
+diff --git a/target/linux/ath79/generic/base-files/etc/board.d/02_network b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+index 4b83ac7d32fc372cd3b493e8ec427c04e0f2e0d1..c2932c1737d97f3eb732620041664f5060d16946 100755
+--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
++++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+@@ -172,6 +172,7 @@ ath79_setup_interfaces()
+ 	comfast,cf-e120a-v3|\
+ 	comfast,cf-e314n-v2|\
+ 	compex,wpj531-16m|\
++	openmesh,a40|\
+ 	openmesh,a60|\
+ 	openmesh,om2p-v4|\
+ 	openmesh,om2p-hs-v4|\
+diff --git a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index b4c8a78a7fe4ba5bd3ca1f9c6e2b5e51e7fd1882..b70a87054b10fbe708d9aa8603ecdb591fc92591 100644
+--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -99,6 +99,7 @@ case "$FIRMWARE" in
+ 		caldata_extract "art" 0x5000 0x844
+ 		ath10k_patch_mac $(mtd_get_mac_binary art 0xc)
+ 		;;
++	openmesh,a40|\
+ 	openmesh,a60|\
+ 	openmesh,mr1750-v1|\
+ 	openmesh,mr1750-v2|\
+diff --git a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+index f7862bb032fbce56be77e9db8ae2e37bf5da30ea..e979c11bb91cb20fd4168b8921499f03572d3512 100644
+--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+@@ -65,6 +65,7 @@ platform_do_upgrade() {
+ 	jjplus,ja76pf2)
+ 		redboot_fis_do_upgrade "$1" linux
+ 		;;
++	openmesh,a40|\
+ 	openmesh,a60|\
+ 	openmesh,mr600-v1|\
+ 	openmesh,mr600-v2|\
+diff --git a/target/linux/ath79/image/generic.mk b/target/linux/ath79/image/generic.mk
+index c669eb2cdb3f868c320412801723ceb112b4089f..c63900dc701bbc21dce12086f7045d7d450fc5f3 100644
+--- a/target/linux/ath79/image/generic.mk
++++ b/target/linux/ath79/image/generic.mk
+@@ -1640,6 +1640,16 @@ define Device/openmesh_common_256k
+ 	openmesh-image ce_type=$$$$(OPENMESH_CE_TYPE) | append-metadata
+ endef
+ 
++define Device/openmesh_a40
++  $(Device/openmesh_common_64k)
++  SOC := qca9558
++  DEVICE_MODEL := A40
++  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct kmod-usb2
++  OPENMESH_CE_TYPE := A60
++  SUPPORTED_DEVICES += a40
++endef
++TARGET_DEVICES += openmesh_a40
++
+ define Device/openmesh_a60
+   $(Device/openmesh_common_64k)
+   SOC := qca9558

--- a/patches/openwrt/0007-ath79-Allow-to-set-spi-nor-mtd-name-via-devicetree.patch
+++ b/patches/openwrt/0007-ath79-Allow-to-set-spi-nor-mtd-name-via-devicetree.patch
@@ -1,0 +1,135 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Thu, 31 Dec 2020 00:25:10 +0100
+Subject: ath79: Allow to set spi-nor mtd name via devicetree
+
+On ar71xx, it was possible to overwrite the name of the spi-nor mtd device
+identifier using the flash_platform_data which each mach-*.c could adjust
+for its devices. A similar feature was introduced for mtd-physmap in
+devicetree's. The property linux,mtd-name can be used to set the name and
+provide a stable identifier for mtdpart from the bootloader.
+
+But this feature is not yet available upstream for spi-nor devices which
+also might receive their partition layout from the bootloader. But the
+OpenWrt pistachio support for this property can simply be imported into
+ath79 to gain this support.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+(cherry picked from commit 7f074fe1a79f27d30560c35778d963bc520e9a3e)
+
+diff --git a/target/linux/ath79/patches-5.10/401-mtd-nor-support-mtd-name-from-device-tree.patch b/target/linux/ath79/patches-5.10/401-mtd-nor-support-mtd-name-from-device-tree.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..af032df51e6dbc3824a45a8efaa1ce8db2261b2a
+--- /dev/null
++++ b/target/linux/ath79/patches-5.10/401-mtd-nor-support-mtd-name-from-device-tree.patch
+@@ -0,0 +1,51 @@
++From f32bc2aa01edcba2f2ed5db151cf183eac9ef919 Mon Sep 17 00:00:00 2001
++From: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
++Date: Sat, 25 Feb 2017 16:42:50 +0000
++Subject: mtd: nor: support mtd name from device tree
++
++Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
++
++--- a/drivers/mtd/spi-nor/core.c
+++++ b/drivers/mtd/spi-nor/core.c
++@@ -3088,6 +3088,7 @@ int spi_nor_scan(struct spi_nor *nor, const char *name,
++ 	struct device *dev = nor->dev;
++ 	struct mtd_info *mtd = &nor->mtd;
++ 	struct device_node *np = spi_nor_get_flash_node(nor);
+++	const char __maybe_unused *of_mtd_name = NULL;
++ 	int ret;
++ 	int i;
++ 
++@@ -3142,7 +3143,12 @@ int spi_nor_scan(struct spi_nor *nor, const char *name,
++ 	if (ret)
++ 		return ret;
++ 
++-	if (!mtd->name)
+++#ifdef CONFIG_MTD_OF_PARTS
+++	of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
+++#endif
+++	if (of_mtd_name)
+++		mtd->name = of_mtd_name;
+++	else if (!mtd->name)
++ 		mtd->name = dev_name(dev);
++ 	mtd->priv = nor;
++ 	mtd->type = MTD_NORFLASH;
++--- a/drivers/mtd/mtdcore.c
+++++ b/drivers/mtd/mtdcore.c
++@@ -762,6 +762,17 @@ int del_mtd_device(struct mtd_info *mtd)
++  */
++ static void mtd_set_dev_defaults(struct mtd_info *mtd)
++ {
+++#ifdef CONFIG_MTD_OF_PARTS
+++	const char __maybe_unused *of_mtd_name = NULL;
+++	struct device_node *np;
+++
+++	np = mtd_get_of_node(mtd);
+++	if (np && !mtd->name) {
+++		of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
+++		if (of_mtd_name)
+++			mtd->name = of_mtd_name;
+++	} else
+++#endif
++ 	if (mtd->dev.parent) {
++ 		if (!mtd->owner && mtd->dev.parent->driver)
++ 			mtd->owner = mtd->dev.parent->driver->owner;
+diff --git a/target/linux/ath79/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch b/target/linux/ath79/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..a02b632e8c48f4a2df7d66b732aa60dd6788b6b1
+--- /dev/null
++++ b/target/linux/ath79/patches-5.4/401-mtd-nor-support-mtd-name-from-device-tree.patch
+@@ -0,0 +1,54 @@
++From f32bc2aa01edcba2f2ed5db151cf183eac9ef919 Mon Sep 17 00:00:00 2001
++From: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
++Date: Sat, 25 Feb 2017 16:42:50 +0000
++Subject: mtd: nor: support mtd name from device tree
++
++Signed-off-by: Abhimanyu Vishwakarma <Abhimanyu.Vishwakarma@imgtec.com>
++---
++ drivers/mtd/spi-nor/spi-nor.c | 8 +++++++-
++ 1 file changed, 7 insertions(+), 1 deletion(-)
++
++--- a/drivers/mtd/spi-nor/spi-nor.c
+++++ b/drivers/mtd/spi-nor/spi-nor.c
++@@ -4937,6 +4937,7 @@ int spi_nor_scan(struct spi_nor *nor, co
++ 	struct mtd_info *mtd = &nor->mtd;
++ 	struct device_node *np = spi_nor_get_flash_node(nor);
++ 	struct spi_nor_flash_parameter *params = &nor->params;
+++	const char __maybe_unused *of_mtd_name = NULL;
++ 	int ret;
++ 	int i;
++ 
++@@ -4999,7 +5000,12 @@ int spi_nor_scan(struct spi_nor *nor, co
++ 	/* Init flash parameters based on flash_info struct and SFDP */
++ 	spi_nor_init_params(nor);
++ 
++-	if (!mtd->name)
+++#ifdef CONFIG_MTD_OF_PARTS
+++	of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
+++#endif
+++	if (of_mtd_name)
+++		mtd->name = of_mtd_name;
+++	else if (!mtd->name)
++ 		mtd->name = dev_name(dev);
++ 	mtd->priv = nor;
++ 	mtd->type = MTD_NORFLASH;
++--- a/drivers/mtd/mtdcore.c
+++++ b/drivers/mtd/mtdcore.c
++@@ -778,6 +778,17 @@ out_error:
++  */
++ static void mtd_set_dev_defaults(struct mtd_info *mtd)
++ {
+++#ifdef CONFIG_MTD_OF_PARTS
+++	const char __maybe_unused *of_mtd_name = NULL;
+++	struct device_node *np;
+++
+++	np = mtd_get_of_node(mtd);
+++	if (np && !mtd->name) {
+++		of_property_read_string(np, "linux,mtd-name", &of_mtd_name);
+++		if (of_mtd_name)
+++			mtd->name = of_mtd_name;
+++	} else
+++#endif
++ 	if (mtd->dev.parent) {
++ 		if (!mtd->owner && mtd->dev.parent->driver)
++ 			mtd->owner = mtd->dev.parent->driver->owner;

--- a/patches/openwrt/0008-ath79-Add-support-for-OpenMesh-OM2P-v1.patch
+++ b/patches/openwrt/0008-ath79-Add-support-for-OpenMesh-OM2P-v1.patch
@@ -1,0 +1,316 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Mon, 23 Nov 2020 13:41:34 +0100
+Subject: ath79: Add support for OpenMesh OM2P v1
+
+Device specifications:
+======================
+
+* Qualcomm/Atheros AR7240 rev 2
+* 350/350/175 MHz (CPU/DDR/AHB)
+* 32 MB of RAM
+* 16 MB of SPI NOR flash
+  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
+* 2x 10/100 Mbps Ethernet
+* 1T1R 2.4 GHz Wi-Fi
+* 6x GPIO-LEDs (3x wifi, 2x ethernet, 1x power)
+* 1x GPIO-button (reset)
+* external h/w watchdog (enabled by default)
+* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
+* 2x fast ethernet
+  - eth0
+    + 18-24V passive POE (mode B)
+    + used as WAN interface
+  - eth1
+    + builtin switch port 4
+    + used as LAN interface
+* 12-24V 1A DC
+* external antenna
+
+The device itself requires the mtdparts from the uboot arguments to
+properly boot the flashed image and to support dual-boot (primary +
+recovery image). Unfortunately, the name of the mtd device in mtdparts is
+still using the legacy name "ar7240-nor0" which must be supplied using the
+Linux-specfic DT parameter linux,mtd-name to overwrite the generic name
+"spi0.0".
+
+Flashing instructions:
+======================
+
+Various methods can be used to install the actual image on the flash.
+Two easy ones are:
+
+ap51-flash
+----------
+
+The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be
+used to transfer the image to the u-boot when the device boots up.
+
+initramfs from TFTP
+-------------------
+
+The serial console must be used to access the u-boot shell during bootup.
+It can then be used to first boot up the initramfs image from a TFTP server
+(here with the IP 192.168.1.21):
+
+   setenv serverip 192.168.1.21
+   setenv ipaddr 192.168.1.1
+   tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr
+
+The actual sysupgrade image can then be transferred (on the LAN port) to the
+device via
+
+  scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/
+
+On the device, the sysupgrade must then be started using
+
+  sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+(cherry picked from commit 8143709c90c3aa0a84e14cf4a9dfbcb365b0d966)
+
+diff --git a/package/boot/uboot-envtools/files/ath79 b/package/boot/uboot-envtools/files/ath79
+index a37057953bc1e9b7fdf2be02136142d0fc145054..f4ccb2faea4e5e6202413a76cd137065dc535fe7 100644
+--- a/package/boot/uboot-envtools/files/ath79
++++ b/package/boot/uboot-envtools/files/ath79
+@@ -95,6 +95,7 @@ netgear,wndr4300tn|\
+ netgear,wndr4300sw)
+ 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x40000" "0x20000"
+ 	;;
++openmesh,om2p-v1|\
+ openmesh,om2p-v2|\
+ openmesh,om2p-v4|\
+ openmesh,om2p-hs-v1|\
+diff --git a/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts b/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..24d406f7ecd2e14729587190de1aecf71029a1eb
+--- /dev/null
++++ b/target/linux/ath79/dts/ar7240_openmesh_om2p-v1.dts
+@@ -0,0 +1,154 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "ar7240.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	compatible = "openmesh,om2p-v1", "qca,ar7240";
++	model = "OpenMesh OM2P v1";
++
++	chosen {
++		/delete-property/ bootargs;
++	};
++
++	aliases {
++		led-boot = &led_power_blue;
++		led-failsafe = &led_power_blue;
++		led-running = &led_power_blue;
++		led-upgrade = &led_power_blue;
++		label-mac-device = &eth0;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&gpio 1 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&switch_led_disable_pins>;
++
++		led_power_blue: power_blue {
++			label = "blue:power";
++			gpios = <&gpio 0 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++		wifi_green {
++			label = "green:wifi";
++			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "phy0tpt";
++		};
++
++		wifi_red {
++			label = "red:wifi";
++			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
++		};
++
++		wifi_yellow {
++			label = "yellow:wifi";
++			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
++		};
++
++		lan_blue {
++			label = "blue:lan";
++			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
++		};
++
++		wan_blue {
++			label = "blue:wan";
++			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	watchdog {
++		compatible = "linux,wdt-gpio";
++		gpios = <&gpio 12 GPIO_ACTIVE_LOW>;
++		hw_algo = "toggle";
++		/* hw_margin_ms is actually 300s but driver limits it to 60s */
++		hw_margin_ms = <60000>;
++		always-running;
++	};
++};
++
++&spi {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++		linux,mtd-name = "ar7240-nor0";
++
++		/* partitions are passed via bootloader */
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "u-boot";
++				reg = <0x000000 0x040000>;
++				read-only;
++			};
++
++			partition@40000 {
++				label = "u-boot-env";
++				reg = <0x040000 0x040000>;
++			};
++
++			partition@80000 {
++				label = "custom";
++				reg = <0x080000 0x140000>;
++				read-only;
++			};
++
++			partition@1c0000 {
++				label = "inactive";
++				reg = <0x1c0000 0x700000>;
++			};
++
++			partition@8c0000 {
++				label = "inactive2";
++				reg = <0x8c0000 0x700000>;
++			};
++
++			art: partition@fc0000 {
++				label = "ART";
++				reg = <0xfc0000 0x040000>;
++				read-only;
++			};
++		};
++	};
++};
++
++&eth0 {
++	mtd-mac-address = <&art 0x0>;
++};
++
++&eth1 {
++	status = "okay";
++
++	mtd-mac-address = <&art 0x6>;
++};
++
++&pcie {
++	status = "okay";
++
++	wifi@0,0 {
++		compatible = "pci168c,002a";
++		reg = <0x0000 0 0 0 0>;
++		qca,no-eeprom;
++		#gpio-cells = <2>;
++		gpio-controller;
++	};
++};
+diff --git a/target/linux/ath79/generic/base-files/etc/board.d/01_leds b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+index 3031b4703bfa885c5036856f0ba6a6dc332da4d8..f5384e7fc3859bab1d6c0422de7e173fad3abae2 100755
+--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
++++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+@@ -253,6 +253,10 @@ openmesh,om2p-hs-v4)
+ 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0"
+ 	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x02"
+ 	;;
++openmesh,om2p-v1)
++	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0"
++	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x10"
++	;;
+ pcs,cr3000)
+ 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
+ 	ucidef_set_led_switch "lan1" "LAN1" "blue:lan1" "switch0" "0x04"
+diff --git a/target/linux/ath79/generic/base-files/etc/board.d/02_network b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+index c2932c1737d97f3eb732620041664f5060d16946..5626f79ee199865df4e9a4f04ce2ff9580bce012 100755
+--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
++++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+@@ -174,6 +174,7 @@ ath79_setup_interfaces()
+ 	compex,wpj531-16m|\
+ 	openmesh,a40|\
+ 	openmesh,a60|\
++	openmesh,om2p-v1|\
+ 	openmesh,om2p-v4|\
+ 	openmesh,om2p-hs-v4|\
+ 	plasmacloud,pa300|\
+diff --git a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+index 08d9e017a734e29c9b3be4c865e32f109847b4f5..cf07f138260170bcac789e617e09978776b3d2c5 100644
+--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
++++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+@@ -128,6 +128,9 @@ case "$FIRMWARE" in
+ 	openmesh,mr600-v2)
+ 		caldata_extract "ART" 0x5000 0x440
+ 		;;
++	openmesh,om2p-v1)
++		caldata_extract "ART" 0x1000 0x440
++		;;
+ 	wd,mynet-n750)
+ 		caldata_extract "art" 0x5000 0x440
+ 		ath9k_patch_mac $(mtd_get_mac_ascii devdata "wlan5mac")
+diff --git a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+index e979c11bb91cb20fd4168b8921499f03572d3512..e9203f3a5b624e1e9b46c474e95e27583bcb6765 100644
+--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+@@ -73,6 +73,7 @@ platform_do_upgrade() {
+ 	openmesh,mr900-v2|\
+ 	openmesh,mr1750-v1|\
+ 	openmesh,mr1750-v2|\
++	openmesh,om2p-v1|\
+ 	openmesh,om2p-v2|\
+ 	openmesh,om2p-v4|\
+ 	openmesh,om2p-hs-v1|\
+diff --git a/target/linux/ath79/image/generic.mk b/target/linux/ath79/image/generic.mk
+index c63900dc701bbc21dce12086f7045d7d450fc5f3..8113b515368b253d0812fbbb86278e7fde63a038 100644
+--- a/target/linux/ath79/image/generic.mk
++++ b/target/linux/ath79/image/generic.mk
+@@ -1722,6 +1722,16 @@ define Device/openmesh_mr1750-v2
+ endef
+ TARGET_DEVICES += openmesh_mr1750-v2
+ 
++define Device/openmesh_om2p-v1
++  $(Device/openmesh_common_256k)
++  SOC := ar7240
++  DEVICE_MODEL := OM2P
++  DEVICE_VARIANT := v1
++  OPENMESH_CE_TYPE := OM2P
++  SUPPORTED_DEVICES += om2p
++endef
++TARGET_DEVICES += openmesh_om2p-v1
++
+ define Device/openmesh_om2p-v2
+   $(Device/openmesh_common_256k)
+   SOC := ar9330

--- a/patches/openwrt/0009-ath79-Add-support-for-OpenMesh-OM5P-AC-v1.patch
+++ b/patches/openwrt/0009-ath79-Add-support-for-OpenMesh-OM5P-AC-v1.patch
@@ -1,0 +1,348 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Mon, 23 Nov 2020 13:41:34 +0100
+Subject: ath79: Add support for OpenMesh OM5P-AC v1
+
+Device specifications:
+======================
+
+* Qualcomm/Atheros QCA9558 ver 1 rev 0
+* 720/600/240 MHz (CPU/DDR/AHB)
+* 128 MB of RAM
+* 16 MB of SPI NOR flash
+  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
+* 2T2R 2.4 GHz Wi-Fi (11n)
+* 2T2R 5 GHz Wi-Fi (11ac)
+* 6x GPIO-LEDs (3x wifi, 2x ethernet, 1x power)
+* external h/w watchdog (enabled by default))
+* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
+* TI tmp423 (package kmod-hwmon-tmp421) for temperature monitoring
+* 2x ethernet
+  - eth0
+    + AR8035 ethernet PHY (RGMII)
+    + 10/100/1000 Mbps Ethernet
+    + 802.3af POE
+    + used as LAN interface
+  - eth1
+    + AR8035 ethernet PHY (SGMII)
+    + 10/100/1000 Mbps Ethernet
+    + 18-24V passive POE (mode B)
+    + used as WAN interface
+* 12-24V 1A DC
+* internal antennas
+
+Flashing instructions:
+======================
+
+Various methods can be used to install the actual image on the flash.
+Two easy ones are:
+
+ap51-flash
+----------
+
+The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be
+used to transfer the image to the u-boot when the device boots up.
+
+initramfs from TFTP
+-------------------
+
+The serial console must be used to access the u-boot shell during bootup.
+It can then be used to first boot up the initramfs image from a TFTP server
+(here with the IP 192.168.1.21):
+
+   setenv serverip 192.168.1.21
+   setenv ipaddr 192.168.1.1
+   tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr
+
+The actual sysupgrade image can then be transferred (on the LAN port) to the
+device via
+
+  scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/
+
+On the device, the sysupgrade must then be started using
+
+  sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+(cherry picked from commit 97f561725962ddb8823b2e01563a0f37f7930477)
+
+diff --git a/package/boot/uboot-envtools/files/ath79 b/package/boot/uboot-envtools/files/ath79
+index f4ccb2faea4e5e6202413a76cd137065dc535fe7..08c066c3494e8ea6fa5db639e11caa6406f3c6f9 100644
+--- a/package/boot/uboot-envtools/files/ath79
++++ b/package/boot/uboot-envtools/files/ath79
+@@ -58,6 +58,7 @@ openmesh,mr900-v2|\
+ openmesh,mr1750-v1|\
+ openmesh,mr1750-v2|\
+ openmesh,om5p|\
++openmesh,om5p-ac-v1|\
+ openmesh,om5p-ac-v2|\
+ samsung,wam250|\
+ ubnt,nanostation-m|\
+diff --git a/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v1.dts b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v1.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..ae69992abf583168a0ab9a017a9aee33758dd4d8
+--- /dev/null
++++ b/target/linux/ath79/dts/qca9558_openmesh_om5p-ac-v1.dts
+@@ -0,0 +1,199 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "qca955x.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	compatible = "openmesh,om5p-ac-v1", "qca,qca9558";
++	model = "OpenMesh OM5P-AC v1";
++
++	chosen {
++		/delete-property/ bootargs;
++	};
++
++	aliases {
++		serial0 = &uart;
++		led-boot = &led_power_blue;
++		led-failsafe = &led_power_blue;
++		led-running = &led_power_blue;
++		led-upgrade = &led_power_blue;
++		label-mac-device = &eth0;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led_power_blue: power_blue {
++			label = "blue:power";
++			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++		wan_blue {
++			label = "blue:wan";
++			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
++		};
++
++		lan_blue {
++			label = "blue:lan";
++			gpios = <&gpio 20 GPIO_ACTIVE_LOW>;
++		};
++
++		wifi_green {
++			label = "green:wifi";
++			gpios = <&gpio 21 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "phy0tpt";
++		};
++
++		wifi_yellow {
++			label = "yellow:wifi";
++			gpios = <&gpio 22 GPIO_ACTIVE_LOW>;
++		};
++
++		wifi_red {
++			label = "red:wifi";
++			gpios = <&gpio 23 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	i2c {
++		compatible = "i2c-gpio";
++		gpios = <&gpio 11 GPIO_ACTIVE_HIGH /* sda */
++			 &gpio 12 GPIO_ACTIVE_HIGH /* scl */
++			>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		i2c-gpio,scl-open-drain;
++		i2c-gpio,sda-open-drain;
++
++		tmp423a@4c {
++			compatible = "ti,tmp423";
++			reg = <0x4c>;
++		};
++	};
++
++	watchdog {
++		compatible = "linux,wdt-gpio";
++		gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
++		hw_algo = "toggle";
++		/* hw_margin_ms is actually 300s but driver limits it to 60s */
++		hw_margin_ms = <60000>;
++		always-running;
++	};
++};
++
++&spi {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++
++		/* partitions are passed via bootloader */
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "u-boot";
++				reg = <0x000000 0x040000>;
++				read-only;
++			};
++
++			partition@40000 {
++				label = "u-boot-env";
++				reg = <0x040000 0x010000>;
++			};
++
++			partition@50000 {
++				label = "custom";
++				reg = <0x050000 0x060000>;
++				read-only;
++			};
++
++			partition@b0000 {
++				label = "inactive";
++				reg = <0x0b0000 0x7a0000>;
++			};
++
++			partition@850000 {
++				label = "inactive2";
++				reg = <0x850000 0x7a0000>;
++			};
++
++			art: partition@ff0000 {
++				label = "ART";
++				reg = <0xff0000 0x010000>;
++				read-only;
++			};
++		};
++	};
++};
++
++&mdio0 {
++	status = "okay";
++
++	phy-mask = <0x6>;
++
++	phy1: ethernet-phy@1 {
++		reg = <1>;
++		eee-broken-100tx;
++		eee-broken-1000t;
++	};
++
++	phy2: ethernet-phy@2 {
++		reg = <2>;
++		eee-broken-100tx;
++		eee-broken-1000t;
++		at803x-override-sgmii-link-check;
++	};
++};
++
++&eth0 {
++	status = "okay";
++
++	pll-data = <0x82000101 0x80000101 0x80001313>;
++
++	mtd-mac-address = <&art 0x0>;
++
++	phy-mode = "rgmii-id";
++	phy-handle = <&phy1>;
++
++	gmac-config {
++		device = <&gmac>;
++		rgmii-enabled = <1>;
++		rxd-delay = <3>;
++		rxdv-delay = <3>;
++		txd-delay = <0>;
++		txen-delay = <0>;
++	};
++};
++
++&eth1 {
++	status = "okay";
++
++	pll-data = <0x03000101 0x80000101 0x80001313>;
++
++	mtd-mac-address = <&art 0x6>;
++
++	qca955x-sgmii-fixup;
++
++	phy-handle = <&phy2>;
++};
++
++&wmac {
++	status = "okay";
++
++	mtd-cal-data = <&art 0x1000>;
++	mtd-mac-address = <&art 0x0>;
++	mac-address-increment = <2>;
++};
++
++&pcie1 {
++	status = "okay";
++};
+diff --git a/target/linux/ath79/generic/base-files/etc/board.d/01_leds b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+index f5384e7fc3859bab1d6c0422de7e173fad3abae2..68ea4281a56bff44147c7792990cc1e26bc10a7c 100755
+--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
++++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+@@ -257,6 +257,10 @@ openmesh,om2p-v1)
+ 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth0"
+ 	ucidef_set_led_switch "lan" "LAN" "blue:lan" "switch0" "0x10"
+ 	;;
++openmesh,om5p-ac-v1)
++	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
++	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
++	;;
+ pcs,cr3000)
+ 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
+ 	ucidef_set_led_switch "lan1" "LAN1" "blue:lan1" "switch0" "0x04"
+diff --git a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index b70a87054b10fbe708d9aa8603ecdb591fc92591..00dbeec6a51457c23ba97aa627bf14acd8349f74 100644
+--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -158,6 +158,10 @@ case "$FIRMWARE" in
+ 	;;
+ "ath10k/cal-pci-0000:01:00.0.bin")
+ 	case $board in
++	openmesh,om5p-ac-v1)
++		caldata_extract "ART" 0x5000 0x844
++		ath10k_patch_mac $(macaddr_add $(cat /sys/class/net/eth0/address) +16)
++		;;
+ 	sitecom,wlr-8100)
+ 		caldata_extract "art" 0x5000 0x844
+ 		ath10k_patch_mac $(macaddr_add $(mtd_get_mac_ascii u-boot-env ethaddr) +1)
+diff --git a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+index e9203f3a5b624e1e9b46c474e95e27583bcb6765..2cac42c9feaed3c0360091a5b7959e741d4a0473 100644
+--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+@@ -82,6 +82,7 @@ platform_do_upgrade() {
+ 	openmesh,om2p-hs-v4|\
+ 	openmesh,om2p-lc|\
+ 	openmesh,om5p|\
++	openmesh,om5p-ac-v1|\
+ 	openmesh,om5p-ac-v2)
+ 		PART_NAME="inactive"
+ 		platform_do_upgrade_openmesh "$1"
+diff --git a/target/linux/ath79/image/generic.mk b/target/linux/ath79/image/generic.mk
+index 8113b515368b253d0812fbbb86278e7fde63a038..75dbc1c03b5c42b81463bf7c4ddd4aa5803afd69 100644
+--- a/target/linux/ath79/image/generic.mk
++++ b/target/linux/ath79/image/generic.mk
+@@ -1810,6 +1810,17 @@ define Device/openmesh_om5p
+ endef
+ TARGET_DEVICES += openmesh_om5p
+ 
++define Device/openmesh_om5p-ac-v1
++  $(Device/openmesh_common_64k)
++  SOC := qca9558
++  DEVICE_MODEL := OM5P-AC
++  DEVICE_VARIANT := v1
++  DEVICE_PACKAGES += kmod-ath10k-ct ath10k-firmware-qca988x-ct
++  OPENMESH_CE_TYPE := OM5PAC
++  SUPPORTED_DEVICES += om5p-ac
++endef
++TARGET_DEVICES += openmesh_om5p-ac-v1
++
+ define Device/openmesh_om5p-ac-v2
+   $(Device/openmesh_common_64k)
+   SOC := qca9558

--- a/patches/openwrt/0010-ath79-Add-support-for-OpenMesh-OM5P-AN.patch
+++ b/patches/openwrt/0010-ath79-Add-support-for-OpenMesh-OM5P-AN.patch
@@ -1,0 +1,365 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Mon, 23 Nov 2020 13:41:34 +0100
+Subject: ath79: Add support for OpenMesh OM5P-AN
+
+Device specifications:
+======================
+
+* Qualcomm/Atheros AR9344 rev 2
+* 560/450/225 MHz (CPU/DDR/AHB)
+* 64 MB of RAM
+* 16 MB of SPI NOR flash
+  - 2x 7 MB available; but one of the 7 MB regions is the recovery image
+* 1T1R 2.4 GHz Wi-Fi
+* 2T2R 5 GHz Wi-Fi
+* 6x GPIO-LEDs (3x wifi, 2x ethernet, 1x power)
+* 1x GPIO-button (reset)
+* external h/w watchdog (enabled by default)
+* TTL pins are on board (arrow points to VCC, then follows: GND, TX, RX)
+* TI tmp423 (package kmod-hwmon-tmp421) for temperature monitoring
+* 2x ethernet
+  - eth0
+    + AR8035 ethernet PHY
+    + 10/100/1000 Mbps Ethernet
+    + 802.3af POE
+    + used as LAN interface
+  - eth1
+    + 10/100 Mbps Ethernet
+    + builtin switch port 1
+    + 18-24V passive POE (mode B)
+    + used as WAN interface
+* 12-24V 1A DC
+* internal antennas
+
+Flashing instructions:
+======================
+
+Various methods can be used to install the actual image on the flash.
+Two easy ones are:
+
+ap51-flash
+----------
+
+The tool ap51-flash (https://github.com/ap51-flash/ap51-flash) should be
+used to transfer the image to the u-boot when the device boots up.
+
+initramfs from TFTP
+-------------------
+
+The serial console must be used to access the u-boot shell during bootup.
+It can then be used to first boot up the initramfs image from a TFTP server
+(here with the IP 192.168.1.21):
+
+   setenv serverip 192.168.1.21
+   setenv ipaddr 192.168.1.1
+   tftpboot 0c00000 <filename-of-initramfs-kernel>.bin && bootm $fileaddr
+
+The actual sysupgrade image can then be transferred (on the LAN port) to the
+device via
+
+  scp <filename-of-squashfs-sysupgrade>.bin root@192.168.1.1:/tmp/
+
+On the device, the sysupgrade must then be started using
+
+  sysupgrade -n /tmp/<filename-of-squashfs-sysupgrade>.bin
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+(cherry picked from commit 72ef5945508193228544bcd7fcfe81b32e8dc042)
+
+diff --git a/package/boot/uboot-envtools/files/ath79 b/package/boot/uboot-envtools/files/ath79
+index 08c066c3494e8ea6fa5db639e11caa6406f3c6f9..78e5fc0a2be25e1ed676ac647214f237f29b4667 100644
+--- a/package/boot/uboot-envtools/files/ath79
++++ b/package/boot/uboot-envtools/files/ath79
+@@ -58,6 +58,7 @@ openmesh,mr900-v2|\
+ openmesh,mr1750-v1|\
+ openmesh,mr1750-v2|\
+ openmesh,om5p|\
++openmesh,om5p-an|\
+ openmesh,om5p-ac-v1|\
+ openmesh,om5p-ac-v2|\
+ samsung,wam250|\
+diff --git a/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts b/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..6950ba3a2936cf8c9b12a22c966dc3b9215f2227
+--- /dev/null
++++ b/target/linux/ath79/dts/ar9344_openmesh_om5p-an.dts
+@@ -0,0 +1,216 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "ar9344.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++
++/ {
++	compatible = "openmesh,om5p-an", "qca,ar9344";
++	model = "OpenMesh OM5P-AN";
++
++	chosen {
++		/delete-property/ bootargs;
++	};
++
++	aliases {
++		led-boot = &led_power_blue;
++		led-failsafe = &led_power_blue;
++		led-running = &led_power_blue;
++		led-upgrade = &led_power_blue;
++		label-mac-device = &eth0;
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&gpio 4 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		pinctrl-names = "default";
++		pinctrl-0 = <&led_lan_wan_blue_pin>;
++
++		led_power_blue: power_blue {
++			label = "blue:power";
++			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++		wan_blue {
++			label = "blue:wan";
++			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
++		};
++
++		lan_blue {
++			label = "blue:lan";
++			gpios = <&gpio 15 GPIO_ACTIVE_LOW>;
++		};
++
++		wifi_green {
++			label = "green:wifi";
++			gpios = <&gpio 16 GPIO_ACTIVE_LOW>;
++			linux,default-trigger = "phy0tpt";
++		};
++
++		wifi_yellow {
++			label = "yellow:wifi";
++			gpios = <&gpio 17 GPIO_ACTIVE_LOW>;
++		};
++
++		wifi_red {
++			label = "red:wifi";
++			gpios = <&gpio 19 GPIO_ACTIVE_LOW>;
++		};
++	};
++
++	i2c {
++		compatible = "i2c-gpio";
++		gpios = <&gpio 21 GPIO_ACTIVE_HIGH /* sda */
++			 &gpio 20 GPIO_ACTIVE_HIGH /* scl */
++			>;
++		#address-cells = <1>;
++		#size-cells = <0>;
++
++		i2c-gpio,scl-open-drain;
++		i2c-gpio,sda-open-drain;
++
++		tmp423a@4c {
++			compatible = "ti,tmp423";
++			reg = <0x4c>;
++		};
++	};
++
++	watchdog {
++		compatible = "linux,wdt-gpio";
++		gpios = <&gpio 11 GPIO_ACTIVE_LOW>;
++		hw_algo = "toggle";
++		/* hw_margin_ms is actually 300s but driver limits it to 60s */
++		hw_margin_ms = <60000>;
++		always-running;
++	};
++};
++
++&ref {
++	clock-frequency = <40000000>;
++};
++
++&pinmux {
++	led_lan_wan_blue_pin: pinmux_lan_wan_blue_pin {
++		pinctrl-single,bits = <0xc 0x0 0xffff0000>;
++	};
++};
++
++&spi {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <40000000>;
++
++		/* partitions are passed via bootloader */
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "u-boot";
++				reg = <0x000000 0x040000>;
++				read-only;
++			};
++
++			partition@40000 {
++				label = "u-boot-env";
++				reg = <0x040000 0x010000>;
++			};
++
++			partition@50000 {
++				label = "custom";
++				reg = <0x050000 0x060000>;
++				read-only;
++			};
++
++			partition@b0000 {
++				label = "inactive";
++				reg = <0x0b0000 0x7a0000>;
++			};
++
++			partition@850000 {
++				label = "inactive2";
++				reg = <0x850000 0x7a0000>;
++			};
++
++			art: partition@ff0000 {
++				label = "ART";
++				reg = <0xff0000 0x010000>;
++				read-only;
++			};
++		};
++	};
++};
++
++&mdio0 {
++	status = "okay";
++
++	phy-mask = <0x80>;
++
++	phy7: ethernet-phy@7 {
++		reg = <7>;
++		eee-broken-100tx;
++		eee-broken-1000t;
++	};
++};
++
++&eth0 {
++	status = "okay";
++
++	pll-data = <0x02000000 0x00000101 0x00001313>;
++
++	mtd-mac-address = <&art 0x0>;
++
++	phy-mode = "rgmii-id";
++	phy-handle = <&phy7>;
++
++	gmac-config {
++		device = <&gmac>;
++		rgmii-gmac0 = <1>;
++		rxd-delay = <2>;
++		rxdv-delay = <2>;
++		switch-phy-swap = <1>;
++	};
++};
++
++&eth1 {
++	status = "okay";
++
++	mtd-mac-address = <&art 0x0>;
++	mac-address-increment = <1>;
++};
++
++&wmac {
++	status = "okay";
++
++	mtd-cal-data = <&art 0x1000>;
++	mtd-mac-address = <&art 0x0>;
++	mac-address-increment = <2>;
++};
++
++&pcie {
++	status = "okay";
++
++	wifi@0,0 {
++		compatible = "pci168c,0030";
++		reg = <0x0000 0 0 0 0>;
++		qca,no-eeprom;
++		mtd-mac-address = <&art 0x0>;
++		mac-address-increment = <16>;
++	};
++};
+diff --git a/target/linux/ath79/generic/base-files/etc/board.d/01_leds b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+index 68ea4281a56bff44147c7792990cc1e26bc10a7c..403ca9edd940d76bf9695cc18fe0c8cdd7e22967 100755
+--- a/target/linux/ath79/generic/base-files/etc/board.d/01_leds
++++ b/target/linux/ath79/generic/base-files/etc/board.d/01_leds
+@@ -261,6 +261,10 @@ openmesh,om5p-ac-v1)
+ 	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
+ 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
+ 	;;
++openmesh,om5p-an)
++	ucidef_set_led_netdev "lan" "LAN" "blue:lan" "eth0"
++	ucidef_set_led_switch "wan" "WAN" "blue:wan" "switch0" "0x02"
++	;;
+ pcs,cr3000)
+ 	ucidef_set_led_netdev "wan" "WAN" "blue:wan" "eth1"
+ 	ucidef_set_led_switch "lan1" "LAN1" "blue:lan1" "switch0" "0x04"
+diff --git a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+index cf07f138260170bcac789e617e09978776b3d2c5..fbce7d672b2306094544aacf527257e7e6a6ba8c 100644
+--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
++++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/10-ath9k-eeprom
+@@ -125,7 +125,8 @@ case "$FIRMWARE" in
+ 		caldata_extract "art" 0x1000 0x1000
+ 		;;
+ 	openmesh,mr600-v1|\
+-	openmesh,mr600-v2)
++	openmesh,mr600-v2|\
++	openmesh,om5p-an)
+ 		caldata_extract "ART" 0x5000 0x440
+ 		;;
+ 	openmesh,om2p-v1)
+diff --git a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+index 2cac42c9feaed3c0360091a5b7959e741d4a0473..67e53c5fdebf29e71b920753be829fa4e41ca207 100644
+--- a/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
++++ b/target/linux/ath79/generic/base-files/lib/upgrade/platform.sh
+@@ -83,7 +83,8 @@ platform_do_upgrade() {
+ 	openmesh,om2p-lc|\
+ 	openmesh,om5p|\
+ 	openmesh,om5p-ac-v1|\
+-	openmesh,om5p-ac-v2)
++	openmesh,om5p-ac-v2|\
++	openmesh,om5p-an)
+ 		PART_NAME="inactive"
+ 		platform_do_upgrade_openmesh "$1"
+ 		;;
+diff --git a/target/linux/ath79/image/generic.mk b/target/linux/ath79/image/generic.mk
+index 75dbc1c03b5c42b81463bf7c4ddd4aa5803afd69..000fec405e161dc4906e88dd967f73c2df95f296 100644
+--- a/target/linux/ath79/image/generic.mk
++++ b/target/linux/ath79/image/generic.mk
+@@ -1832,6 +1832,15 @@ define Device/openmesh_om5p-ac-v2
+ endef
+ TARGET_DEVICES += openmesh_om5p-ac-v2
+ 
++define Device/openmesh_om5p-an
++  $(Device/openmesh_common_64k)
++  SOC := ar9344
++  DEVICE_MODEL := OM5P-AN
++  OPENMESH_CE_TYPE := OM5P
++  SUPPORTED_DEVICES += om5p-an
++endef
++TARGET_DEVICES += openmesh_om5p-an
++
+ define Device/pcs_cap324
+   SOC := ar9344
+   DEVICE_VENDOR := PowerCloud Systems

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -145,6 +145,16 @@ device('openmesh-om2p-v1', 'openmesh_om2p-v1', {
 	manifest_aliases = {'openmesh-om2p'},
 })
 
+device('openmesh-om2p-v2', 'openmesh_om2p-v2', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x; deacticated at the moment because
+	-- the physical ethernet port for this device changed between 19.07
+	-- and 21.02. And automated update could therefore "break" the
+	-- device until someone physically changed the ethernet cable.
+	-- See https://github.com/freifunk-gluon/gluon/pull/2325#issuecomment-940749284
+	--manifest_aliases = {'openmesh-om2pv2'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -88,6 +88,15 @@ device('ocedo-raccoon', 'ocedo_raccoon', {
 -- setup via integrated (USB-)tty is possible as well
 device('onion-omega', 'onion_omega')
 
+
+-- OpenMesh
+
+device('openmesh-a60', 'openmesh_a60', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
+
 -- Plasma Cloud
 
 device('plasma-cloud-pa300', 'plasmacloud_pa300')

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -193,6 +193,13 @@ device('openmesh-om5p', 'openmesh_om5p', {
 	factory = false,
 })
 
+device('openmesh-om5p-ac-v1', 'openmesh_om5p-ac-v1', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-om5p-ac'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -132,6 +132,13 @@ device('openmesh-mr1750-v1', 'openmesh_mr1750-v1', {
 	manifest_aliases = {'openmesh-mr1750'},
 })
 
+device('openmesh-mr1750-v2', 'openmesh_mr1750-v2', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-mr1750v2'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -189,6 +189,10 @@ device('openmesh-om2p-lc', 'openmesh_om2p-lc', {
 	factory = false,
 })
 
+device('openmesh-om5p', 'openmesh_om5p', {
+	factory = false,
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -161,6 +161,12 @@ device('openmesh-om2p-v4', 'openmesh_om2p-v4', {
 	manifest_aliases = {'openmesh-om2pv4'},
 })
 
+device('openmesh-om2p-hs-v1', 'openmesh_om2p-hs-v1', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-om2p-hs'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -101,6 +101,12 @@ device('openmesh-a60', 'openmesh_a60', {
 	factory = false,
 })
 
+device('openmesh-mr600-v1', 'openmesh_mr600-v1', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-mr600'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -139,6 +139,12 @@ device('openmesh-mr1750-v2', 'openmesh_mr1750-v2', {
 	manifest_aliases = {'openmesh-mr1750v2'},
 })
 
+device('openmesh-om2p-v1', 'openmesh_om2p-v1', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-om2p'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -200,6 +200,13 @@ device('openmesh-om5p-ac-v1', 'openmesh_om5p-ac-v1', {
 	manifest_aliases = {'openmesh-om5p-ac'},
 })
 
+device('openmesh-om5p-ac-v2', 'openmesh_om5p-ac-v2', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-om5p-acv2'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -167,6 +167,12 @@ device('openmesh-om2p-hs-v1', 'openmesh_om2p-hs-v1', {
 	manifest_aliases = {'openmesh-om2p-hs'},
 })
 
+device('openmesh-om2p-hs-v2', 'openmesh_om2p-hs-v2', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-om2p-hsv2'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -185,6 +185,10 @@ device('openmesh-om2p-hs-v4', 'openmesh_om2p-hs-v4', {
 	manifest_aliases = {'openmesh-om2p-hsv4'},
 })
 
+device('openmesh-om2p-lc', 'openmesh_om2p-lc', {
+	factory = false,
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -207,6 +207,10 @@ device('openmesh-om5p-ac-v2', 'openmesh_om5p-ac-v2', {
 	manifest_aliases = {'openmesh-om5p-acv2'},
 })
 
+device('openmesh-om5p-an', 'openmesh_om5p-an', {
+	factory = false,
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -91,6 +91,11 @@ device('onion-omega', 'onion_omega')
 
 -- OpenMesh
 
+device('openmesh-a40', 'openmesh_a40', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 device('openmesh-a60', 'openmesh_a60', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -179,6 +179,12 @@ device('openmesh-om2p-hs-v3', 'openmesh_om2p-hs-v3', {
 	manifest_aliases = {'openmesh-om2p-hsv3'},
 })
 
+device('openmesh-om2p-hs-v4', 'openmesh_om2p-hs-v4', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-om2p-hsv4'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -173,6 +173,12 @@ device('openmesh-om2p-hs-v2', 'openmesh_om2p-hs-v2', {
 	manifest_aliases = {'openmesh-om2p-hsv2'},
 })
 
+device('openmesh-om2p-hs-v3', 'openmesh_om2p-hs-v3', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-om2p-hsv3'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -113,6 +113,12 @@ device('openmesh-mr600-v2', 'openmesh_mr600-v2', {
 	manifest_aliases = {'openmesh-mr600v2'},
 })
 
+device('openmesh-mr900-v1', 'openmesh_mr900-v1', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-mr900'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -107,6 +107,12 @@ device('openmesh-mr600-v1', 'openmesh_mr600-v1', {
 	manifest_aliases = {'openmesh-mr600'},
 })
 
+device('openmesh-mr600-v2', 'openmesh_mr600-v2', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-mr600v2'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -155,6 +155,12 @@ device('openmesh-om2p-v2', 'openmesh_om2p-v2', {
 	--manifest_aliases = {'openmesh-om2pv2'},
 })
 
+device('openmesh-om2p-v4', 'openmesh_om2p-v4', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-om2pv4'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -119,6 +119,12 @@ device('openmesh-mr900-v1', 'openmesh_mr900-v1', {
 	manifest_aliases = {'openmesh-mr900'},
 })
 
+device('openmesh-mr900-v2', 'openmesh_mr900-v2', {
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-mr900v2'},
+})
+
 
 -- Plasma Cloud
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -125,6 +125,13 @@ device('openmesh-mr900-v2', 'openmesh_mr900-v2', {
 	manifest_aliases = {'openmesh-mr900v2'},
 })
 
+device('openmesh-mr1750-v1', 'openmesh_mr1750-v1', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+	-- old name from OpenWrt 19.07.x
+	manifest_aliases = {'openmesh-mr1750'},
+})
+
 
 -- Plasma Cloud
 


### PR DESCRIPTION
Support for the OpenMesh devices was dropped in the commit 9fdc57c175b4 ("treewide: drop ar71xx platform specific code"). These devices will now be introduced for the ath79-generic architecture.


Source of device support
========================

Upstream in OpenWrt 21.02
-------------------------

* MR600 (v1, v2)
* MR900 (v1, v2)
* MR1750 (v1, v2)
* OM2P (v2, v4)
* OM2P-HS (v1, v2, v3, v4)
* OM2P-LC
* OM5P


Upstream in OpenWrt master
-------------------------

* A40
* A60
* OM2P (v1)
* OM5P-AC (v1, v2)
* OM5P-AN


Pending fix for OpenWrt 21.02
-----------------------------

* OM5P-AC (v2) https://github.com/openwrt/openwrt/pull/4966


Image name changes
==================

The switch to OpenWrt 21.02 also changed some device names slightly. manifest_aliases were added for these (but the one for OM2P-v2 was disabled and an explanation was added to targets/ath79-generic

* openmesh-mr600 => openmesh-mr600-v1
* openmesh-mr600v2 => openmesh-mr600-v2
* openmesh-mr900 => openmesh-mr900-v1
* openmesh-mr900v2 => openmesh-mr900-v2
* openmesh-mr1750 => openmesh-mr1750-v1
* openmesh-mr1750v2 => openmesh-mr1750-v2
* openmesh-om2p => openmesh-om2p-v1
* openmesh-om2pv2 => openmesh-om2p-v2
* openmesh-om2pv4 => openmesh-om2p-v4
* openmesh-om2p-hs  => openmesh-om2p-hs-v1
* openmesh-om2p-hsv2 => openmesh-om2p-hs-v2
* openmesh-om2p-hsv3 => openmesh-om2p-hs-v3
* openmesh-om2p-hsv4 => openmesh-om2p-hs-v4
* openmesh-om5p-ac => openmesh-om5p-ac-v1
* openmesh-om5p-acv2 => openmesh-om5p-ac-v2