### PR TITLE
Add archer c25 v1

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -105,7 +105,7 @@ device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })
 
-device('tp-link-archer-c25-v1', 'archer-c25-v1', {
+device('tp-link-archer-c25-v1', 'tplink_archer-c25-v1', {
 	packages = ATH10K_PACKAGES_QCA9887,
 	class = 'tiny', -- 64M ath9k + ath10k
 })

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -105,6 +105,11 @@ device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })
 
+device('tp-link-archer-c25-v1', 'archer-c25-v1', {
+	packages = ATH10K_PACKAGES_QCA9887,
+	class = 'tiny', -- 64M ath9k + ath10k
+})
+
 device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -107,7 +107,8 @@ device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 
 device('tp-link-archer-c25-v1', 'tplink_archer-c25-v1', {
 	packages = ATH10K_PACKAGES_QCA9887,
-	class = 'tiny', -- 64M ath9k + ath10k
+	class = 'tiny',
+	broken = true, -- 64M ath9k + ath10k
 })
 
 device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {


### PR DESCRIPTION
Hello,
I've added the archer c25 v1 again, because we got a firmware request for the device over at Freifunk München. We built an image and sent that to the requestor. He seems to be able to use it now without OOM problems. Maybe the OOM problem was fixed by OpenWrt 21.02?