### PR TITLE
ath79-generic: add support for Enterasys WS-AP3705i

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -13,6 +13,10 @@ ath79-generic
   - WiFi pro 1750i
   - WiFi pro 1750x
 
+* Enterasys
+
+  - WS-AP3705i
+
 * GL.iNet
 
   - GL-AR300M-Lite

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -54,6 +54,14 @@ device('devolo-wifi-pro-1750x', 'devolo_dvl1750x', {
 	factory = false,
 })
 
+
+-- Enterasys
+
+device('enterasys-ws-ap3705', 'enterasys_ws-ap3705i', {
+	factory = false,
+})
+
+
 -- GL.iNet
 
 device('gl.inet-gl-ar300m-lite', 'glinet_gl-ar300m-lite', {


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: TFTP initramfs via external Cisco RJ-45 console

- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN) (single port)
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds (none present)
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only (none)
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`