### PR TITLE
Adjust for OpenWrt hwmode -> band wireless config change

### DIFF
--- a/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
+++ b/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
@@ -31,7 +31,7 @@ return function(form, uci)
 			if data == false then
 				local mesh_ifaces_5ghz = {}
 				uci:foreach('wireless', 'wifi-device', function(config)
-					if config.hwmode ~= '11a' and config.hwmode ~= '11na' then
+					if config.band ~= '5g' then
 						return
 					end
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/005-wireless-migration
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/005-wireless-migration
@@ -1,0 +1,20 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+
+-- Migration from hwmode to band (OpenWrt 21.02)
+-- Use uci:foreach(), as wireless.foreach_radio() depends on band already being set
+uci:foreach('wireless', 'wifi-device', function(radio)
+	local radio_name = radio['.name']
+	local hwmode = radio.hwmode
+	if not radio.band then
+		if hwmode == '11g' or hwmode == '11ng' then
+			uci:set('wireless', radio_name, 'band', '2g')
+		elseif hwmode == '11a' or hwmode == '11na' then
+			uci:set('wireless', radio_name, 'band', '5g')
+		end
+	end
+	uci:delete('wireless', radio_name, 'hwmode')
+end)
+
+uci:save('wireless')

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -38,11 +38,11 @@ if not sysconfig.gluon_version then
 			if radio_band_count["band24"] <= radio_band_count["band5"] then
 				-- Assign radio to 2.4GHz band
 				radio_band_count["band24"] = radio_band_count["band24"] + 1
-				uci:set('wireless', radio_name, 'hwmode', '11g')
+				uci:set('wireless', radio_name, 'band', '2g')
 			else
 				-- Assign radio to 5GHz band
 				radio_band_count["band5"] = radio_band_count["band5"] + 1
-				uci:set('wireless', radio_name, 'hwmode', '11a')
+				uci:set('wireless', radio_name, 'band', '5g')
 			end
 		end
 	end)
@@ -57,7 +57,7 @@ local function get_channel(radio, config)
 	if wireless.preserve_channels(uci) then
 		-- preserved channel always wins
 		channel = radio.channel
-	elseif  (radio.hwmode == '11a' or radio.hwmode == '11na') and is_outdoor() then
+	elseif radio.band == '5g' and is_outdoor() then
 		-- actual channel will be picked and probed from chanlist
 		channel = 'auto'
 	end
@@ -66,7 +66,7 @@ local function get_channel(radio, config)
 end
 
 local function get_htmode(radio)
-	if (radio.hwmode == '11a' or radio.hwmode == '11na') and is_outdoor() then
+	if radio.band == '5g' and is_outdoor() then
 		local outdoor_htmode = uci:get('gluon', 'wireless', 'outdoor_' .. radio['.name'] .. '_htmode')
 		if outdoor_htmode ~= nil then
 			return outdoor_htmode
@@ -207,11 +207,11 @@ wireless.foreach_radio(uci, function(radio, index, config)
 	uci:delete('wireless', radio_name, 'supported_rates')
 	uci:delete('wireless', radio_name, 'basic_rate')
 
-	local hwmode = radio.hwmode
-	if hwmode == '11g' or hwmode == '11ng' then
+	local band = radio.band
+	if band == '2g' then
 		uci:set('wireless', radio_name, 'legacy_rates', false)
 		configure_mesh_wireless(radio, index, config)
-	elseif (hwmode == '11a' or hwmode == '11na') then
+	elseif (band == '5g') then
 		if is_outdoor() then
 			uci:set('wireless', radio_name, 'channels', config.outdoor_chanlist())
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -112,11 +112,11 @@ function M.foreach_radio(uci, f)
 	end)
 
 	for index, radio in ipairs(radios) do
-		local hwmode = radio.hwmode
+		local band = radio.band
 
-		if hwmode == '11g' or hwmode == '11ng' then
+		if band == '2g' then
 			f(radio, index, site.wifi24)
-		elseif hwmode == '11a' or hwmode == '11na' then
+		elseif band == '5g' then
 			f(radio, index, site.wifi5)
 		end
 	end
@@ -165,7 +165,7 @@ function M.device_uses_11a(uci)
 	local ret = false
 
 	uci:foreach('wireless', 'wifi-device', function(radio)
-		if radio.hwmode == '11a' or radio.hwmode == '11na' then
+		if radio.band == '5g' then
 			ret = true
 			return false
 		end

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -44,9 +44,9 @@ uci:foreach('wireless', 'wifi-device', function(config)
 
 	local is_5ghz = false
 	local title
-	if config.hwmode == '11g' or config.hwmode == '11ng' then
+	if config.band == '2g' then
 		title = translate("2.4GHz WLAN")
-	elseif config.hwmode == '11a' or config.hwmode == '11na' then
+	elseif config.band == '5g' then
 		is_5ghz = true
 		title = translate("5GHz WLAN")
 	else
@@ -155,9 +155,9 @@ if wireless.device_uses_11a(uci) and not wireless.preserve_channels(uci) then
 
 	uci:foreach('wireless', 'wifi-device', function(config)
 		local radio = config['.name']
-		local hwmode = uci:get('wireless', radio, 'hwmode')
+		local band = uci:get('wireless', radio, 'band')
 
-		if hwmode ~= '11a' and hwmode ~= '11na' then
+		if band ~= '5g' then
 			return
 		end
 


### PR DESCRIPTION
OpenWrt recently backported a number of changes to the wireless setup scripts to 21.02, breaking our wireless configuration.

- Change our code to use the new option (by @blocktrron, added commit message)
- Add migration code