### PR TITLE
gluon-ebtables-limit-arp: declare clock as extern

### DIFF
--- a/package/gluon-ebtables-limit-arp/src/gluon-arp-limiter.c
+++ b/package/gluon-ebtables-limit-arp/src/gluon-arp-limiter.c
@@ -25,6 +25,8 @@
 static struct addr_store ip_store;
 static struct addr_store mac_store;
 
+int clock;
+
 char *addr_mac_ntoa(void *addr)
 {
 	return mac_ntoa((struct mac_addr *)addr);

--- a/package/gluon-ebtables-limit-arp/src/gluon-arp-limiter.h
+++ b/package/gluon-ebtables-limit-arp/src/gluon-arp-limiter.h
@@ -8,6 +8,6 @@
 #ifndef _GLUON_ARP_LIMITER_H_
 #define _GLUON_ARP_LIMITER_H_
 
-int clock;
+extern int clock;
 
 #endif /* _GLUON_ARP_LIMITER_H_ */


### PR DESCRIPTION
Declare the clock variable as extern in the header file.

Fixes compilation of gluon-ebtables-limit-arp with OpenWrt master:

multiple definition of `clock'; /gluon/openwrt/tmp/ccuynR0G.o:(.bss+0x230): first defined here

Signed-off-by: David Bauer <mail@david-bauer.net>