### PR TITLE
targets/ramips-mt76x8: add device TP-Link RE200 V4

### DIFF
--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -60,6 +60,10 @@ device('tp-link-archer-c50-v4', 'tplink_archer-c50-v4', {
 
 device('tp-link-re200-v2', 'tplink_re200-v2')
 
+device('tp-link-re200-v4', 'tplink_re200-v4', {
+	broken = true, -- no 5GHz connectivity (scanning works)
+})
+
 device('tp-link-re305', 'tplink_re305-v1', {
 	class = 'tiny', -- Only 6M of usable Firmware space
 })


### PR DESCRIPTION
Signed-off-by: Richard Fröhning <misanthropos@gmx.de>

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [ ] association with AP must be possible on all radios
  - [ ] association with 802.11s mesh must be working on all radios 
  - [ ] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`