### PR TITLE
gluon-respondd: remove obsolete migration from upgrade script

### DIFF
--- a/package/gluon-respondd/luasrc/lib/gluon/upgrade/400-respondd-firewall
+++ b/package/gluon-respondd/luasrc/lib/gluon/upgrade/400-respondd-firewall
@@ -3,8 +3,6 @@
 local uci = require('simple-uci').cursor()
 local site = require('gluon.site')
 
-uci:delete('firewall', 'wan_announced')
-
 -- Allow respondd port on WAN to allow resolving neighbours over mesh-on-wan
 uci:section('firewall', 'rule', 'wan_respondd', {
 	name = 'wan_respondd',


### PR DESCRIPTION
announced was renamed to respondd in 2016. Let's remove the obsolete
migration code.