### PR TITLE
RFC: gluon-mesh-vpn-*: make MTU of VPN device provider specific

### DIFF
--- a/contrib/ci/minimal-site/site.conf
+++ b/contrib/ci/minimal-site/site.conf
@@ -93,7 +93,6 @@
 
   mesh_vpn = {
     -- enabled = true,
-    mtu = 1312,
 
     fastd = {
       -- Refer to https://fastd.readthedocs.io/en/latest/ to better understand
@@ -101,6 +100,7 @@
 
       -- List of crypto-methods to use.
       methods = {'salsa2012+umac'},
+      mtu = 1312,
       -- configurable = true,
       -- syslog_level = 'warn',
 

--- a/docs/multidomain-site-example/site.conf
+++ b/docs/multidomain-site-example/site.conf
@@ -20,10 +20,10 @@
   },
 
   mesh_vpn = {
-    mtu = 1312,
 
     fastd = {
       methods = {'salsa2012+umac'},
+      mtu = 1312,
     },
 
     bandwidth_limit = {

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -105,7 +105,6 @@
 
   mesh_vpn = {
     -- enabled = true,
-    mtu = 1312,
 
     fastd = {
       -- Refer to https://fastd.readthedocs.io/en/latest/ to better understand
@@ -113,6 +112,7 @@
 
       -- List of crypto-methods to use.
       methods = {'salsa2012+umac'},
+      mtu = 1312,
       -- configurable = true,
       -- syslog_level = 'warn',
 

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -331,10 +331,10 @@ mesh_vpn
 
     mesh_vpn = {
       -- enabled = true,
-      mtu = 1312,
       -- pubkey_privacy = true,
 
       fastd = {
+        mtu = 1312,
         methods = {'salsa2012+umac'},
         -- configurable = true,
         -- syslog_level = 'warn',
@@ -384,6 +384,7 @@ mesh_vpn
       },
 
       tunneldigger = {
+        mtu = 1312,
         brokers = {'vpn1.alpha-centauri.freifunk.net'}
       },
 

--- a/package/gluon-mesh-vpn-core/check_site.lua
+++ b/package/gluon-mesh-vpn-core/check_site.lua
@@ -1,5 +1,4 @@
 need_boolean(in_site({'mesh_vpn', 'enabled'}), false)
-need_number({'mesh_vpn', 'mtu'})
 need_boolean(in_site({'mesh_vpn', 'pubkey_privacy'}), false)
 
 need_boolean(in_site({'mesh_vpn', 'bandwidth_limit', 'enabled'}), false)

--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
@@ -7,6 +7,7 @@ local util = require 'gluon.util'
 local uci = require('simple-uci').cursor()
 
 local vpn_core = require 'gluon.mesh-vpn'
+local _, active_vpn = vpn_core.get_active_provider()
 
 uci:section('network', 'interface', 'mesh_vpn', {
 	ifname = vpn_core.get_interface(),
@@ -14,7 +15,7 @@ uci:section('network', 'interface', 'mesh_vpn', {
 	transitive = true,
 	fixed_mtu = true,
 	macaddr = util.generate_mac(7),
-	mtu = site.mesh_vpn.mtu(),
+	mtu = active_vpn.mtu(),
 })
 
 uci:save('network')

--- a/package/gluon-mesh-vpn-fastd/check_site.lua
+++ b/package/gluon-mesh-vpn-fastd/check_site.lua
@@ -1,6 +1,7 @@
 local fastd_methods = {'salsa2012+umac', 'null+salsa2012+umac', 'null@l2tp', 'null'}
 need_array_of({'mesh_vpn', 'fastd', 'methods'}, fastd_methods)
 need_boolean(in_site({'mesh_vpn', 'fastd', 'configurable'}), false)
+need_number({'mesh_vpn', 'fastd', 'mtu'})
 
 need_one_of(in_site({'mesh_vpn', 'fastd', 'syslog_level'}),
 	{'error', 'warn', 'info', 'verbose', 'debug', 'debug2'}, false)

--- a/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
+++ b/package/gluon-mesh-vpn-fastd/luasrc/lib/gluon/upgrade/400-mesh-vpn-fastd
@@ -3,6 +3,7 @@
 local site = require 'gluon.site'
 local util = require 'gluon.util'
 local vpn_core = require 'gluon.mesh-vpn'
+local _, active_vpn = vpn_core.get_active_provider()
 
 local uci = require('simple-uci').cursor()
 local unistd = require 'posix.unistd'
@@ -49,7 +50,7 @@ uci:section('fastd', 'fastd', 'mesh_vpn', {
 	secret = secret,
 	interface = vpn_core.get_interface(),
 	mode = 'tap',
-	mtu = site.mesh_vpn.mtu(),
+	mtu = active_vpn.mtu(),
 	secure_handshakes = true,
 	method = methods,
 	packet_mark = 1,

--- a/package/gluon-mesh-vpn-fastd/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/fastd.lua
+++ b/package/gluon-mesh-vpn-fastd/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/fastd.lua
@@ -39,4 +39,8 @@ function M.set_limit(ingress_limit, egress_limit)
 	uci:save('simple-tc')
 end
 
+function M.mtu()
+	return site.mesh_vpn.fastd.mtu()
+end
+
 return M

--- a/package/gluon-mesh-vpn-tunneldigger/check_site.lua
+++ b/package/gluon-mesh-vpn-tunneldigger/check_site.lua
@@ -1,1 +1,2 @@
 need_string_array(in_domain({'mesh_vpn', 'tunneldigger', 'brokers'}))
+need_number({'mesh_vpn', 'tunneldigger', 'mtu'})

--- a/package/gluon-mesh-vpn-tunneldigger/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/tunneldigger.lua
+++ b/package/gluon-mesh-vpn-tunneldigger/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/tunneldigger.lua
@@ -39,4 +39,8 @@ function M.set_limit(ingress_limit, egress_limit)
 	uci:save('simple-tc')
 end
 
+function M.mtu()
+	return site.mesh_vpn.tunneldigger.mtu()
+end
+
 return M

--- a/package/gluon-mesh-vpn-wireguard/check_site.lua
+++ b/package/gluon-mesh-vpn-wireguard/check_site.lua
@@ -7,3 +7,4 @@ local function check_peer(k)
 end
 
 need_table({'mesh_vpn', 'wireguard', 'peers'}, check_peer)
+need_number({'mesh_vpn', 'wireguard', 'mtu'})

--- a/package/gluon-mesh-vpn-wireguard/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
+++ b/package/gluon-mesh-vpn-wireguard/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
@@ -40,4 +40,8 @@ function M.set_limit(ingress_limit, egress_limit)
 	uci:save('simple-tc')
 end
 
+function M.mtu()
+	return site.mesh_vpn.wireguard.mtu()
+end
+
 return M


### PR DESCRIPTION
If a community uses different vpn providers, they typically
assume the same MTU for the wan device underneath the VPN. As
different VPN providers however have different overhead, the MTU
of the VPN device differs for each provider. Therefore this
commit makes the MTU of the VPN device provider specific.

This has two advantages:
1. The same site.conf can used to bake firmwares for different
   VPN providers (only by selecting a diferent vpn feature in the
   site.mk).
2. We are coming closer to the option of integrating multiple VPN
   providers into one firmware.