### PR TITLE
README.md: add link to Matrix room

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you're new to Gluon and ready to get your feet wet, have a look at the
 
 Gluon's developers frequent an IRC chatroom at [#gluon](ircs://irc.hackint.org/#gluon)
 on [hackint](https://hackint.org/). There is also a [webchat](https://webirc.hackint.org/#irc://irc.hackint.org/#gluon)
-that allows for uncomplicated access from within your browser.
+that allows for uncomplicated access from within your browser and a bridged Matrix Room under [#gluon:hackint.org](https://matrix.to/#/#gluon:hackint.org).
 
 ## Issues & Feature requests
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you're new to Gluon and ready to get your feet wet, have a look at the
 
 Gluon's developers frequent an IRC chatroom at [#gluon](ircs://irc.hackint.org/#gluon)
 on [hackint](https://hackint.org/). There is also a [webchat](https://webirc.hackint.org/#irc://irc.hackint.org/#gluon)
-that allows for uncomplicated access from within your browser and a bridged Matrix Room under [#gluon:hackint.org](https://matrix.to/#/#gluon:hackint.org).
+that allows for uncomplicated access from within your browser. This channel is also available as a bridged Matrix Room at [#gluon:hackint.org](https://matrix.to/#/#gluon:hackint.org).
 
 ## Issues & Feature requests
 


### PR DESCRIPTION
Since hackint started offering a Matrix Bridge once again this should be documented as a contact option.