### PR TITLE
x86: copy separate kernel and rootfs images to "other" directory

### DIFF
--- a/targets/x86-64
+++ b/targets/x86-64
@@ -1,9 +1,9 @@
 include 'x86.inc'
 
 packages {
-        'kmod-gpio-nct5104d',
-        'kmod-leds-gpio',
-        'kmod-pcengines-apuv2',
+	'kmod-gpio-nct5104d',
+	'kmod-leds-gpio',
+	'kmod-pcengines-apuv2',
 }
 
 device('x86-64', 'generic')

--- a/targets/x86-64
+++ b/targets/x86-64
@@ -6,4 +6,9 @@ packages {
 	'kmod-pcengines-apuv2',
 }
 
-device('x86-64', 'generic')
+device('x86-64', 'generic', {
+	extra_images = {
+		{'-kernel', '-kernel', '.bin'},
+		{'-squashfs-rootfs', '-rootfs', '.img.gz'},
+	},
+})

--- a/targets/x86-generic
+++ b/targets/x86-generic
@@ -7,6 +7,10 @@ packages {
 }
 
 device('x86-generic', 'generic', {
+	extra_images = {
+		{'-kernel', '-kernel', '.bin'},
+		{'-squashfs-rootfs', '-rootfs', '.img.gz'},
+	},
 	manifest_aliases = {
 		'x86-kvm',
 		'x86-xen_domu',

--- a/targets/x86-generic
+++ b/targets/x86-generic
@@ -1,9 +1,9 @@
 include 'x86.inc'
 
 packages {
-        'kmod-gpio-nct5104d',
-        'kmod-leds-gpio',
-        'kmod-pcengines-apuv2',
+	'kmod-gpio-nct5104d',
+	'kmod-leds-gpio',
+	'kmod-pcengines-apuv2',
 }
 
 device('x86-generic', 'generic', {


### PR DESCRIPTION
For regular use, a full disk image is always recommended, as it is
required to support sysupgrades.

During development or for automated tests, separate images for the
kernel and rootfs may be useful to pass additional kernel cmdline or use
nfsroot/virtiofs. The rootfs is only available as a (squashfs)
filesystem image, not as a TAR archive (the TAR archive in OpenWrt's bin
directory does not contain DEVICE_PACKAGES, so it is missing most of
Gluon's packages).

As suggested in #2355.