### PR TITLE
Target build cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ include $(GLUON_SITEDIR)/site.mk
 
 GLUON_RELEASE ?= $(error GLUON_RELEASE not set. GLUON_RELEASE can be set in site.mk or on the command line)
 
-GLUON_DEPRECATED ?= $(error GLUON_DEPRECATED not set. Please consult the documentation)
+GLUON_DEPRECATED ?= 0
 
 ifneq ($(GLUON_BRANCH),)
   $(warning *** Warning: GLUON_BRANCH has been deprecated, please set GLUON_AUTOUPDATER_BRANCH and GLUON_AUTOUPDATER_ENABLED instead.)

--- a/docs/multidomain-site-example/site.mk
+++ b/docs/multidomain-site-example/site.mk
@@ -58,6 +58,3 @@ GLUON_REGION ?= eu
 
 # Languages to include
 GLUON_LANGS ?= en de
-
-# Do not build images for deprecated devices
-GLUON_DEPRECATED ?= 0

--- a/docs/site-example/site.mk
+++ b/docs/site-example/site.mk
@@ -55,6 +55,3 @@ GLUON_REGION ?= eu
 
 # Languages to include
 GLUON_LANGS ?= en de
-
-# Do not build images for deprecated devices
-GLUON_DEPRECATED ?= 0

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -213,7 +213,7 @@ GLUON_DEPRECATED
   Usually, devices are deprecated because their flash size is insufficient to
   support future Gluon versions. The recommended setting is ``0`` for new sites,
   and ``upgrade`` for existing configurations (where upgrades for existing
-  deployments of low-flash devices are required).
+  deployments of low-flash devices are required). Defaults to ``0``.
 
 GLUON_LANGS
   Space-separated list of languages to include for the config mode/advanced settings. Defaults to ``en``.

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -562,7 +562,7 @@ GLUON_DEPRECATED
   Usually, devices are deprecated because their flash size is insufficient to
   support future Gluon versions. The recommended setting is ``0`` for new sites,
   and ``upgrade`` for existing configurations (where upgrades for existing
-  deployments of low-flash devices are required).
+  deployments of low-flash devices are required). Defaults to ``0``.
 
 GLUON_FEATURES
   Defines a list of features to include. Depending on the device, the feature list

--- a/scripts/target_lib.lua
+++ b/scripts/target_lib.lua
@@ -267,47 +267,6 @@ function F.device(image, name, options)
 	end
 end
 
-function F.factory_image(image, name, ext, options)
-	options = merge(default_options, options)
-
-	if not want_device(image, options) then
-		return
-	end
-
-	if options.deprecated and not full_deprecated then
-		return
-	end
-
-	add_image {
-		image = image,
-		name = name,
-		subdir = 'factory',
-		in_suffix = '',
-		out_suffix = '',
-		extension = ext,
-		aliases = options.aliases,
-	}
-end
-
-function F.sysupgrade_image(image, name, ext, options)
-	options = merge(default_options, options)
-
-	if not want_device(image, options) then
-		return
-	end
-
-	add_image {
-		image = image,
-		name = name,
-		subdir = 'sysupgrade',
-		in_suffix = '',
-		out_suffix = '-sysupgrade',
-		extension = ext,
-		aliases = options.aliases,
-		manifest_aliases = options.manifest_aliases,
-	}
-end
-
 function F.defaults(options)
 	default_options = merge(default_options, options)
 end


### PR DESCRIPTION
- Remove obsolete `sysupgrade_image` and `factory_image` target DSL handlers
- Add default for GLUON_DEPRECATED