### PR TITLE
scripts/container.sh: allow for empty Branch Names

### DIFF
--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -6,8 +6,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 # normalize branch name to reflect a valid image name
-BRANCH=$(git branch --show-current | sed 's/[^a-z0-9-]/_/ig')
-TAG=gluon:${BRANCH}
+BRANCH=$(git branch --show-current 2>/dev/null | sed 's/[^a-z0-9-]/_/ig')
+TAG="gluon:${BRANCH:-latest}"
 
 if [ "$(command -v podman)" ]
 then


### PR DESCRIPTION
I'm sure there are better solutions. I just want to put the simplest and fastest one I can think of with the PR up for discussion. 

An interesting solution I could think of would be to get a hash of the Dockerfile and tag the container with it. But that would probably be a bit over engineered and in itself error prone.

resolves #2362