### PR TITLE
lint-sh fixes

### DIFF
--- a/contrib/push_pkg.sh
+++ b/contrib/push_pkg.sh
@@ -48,7 +48,7 @@ shift $(( OPTIND - 1 ))
 if [ "$build_only" -eq 0 ]; then
 	remote_info=$(ssh -p "${ssh_port}" "root@${ssh_host}" '
 		source /etc/os-release
-		printf "%s\t%s\n" "$OPENWRT_BOARD" "$OPENWRT_ARCH"
+		printf "%s\\t%s\\n" "$OPENWRT_BOARD" "$OPENWRT_ARCH"
 	')
 	REMOTE_OPENWRT_BOARD="$(echo "$remote_info" | cut -f 1)"
 	REMOTE_OPENWRT_ARCH="$(echo "$remote_info" | cut -f 2)"
@@ -92,7 +92,7 @@ while [ $# -gt 0 ]; do
 	opkg_packages="$(make TOPDIR="${topdir}" -C "${pkgdir}" DUMP=1 | awk '/^Package: / { print $2 }')"
 
 	search_package() {
-		find "$2" -name "$1_*.ipk" -printf "%f\n"
+		find "$2" -name "$1_*.ipk" -printf '%f\n'
 	}
 
 	make TOPDIR="${topdir}" -C "${pkgdir}" clean

--- a/scripts/lint-sh.sh
+++ b/scripts/lint-sh.sh
@@ -17,7 +17,7 @@ find package -type f | while read -r file; do
 	is_scriptfile "$file" || continue
 
 	echo "Checking $file"
-	shellcheck -f gcc -x -s sh -e SC2039,SC1091,SC2155,SC2034 "$file"
+	shellcheck -f gcc -x -s sh -e SC2039,SC1091,SC2155,SC2034,SC3043,SC3037,SC3057 "$file"
 done
 
 find scripts -type f | while read -r file; do


### PR DESCRIPTION
Our CI currently uses shellcheck 0.7.0. shellcheck 0.7.1 (used by `make container`) and 0.7.2 (current version) report different errors each for some of our current scripts. Fix these issues (one by fixing the script, the other by ignoring certain warnings).