### PR TITLE
targets/ramips-mt7621: add device Totolink X5000R

### DIFF
--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -39,6 +39,13 @@ device('ubiquiti-unifi-6-lite', 'ubnt_unifi-6-lite', {
 })
 
 
+-- Totolink
+
+device('totolink-x5000r', 'totolink_x5000r', {
+	factory = false,
+})
+
+
 -- Xiaomi
 
 device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {


### PR DESCRIPTION
Running device:
[http://[2a03:2260:115:100:5e92:5eff:fea3:1510]/cgi-bin/status](http://[2a03:2260:115:100:5e92:5eff:fea3:1510]/cgi-bin/status)
https://meshviewer.freifunk-muensterland.de/map/#!/de/map/5c925ea31510

WIP:
- [ ] must be flashable from vendor firmware
  - [x] ~~webinterface~~ (In refer to https://openwrt.org/toh/totolink/x5000r#installation this should be possible. In my case I was only able to do a "cloud"-update.)
  - [ ] tftp
  - [x] other: "Image Flashing mode: See https://openwrt.org/toh/totolink/x5000r#back_to_stock_firmware"
- [ ] must support upgrade mechanism
  - [ ] must have working sysupgrade
    - [ ] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [ ] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~radio leds~~
    - [x] ~~should map to their respective radio~~
    - [x] ~~should show activity~~
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- ~~outdoor devices only~~
  - [x] ~~added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~