### PR TITLE
gluon-core: add gluon info binary

### DIFF
--- a/package/gluon-core/luasrc/usr/bin/gluon-info
+++ b/package/gluon-core/luasrc/usr/bin/gluon-info
@@ -22,8 +22,8 @@ local values = {
 	{ 'Hostname', pretty_hostname.get(uci) },
 	{ 'MAC address', sysconfig.primary_mac },
 	{ 'Hardware model', platform.get_model() },
-	{ 'Gluon version' .. " / " .. 'Site version', util.trim(util.readfile('/lib/gluon/gluon-version'))
-		.. " / " .. util.trim(util.readfile('/lib/gluon/site-version')) },
+	{ 'Gluon version / Site version', util.trim(util.readfile('/lib/gluon/gluon-version'))
+		.. ' / ' .. util.trim(util.readfile('/lib/gluon/site-version')) },
 	{ 'Firmware release', util.trim(util.readfile('/lib/gluon/release')) },
 	{ 'Site', site.site_name() },
 	{ 'Public VPN key', pubkey or 'n/a' },

--- a/package/gluon-core/luasrc/usr/bin/gluon-info
+++ b/package/gluon-core/luasrc/usr/bin/gluon-info
@@ -1,0 +1,38 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+local pretty_hostname = require 'pretty_hostname'
+
+local site = require 'gluon.site'
+local sysconfig = require 'gluon.sysconfig'
+local platform = require 'gluon.platform'
+local util = require 'gluon.util'
+local has_vpn, vpn = pcall(require, 'gluon.mesh-vpn')
+
+local pubkey
+if has_vpn and vpn.enabled() then
+	local _, active_vpn = vpn.get_active_provider()
+
+	if active_vpn ~= nil then
+		pubkey = active_vpn.public_key()
+	end
+end
+
+local values = {
+	{ 'Hostname', pretty_hostname.get(uci) },
+	{ 'MAC address', sysconfig.primary_mac },
+	{ 'Hardware model', platform.get_model() },
+	{ 'Gluon version' .. " / " .. 'Site version', util.trim(util.readfile('/lib/gluon/gluon-version'))
+		.. " / " .. util.trim(util.readfile('/lib/gluon/site-version')) },
+	{ 'Firmware release', util.trim(util.readfile('/lib/gluon/release')) },
+	{ 'Site', site.site_name() },
+	{ 'Public VPN key', pubkey or 'n/a' },
+}
+
+local padTo = 24
+
+for _, info in ipairs(values) do
+	local labelLen = string.len(info[1]) + 1
+
+	print(info[1] .. ':' .. string.rep(' ', padTo - labelLen), info[2])
+end

--- a/package/gluon-mesh-vpn-fastd/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/fastd.lua
+++ b/package/gluon-mesh-vpn-fastd/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/fastd.lua
@@ -7,7 +7,13 @@ local vpn_core = require 'gluon.mesh-vpn'
 local M = {}
 
 function M.public_key()
-	return util.trim(util.exec('/etc/init.d/fastd show_key mesh_vpn'))
+	local key = util.trim(util.exec('/etc/init.d/fastd show_key mesh_vpn'))
+
+	if key == '' then
+		key = nil
+	end
+
+	return key
 end
 
 function M.enable(val)

--- a/package/gluon-mesh-vpn-wireguard/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
+++ b/package/gluon-mesh-vpn-wireguard/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
@@ -7,7 +7,13 @@ local vpn_core = require 'gluon.mesh-vpn'
 local M = {}
 
 function M.public_key()
-	return util.trim(util.exec("/lib/gluon/mesh-vpn/wireguard_pubkey.sh"))
+	local key = util.trim(util.exec("/lib/gluon/mesh-vpn/wireguard_pubkey.sh"))
+
+	if key == '' then
+		key = nil
+	end
+
+	return key
 end
 
 function M.enable(val)

--- a/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/info.html
+++ b/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/info.html
@@ -18,17 +18,13 @@
 		if active_vpn ~= nil then
 			pubkey = active_vpn.public_key()
 		end
-
-		if pubkey == '' then
-			pubkey = nil
-		end
 	end
 
 	local values = {
 		{ _('Hostname'), pretty_hostname.get(uci) },
 		{ _('MAC address'), sysconfig.primary_mac },
 		{ _('Hardware model'), platform.get_model() },
-		{ _('Gluon version') .. " / " .. _('Site version'), util.trim(util.readfile('/lib/gluon/gluon-version')) 
+		{ _('Gluon version') .. " / " .. _('Site version'), util.trim(util.readfile('/lib/gluon/gluon-version'))
 			.. " / " .. util.trim(util.readfile('/lib/gluon/site-version')) },
 		{ _('Firmware release'), util.trim(util.readfile('/lib/gluon/release')) },
 		{ _('Site'), site.site_name() },


### PR DESCRIPTION
This copies the code from web-admin and uses it to create a neat 
cli-accessible summary about a node

This could also be extended or possibly have all the data the status 
page has (the one when the node is no longer in config mode9

Example

```
Hostname				gluon-b0a7b902343c
MAC address				b0:a7:b9:02:34:3c
Hardware model				TP-Link CPE210 v3
Gluon version / Site version		v2021.1-309-g9085237 / 8ed7e6a
Firmware release			0.0+exp20220109
Site					Funkfeuer Graz
Public VPN key				nil
```
(tabs display properly in terminal - in retrospect not sure if spaces would've been better)