### PR TITLE
ath79-generic: add support for TP-Link Archer A7 v5

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -44,6 +44,7 @@ ath79-generic
 
 * TP-Link
 
+  - Archer A7 (v5)
   - Archer C6 (v2)
   - CPE220 (v3.0)
   - CPE510 (v2.0)

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -74,6 +74,7 @@ local primary_addrs = {
 		{'ath79', 'generic', {
 			'glinet,gl-ar750s-nor',
 			'ocedo,raccoon',
+			'tplink,archer-a7-v5',
 			'tplink,archer-c2-v3',
 			'tplink,archer-d50-v1',
 		}},

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -103,6 +103,10 @@ device('siemens-ws-ap3610', 'siemens_ws-ap3610', {
 
 -- TP-Link
 
+device('tp-link-archer-a7-v5', 'tplink_archer-a7-v5', {
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('tp-link-archer-c2-v3', 'tplink_archer-c2-v3', {
 	packages = ATH10K_PACKAGES_QCA9887,
 	class = 'tiny',


### PR DESCRIPTION
This is my first contribution, so please tell me if I did something incorrectly.

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`