### PR TITLE
gluon-mesh-babel: do not allow disabling VXLAN

### DIFF
--- a/package/gluon-mesh-babel/check_site.lua
+++ b/package/gluon-mesh-babel/check_site.lua
@@ -5,3 +5,5 @@ need_string_match(in_domain({'next_node', 'ip6'}), '^[%x:]+$', false)
 need_string_match(in_domain({'next_node', 'ip4'}), '^%d+.%d+.%d+.%d+$', false)
 
 need_string_match(in_domain({'next_node', 'mac'}), '^%x[02468aAcCeE]:%x%x:%x%x:%x%x:%x%x:%x%x$', false)
+
+need_value(in_domain({'mesh', 'vxlan'}), true, false)


### PR DESCRIPTION
With Babel, wired meshing cannot run on the same logical interface as
non-mesh traffic, so using VXLAN is mandatory.

See https://github.com/freifunk-gluon/gluon/issues/2375#issuecomment-1015683959