### PR TITLE
ath79-mikrotik: add support for Mikrotik RB951Ui-2nD

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -17,6 +17,16 @@
     "targets/generic",
     "targets/targets.mk"
   ],
+  "ath79-mikrotik": [
+    "targets/ath79-mikrotik",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk",
+    "targets/mikrotik.inc"
+  ],
   "bcm27xx-bcm2708": [
     "targets/bcm27xx-bcm2708",
     "modules",

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -118,6 +118,13 @@ ath79-nand
   - GL-AR300M
   - GL-AR750S
 
+ath79-mikrotik
+--------------
+
+* Mikrotik
+
+  - RB951Ui-2nD (hAP)
+
 brcm2708-bcm2708
 ----------------
 

--- a/targets/ath79-mikrotik
+++ b/targets/ath79-mikrotik
@@ -1,0 +1,3 @@
+include 'mikrotik.inc'
+
+device('mikrotik-routerboard-951ui-2nd-hap', 'mikrotik_routerboard-951ui-2nd')

--- a/targets/mikrotik.inc
+++ b/targets/mikrotik.inc
@@ -1,0 +1,7 @@
+-- Mikrotik images are netbooted via TFTP, then persisted with sysupgrade
+defaults {
+	factory = '-initramfs-kernel'
+}
+
+config('TARGET_ROOTFS_INITRAMFS', true)
+config('TARGET_INITRAMFS_COMPRESSION_LZMA', true)

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -1,5 +1,6 @@
 $(eval $(call GluonTarget,ath79,generic))
 $(eval $(call GluonTarget,ath79,nand))
+$(eval $(call GluonTarget,ath79,mikrotik))
 $(eval $(call GluonTarget,bcm27xx,bcm2708))
 $(eval $(call GluonTarget,bcm27xx,bcm2709))
 $(eval $(call GluonTarget,ipq40xx,generic))


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [x] tftp
  - [ ] other: <specify>
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - n/a should map to their respective radio
    - n/a should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - n/a added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

Note that mikrotik was a target back in the days,
but that target was mostly a generic catch-all image

Now that the images are per-device the sysupgrade
should just work :tm:

That means there's basically no migration path,
but this is a very special case as previously it was
a generic image and now it's a custom one,
so forgive that.

Installation is done by netbooting the image (initramfs),
then in config-mode doing a manual upgrade

Perhaps that second sysupgrade step could be automated somehow