### PR TITLE
gluon-web: prohibit cross-origin POST requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
-        run: sudo apt install lua-check
+        run: sudo apt-get -y update && sudo apt-get -y install lua-check
       - name: Install example site
         run: ln -s ./docs/site-example ./site
       - name: Lint Lua code
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Dependencies
-        run: sudo apt install shellcheck
+        run: sudo apt-get -y update && sudo apt-get -y install shellcheck
       - name: Install example site
         run: ln -s ./docs/site-example ./site
       - name: Lint shell code

--- a/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/upgrade.html
+++ b/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/upgrade.html
@@ -44,7 +44,6 @@ $Id$
 
 	<div class="gluon-page-actions">
 		<input type="hidden" name="step" value="2" />
-		<input type="hidden" name="token" value="<%=token%>" />
 		<input class="gluon-button gluon-button-submit" type="submit" value="<%:Upload image%>" />
 	</div>
 </form>

--- a/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/upgrade_confirm.html
+++ b/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/upgrade_confirm.html
@@ -49,13 +49,11 @@ You may obtain a copy of the License at
   <form method="post" enctype="multipart/form-data" action="<%|url(request)%>" style="display:inline">
     <input type="hidden" name="step" value="3" />
     <input type="hidden" name="keepcfg" value="<%=keepconfig and "1" or "0"%>" />
-    <input type="hidden" name="token" value="<%=token%>" />
     <input class="gluon-button gluon-button-submit" type="submit" value="<%:Continue%>" />
   </form>
   <form method="post" enctype="multipart/form-data" action="<%|url(request)%>" style="display:inline">
     <input type="hidden" name="step" value="1" />
     <input type="hidden" name="keepcfg" value="<%=keepconfig and "1" or "0"%>" />
-    <input type="hidden" name="token" value="<%=token%>" />
     <input class="gluon-button gluon-button-reset" type="submit" value="<%:Cancel%>" />
   </form>
 </div>

--- a/package/gluon-web-model/files/lib/gluon/web/view/model/form.html
+++ b/package/gluon-web-model/files/lib/gluon/web/view/model/form.html
@@ -1,5 +1,4 @@
 <form method="post" enctype="multipart/form-data" action="<%|url(request)%>" data-update="reset">
-	<input type="hidden" name="token" value="<%=token%>" />
 	<input type="hidden" name="<%=id%>" value="1" />
 
 	<div class="gluon-form" id="form-<%=id%>">

--- a/package/gluon-web/luasrc/usr/lib/lua/gluon/web/dispatcher.lua
+++ b/package/gluon-web/luasrc/usr/lib/lua/gluon/web/dispatcher.lua
@@ -184,9 +184,15 @@ local function dispatch(config, http, request)
 		return
 	end
 
-	http:parse_input(node.filehandler)
+	local ok, err = pcall(http.parse_input, http, node.filehandler)
+	if not ok then
+		http:status(400, "Bad request")
+		http:prepare_content("text/plain")
+		http:write(err .. "\r\n")
+		return
+	end
 
-	local ok, err = pcall(node.target)
+	ok, err = pcall(node.target)
 	if not ok then
 		http:status(500, "Internal Server Error")
 		renderer.render_layout("error/500", {

--- a/package/gluon-web/luasrc/usr/lib/lua/gluon/web/dispatcher.lua
+++ b/package/gluon-web/luasrc/usr/lib/lua/gluon/web/dispatcher.lua
@@ -208,6 +208,6 @@ return function(config, http)
 	if not ok then
 		http:status(500, "Internal Server Error")
 		http:prepare_content("text/plain")
-		http:write(err)
+		http:write(err .. "\r\n")
 	end
 end


### PR DESCRIPTION
It is currently possible for malicious sites to inject POST requests, allowing to change settings on nodes in config mode that are reachable from the client's host. A simple PoC can be found under https://home.universe-factory.net/neoraider/gluon-cors.html (note that you will need to allow mixed content to make the HTTPS -> HTTP request work - an actual attacker would simply host the site on HTTP). My example simply changes the fastd mode from "security" to "performance", but uploading an SSH key would be just as simple.

I did not actually test the HTTPS code path, but I used curl to simulate various different Origin headers (including different ports and schemes) and tested using the config mode both without and with redirects TCP from Firefox and Chrome, including manual firmware updates.