### PR TITLE
ath79-generic: swap interfaces on TP-Link WBS210 v2

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -50,7 +50,11 @@ end
 local lan_ifname = iface_exists(lan_interfaces)
 local wan_ifname = iface_exists(wan_interfaces)
 
-if platform.match('lantiq') then
+if platform.match('ath79', 'generic', {
+	'tplink,wbs210-v2',
+}) then
+	lan_ifname, wan_ifname = wan_ifname, lan_ifname
+elseif platform.match('lantiq') then
 	local switch_data = board_data.switch or {}
 	local switch0_data = switch_data.switch0 or {}
 	local roles_data = switch0_data.roles or {}


### PR DESCRIPTION
Swap the interfaces so than the PoE input port LAN0 is used for WAN and
config mode, and LAN1 becomes LAN.

To this end, the code previously used for ar71xx and removed in
commit 9fdc57c175b4 ("treewide: drop ar71xx platform specific code") is
reintroduced.

Fixes #2384