### PR TITLE
workflows: add backports action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,21 @@
+name: Backport
+on:
+  pull_request_target:
+    types: [closed, labeled]
+jobs:
+  backport:
+    name: Backport Pull Request
+    if: github.repository_owner == 'freifunk-gluon' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Create backport PRs
+        uses: zeebe-io/backport-action@v0.0.7
+        with:
+          # Config README: https://github.com/zeebe-io/backport-action#backport-action
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_workspace: ${{ github.workspace }}
+          pull_description: |-
+            Automatic backport to `${target_branch}`, triggered by a label in #${pull_number}.


### PR DESCRIPTION
By applying a label `backport <branch>` the action will automatically
try to cherry-pick the change to the target branch after the pull
request was successfully merged.