### PR TITLE
gluon-web-osm: update OpenLayers default URL to 5.3.0

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -471,7 +471,7 @@ config_mode \: optional
 
   *openlayers_url* allows to override the base URL of the
   *build/ol.js* and *css/ol.css* files (the default is
-  ``https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.2.0``).
+  ``https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@35ffe7626ce16c372143f3c903950750075e7068/en/v5.3.0``).
   It is also possible to replace the default tile layer (which is OpenStreetMap)
   with a custom one using the *tile_layer* section. Only XYZ layers are supported
   at this point.

--- a/package/gluon-web-osm/luasrc/usr/lib/lua/gluon/web/model/osm.lua
+++ b/package/gluon-web-osm/luasrc/usr/lib/lua/gluon/web/model/osm.lua
@@ -4,7 +4,8 @@ local util = require "gluon.web.util"
 local class = util.class
 
 
-local DEFAULT_URL = 'https://cdn.rawgit.com/openlayers/openlayers.github.io/master/en/v5.2.0'
+local DEFAULT_URL =
+	'https://cdn.jsdelivr.net/gh/openlayers/openlayers.github.io@35ffe7626ce16c372143f3c903950750075e7068/en/v5.3.0'
 
 
 local M = {}


### PR DESCRIPTION
The OpenLayers JS/CSS download URL is dead. Update it to make the map
work again:

- Update from OpenLayers 5.2.0 to 5.3.0
- Switch from the obsolete rawgit.com URL to jsdelivr.net (rawgit.com
  was only redirecting to jsdelivr.net for the last few years anyways)
- Set a fixed commit in the URL, so the URL doesn't become outdated again

Reported-by: @AiyionPrime 

I have not looked into updating to a 6.x release yet. For a v2021.1.x backport, the minor 5.3.0 update makes more sense anyways.