### PR TITLE
gluon-config-mode-core: discard gluon-reconfigure output

### DIFF
--- a/package/gluon-config-mode-core/luasrc/lib/gluon/config-mode/model/gluon-config-mode/wizard.lua
+++ b/package/gluon-config-mode-core/luasrc/lib/gluon/config-mode/model/gluon-config-mode/wizard.lua
@@ -22,7 +22,7 @@ function f:write()
 	uci:set("gluon-setup-mode", uci:get_first("gluon-setup-mode", "setup_mode"), "configured", true)
 	uci:save("gluon-setup-mode")
 
-	os.execute('gluon-reconfigure')
+	os.execute('exec gluon-reconfigure >/dev/null')
 
 	f.template = "wizard/reboot"
 	f.package = "gluon-config-mode-core"


### PR DESCRIPTION
The stdout output of gluon-web scripts is directly sent to uhttpd,
becoming a part of the HTML output or even replacing HTTP status or
headers. The output of gluon-reconfigure is not supposed to end up
there.

While we're at it, also add an exec to avoid an unnecessary shell
process.

Extracted from #2372, as we'll also want to backport this commit to v2021.1.x as soon as possible.