### PR TITLE
gluon-web-osm: Fix " rendering in attribution with CDATA tag

### DIFF
--- a/package/gluon-web-osm/files/lib/gluon/web/view/model/osm/map.html
+++ b/package/gluon-web-osm/files/lib/gluon/web/view/model/osm/map.html
@@ -1,6 +1,7 @@
 <div id="<%=id%>" class="gluon-osm-map" style="display: none"></div>
 <script type="text/javascript" src="/static/gluon-web-osm.js"></script>
 <script type="text/javascript">
+	//<![CDATA[
 	(function() {
 		var elMap = document.getElementById(<%=json(id)%>);
 		var wrapper = elMap.parentNode;
@@ -41,4 +42,5 @@
 			});
 		});
 	})();
+	//]]>
 </script>


### PR DESCRIPTION
When configuring osm and setting the `tile_layer` `attributions` value to a content that contains `"` the resulting config gets json encoded (as expected) which escapes it with `\"`, This seems to be invalid xhtml which can be fixed by wrapping the code in a `CDATA`.

example config:
```
    geo_location = {
      show_altitude = false,
      osm = {
        center = {
          lat = 50.1103,
          lon = 8.6821,
        },
        zoom = 11,
        openlayers_url = 'https://firmware.ffffm.net/openlayers/v5.3.0',
	    tile_layer = {
	      type = 'XYZ',
	      url = 'https://tiles.ffm.freifunk.net/{z}/{x}/{y}.png',
	      attributions = '&#169; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap</a> contributors.',
	    },
      },
    },
  },
```

![image](https://user-images.githubusercontent.com/1448057/154803630-d6557baf-6bc7-41c5-9a36-6ee03f1d0f84.png)
(Error in a up to date Firefox while trying to visit the initial config page)
