### PR TITLE
x86: switch to EFI-compatible images

### DIFF
--- a/targets/x86.inc
+++ b/targets/x86.inc
@@ -44,8 +44,8 @@ packages {
 config('TARGET_ROOTFS_EXT4FS', false)
 
 defaults {
-	factory = '-squashfs-combined',
+	factory = '-squashfs-combined-efi',
 	factory_ext = {'.img.gz', '.vmdk', '.vdi'},
-	sysupgrade = '-squashfs-combined',
+	sysupgrade = '-squashfs-combined-efi',
 	sysupgrade_ext = '.img.gz',
 }


### PR DESCRIPTION
The main difference between the non-EFI and EFI images generated by
OpenWrt is that the former uses an MS-DOS partition table, while the
latter uses GPT. The EFI images still have a BIOS-compatible MBR, so
they work fine on non-EFI systems.

Closes #2403

Draft PR for testing. Boot test in qemu was successful for x86-64 both with default BIOS and UEFI (OVMF). In particular it needs to be tested whether upgrading from a non-EFI image to an EFI image works smoothly - ideally replacing the partition table with GPT, so we don't need to think about upgrades from old systems using MS-DOS partitions forever...