### PR TITLE
gluon-blink: add command to make the current device's status led blink

### DIFF
--- a/package/gluon-core/files/usr/bin/gluon-blink
+++ b/package/gluon-core/files/usr/bin/gluon-blink
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Makes your current device blink
+
+. /etc/diag.sh
+
+start() {
+	set_led_state preinit
+}
+
+stop() {
+	status_led_off
+}
+
+trap stop EXIT SIGTERM SIGINT
+start
+
+echo "Blinking on $(pretty-hostname) ($(cat /lib/gluon/core/sysconfig/primary_mac)) ... (ctrl-c to stop)"
+
+sleep infinity


### PR DESCRIPTION
This allows a user to find out which device he's connected to by running 
gluon-blink

The command will trigger a fast-blinnk on the status led