### PR TITLE
ath79-generic: add AVM FRITZ!WLAN Repeater 300E support

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -6,6 +6,7 @@ ath79-generic
 
 * AVM
 
+  - FRITZ!WLAN Repeater 300E [#avmflash]_
   - Fritz!WLAN Repeater 450E [#avmflash]_
   - Fritz!Box 4020 [#avmflash]_
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -28,6 +28,10 @@ device('avm-fritz-box-4020', 'avm_fritz4020', {
 	factory = false,
 })
 
+device('avm-fritz-wlan-repeater-300e', 'avm_fritz300e', {
+	factory = false,
+})
+
 device('avm-fritz-wlan-repeater-450e', 'avm_fritz450e', {
 	factory = false,
 })


### PR DESCRIPTION
Specifications:
* SoC: AR7242 (Virian 400MHz)
* RAM: 64 MB DDR (W9751G6JB-25)
* Flash: 16MB SPI flash (S25FL129PIF)
* WiFi: AR9382 (2.4/5GHz)
* LAN: 1x1000M (PEF7071V)

The device has only one dual band radio and prefers the 5GHz band as described in the gluon documentation. The only RJ45 connector works as WAN.

Test Device https://map.chemnitz.freifunk.net/#!v:m;n:BC0543DBD8BD

Device Integration checklist

- [X] must be flashable from vendor firmware
  - [X] other: fritz flash tools
- [X] must support upgrade mechanism
  - [X] must have working sysupgrade
    - [X] must keep/forget configuration (if applicable)
  - [X] must have working autoupdate
    *avm-fritz-wlan-repeater-r300e* 
- [X] wpsbutton must return device into config mode
- [X] primary mac should match address on device label (or packaging) 
- wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN)
- wifi (if applicable)
  - [X] association with AP must be possible on all radios
  - [X] association with 802.11s mesh must be working on all radios 
  - [X] ap/mesh mode must work in parallel on all radios
- led mapping
  - power (_critical, because led definitions are setup on firstboot only_)
    - [X] lit while the device is on
    - [X] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [X] should map to their respective radio
    - [X] should show activity
  - switchport leds
    - [X] should map to their respective port (or switch, if only one led present) 
    - [X] should show link state and activity