### PR TITLE
docs: fix invalid fritztools link

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -329,7 +329,7 @@ Footnotes
   developer documentation: :ref:`device-class-definition`.
 
 .. [#avmflash]
-  For instructions on how to flash AVM devices, visit https://fritzfla.sh
+  For instructions on how to flash AVM devices, visit https://fritz-tools.readthedocs.io
 
 .. [#eva_ramboot]
   For instructions on how to flash AVM NAND devices, see the respective


### PR DESCRIPTION
As @ambassador86 spotted earlier, the domain https://fritzfla.sh has changed its target audience.
The appropriate substitute would be the one referenced on the projects page https://github.com/freifunk-darmstadt/fritz-tools.

I think this could be merged as soon as somebody confirmed the link works as intended ;)