### PR TITLE
ath79-generic: add support for D-Link DAP-2660 A1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -13,6 +13,10 @@ ath79-generic
   - WiFi pro 1750i
   - WiFi pro 1750x
 
+* D-Link
+
+  - DAP-2660 A1 [#lan_as_wan]_
+
 * Enterasys
 
   - WS-AP3705i

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -55,6 +55,14 @@ device('devolo-wifi-pro-1750x', 'devolo_dvl1750x', {
 })
 
 
+-- D-Link
+
+device('d-link-dap-2660-a1', 'dlink_dap-2660-a1', {
+	factory_ext = '.img',
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
+
 -- Enterasys
 
 device('enterasys-ws-ap3705', 'enterasys_ws-ap3705i', {


### PR DESCRIPTION
```
Specifications:

 * QCA9557, 16 MiB Flash, 128 MiB RAM, 802.11n 2T2R
 * QCA9882, 802.11ac 2T2R
 * Gigabit LAN Port (AR8035), 802.3af PoE
 * 3,5 x 1,35 mm DC plug (12V) alternative supply
```
 
- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp
  - [x] other: recovery webinterface (keep reset button pressed during power-on, until upload started)
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`


Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>