### PR TITLE
ath79: (re)add support for tl-wr1043nd-v3

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -52,6 +52,7 @@ ath79-generic
   - EAP225-Outdoor (v1)
   - TL-WDR3600 (v1)
   - TL-WDR4300 (v1)
+  - TL-WR1043N/ND (v3)
   - WBS210 (v2.0)
 
 ath79-nand

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -134,4 +134,10 @@ device('tp-link-eap225-outdoor-v1', 'tplink_eap225-outdoor-v1', {
 device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
 device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
 
+device('tp-link-tl-wr1043nd-v3', 'tplink_tl-wr1043nd-v3', {
+	manifest_aliases = {
+		'tp-link-tl-wr1043n-nd-v3', -- upgrade from OpenWrt 19.07
+	},
+})
+
 device('tp-link-wbs210-v2', 'tplink_wbs210-v2')


### PR DESCRIPTION
Has been tested by @lemoer, will verify the checklist tomorrow.

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] tftp
  - ~~other: <specify>~~
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- ~~outdoor devices only~~
  - added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`