### PR TITLE
ath79-generic: (re)add support for UniFi AP PRO

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -86,6 +86,7 @@ ath79-generic
 
   - UniFi AP
   - UniFi AP LR
+  - UniFi AP PRO
 
 ath79-nand
 ----------

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -46,6 +46,7 @@ if platform.match('ath79', 'generic', {
 	'tplink,cpe210-v1',
 	'tplink,cpe210-v2',
 	'tplink,wbs210-v2',
+	'ubnt,unifi-ap-pro',
 }) then
 	lan_ifname, wan_ifname = wan_ifname, lan_ifname
 elseif platform.match('lantiq') then

--- a/package/gluon-setup-mode/luasrc/lib/gluon/upgrade/320-setup-ifname
+++ b/package/gluon-setup-mode/luasrc/lib/gluon/upgrade/320-setup-ifname
@@ -3,7 +3,11 @@
 local platform = require 'gluon.platform'
 local sysconfig = require 'gluon.sysconfig'
 
-if platform.is_outdoor_device() then
+if platform.is_outdoor_device() or
+	platform.match('ath79', 'generic', {
+		'ubnt,unifi-ap-pro',
+	})
+then
 	sysconfig.setup_ifname = sysconfig.single_ifname or sysconfig.wan_ifname
 else
 	sysconfig.setup_ifname = sysconfig.single_ifname or sysconfig.lan_ifname

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -312,3 +312,5 @@ device('ubiquiti-unifi-ap', 'ubnt_unifi', {
 		'ubiquiti-unifi',
 	},
 })
+
+device('ubiquiti-unifi-ap-pro', 'ubnt_unifi-ap-pro')


### PR DESCRIPTION
The device appears to be working as expected.
This is ready for review.

Lastly the LED (the circle in the middle is off during normal operation).

- [x] must be flashable from vendor firmware
  - ~~webinterface~~
  - [x] tftp
  - [x] other: some versions are flashable from the unifi firmware. not recommended.
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on (most of these devices have a broken blue led these days, but when its perfectly dark its working)
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~radio leds~~ (there are none)
  - ~~switchport leds~~ (there are none)
- ~~outdoor devices only~~