### PR TITLE
ath79: migrate D-Link DAP-1330 and DIR-550 from ar71xx

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -19,7 +19,11 @@ ath79-generic
 
 * D-Link
 
+  - DAP-1330 A1 [#lan_as_wan]_
+  - DAP-1365 A1 [#lan_as_wan]_
   - DAP-2660 A1 [#lan_as_wan]_
+  - DIR-505 A1 [#lan_as_wan]_
+  - DIR-505 A2 [#lan_as_wan]_
 
 * Enterasys
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -63,9 +63,20 @@ device('devolo-wifi-pro-1750x', 'devolo_dvl1750x', {
 
 -- D-Link
 
+device('d-link-dap-1330-a1', 'dlink_dap-1330-a1')
+device('d-link-dap-1365-a1', 'dlink_dap-1365-a1')
+
 device('d-link-dap-2660-a1', 'dlink_dap-2660-a1', {
 	factory_ext = '.img',
 	packages = ATH10K_PACKAGES_QCA9880,
+})
+
+device('d-link-dir-505', 'dlink_dir-505', {
+        factory = false,
+        manifest_aliases = {
+                'd-link-dir-505-rev-a1', -- Upgrade from OpenWrt 19.07
+                'd-link-dir-505-rev-a2', -- Upgrade from OpenWrt 19.07
+        },
 })
 
 


### PR DESCRIPTION
also add DAP-1365, which is a different case variant of DAP-1330

The checklist actually applies to all 3 devices; is it acceptable to have these within a single PR and/or should these be split into several PRs / commits?

- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [ ] tftp
  - [x] other: web recovery (works best with curl); 192.168.0.50 (DAP-1330/65), 192.168.0.1 (DIR-505)
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [ ] should map to their respective radio
    - [ ] should show activity
  - switchport leds
    - [ ] should map to their respective port (or switch, if only one led present) 
    - [ ] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

Signed-off-by: Sebastian Schaper <openwrt@sebastianschaper.net>