### PR TITLE
scripts: target_lib: remove profile override support

### DIFF
--- a/scripts/target_config_lib.lua
+++ b/scripts/target_config_lib.lua
@@ -155,8 +155,6 @@ if #lib.devices > 0 then
 	handle_target_pkgs(lib.target_packages)
 
 	for _, dev in ipairs(lib.devices) do
-		local profile = dev.options.profile or dev.name
-
 		local device_pkgs = {}
 		local function handle_pkgs(pkgs)
 			for _, pkg in ipairs(pkgs) do
@@ -172,10 +170,10 @@ if #lib.devices > 0 then
 		handle_pkgs(dev.options.packages or {})
 		handle_pkgs(site_packages(dev.image))
 
-		local profile_config = string.format('%s_DEVICE_%s', openwrt_config_target, profile)
+		local profile_config = string.format('%s_DEVICE_%s', openwrt_config_target, dev.name)
 		lib.config(
 			'TARGET_DEVICE_' .. profile_config, true,
-			string.format("unable to enable device '%s'", profile)
+			string.format("unable to enable device '%s'", dev.name)
 		)
 		lib.config(
 			'TARGET_DEVICE_PACKAGES_' .. profile_config,

--- a/scripts/target_lib.lua
+++ b/scripts/target_lib.lua
@@ -31,7 +31,6 @@ M.images = {}
 
 
 local default_options = {
-	profile = false,
 	factory = '-squashfs-factory',
 	factory_ext = '.bin',
 	sysupgrade = '-squashfs-sysupgrade',


### PR DESCRIPTION
No legacy OpenWrt targets exist anymore which require the .config profile
name to differ from the image name.