### PR TITLE
gluon.mk: print source file name in GluonSrcDiet

### DIFF
--- a/package/gluon.mk
+++ b/package/gluon.mk
@@ -67,6 +67,7 @@ define GluonSrcDiet
   ifdef CONFIG_GLUON_MINIFY
 	# Use cp + rm instead of mv to preserve destination permissions
 	set -e; $(FIND) $(2) -type f | while read src; do \
+		echo "Minifying $$$$src..."; \
 		luasrcdiet --noopt-binequiv -o "$$$$src.tmp" "$$$$src"; \
 		cp "$$$$src.tmp" "$$$$src"; \
 		rm "$$$$src.tmp"; \


### PR DESCRIPTION
luasrcdiet will not print the name of its input file when an error
occurs. To facilitate debugging, echo the name before calling it, so it
is visible with V=s or BUILD_LOG=1.