### PR TITLE
ci: build all targets on changes in scripts/

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -4,6 +4,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -12,6 +13,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -20,6 +22,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk",
     "targets/bcm27xx.inc"
@@ -29,6 +32,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk",
     "targets/bcm27xx.inc"
@@ -38,6 +42,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -46,6 +51,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -54,6 +60,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -62,6 +69,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -70,6 +78,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -78,6 +87,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -86,6 +96,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -94,6 +105,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -102,6 +114,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -110,6 +123,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -118,6 +132,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -126,6 +141,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -134,6 +150,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk",
     "targets/x86.inc"
@@ -143,6 +160,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ],
@@ -151,6 +169,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk",
     "targets/x86.inc"
@@ -160,6 +179,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk",
     "targets/x86.inc",
@@ -171,6 +191,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk",
     "targets/bcm27xx.inc"
@@ -180,6 +201,7 @@
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk"
   ]

--- a/contrib/actions/generate-target-filters.py
+++ b/contrib/actions/generate-target-filters.py
@@ -13,6 +13,7 @@ common = [
     "modules",
     "Makefile",
     "patches/**",
+    "scripts/**",
     "targets/generic",
     "targets/targets.mk",
 ]


### PR DESCRIPTION
The scripts directory contains most of our build system, so changing it
should trigger a build of all targets.