### PR TITLE
ath79-generic: (re)add Archer C5 v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -72,6 +72,7 @@ ath79-generic
 * TP-Link
 
   - Archer A7 (v5)
+  - Archer C5 (v1)
   - Archer C6 (v2)
   - Archer C7 (v2, v5)
   - CPE210 (v1.0, v1.1, v2.0)

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -266,6 +266,10 @@ device('tp-link-archer-c2-v3', 'tplink_archer-c2-v3', {
 	broken = true,  -- 64M ath9k + ath10k
 })
 
+device('tp-link-archer-c5-v1', 'tplink_archer-c5-v1', {
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })
@@ -306,7 +310,7 @@ device('tp-link-cpe510-v2', 'tplink_cpe510-v2')
 device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
 
 device('tp-link-eap225-outdoor-v1', 'tplink_eap225-outdoor-v1', {
-       packages = ATH10K_PACKAGES_QCA9888,
+	packages = ATH10K_PACKAGES_QCA9888,
 })
 
 device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] tftp
  - ~~other: <specify>~~
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- ~~outdoor devices only~~
  - ~~added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~