### PR TITLE
ath79-generic: (re)add support for UniFi AC Mesh

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -84,6 +84,7 @@ ath79-generic
 
 * Ubiquiti
 
+  - UniFi AC Mesh
   - UniFi AP
   - UniFi AP LR
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -34,6 +34,7 @@ function M.is_outdoor_device()
 		'tplink,cpe510-v3',
 		'tplink,eap225-outdoor-v1',
 		'tplink,wbs210-v2',
+		'ubnt,unifiac-mesh',
 	}) then
 		return true
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -304,6 +304,11 @@ device('tp-link-wbs210-v2', 'tplink_wbs210-v2')
 
 -- Ubiquiti
 
+device('ubiquiti-unifi-ac-mesh', 'ubnt_unifiac-mesh', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('ubiquiti-unifi-ap', 'ubnt_unifi', {
 	aliases = {
 		'ubiquiti-unifi-ap-lr',


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - ~~webinterface~~
  - [x] tftp
  - [x] other: (downgrade), scp than ssh syswraper...
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~radio leds~~
    - ~~should map to their respective radio~~
    - ~~should show activity~~
  - ~~switchport leds~~
    - ~~should map to their respective port (or switch, if only one led present) ~~
    - ~~should show link state and activity~~
- outdoor devices only
  - [x] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`