### PR TITLE
ath79-generic: (re)add support for CPE510 v1.x

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -70,6 +70,7 @@ ath79-generic
   - Archer C6 (v2)
   - CPE210 (v1.0, v1.1, v2.0)
   - CPE220 (v3.0)
+  - CPE510 (v1.0, v1.1)
   - CPE510 (v2.0)
   - CPE510 (v3.0)
   - EAP225-Outdoor (v1)

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -45,6 +45,7 @@ local wan_ifname = iface_exists(wan_interfaces)
 if platform.match('ath79', 'generic', {
 	'tplink,cpe210-v1',
 	'tplink,cpe210-v2',
+	'tplink,cpe510-v1',
 	'tplink,wbs210-v2',
 }) then
 	lan_ifname, wan_ifname = wan_ifname, lan_ifname

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -30,6 +30,7 @@ function M.is_outdoor_device()
 		'tplink,cpe210-v1',
 		'tplink,cpe210-v2',
 		'tplink,cpe220-v3',
+		'tplink,cpe510-v1',
 		'tplink,cpe510-v2',
 		'tplink,cpe510-v3',
 		'tplink,eap225-outdoor-v1',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -273,6 +273,12 @@ device('tp-link-cpe210-v2', 'tplink_cpe210-v2', {
 	},
 })
 device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
+device('tp-link-cpe510-v1', 'tplink_cpe510-v1', {
+	manifest_aliases = {
+		'tp-link-cpe510-v1.0', -- upgrade from OpenWrt 19.07
+		'tp-link-cpe510-v1.1', -- upgrade from OpenWrt 19.07
+	},
+})
 device('tp-link-cpe510-v2', 'tplink_cpe510-v2')
 device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
 


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - [x] webinterface
  - [x] tftp
  - ~~other: <specify>~~
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [x] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`