### PR TITLE
ath79-generic: migrate  NanoBeam M5

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -102,6 +102,7 @@ ath79-generic
 
 * Ubiquiti
 
+  - NanoBeam M5 (XW)
   - NanoStation M2/M5 (XW)
   - UniFi AC Lite
   - UniFi AC LR

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -37,6 +37,7 @@ function M.is_outdoor_device()
 		'tplink,eap225-outdoor-v1',
 		'tplink,wbs210-v1',
 		'tplink,wbs210-v2',
+		'ubnt,nanobeam-m5-xw',
 		'ubnt,nanostation-m-xw',
 		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -457,6 +457,8 @@ device('ubiquiti-unifi-ap', 'ubnt_unifi', {
 	},
 })
 
+device('ubiquiti-nanobeam-m5-xw', 'ubnt_nanobeam-m5-xw')
+
 device('ubiquiti-unifi-ap-outdoor+', 'ubnt_unifi-ap-outdoor-plus', {
 	manifest_aliases = {
 		'ubiquiti-unifiap-outdoor+', -- upgrade from OpenWrt 19.07


### PR DESCRIPTION
Flashing back and forth to stock was not tested with gluon in ath79.
Flashing it to ar71xx worked.

- ~~Must be flashable from vendor firmware~~
  - ~~Web interface~~
  - ~~TFTP~~
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity (**rssi**)
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`