### PR TITLE
Dockerfile: update base to ubuntu:jammy

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Among other things `git branch --show-current` from `scripts/update-modules.sh` didn't work with the git version (2.20.x) in buster, because it requires 2.22.0.

> localhost/gluon           docker-base     6d337bc0846e  4 seconds ago   451 MB
