### PR TITLE
 ath79-generic: (re)add support for avm_fritz4020

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -7,6 +7,7 @@ ath79-generic
 * AVM
 
   - Fritz!WLAN Repeater 450E [#avmflash]_
+  - Fritz!Box 4020 [#avmflash]_
 
 * devolo
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -24,6 +24,10 @@ local ATH10K_PACKAGES_QCA9888 = {
 
 -- AVM
 
+device('avm-fritz-box-4020', 'avm_fritz4020', {
+	factory = false,
+})
+
 device('avm-fritz-wlan-repeater-450e', 'avm_fritz450e', {
 	factory = false,
 })


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - n/a webinterface
  - n/a tftp
  - [x] other: fritzflash tools
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [ ] ! primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
`My EOLO Edition of the 4020 has a Mac Address written on it that is different from the one that openwrt and gluon uses even before migration. In the bootloader it is labeled as macdsl and the one gluon uses is labeled as macwlan. The Mac Address that gluon uses is also found on the label but in the CWMP account (ID?) on my device.`
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - n/a added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

made it a draft until i got the ok that the mac address issue ist not really an issue of openwrt but my "speciel edition" device.