### PR TITLE
ath79-generic: (re)add Archer C7 v5

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -72,7 +72,7 @@ ath79-generic
 
   - Archer A7 (v5)
   - Archer C6 (v2)
-  - Archer C7 (v2)
+  - Archer C7 (v2, v5)
   - CPE210 (v1.0, v1.1, v2.0)
   - CPE220 (v3.0)
   - CPE510 (v1.0, v1.1)

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -270,6 +270,10 @@ device('tp-link-archer-c7-v2', 'tplink_archer-c7-v2', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })
 
+device('tp-link-archer-c7-v5', 'tplink_archer-c7-v5', {
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
~~FunkyFreezer (hackint#freifunkh) offered to test this thursday.~~

@Dark4MD was faster, this is ready to merge:

> As i got one laying around doing nothing i tested and checked everything with a build by @AiyionPrime. Tested both an Upgrade from an older Build with ar71xx and Flash over the Stock Web IF.

* [x]  Must be flashable from vendor firmware
  * [x]  Web interface
  * [x]  TFTP
* [x]  Must support upgrade mechanism
  * [x]  Must have working sysupgrade
    * [x]  Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  * [x]  Must have working autoupdate
    _Usually means: Gluon profile name must match image name_
* [x]  Reset/WPS/... button must return device into config mode
* [x]  Primary MAC address should match address on device label (or packaging)
  (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
* Wired network
  * [x]  should support all network ports on the device
  * [x]  must have correct port assignment (WAN/LAN)
    * On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
* Wireless network (if applicable)
  * [x]  Association with AP must be possible on all radios
  * [x]  Association with 802.11s mesh must work on all radios
  * [x]  AP+mesh mode must work in parallel on all radios
* LED mapping
  * Power/sys LED
    * [x]  Lit while the device is on
    * [x]  Should display config mode blink sequence
      (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  * Radio LEDs
    * [x]  Should map to their respective radio
    * [x]  Should show activity
  * Switch port LEDs
    * [x]  Should map to their respective port (or switch, if only one led present)
    * [x]  Should show link state and activity
* Outdoor devices only:
  * n/a Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

