### PR TITLE
mpc85xx-p1010: add Sophos RED 15w rev.1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -197,6 +197,10 @@ mediatek-mt7622
 mpc85xx-generic
 ---------------
 
+* Sophos
+
+  - RED 15w Rev.1
+
 * TP-Link
 
   - TL-WDR4900 (v1)

--- a/targets/mpc85xx-p1010
+++ b/targets/mpc85xx-p1010
@@ -1,1 +1,10 @@
+-- Sophos
+
+device('sophos-red-15w-rev.1', 'sophos_red-15w-rev1', {
+	factory = false,
+})
+
+
+-- TP-Link
+
 device('tp-link-tl-wdr4900-v1', 'tplink_tl-wdr4900-v1')


### PR DESCRIPTION
This adds support for the Sophos RED 15w rev.1 gateway.

It is a branch-office SD-WAN device based on the P1014 networking SoC.

- [x] must be flashable from vendor firmware
  - [ ] webinterface
  - [ ] tftp
  - [x] other: Cisco Serial adapter
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [x] should map to their respective radio
    - [x] should show activity
  - switchport leds
    - [x] should map to their respective port (or switch, if only one led present) 
    - [x] should show link state and activity
- outdoor devices only
  - [ ] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`