### PR TITLE
ath79-generic: (re)add support for unifiac-pro

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -98,6 +98,7 @@ ath79-generic
   - UniFi AC Lite
   - UniFi AC LR
   - UniFi AC Mesh
+  - UniFi AC Pro
   - UniFi AP
   - UniFi AP LR
   - UniFi AP PRO

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -388,6 +388,11 @@ device('ubiquiti-unifi-ac-mesh', 'ubnt_unifiac-mesh', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })
 
+device('ubiquiti-unifi-ac-pro', 'ubnt_unifiac-pro', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('ubiquiti-unifi-ap', 'ubnt_unifi', {
 	aliases = {
 		'ubiquiti-unifi-ap-lr',


### PR DESCRIPTION
Testing the device this weekend.

- [x] must be flashable from vendor firmware
  - [x] other: ssh via oem firmware:
  easiest is using dd cause that even works with the newer OEM firmware versions:
https://wiki.freifunk.net/Ubiquiti_Unifi_AC/Flash-Anleitung
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [?] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.

> Both Ports on the device are WAN/Config Mode Ports now

- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 

> After upgrade the LEDs are switched. ar71xx White was the Status LED, ATH79 the Blue one is. The ATH79 one is correct if you look at the dts file.

(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - radio leds
    - [n/a] should map to their respective radio
    - [n/a] should show activity
  - switchport leds
    - [n/a] should map to their respective port (or switch, if only one led present) 
    - [n/a] should show link state and activity
- outdoor devices only
  - [n/a] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`