### PR TITLE
Re-add UniFi AP Outdoor+ support

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -101,6 +101,7 @@ ath79-generic
   - UniFi AC Pro
   - UniFi AP
   - UniFi AP LR
+  - UniFi AP Outdoor+
   - UniFi AP PRO
 
 ath79-nand

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -52,6 +52,11 @@ if platform.match('ath79', 'generic', {
 	'ubnt,unifi-ap-pro',
 }) then
 	lan_ifname, wan_ifname = wan_ifname, lan_ifname
+elseif platform.match('ath79', 'generic', {
+	'ubnt,unifi-ap-outdoor-plus',
+}) then
+	-- Temporary solution to separate interfaces in bridged default setup
+	lan_ifname, wan_ifname = 'eth0', 'eth1'
 elseif platform.match('lantiq') then
 	local switch_data = board_data.switch or {}
 	local switch0_data = switch_data.switch0 or {}

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -37,6 +37,7 @@ function M.is_outdoor_device()
 		'tplink,wbs210-v1',
 		'tplink,wbs210-v2',
 		'ubnt,nanostation-m-xw',
+		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',
 	}) then
 		return true

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -403,4 +403,10 @@ device('ubiquiti-unifi-ap', 'ubnt_unifi', {
 	},
 })
 
+device('ubiquiti-unifi-ap-outdoor+', 'ubnt_unifi-ap-outdoor-plus', {
+	manifest_aliases = {
+		'ubiquiti-unifiap-outdoor+', -- upgrade from OpenWrt 19.07
+	},
+})
+
 device('ubiquiti-unifi-ap-pro', 'ubnt_unifi-ap-pro')


### PR DESCRIPTION
- [x] must be flashable from vendor firmware
  - ~[ ] webinterface~
  - ~[ ] tftp~
  - [x] other: SSH
- [x] must support upgrade mechanism
  - [x] must have working sysupgrade
    - [x] must keep/forget configuration (if applicable)
      *think `sysupgrade [-n]` or `firstboot`*
  - [x] must have working autoupdate
    *usually means: gluon profile name must match image name*
- [x] reset/wps/phone button must return device into config mode
- [x] primary mac should match address on device label (or packaging) (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- wifi (if applicable)
  - [x] association with AP must be possible on all radios
  - [x] association with 802.11s mesh must be working on all radios 
  - [x] ap/mesh mode must work in parallel on all radios
- led mapping
  - power/sys led (_critical, because led definitions are setup on firstboot only_)
    - [x] lit while the device is on
    - [x] should display config mode blink sequence 
(https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~radio leds~
    - ~[ ] should map to their respective radio~
    - ~[ ] should show activity~
  - ~switchport leds~
    - ~[ ] should map to their respective port (or switch, if only one led present)~
    - ~[ ] should show link state and activity~
- outdoor devices only
  - [x] added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
 
As OpenWrt bridges the Ethernet ports by default, we unfortunately need some model-specific handling to get a more useful setup.