### PR TITLE
ath79-generic: (re)add support for GL-AR150

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -31,6 +31,7 @@ ath79-generic
 
 * GL.iNet
 
+  - GL-AR150
   - GL-AR300M-Lite
 
 * Joy-IT

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -89,6 +89,10 @@ device('enterasys-ws-ap3705', 'enterasys_ws-ap3705i', {
 
 -- GL.iNet
 
+device('gl.inet-gl-ar150', 'glinet_gl-ar150', {
+	factory = false,
+})
+
 device('gl.inet-gl-ar300m-lite', 'glinet_gl-ar300m-lite', {
 	factory = false,
 })


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Must have working autoupdate
        *Usually means: Gluon profile name must match image name*
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/sys LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~