### PR TITLE
 ath79-generic: (re)add support for tl-wr810n-v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -81,6 +81,7 @@ ath79-generic
   - EAP225-Outdoor (v1)
   - TL-WDR3600 (v1)
   - TL-WDR4300 (v1)
+  - TL-WR810N (v1)
   - TL-WR1043N/ND (v3, v4)
   - WBS210 (v2.0)
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -304,6 +304,8 @@ device('tp-link-eap225-outdoor-v1', 'tplink_eap225-outdoor-v1', {
 device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
 device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
 
+device('tp-link-tl-wr810n-v1', 'tplink_tl-wr810n-v1')
+
 device('tp-link-tl-wr1043nd-v3', 'tplink_tl-wr1043nd-v3', {
 	manifest_aliases = {
 		'tp-link-tl-wr1043n-nd-v3', -- upgrade from OpenWrt 19.07


### PR DESCRIPTION
Just found it and quickly but thorughly tested everything.

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Must have working autoupdate
        *Usually means: Gluon profile name must match image name*
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/sys LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - n/a Should map to their respective radio
    - n/a Should show activity
  - Switch port LEDs
    - n/a Should map to their respective port (or switch, if only one led present) 
    - n/a Should show link state and activity
- Outdoor devices only:
  - n/a Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`