### PR TITLE
ath79-generic: (re)add NanoStation M (XW)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -89,6 +89,7 @@ ath79-generic
 
 * Ubiquiti
 
+  - NanoStation M2/M5 (XW)
   - UniFi AC Lite
   - UniFi AC LR
   - UniFi AC Mesh

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -47,6 +47,7 @@ if platform.match('ath79', 'generic', {
 	'tplink,cpe210-v2',
 	'tplink,cpe510-v1',
 	'tplink,wbs210-v2',
+	'ubnt,nanostation-m-xw',
 	'ubnt,unifi-ap-pro',
 }) then
 	lan_ifname, wan_ifname = wan_ifname, lan_ifname

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -35,6 +35,7 @@ function M.is_outdoor_device()
 		'tplink,cpe510-v3',
 		'tplink,eap225-outdoor-v1',
 		'tplink,wbs210-v2',
+		'ubnt,nanostation-m-xw',
 		'ubnt,unifiac-mesh',
 	}) then
 		return true

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -333,6 +333,13 @@ device('tp-link-wbs210-v2', 'tplink_wbs210-v2')
 
 -- Ubiquiti
 
+device('ubiquiti-nanostation-m-xw', 'ubnt_nanostation-m-xw', {
+	manifest_aliases = {
+		'ubiquiti-nanostation-m2-xw', -- upgrade from OpenWrt 19.07
+		'ubiquiti-nanostation-m5-xw', -- upgrade from OpenWrt 19.07
+	},
+})
+
 device('ubiquiti-unifi-ac-lite', 'ubnt_unifiac-lite', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9880,


### PR DESCRIPTION
I'll get the test device on saturday afternoon.

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Must have working autoupdate
        *Usually means: Gluon profile name must match image name*
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/sys LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`