### PR TITLE
ath79-generic: (re)add unifi-ap-ac-lr

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -91,6 +91,7 @@ ath79-generic
 
   - UniFi AC Mesh
   - UniFi AP
+  - UniFi AP AC LR
   - UniFi AP LR
   - UniFi AP PRO
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -333,6 +333,11 @@ device('tp-link-wbs210-v2', 'tplink_wbs210-v2')
 
 -- Ubiquiti
 
+device('ubiquiti-unifi-ac-lr', 'ubnt_unifiac-lr', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('ubiquiti-unifi-ac-mesh', 'ubnt_unifiac-mesh', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9880,


### PR DESCRIPTION
the second follw-up on #2428.

> AC LR can also be added without another test

_@neoraider in hackint#gluon_