### PR TITLE
ath79-generic: (re)add support for glinet_6416

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -32,6 +32,7 @@ ath79-generic
 
 * GL.iNet
 
+  - 6416A
   - GL-AR150
   - GL-AR300M-Lite
   - GL-AR750

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -93,6 +93,13 @@ device('enterasys-ws-ap3705', 'enterasys_ws-ap3705i', {
 
 -- GL.iNet
 
+device('gl.inet-6416', 'glinet_6416', {
+	factory = false,
+	manifest_aliases = {
+		'gl-inet-6416a-v1', -- Upgrade from OpenWrt 19.07
+	},
+})
+
 device('gl.inet-gl-ar150', 'glinet_gl-ar150', {
 	factory = false,
 })


### PR DESCRIPTION
@rotanid received the images for testing

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Must have working autoupdate
        *Usually means: Gluon profile name must match image name*
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/sys LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~