### PR TITLE
ath79-nand: (re)add support for glinet_gl-ar300m

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -99,6 +99,7 @@ ath79-nand
 
 * GL.iNet
 
+  - GL-AR300M
   - GL-AR750S
 
 brcm2708-bcm2708

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -7,6 +7,10 @@ local ATH10K_PACKAGES_QCA9887 = {
 }
 
 
+device('gl.inet-gl-ar300m-nor', 'glinet_gl-ar300m-nor', {
+	factory = false,
+})
+
 device('gl.inet-gl-ar750s-nor', 'glinet_gl-ar750s-nor', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9887,


### PR DESCRIPTION
@rotanid received the image for testing.

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Must have working autoupdate
        *Usually means: Gluon profile name must match image name*
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/sys LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~