### PR TITLE
ath79-generic: (re)add support for zyxel-nbg6616

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -101,6 +101,10 @@ ath79-generic
   - UniFi AP LR
   - UniFi AP PRO
 
+* ZyXEL
+
+  - NBG6616
+
 ath79-nand
 ----------
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -392,3 +392,9 @@ device('ubiquiti-unifi-ap', 'ubnt_unifi', {
 })
 
 device('ubiquiti-unifi-ap-pro', 'ubnt_unifi-ap-pro')
+
+-- ZyXEL
+
+device('zyxel-nbg6616', 'zyxel_nbg6616', {
+	packages = ATH10K_PACKAGES_QCA9880,
+})


### PR DESCRIPTION
[Nordmann](https://forum.freifunk.net/u/nordmann) offered a test of this device.
Sadly his last reply was 13 days ago. Not sure how or if he still intends to test anything...
**edit** corona sucks and so does his ongoing infection, apparently. Will test in a few days.


- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [ ] Must support upgrade mechanism
  - [ ] Must have working sysupgrade
    - [ ] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [ ] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [ ] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios 
  - [ ] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [ ] Lit while the device is on
    - [ ] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~