### PR TITLE
ath79-generic: (re)add support for wbs210v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -89,6 +89,7 @@ ath79-generic
   - TL-WR810N (v1)
   - TL-WR842N/ND (v3)
   - TL-WR1043N/ND (v2, v3, v4)
+  - WBS210 (v1.20)
   - WBS210 (v2.0)
 
 * Ubiquiti

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -46,6 +46,7 @@ if platform.match('ath79', 'generic', {
 	'tplink,cpe210-v1',
 	'tplink,cpe210-v2',
 	'tplink,cpe510-v1',
+	'tplink,wbs210-v1',
 	'tplink,wbs210-v2',
 	'ubnt,nanostation-m-xw',
 	'ubnt,unifi-ap-pro',

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -34,6 +34,7 @@ function M.is_outdoor_device()
 		'tplink,cpe510-v2',
 		'tplink,cpe510-v3',
 		'tplink,eap225-outdoor-v1',
+		'tplink,wbs210-v1',
 		'tplink,wbs210-v2',
 		'ubnt,nanostation-m-xw',
 		'ubnt,unifiac-mesh',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -356,6 +356,12 @@ device('tp-link-tl-wr1043nd-v4', 'tplink_tl-wr1043nd-v4', {
 	},
 })
 
+device('tp-link-wbs210-v1', 'tplink_wbs210-v1', {
+	manifest_aliases = {
+		'tp-link-wbs210-v1.20', -- upgrade from OpenWrt 19.07
+	},
+})
+
 device('tp-link-wbs210-v2', 'tplink_wbs210-v2')
 
 -- Ubiquiti


### PR DESCRIPTION
Build is running, @rotanid found such a device near him.
~~Images will reach him soon.~~
He got the images yesterday and reported:

> check, done.

_in hackint#gluon_

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) - tp-link-wbs210-v1
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`