### PR TITLE
ath79-generic: (re)add support for UniFi AC Mesh Pro

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -115,6 +115,7 @@ ath79-generic
   - UniFi AC Lite
   - UniFi AC LR
   - UniFi AC Mesh
+  - UniFi AC Mesh Pro
   - UniFi AC Pro
   - UniFi AP
   - UniFi AP LR

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -59,6 +59,7 @@ elseif platform.match('ath79', 'generic', {
 	-- Temporary solution to separate interfaces in bridged default setup
 	lan_ifname, wan_ifname = 'eth0', 'eth1'
 elseif platform.match('ath79', 'generic', {
+	'ubnt,unifiac-mesh-pro',
 	'ubnt,unifiac-pro',
 }) then
 	lan_ifname, wan_ifname = 'eth0.2', 'eth0.1'

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/115-swconfig
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/115-swconfig
@@ -5,6 +5,7 @@ local uci = require('simple-uci').cursor()
 
 local switch_vlans = {
 	-- device identifier, lan ports, wan ports
+	["ubnt,unifiac-mesh-pro"] = {"3 0t", "2 0t"},
 	["ubnt,unifiac-pro"] = {"2 0t", "3 0t"},
 }
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -44,6 +44,7 @@ function M.is_outdoor_device()
 		'ubnt,nanostation-m-xw',
 		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',
+		'ubnt,unifiac-mesh-pro',
 	}) then
 		return true
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -476,6 +476,11 @@ device('ubiquiti-unifi-ac-mesh', 'ubnt_unifiac-mesh', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })
 
+device('ubiquiti-unifi-ac-mesh-pro', 'ubnt_unifiac-mesh-pro', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('ubiquiti-unifi-ac-pro', 'ubnt_unifiac-pro', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9880,


### PR DESCRIPTION
@udoschneider offered to test this migration.
The ath79 image can be found here: http://aiyionpri.me/shared/udoschneider/

A proper image to migrate from would be http://firmware.ffh.zone/vH21/sysupgrade/gluon-ffh-vH21-ubiquiti-unifi-ac-mesh-pro-sysupgrade.bin


- [x] Must be flashable from vendor firmware
  - ~~Web interface~~
  - ~~TFTP~~
  - [x] Other: [According to https://wiki.freifunk-dresden.de/index.php/Unifi_AP_AC_Pro/Mesh_Pro]
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - ~~Should map to their respective radio~~
    - ~~Should show activity~~
  - Switch port LEDs
    - ~~Should map to their respective port (or switch, if only one led present)~~
    - ~~Should show link state and activity~~
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`