### PR TITLE
ipq40xx-mikrotik: add mikrotik-hap-ac2

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -56,6 +56,16 @@
     "targets/generic",
     "targets/targets.mk"
   ],
+  "ipq40xx-mikrotik": [
+    "targets/ipq40xx-mikrotik",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk",
+    "targets/mikrotik.inc"
+  ],
   "ipq806x-generic": [
     "targets/ipq806x-generic",
     "modules",

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -223,6 +223,7 @@ ipq40xx-mikrotik
 * Mikrotik
 
   - DISC Lite5 ac (RBDiscG-5acD)
+  - hAP ac2
   - SXTsq 5 ac (RBSXTsqG-5acD)
 
 ipq806x-generic

--- a/targets/ipq40xx-mikrotik
+++ b/targets/ipq40xx-mikrotik
@@ -1,6 +1,12 @@
 include 'mikrotik.inc'
 
+local ATH10K_PACKAGES_IPQ40XX = {}
+
 device('mikrotik-sxtsq-5-ac-rbsxtsqg-5acd', 'mikrotik_sxtsq-5-ac', {
 	factory = false,
 	aliases = {'mikrotik-discg-5acd'},
+})
+
+device('mikrotik-hap-ac2', 'mikrotik_hap-ac2', {
+	packages = ATH10K_PACKAGES_IPQ40XX,
 })


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~