### PR TITLE
gluon-core: fix gluon.util.get_role_interfaces() with empty role list

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -158,7 +158,8 @@ function M.get_role_interfaces(uci, role, exclusive)
 	end
 
 	uci:foreach('gluon', 'interface', function(s)
-		if M.contains(s.role, role) and (not exclusive or #s.role == 1) then
+		local roles = s.role or {}
+		if M.contains(roles, role) and (not exclusive or #roles == 1) then
 			add(s.name)
 		end
 	end)


### PR DESCRIPTION
The function failed when an interface has no roles assigned, breaking
several upgrade scripts.

Closes #2471