### PR TITLE
ath79-generic: (re)add support for tl-wr1043nd-v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -88,7 +88,7 @@ ath79-generic
   - TL-WDR4300 (v1)
   - TL-WR810N (v1)
   - TL-WR842N/ND (v3)
-  - TL-WR1043N/ND (v2, v3, v4)
+  - TL-WR1043N/ND (v1, v2, v3, v4)
   - WBS210 (v1.20)
   - WBS210 (v2.0)
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -340,6 +340,13 @@ device('tp-link-tl-wr842n-v3', 'tplink_tl-wr842n-v3', {
 	},
 })
 
+device('tp-link-tl-wr1043nd-v1', 'tplink_tl-wr1043nd-v1', {
+	class = 'tiny', -- 32M ath9k
+	manifest_aliases = {
+		'tp-link-tl-wr1043n-nd-v1', -- upgrade from OpenWrt 19.07
+	},
+	packages = { 'zram-swap' },
+})
 device('tp-link-tl-wr1043nd-v2', 'tplink_tl-wr1043nd-v2', {
 	manifest_aliases = {
 		'tp-link-tl-wr1043n-nd-v2', -- upgrade from OpenWrt 19.07


### PR DESCRIPTION
@rotanid intends to test this device and has been provided access to the images.

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~