### PR TITLE
ath79-generic: (re)add support for gl-usb150

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -36,6 +36,7 @@ ath79-generic
   - GL-AR150
   - GL-AR300M-Lite
   - GL-AR750
+  - GL-USB150 (Microuter)
 
 * Joy-IT
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -113,6 +113,10 @@ device('gl.inet-gl-ar750', 'glinet_gl-ar750', {
 	packages = ATH10K_PACKAGES_QCA9887,
 })
 
+device('gl.inet-gl-usb150', 'glinet_gl-usb150', {
+	factory = false,
+})
+
 -- JOY-IT
 
 device('joy-it-jt-or750i', 'joyit_jt-or750i', {


### PR DESCRIPTION
@rotanid intends to test this device.
He got the image a moment ago.

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [ ] should support all network ports on the device - **device has no LAN ports**
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs - **device has no LAN ports**
    - ~~Should map to their respective port (or switch, if only one led present)~~
    - ~~Should show link state and activity~~
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~