### PR TITLE
ath79-generic: (re)add support for archer-c25-v1

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -282,6 +282,12 @@ device('tp-link-archer-c2-v3', 'tplink_archer-c2-v3', {
 	broken = true,  -- 64M ath9k + ath10k
 })
 
+device('tp-link-archer-c25-v1', 'tplink_archer-c25-v1', {
+	packages = ATH10K_PACKAGES_QCA9887,
+	broken = true, -- OOM with 5GHz enabled in most environments
+	class = 'tiny', -- 64M ath9k + ath10k
+})
+
 device('tp-link-archer-c5-v1', 'tplink_archer-c5-v1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })


### PR DESCRIPTION
@rotanid intends to test this device

Its broken, as it will run out of memory, when the 5GHz interfaces are active.
I therefore did not add it to the supported list yet.

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~