### PR TITLE
gluon-core: use copy of "WAN" role list for "single" default

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/021-interface-roles
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/021-interface-roles
@@ -10,7 +10,7 @@ local roles = {
 	lan = site.interfaces.lan.default_roles({'client'}),
 	wan = site.interfaces.wan.default_roles({'uplink'}),
 }
-roles.single = site.interfaces.single.default_roles(roles.wan)
+roles.single = site.interfaces.single.default_roles({unpack(roles.wan)})
 
 -- Migration of Mesh-on-WAN/LAN setting from Gluon 2021.1 and older (to be removed in 2024)
 --


### PR DESCRIPTION
Instead of using roles.wan directly as the default for roles.single,
create a copy of the table, so subsequent modifications of roles.single
don't affect roles.wan as well.

Fixes migration of Mesh-on-WAN status when no default for "single"
interfaces is set in site.conf.