### PR TITLE
push_pkg.sh: use scp protocol for openssh scp

### DIFF
--- a/contrib/push_pkg.sh
+++ b/contrib/push_pkg.sh
@@ -127,7 +127,7 @@ while [ $# -gt 0 ]; do
 
 		# shellcheck disable=SC2029
 		if [ -n "$filename" ]; then
-			scp -P "${ssh_port}" "$feed/$filename" "root@${BL}${ssh_host}${BR}:/tmp/${filename}"
+			scp -O -P "${ssh_port}" "$feed/$filename" "root@${BL}${ssh_host}${BR}:/tmp/${filename}"
 			ssh -p "${ssh_port}" "root@${ssh_host}" "
 				set -e
 				echo Running opkg:


### PR DESCRIPTION
Starting from OpenSSH 9.0p, scp started to use sftp in favor of the
scp protocol by default. As dropbear in OpenWrt currently does not
support sftp by default, we now use the fallback cli switch "-O"
to use the scp protocol for scp.