### PR TITLE
ramips-mt76x8: add support for TP-Link Archer C20 v5

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -262,6 +262,7 @@ ramips-mt76x8
 
 * TP-Link
 
+  - Archer C20 (v5)
   - Archer C50 (v3)
   - Archer C50 (v4)
   - RE200 (v2)

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -32,6 +32,10 @@ device('ravpower-rp-wd009', 'ravpower_rp-wd009')
 
 -- TP-Link
 
+device('tp-link-archer-c20-v5', 'tplink_archer-c20-v5', {
+	factory = false,
+})
+
 device('tp-link-archer-c50-v3', 'tplink_archer-c50-v3', {
 	factory = false,
 	extra_images = {


### PR DESCRIPTION
With this PR I would like to propose TP-Link Archer C20 v5 support. Owning a C20 v5, based on @herbetom's commit, I did the device-Integration-checklist[1], please find it here:

- [X] Must be flashable from vendor firmware
  - [X] Web interface
  - [ ] TFTP (possible[2] but not tested)
  - [ ] Other: TP-Link recovery mode (possible[2] but not tested)
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade (`sysupgrade sysupgrade.bin` works)
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        -> Gluon profile name: tp-link-archer-c20-v5 (device name in ramips-mt76x8 target file)
        -> Autoupdater image name: tp-link-archer-c20-v5 (via lua get_image_name())
- [X] Reset button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      -> /lib/gluon/core/sysconfig/primary_mac contains primary mac on device label
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
        -> Wan: eth0.2 (SW Port 0), Lan: eth0.1 (SW Ports 1-4)
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          - The device has no "sys" LED, so instead the power LED is flashing
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
          - only one LED present
    - [X] Should show link state and activity

One other thing to mention with this device, is that OpenWRT cannot build factory firmware[2], only sysupgrade. In order to create a first-install/ factory image one needs to download the official tp-link firmware[3] and prepend the first 131584 bytes to the sysupgrade image. This is one extra step and very easy to do. It is explained in more detail in [2].

Links:
[1] https://github.com/freifunk-gluon/gluon/wiki/Device-Integration-checklist
[2] https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=86e7353bff2a5de257de8ec62e782f016eed143c
[3] https://static.tp-link.com/2021/202101/20210127/Archer%20C20(US)_V5_201214.zip
