### PR TITLE
ath79-generic: (re)add support for tl-wr1043n-v5

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -88,7 +88,7 @@ ath79-generic
   - TL-WDR4300 (v1)
   - TL-WR810N (v1)
   - TL-WR842N/ND (v3)
-  - TL-WR1043N/ND (v2, v3, v4)
+  - TL-WR1043N/ND (v2, v3, v4, v5)
   - WBS210 (v1.20)
   - WBS210 (v2.0)
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -355,6 +355,7 @@ device('tp-link-tl-wr1043nd-v4', 'tplink_tl-wr1043nd-v4', {
 		'tp-link-tl-wr1043n-nd-v4', -- upgrade from OpenWrt 19.07
 	},
 })
+device('tp-link-tl-wr1043n-v5', 'tplink_tl-wr1043n-v5')
 
 device('tp-link-wbs210-v1', 'tplink_wbs210-v1', {
 	manifest_aliases = {


### PR DESCRIPTION
Gone due to commit 45c84a117bf8 ("ar71xx: drop target")

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP
  - Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - [x] When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`