### PR TITLE
gluon-core: add isolated option to gluon_wired proto

### DIFF
--- a/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
+++ b/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
@@ -56,6 +56,12 @@ proto_gluon_wired_setup() {
         proto_init_update "$ifname" 1
         proto_send_update "$config"
 
+        if [ -d "/sys/devices/virtual/net/${ifname}/bridge" ]; then
+                for brif in "/sys/class/net/${ifname}/brif/"* ; do
+                        echo 1 > "${brif}/isolated"
+                done
+        fi
+
         if [ "$vxlan" -eq 1 ]; then
                 meshif="vx_$config"
 


### PR DESCRIPTION
As discussed in https://github.com/freifunk-gluon/gluon/issues/2393 and https://github.com/freifunk-gluon/gluon/issues/1104 it would be nice if the individual switch ports could be isolated and connected nodes would only see nodes they are directly attached to. With devices already migrated to DSA this is fairly easy as the isolated flag can be set on the bridged interfaces.

As I could not find any option in OpenWrt to set the isolated flag on bridge ports I added it to the gluon_wired proto which takes care of setting all ports to isolated in interfaces with type=bridge and proto=gluon_wired.

**TODO**
- [x] test on DSA device
- [x] test on swconfig device (check that nothing breaks)
- [ ] ~add config mode option (maybe wait for #2480?)~