### PR TITLE
ath79-generic: (re)add support for wndr3700v2

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -41,6 +41,10 @@ ath79-generic
 
   - JT-OR750i
 
+* Netgear
+
+  - WNDR3700 (v2)
+
 * OCEDO
 
   - Raccoon

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -121,6 +121,15 @@ device('joy-it-jt-or750i', 'joyit_jt-or750i', {
 })
 
 
+-- Netgear
+device('netgear-wndr3700-v2', 'netgear_wndr3700-v2', {
+	manifest_aliases = {
+		'netgear-wndr3700v2', -- Upgrade from OpenWrt 19.07
+	},
+	factory_ext = '.img',
+})
+
+
 -- OCEDO
 
 device('ocedo-raccoon', 'ocedo_raccoon', {


### PR DESCRIPTION
[rabbit83](https://forum.freifunk.net/u/rabbit83/) intends to test this device.
He built and ran his own build based on 2021.1.1 a while ago, building on master failed for his local site, so he was provided an image.

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
