### PR TITLE
ath79-generic: (re)add support for archer-c59-v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -78,6 +78,7 @@ ath79-generic
   - Archer C5 (v1)
   - Archer C6 (v2)
   - Archer C7 (v2, v5)
+  - Archer C59 (v1)
   - CPE210 (v1.0, v1.1, v2.0)
   - CPE220 (v3.0)
   - CPE510 (v1.0, v1.1)

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -298,6 +298,10 @@ device('tp-link-archer-c7-v5', 'tplink_archer-c7-v5', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })
 
+device('tp-link-archer-c59-v1', 'tplink_archer-c59-v1', {
+	packages = ATH10K_PACKAGES_QCA9888,
+})
+
 device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
    
did not test flashing from stock firmware