### PR TITLE
docs: fix mpc85xx-p1010 target name

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -211,8 +211,8 @@ mediatek-mt7622
 
   - UniFi 6 LR
 
-mpc85xx-generic
----------------
+mpc85xx-p1010
+-------------
 
 * Sophos
 


### PR DESCRIPTION
The mpc85xx-generic target was renamed to mpc85xx-p1010 in OpenWrt
21.02. The target name in Gluon docs was never adjusted however.

Signed-off-by: David Bauer <mail@david-bauer.net>