### PR TITLE
ramips-mt7620: remove "broken" status for ASUS RT-AC51U

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -243,6 +243,10 @@ mpc85xx-p1020
 ramips-mt7620
 -------------
 
+* ASUS
+
+  - RT-AC51U
+
 * GL.iNet
 
   - GL-MT300A
@@ -275,6 +279,7 @@ ramips-mt7621
 * ASUS
 
   - RT-AC57U
+  
 
 * D-Link
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -279,7 +279,6 @@ ramips-mt7621
 * ASUS
 
   - RT-AC57U
-  
 
 * D-Link
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -117,6 +117,7 @@ local primary_addrs = {
 		}},
 		{'ramips', 'mt7620', {
 			'xiaomi,miwifi-mini',
+			'asus,rt-ac51u',
 		}},
 	}},
 	{phy(1), {

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -2,7 +2,6 @@
 
 device('asus-rt-ac51u', 'asus_rt-ac51u', {
 	factory = false,
-	broken = true, -- no 5GHz usable, LEDs not fully supported
 })
 
 


### PR DESCRIPTION
The reasons for "broken" status (no 5 GHz WLAN, LEDs not working) are [fixed in OpenWRT.](https://openwrt.org/toh/asus/rt-ac51u) Only 5 GHz-LED isn't working at all.

- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [x] TFTP
  - [x] Other: ASUS Firmware Restoration Tool, see [OpenWRT-Wiki](https://openwrt.org/toh/asus/rt-ac51u)
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name:  is asus-rt-ac51u
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs --> Only 2,4. GHz LED is working, 5 GHz doen't work
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only: (not applicable, indoor device)
