### PR TITLE
mpc85xx-p1020: add Extreme Networks WS-AP3825i

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -233,6 +233,10 @@ mpc85xx-p1020
 
   - WS-AP3710i
 
+* Extreme Networks
+
+  - WS-AP3825i
+
 * OCEDO
 
   - Panda

--- a/targets/mpc85xx-p1020
+++ b/targets/mpc85xx-p1020
@@ -1,3 +1,11 @@
+local ATH10K_PACKAGES_QCA9880 = {
+	'kmod-ath10k',
+	'-kmod-ath10k-ct',
+	'-kmod-ath10k-ct-smallbuffers',
+	'ath10k-firmware-qca988x',
+	'-ath10k-firmware-qca988x-ct',
+}
+
 -- Aerohive
 
 device('aerohive-hiveap-330', 'aerohive_hiveap-330', {
@@ -9,6 +17,14 @@ device('aerohive-hiveap-330', 'aerohive_hiveap-330', {
 
 device('enterasys-ws-ap3710i', 'enterasys_ws-ap3710i', {
 	factory = false,
+})
+
+
+-- Extreme Networks
+
+device('extreme-networks-ws-ap3825i', 'extreme-networks_ws-ap3825i', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9880,
 })
 
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - Web interface
  - [x] TFTP
  - Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
         LAN 1 is WAN (eth1)
         LAN 2 is LAN (eth0)
         It is possible to supply the AP with power via either of the two ports. However, there is no seamless failover. Additionally there is a DC-IN.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

The instructions from the initial OpenWRT commit didn't work for me. I've written down some that should work: https://forum.darmstadt.freifunk.net/t/flashing-of-the-extreme-networks-ws-ap3825i/923

cc @blocktrron 