### PR TITLE
ath79-generic: (re)add archer c60

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -290,6 +290,12 @@ device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })
 
+device('tp-link-archer-c60-v1', 'tplink_archer-c60-v1', {
+	packages = ATH10K_PACKAGES_QCA9888,
+	broken = true, -- OOM with 5GHz enabled in most environments
+	class = 'tiny', -- 64M ath9k + ath10k
+})
+
 device('tp-link-archer-c7-v2', 'tplink_archer-c7-v2', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })


### PR DESCRIPTION
The device got even more sensitive regarding 5GHz environments.
As its already marked as broken for that very reason, this PR should be fine.


- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios **unstable -> broken**
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
