### PR TITLE
ramips-mt76x8: add support for TP-Link Archer C20 v4

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -323,7 +323,7 @@ ramips-mt76x8
 
 * TP-Link
 
-  - Archer C20 (v5)
+  - Archer C20 (v4, v5)
   - Archer C50 (v3)
   - Archer C50 (v4)
   - RE200 (v2)

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -32,6 +32,13 @@ device('ravpower-rp-wd009', 'ravpower_rp-wd009')
 
 -- TP-Link
 
+device('tp-link-archer-c20-v4', 'tplink_archer-c20-v4', {
+	factory = false,
+	extra_images = {
+		{'-squashfs-tftp-recovery', '-bootloader', '.bin'},
+	},
+})
+
 device('tp-link-archer-c20-v5', 'tplink_archer-c20-v5', {
 	factory = false,
 })


### PR DESCRIPTION
@gerhardt tracked this device for a while now and lent me one to add it in gluon as well.

The device is expected to works good as revision five, which was added a few weeks ago.

Flashing the device must only be done via tftp from stock, if flashed via their UI the router is soft-bricked.

Test is scheduled for tomorrow 09:00.

- [x] Must be flashable from vendor firmware
  - ~~Web interface~~ Does softbrick the device
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~