### PR TITLE
ath79-generic: (re)add CPE210v3

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -84,7 +84,7 @@ ath79-generic
   - Archer C6 (v2)
   - Archer C7 (v2, v4, v5)
   - Archer C59 (v1)
-  - CPE210 (v1.0, v1.1, v2.0)
+  - CPE210 (v1.0, v1.1, v2.0, v3.0, v3.1, v3.20)
   - CPE220 (v3.0)
   - CPE510 (v1.0, v1.1)
   - CPE510 (v2.0)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -29,6 +29,7 @@ function M.is_outdoor_device()
 		'plasmacloud,pa300e',
 		'tplink,cpe210-v1',
 		'tplink,cpe210-v2',
+		'tplink,cpe210-v3',
 		'tplink,cpe220-v3',
 		'tplink,cpe510-v1',
 		'tplink,cpe510-v2',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -348,6 +348,13 @@ device('tp-link-cpe210-v2', 'tplink_cpe210-v2', {
 		'tp-link-cpe210-v2.0', -- Upgrade from OpenWrt 19.07
 	},
 })
+device('tp-link-cpe210-v3', 'tplink_cpe210-v3', {
+	manifest_aliases = {
+		'tp-link-cpe210-v3.0', -- Upgrade from OpenWrt 19.07
+		'tp-link-cpe210-v3.1', -- Upgrade from OpenWrt 19.07
+		'tp-link-cpe210-v3.20', -- Upgrade from OpenWrt 19.07
+	},
+})
 device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
 device('tp-link-cpe510-v1', 'tplink_cpe510-v1', {
 	manifest_aliases = {


### PR DESCRIPTION
@moridius intends to test the device

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`