### PR TITLE
treewide: switch crypto lib to WolfSSL

### DIFF
--- a/package/gluon-mesh-wireless-sae/Makefile
+++ b/package/gluon-mesh-wireless-sae/Makefile
@@ -6,7 +6,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-wireless-sae
   TITLE:=Encryption of 802.11s Mesh Links through SAE
-  DEPENDS:=+gluon-core +wpa-supplicant-mesh-openssl
+  DEPENDS:=+gluon-core +wpa-supplicant-mesh-wolfssl
 endef
 
 $(eval $(call BuildPackageGluon,gluon-mesh-wireless-sae))

--- a/package/gluon-wireless-encryption/Makefile
+++ b/package/gluon-wireless-encryption/Makefile
@@ -5,7 +5,7 @@ PKG_NAME:=gluon-wireless-encryption
 include ../gluon.mk
 
 define Package/gluon-wireless-encryption-wpa3
-  DEPENDS:=+hostapd-openssl
+  DEPENDS:=+hostapd-wolfssl
   TITLE:=Package for supporting WPA3 encrypted wireless networks
 endef
 


### PR DESCRIPTION
WolfSSL has a significant lower flash footprint. Also, issues with OWE / SAE connections were fixed in OpenWrt a while ago.

See https://github.com/openwrt/openwrt/commit/ddcb970274c011d3db611ec39350ee4704ff0e02

```
Before: 6030120
After: 5636904
```
