### PR TITLE
generic: reduce kernel size some more

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -44,11 +44,20 @@ try_config('PACKAGE_ATH_DEBUG', true)
 
 try_config('TARGET_SQUASHFS_BLOCK_SIZE', 256)
 
+config('KERNEL_PROC_STRIPPED', true)
+config('KERNEL_AIO', false)
+config('KERNEL_IO_URING', false)
+config('KERNEL_FHANDLE', false)
+config('KERNEL_FANOTIFY', false)
+config('KERNEL_CGROUPS', false)
 config('KERNEL_IP_MROUTE', false)
 config('KERNEL_IPV6_MROUTE', false)
 config('KERNEL_IPV6_SEG6_LWTUNNEL', false)
 config('SECCOMP', false)
 config('KERNEL_SECCOMP', false)
+-- kmod-mt7915e pulls in CONFIG_KERNEL_RELAY
+-- use try_config, so enabling the package is still possible
+try_config('PACKAGE_kmod-mt7915e', false)
 
 config('COLLECT_KERNEL_DEBUG', true)
 


### PR DESCRIPTION
Remove a few features that became enabled by default since OpenWrt 19.07.
Disabling CONFIG_RELAY also reduces RAM usage.

Sysupgrade image size for TL-WDR3600 (content size, not padded to erase blocks):
- Before: 5221790
- After: 5066042