### PR TITLE
ath79: add patch to fix serial console and sysupgrade on OR750

### DIFF
--- a/patches/openwrt/0026-ath79-Joy-IT-OR750i-fix-UART.patch
+++ b/patches/openwrt/0026-ath79-Joy-IT-OR750i-fix-UART.patch
@@ -1,0 +1,21 @@
+From: Nico Boehr <freifunk@nicoboehr.de>
+Date: Sat, 7 May 2022 08:39:05 +0200
+Subject: ath79: Joy-IT OR750i: fix UART
+
+The serial console defaults to disabled in the DTSI files, explicitly
+enable it for the Joy-IT OR750i, so we can get a console in linux.
+
+Signed-off-by: Nico Boehr <freifunk@nicoboehr.de>
+
+diff --git a/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts b/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
+index 60fa922878355ebdaf7d2983fe926efdf8b97207..042348d82c479c097f534f0bf2bb383ace55e02d 100644
+--- a/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
++++ b/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
+@@ -121,3 +121,7 @@
+ 
+ 	mtd-cal-data = <&art 0x1000>;
+ };
++
++&uart {
++       status = "okay";
++};


### PR DESCRIPTION
The serial console on the Joy-IT OR750i doesn't work, because the UART
node is disabled in device tree. This also breaks sysupgrade.

The issue is already fixed upstream in OpenWRT by
7054721cf94f4aa8fe71ac4c28c922b19a69ba1d ("ath79: enable UART in SoC
DTSI files"), but since 19.07 doesn't support the OR750, we need our own
patch.

Signed-off-by: Nico Boehr <freifunk@nicoboehr.de>