### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - 'docs**/'
       - '.github/workflows/build-docs.yml'
+permissions:
+  contents: read
+
 jobs:
   build-documentation:
     name: docs

--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -8,8 +8,14 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   changed:
+    permissions:
+      contents: read  # for dorny/paths-filter to fetch a list of changed files
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     runs-on: ubuntu-latest
     outputs:
       targets: ${{ steps.filter.outputs.changes }}

--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -12,6 +12,9 @@ on:
       - 'modules'
       - 'patches/**'
       - '.github/workflows/check-patches.yml'
+permissions:
+  contents: read
+
 jobs:
   check-patches:
     name: Check patches

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -4,8 +4,14 @@ on:
   # only execute base branch actions
   pull_request_target:
 
+permissions:
+  contents: read
+
 jobs:
   labels:
+    permissions:
+      contents: read  # for actions/labeler to determine modified files
+      pull-requests: write  # for actions/labeler to add labels to PRs
     runs-on: ubuntu-latest
     if: github.repository_owner == 'freifunk-gluon'
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,9 @@ on:
   push:
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+
 jobs:
   lua:
     name: Lua


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
