### PR TITLE
treewide: remove leftover GLUON_SPECIALIZE_KERNEL dependencies

### DIFF
--- a/package/gluon-mesh-vpn-fastd-l2tp/Makefile
+++ b/package/gluon-mesh-vpn-fastd-l2tp/Makefile
@@ -7,7 +7,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-vpn-fastd-l2tp
   TITLE:=Support for connecting meshes via fastd (with L2TP kernel offloading)
-  DEPENDS:=+gluon-core +gluon-mesh-vpn-fastd +kmod-l2tp-eth +@GLUON_SPECIALIZE_KERNEL:KERNEL_L2TP
+  DEPENDS:=+gluon-core +gluon-mesh-vpn-fastd +kmod-l2tp-eth
 endef
 
 $(eval $(call BuildPackageGluon,gluon-mesh-vpn-fastd-l2tp))

--- a/package/gluon-mesh-vpn-wireguard/Makefile
+++ b/package/gluon-mesh-vpn-wireguard/Makefile
@@ -6,7 +6,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-vpn-wireguard
   TITLE:=Support for connecting meshes via wireguard
-  DEPENDS:=+gluon-core +libgluonutil +gluon-mesh-vpn-core +wireguard-tools +@GLUON_SPECIALIZE_KERNEL:KERNEL_TUN +wgpeerselector +libubus
+  DEPENDS:=+gluon-core +libgluonutil +gluon-mesh-vpn-core +wireguard-tools +wgpeerselector +libubus
 endef
 
 $(eval $(call BuildPackageGluon,gluon-mesh-vpn-wireguard))


### PR DESCRIPTION
This was removed in commit c23bc293ef99 ("treewide: remove
GLUON_SPECIALIZE_KERNEL").