### PR TITLE
ath79-generic: (re)add wzr-hp-ag-300h / wzr-600dhp

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -9,6 +9,10 @@ ath79-generic
   - Fritz!WLAN Repeater 450E [#avmflash]_
   - Fritz!Box 4020 [#avmflash]_
 
+* Buffalo
+
+  - WZR-HP-AG300H / WZR-600DHP
+
 * devolo
 
   - WiFi pro 1200e [#lan_as_wan]_

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -26,6 +26,11 @@ device('avm-fritz-wlan-repeater-450e', 'avm_fritz450e', {
 	factory = false,
 })
 
+-- Buffalo
+
+device('buffalo-wzr-hp-ag300h', 'buffalo_wzr-hp-ag300h')
+device('buffalo-wzr-600dhp', 'buffalo_wzr-600dhp')
+
 -- devolo
 
 device('devolo-wifi-pro-1200e', 'devolo_dvl1200e', {


### PR DESCRIPTION
@ce-4 intends to test this device.
 
> Both are effectively the same hardware, the latter being Bufalos
> replacement model.

> Gone due to
> commit 45c84a117bf8 ("ar71xx: drop target")

- ~~Must be flashable from vendor firmware~~ wonttest
  - ~~Web interface~~
  - ~~TFTP~~
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity **not sure whether they blink for beacons, but they do until the respective device is down**
  - Switch port LEDs **none present**
    - ~~Should map to their respective port (or switch, if only one led present)~~
    - ~~Should show link state and activity~~
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
