### PR TITLE
ath79-generic: (re)add Archer C58 v1

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -312,6 +312,12 @@ device('tp-link-archer-c5-v1', 'tplink_archer-c5-v1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })
 
+device('tp-link-archer-c58-v1', 'tplink_archer-c58-v1', {
+	packages = ATH10K_PACKAGES_QCA9888,
+	broken = true, -- OOM with 5GHz enabled in most environments
+	class = 'tiny', -- 64M ath9k + ath10k
+})
+
 device('tp-link-archer-c6-v2-eu-ru-jp', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
 	manifest_aliases = {


### PR DESCRIPTION
@moridius intends to test this device.

The device is expected to not work properly due to 64M ath9k + ath10k.
Its marked as `BROKEN`, like it was in ar71xx.

@moridius please take special care regarding testing the primary mac.


- ~~Must be flashable from vendor firmware~~ **not tested, expected to work**
  - ~~Web interface~~
  - ~~TFTP~~
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must forget configuration (`sysupgrade [-n]`, `firstboot`)
    - [x] Must keep configuration (`sysupgrade [-n]`, `firstboot`) ~~keep was not tested, forget works~~ **both tested, both work***
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable) **wont work reliably**
  - ~~Association with AP must be possible on all radios~~
  - ~~Association with 802.11s mesh must work on all radios~~
  - ~~AP+mesh mode must work in parallel on all radios~~
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~