### PR TITLE
ath79-nand: migrate wndr3700v4

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -134,6 +134,10 @@ ath79-nand
   - GL-AR300M
   - GL-AR750S
 
+* Netgear
+
+  - WNDR3700 (v4)
+
 ath79-mikrotik
 --------------
 

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -7,6 +7,8 @@ local ATH10K_PACKAGES_QCA9887 = {
 }
 
 
+-- GL.iNet
+
 device('gl.inet-gl-ar300m-nor', 'glinet_gl-ar300m-nor', {
 	factory = false,
 })

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -17,3 +17,13 @@ device('gl.inet-gl-ar750s-nor', 'glinet_gl-ar750s-nor', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9887,
 })
+
+
+-- Netgear
+
+device('netgear-wndr3700-v4', 'netgear_wndr3700-v4', {
+	factory_ext = '.img',
+	manifest_aliases = {
+		'netgear-wndr3700v4', -- Upgrade from OpenWrt 19.07
+	},
+})


### PR DESCRIPTION
This contains a minor title-addition to ath79-nand.

~~freifunk-springe~~ @gRaSmOnStEr intends to test the device.

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~