### PR TITLE
ath79-generic: migrate D-Link DIR-825 B1 from ar71xx

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -25,6 +25,7 @@ ath79-generic
   - DAP-2660 A1 [#lan_as_wan]_
   - DIR-505 A1 [#lan_as_wan]_
   - DIR-505 A2 [#lan_as_wan]_
+  - DIR-825 B1
 
 * Enterasys
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -83,6 +83,14 @@ device('d-link-dir-505', 'dlink_dir-505', {
 	},
 })
 
+device('d-link-dir825b1', 'dlink_dir-825-b1', {
+	factory = false,
+	class = 'tiny', -- Only 6M of usable Firmware space
+	manifest_aliases = {
+		'd-link-dir-825-rev-b1', -- Upgrade from OpenWrt 19.07
+	},
+})
+
 
 -- Enterasys
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -76,11 +76,11 @@ device('d-link-dap-2660-a1', 'dlink_dap-2660-a1', {
 })
 
 device('d-link-dir-505', 'dlink_dir-505', {
-        factory = false,
-        manifest_aliases = {
-                'd-link-dir-505-rev-a1', -- Upgrade from OpenWrt 19.07
-                'd-link-dir-505-rev-a2', -- Upgrade from OpenWrt 19.07
-        },
+	factory = false,
+	manifest_aliases = {
+		'd-link-dir-505-rev-a1', -- Upgrade from OpenWrt 19.07
+		'd-link-dir-505-rev-a2', -- Upgrade from OpenWrt 19.07
+	},
 })
 
 


### PR DESCRIPTION
also fix whitespace (tabs vs. spaces) my text editor messed up while migrating dir-505


- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [-] TFTP
  - [x] Other: _recovery web interface, but very cumbersome with latest operating systems / browsers_
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [-] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
      _-> MAC address on map equals label mac - 1, consistent with ar71xx (will not spawn a new node on the map)_
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
    _-> label mac -1 prevails even after reset_
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [-] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`