### PR TITLE
Create interfaces for each "port" in /etc/config/gluon

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/021-interface-roles
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/021-interface-roles
@@ -52,14 +52,35 @@ local interfaces = {
 	single = sysconfig.single_ifname,
 }
 
-for iface in pairs(interfaces) do
-	local section_name = 'iface_' .. iface
-	if not uci:get('gluon', section_name) then
-		uci:section('gluon', 'interface', section_name, {
-			-- / prefix refers to sysconfig ifnames
-			name = '/' .. iface,
-			role = roles[iface],
-		})
+for iface, ifnames in pairs(interfaces) do
+	local default_roles = roles[iface]
+
+	-- migration from intermediate gluon master
+	local section_name_old = 'iface_' .. iface
+	if uci:get('gluon', section_name_old) then
+		default_roles = uci:get('gluon', section_name_old, 'role')
+		uci:delete('gluon', section_name_old)
+	end
+
+	local interface_count = 1
+	if type(ifnames) == 'table' then
+		interface_count = #ifnames
+	end
+
+	for i = 0, interface_count-1 do
+		local section_name = 'iface_' .. iface .. '_' .. tostring(i)
+
+		if not uci:get('gluon', section_name) then
+			uci:section('gluon', 'interface', section_name, {
+				-- / prefix refers to sysconfig ifnames
+				name = '/' .. iface .. '[' .. tostring(i) .. ']',
+				role = default_roles,
+			})
+		else
+			-- In case we have existing interfaces in that category, we want to
+			-- use their roles as default for other new interfaces in that category.
+			default_roles = uci:get('gluon', section_name, 'role')
+		end
 	end
 end
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -147,13 +147,26 @@ function M.get_role_interfaces(uci, role, exclusive)
 	local ret = {}
 
 	local function add(name)
+		local subindex = nil
+
 		-- Interface names with a / prefix refer to sysconfig interfaces
 		-- (lan_ifname/wan_ifname/single_ifname)
 		if string.sub(name, 1, 1) == '/' then
+			subindex = tonumber(string.match(name, "%[(%d+)%]"))
+			if subindex then
+				-- handle something like "/lan[10]":
+				name = string.gsub(name, "%[%d+%]", "")
+			end
+
 			name = sysconfig[string.sub(name, 2) .. '_ifname'] or ''
 		end
+		local i = 0
 		for iface in string.gmatch(name, '%S+') do
-			M.add_to_set(ret, iface)
+			if not subindex or subindex == i then
+				M.add_to_set(ret, iface)
+			end
+
+			i = i + 1
 		end
 	end
 


### PR DESCRIPTION
This PR enables (migration-safe) role assignment for individual "lan"
and "wan" interfaces. This is helpful especially on devices with multiple
"lan" or "wan" interfaces (as they appear for devices with DSA support).

For interfaces in /lib/gluon/lan_ifname, we now create individual
entries in /etc/config/gluon using a new introduced "/lan[0]", "/lan[1]", ...
syntax. Before this PR,  all interfaces were referenced as a single
interface "/lan" in /etc/config/gluon.

The same is done for wan_ifname and single_ifname.

Migration strategy:

If new interfaces show up during gluon-reconfigure, the assigned roles
of prior existing interfaces in the same category will be applied to the
new interface.

(This PR is based on discussions in #2490)