### PR TITLE
ramips-mt7621: add TP-Link RE650v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -285,6 +285,10 @@ ramips-mt7621
   - EX6150 (v1)
   - R6220
 
+* TP-Link
+
+  - RE650 (v1)
+
 * Ubiquiti
 
   - EdgeRouter X

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -28,6 +28,9 @@ device('netgear-wndr3700-v5', 'netgear_wndr3700-v5', {
 	},
 })
 
+-- TP-Link
+
+device('tp-link-re650-v1', 'tplink_re650-v1')
 
 -- Ubiquiti
 


### PR DESCRIPTION
Test protocol created by the device owner.

https://meshviewer.darmstadt.freifunk.net/#!/en/map/74da88f287c3

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP (untested, but possible according to OpenWrt wiki)
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present)
    - [x] Should show link state and activity