### PR TITLE
generic: add openssh-sftp-server

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -95,4 +95,5 @@ packages {
 	'-firewall4',
 	'gluon-core',
 	'ip6tables-legacy',
+	'openssh-sftp-server',
 }


### PR DESCRIPTION
* adds ~800 KB binary size to ath79-generic because it pulls in openssl
* since OpenSSH 9.0 the old scp protocol is finally deprecated. To use
  that ancient protocol OpenSSH scp client needs a special parameter or
  a sftp server on the server side.

EDIT: kind of an alternative to https://github.com/freifunk-gluon/gluon/pull/2479 Sooner or later we should get rid of the old scp protocol anyway.