### PR TITLE
ath79-generic: update Archer C6 v2 image name

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -81,7 +81,7 @@ ath79-generic
 
   - Archer A7 (v5)
   - Archer C5 (v1)
-  - Archer C6 (v2)
+  - Archer C6 (v2 EU/RU/JP)
   - Archer C7 (v2, v4, v5)
   - Archer C59 (v1)
   - CPE210 (v1.0, v1.1, v2.0, v3.0, v3.1, v3.20)

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -310,8 +310,11 @@ device('tp-link-archer-c5-v1', 'tplink_archer-c5-v1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })
 
-device('tp-link-archer-c6-v2', 'tplink_archer-c6-v2', {
+device('tp-link-archer-c6-v2-eu-ru-jp', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
+	manifest_aliases = {
+		'tp-link-archer-c6-v2', -- Upgrade from OpenWrt 19.07
+	},
 })
 
 device('tp-link-archer-c60-v1', 'tplink_archer-c60-v1', {


### PR DESCRIPTION
The DTS model name has been changed to "TP-Link Archer C6 v2 (EU/RU/JP)"
to distinguish it from the US version.

Closes #2533