### PR TITLE
docs: use default language 'en'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
We are currently using Sphinx-5.0.0.

> [...]Since v5.0, `language = None` is not recommended. So please remove the configuration from these projects.
> Thank you for reporting.

_Originally posted by @tk0miya in https://github.com/sphinx-doc/sphinx/issues/10474#issuecomment-1140389657_