### PR TITLE
ipq40xx: switch QCA4019 firmware to -ct

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -14,13 +14,7 @@ local ATH10K_PACKAGES_QCA9887 = {
 	'-ath10k-firmware-qca9887-ct',
 }
 
-local ATH10K_PACKAGES_QCA9888 = {
-	'kmod-ath10k',
-	'-kmod-ath10k-ct',
-	'-kmod-ath10k-ct-smallbuffers',
-	'ath10k-firmware-qca9888',
-	'-ath10k-firmware-qca9888-ct',
-}
+local ATH10K_PACKAGES_QCA9888 = {}
 
 -- AVM
 

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -1,19 +1,5 @@
-local ATH10K_PACKAGES_IPQ40XX = {
-	'kmod-ath10k',
-	'-kmod-ath10k-ct',
-	'-kmod-ath10k-ct-smallbuffers',
-	'ath10k-firmware-qca4019',
-	'-ath10k-firmware-qca4019-ct',
-}
-local ATH10K_PACKAGES_IPQ40XX_QCA9888 = {
-	'kmod-ath10k',
-	'-kmod-ath10k-ct',
-	'-kmod-ath10k-ct-smallbuffers',
-	'ath10k-firmware-qca4019',
-	'-ath10k-firmware-qca4019-ct',
-	'ath10k-firmware-qca9888',
-	'-ath10k-firmware-qca9888-ct',
-}
+local ATH10K_PACKAGES_IPQ40XX = {}
+local ATH10K_PACKAGES_IPQ40XX_QCA9888 = {}
 
 
 defaults {

--- a/targets/ipq806x-generic
+++ b/targets/ipq806x-generic
@@ -4,7 +4,7 @@
 -- The QCA9984 on the other hand works fine for 11s meshes on both bands.
 
 local QCA9980_PACKAGES = {'-kmod-ath10k', 'kmod-ath10k-ct', '-ath10k-firmware-qca99x0', 'ath10k-firmware-qca99x0-ct'}
-local QCA9984_PACKAGES = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca9984', '-ath10k-firmware-qca9984-ct'}
+local QCA9984_PACKAGES = {}
 
 
 --


### PR DESCRIPTION
Use the candelatech firmware for the QCA4019 WiSoC.

The Qualcomm firmware used for this specific chip in OpenWrt in 22.03
is experiencing heavily degraded performance due to excessive
retransmits when using A-MSDU. Disabling VHT modes or switching to the
candelatech firmware circumvents this issue.

Signed-off-by: David Bauer <mail@david-bauer.net>