### PR TITLE
ath79-generic: (re)add support for TL-WR710N v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -94,6 +94,7 @@ ath79-generic
   - TL-WDR3500 (v1)
   - TL-WDR3600 (v1)
   - TL-WDR4300 (v1)
+  - TL-WR710N (v1)
   - TL-WR810N (v1)
   - TL-WR842N/ND (v3)
   - TL-WR1043N/ND (v2, v3, v4, v5)

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -383,6 +383,11 @@ device('tp-link-tl-wdr3500-v1', 'tplink_tl-wdr3500-v1')
 device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
 device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
 
+device('tp-link-tl-wr710n-v1', 'tplink_tl-wr710n-v1', {
+	class = 'tiny', -- 32M ath9k
+	packages = { 'zram-swap' },
+})
+
 device('tp-link-tl-wr810n-v1', 'tplink_tl-wr810n-v1')
 
 device('tp-link-tl-wr842n-v3', 'tplink_tl-wr842n-v3', {


### PR DESCRIPTION
> Gone due to
> commit 45c84a117bf8 ("ar71xx: drop target")

@moridius tested the device yesterday and I confirmed his conclusion using a fresh build based on todays master:
in ath79 this device is currently a waste of energy;
powercycles every few minutes.

Even though the checklist is technically fulfilled this should be marked as **blocked**, until we decide if it can be saved or is done for good. (same decision as for 1043v1 I suppose)


- ~~Must be flashable from vendor firmware~~ **won't test**
  - ~~Web interface~~
  - ~~TFTP~~
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs **not available**
    - ~~Should map to their respective radio~~
    - ~~Should show activity~~
  - Switch port LEDs **not available**
    - ~~Should map to their respective port (or switch, if only one led present) ~~
    - ~~Should show link state and activity~~
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
