### PR TITLE
lantiq-xrx200: split 7360v2 into own device

### DIFF
--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -32,7 +32,11 @@ device('avm-fritz-box-3370-rev-2-micron-nand', 'avm_fritz3370-rev2-micron', {
 
 device('avm-fritz-box-7360-sl', 'avm_fritz7360sl', {
 	factory = false,
-	aliases = {'avm-fritz-box-7360-v1', 'avm-fritz-box-7360-v2'},
+	aliases = {'avm-fritz-box-7360-v1'},
+})
+
+device('avm-fritz-box-7360-v2', 'avm_fritz7360-v2', {
+	factory = false,
 })
 
 device('avm-fritz-box-7362-sl', 'avm_fritz7362sl', {


### PR DESCRIPTION
Talked with @Dark4MD about the device on Thursday and we came to the conclusion, that it could not be using all of it's available memory if it had the same image as `v1`/`sl`.

@grische from @freifunkMUC encountered an issue with the current implementation as well, as it's currently not flashable on their stable or next branch:

```console
root@OpenWrt:/tmp# sysupgrade -n gluon-ffmuc-v2022.5.2-next3-avm-fritz-box-7360-v2-sysupgrade.bin
Sat Apr 16 13:21:46 UTC 2022 upgrade: Device avm,fritz7360-v2 not supported by this image
Sat Apr 16 13:21:46 UTC 2022 upgrade: Supported devices: avm,fritz7360sl FRITZ7360SL
```

I think this would be sufficient, let me know if I forgot something.
I'll ask @grische to test the PR before opening it for merging.