### PR TITLE
ath79-generic: (re)add support for NanoStation Loco M2 (XW)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -103,6 +103,7 @@ ath79-generic
 * Ubiquiti
 
   - NanoBeam M5 (XW)
+  - NanoStation Loco M2 (XW)
   - NanoStation M2/M5 (XW)
   - UniFi AC Lite
   - UniFi AC LR

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -38,6 +38,7 @@ function M.is_outdoor_device()
 		'tplink,wbs210-v1',
 		'tplink,wbs210-v2',
 		'ubnt,nanobeam-m5-xw',
+		'ubnt,nanostation-loco-m-xw',
 		'ubnt,nanostation-m-xw',
 		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -424,6 +424,12 @@ device('tp-link-wbs210-v2', 'tplink_wbs210-v2')
 
 -- Ubiquiti
 
+device('ubiquiti-nanostation-loco-m-xw', 'ubnt_nanostation-loco-m-xw', {
+	manifest_aliases = {
+		'ubiquiti-nanostation-loco-m2-xw', -- upgrade from OpenWrt 19.07
+	},
+})
+
 device('ubiquiti-nanostation-m-xw', 'ubnt_nanostation-m-xw', {
 	manifest_aliases = {
 		'ubiquiti-nanostation-m2-xw', -- upgrade from OpenWrt 19.07


### PR DESCRIPTION
> Gone due to
> commit 45c84a117bf8 ("ar71xx: drop target")

"nordm4nn" from @freifunkMUC intends to test this device.
Will likely be done by tomorrow evening.

- ~~Must be flashable from vendor firmware~~ **wont test**
  - ~~Web interface~~
  - ~~TFTP~~
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`