### PR TITLE
gluon-core: split dual lan devices

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -57,6 +57,10 @@ elseif platform.match('ath79', 'generic', {
 }) then
 	-- Temporary solution to separate interfaces in bridged default setup
 	lan_ifname, wan_ifname = 'eth0', 'eth1'
+elseif platform.match('ath79', 'generic', {
+	'ubnt,unifiac-pro',
+}) then
+	lan_ifname, wan_ifname = 'eth0.2', 'eth0.1'
 elseif platform.match('lantiq') then
 	local switch_data = board_data.switch or {}
 	local switch0_data = switch_data.switch0 or {}

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/115-swconfig
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/115-swconfig
@@ -1,0 +1,28 @@
+#!/usr/bin/lua
+
+local platform = require 'gluon.platform'
+local uci = require('simple-uci').cursor()
+
+local switch_vlans = {
+	-- device identifier, lan ports, wan ports
+	["ubnt,unifiac-pro"] = {"2 0t", "3 0t"},
+}
+
+local board_name = platform.get_board_name()
+local assignments = switch_vlans[board_name]
+
+if not platform.match('ath79', 'generic') or not assignments then
+	return
+end
+
+uci:delete_all('network', 'switch_vlan')
+
+for vlan, ports in ipairs(assignments) do
+	uci:section("network", "switch_vlan", nil, {
+		device = "switch0",
+		vlan = vlan,
+		ports = ports,
+	})
+end
+
+uci:save('network')

--- a/package/gluon-setup-mode/luasrc/lib/gluon/upgrade/320-setup-ifname
+++ b/package/gluon-setup-mode/luasrc/lib/gluon/upgrade/320-setup-ifname
@@ -6,6 +6,7 @@ local sysconfig = require 'gluon.sysconfig'
 if platform.is_outdoor_device() or
 	platform.match('ath79', 'generic', {
 		'ubnt,unifi-ap-pro',
+		'ubnt,unifiac-pro',
 	})
 then
 	sysconfig.setup_ifname = sysconfig.single_ifname or sysconfig.wan_ifname


### PR DESCRIPTION
This allows to split port assignments of devices, that were previously distinct and are now part of one `switch_vlan`.

Following the discussion in the latest meetup,
a variant of this should either be merged to account for #2439 before the next release,
or the other way around (reverting #2439).

I'll rebase #2462 onto this to show my intent.

Currently the statement to check, whether recreating the switch_vlans is necessary is not implemented. If you've got suggestions how to do it properly? 