### PR TITLE
ath79-generic: (re)add wzr-hp-g300nh-s

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -17,6 +17,7 @@ ath79-generic
 * Buffalo
 
   - WZR-HP-AG300H / WZR-600DHP
+  - WZR-HP-G300NH (rtl8366s)
 
 * devolo
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -41,6 +41,12 @@ device('avm-fritz-wlan-repeater-450e', 'avm_fritz450e', {
 device('buffalo-wzr-hp-ag300h', 'buffalo_wzr-hp-ag300h')
 device('buffalo-wzr-600dhp', 'buffalo_wzr-600dhp')
 
+device('buffalo-wzr-hp-g300nh-rtl8366s', 'buffalo_wzr-hp-g300nh-s', {
+	manifest_aliases = {
+		'buffalo-wzr-hp-g300nh', -- Upgrade from OpenWrt 19.07
+	},
+})
+
 -- devolo
 
 device('devolo-wifi-pro-1200e', 'devolo_dvl1200e', {


### PR DESCRIPTION
> Note: Buffalo has introduced hardware changes without bumping the
> revision number. 19.07 did not support the rb-variant so there's no need
> to implement a migration for the rb-variant.
> Every g300nh supported by Gluon should either be the s-variant or
> been flashed wrongly.
> 
> Gone due to
> commit 45c84a117bf8 ("ar71xx: drop target")

@kpanic23 wrote earlier today he'd intend to test this

- ~~Must be flashable from vendor firmware~~ **wont test**
  - ~~Web interface~~
  - ~~TFTP~~
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~