### PR TITLE
ath79-nand: (re)add hiveap-121

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -139,6 +139,10 @@ ath79-generic
 ath79-nand
 ----------
 
+* Aerohive
+
+  - HiveAP 121
+
 * GL.iNet
 
   - GL-AR300M

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -9,6 +9,11 @@ local ATH10K_PACKAGES_QCA9887 = {
 local ATH10K_PACKAGES_QCA9888 = {}
 
 
+-- Aerohive
+
+device('aerohive-hiveap-121', 'aerohive_hiveap-121')
+
+
 -- GL.iNet
 
 device('gl.inet-gl-ar300m-nor', 'glinet_gl-ar300m-nor', {


### PR DESCRIPTION
> ath79-nand: (re)add hiveap-121
>     
>     Gone due to
>     commit 45c84a117bf8 ("ar71xx: drop target")

> ath79-nand: add vendor to GL.iNet devices

@kpanic23 intends to test this device starting monday.

- [x] Must be flashable from vendor firmware
  - ~~Web interface~~
  - ~~TFTP~~
  - ~~Other: install via serial, and load via tftp following the commit message https://github.com/openwrt/openwrt/commit/62db255543c8fb5d1787caf36c6c7c9c51db71cd~~
  - [x] Other other: In case the bootloader does not allow regular flashing, it does allow flashing these ancient initramfs files: https://github.com/riptidewave93/LEDE-HiveAP-121 (in Releases)
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~ none
    - ~~Should map to their respective radio~~
    - ~~Should show activity~~
  - ~~Switch port LEDs~~ has none
    - ~~Should map to their respective port (or switch, if only one led present)~~
    - ~~Should show link state and activity~~
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
