### PR TITLE
ath79-nand: (re)add WNDR4300v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -146,6 +146,7 @@ ath79-nand
 * Netgear
 
   - WNDR3700 (v4)
+  - WNDR4300 (v1)
 
 ath79-mikrotik
 --------------

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -33,6 +33,10 @@ device('netgear-wndr3700-v4', 'netgear_wndr3700-v4', {
 	},
 })
 
+device('netgear-wndr4300', 'netgear_wndr4300', {
+	factory_ext = '.img',
+})
+
 
 -- ZTE
 


### PR DESCRIPTION
> Gone due to
> commit 45c84a1 ("ar71xx: drop target")

~~"alexp" from hackint#ffda intends to test this device.~~

- Must be flashable from vendor firmware
  - ~~Web interface~~
  - ~~TFTP~~
  - Other: https://github.com/jclehner/nmrpflash
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~