### PR TITLE
rampis-mt7621: add support for Cudy WR2100

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -291,6 +291,10 @@ ramips-mt7621
 
   - RT-AC57U
 
+* Cudy
+
+  - WR2100
+
 * D-Link
 
   - DIR-860L (B1)

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -5,6 +5,13 @@ device('asus-rt-ac57u', 'asus_rt-ac57u', {
 })
 
 
+-- Cudy
+
+device('cudy-wr2100', 'cudy_wr2100', {
+        factory = false,
+})
+
+
 -- D-Link
 
 device('d-link-dir-860l-b1', 'dlink_dir-860l-b1')


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: Flash official OpenWrt image of cudy website first, then sysupgrade via Webinterface is possible
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs (None available)
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`