### PR TITLE
ramips-mt7621: add support for Netgear R6260

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -304,6 +304,7 @@ ramips-mt7621
 
   - EX6150 (v1)
   - R6220
+  - R6260
   - WAC104
 
 * TP-Link

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -27,6 +27,10 @@ device('netgear-r6220', 'netgear_r6220', {
 	factory_ext = '.img',
 })
 
+device('netgear-r6260', 'netgear_r6260', {
+	factory_ext = '.img',
+})
+
 device('netgear-wac104', 'netgear_wac104', {
 	factory_ext = '.img',
 })


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [X] Web interface
  - [ ] TFTP
  - [X] Other: nmrpflash
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`


~~it seems there is still  a problem, and Cudy WR2100 doesn't have this problem despite it having exactly the same wifi chips.
the 802.11s mesh does not work immediately, though after a while it suddenly starts working, which confuses me...~~
this issue currently affects all devices due to openwrt commit [33df033b73365487c5bb5a58b77aed04d4ca6ac1](https://github.com/openwrt/openwrt/commit/33df033b73365487c5bb5a58b77aed04d4ca6ac1) which was introduced in Gluons openwrt bump 52d4ae5ad71fb8d9a96acb0f48486d9a57f8facd #2545