### PR TITLE
rampis-mt7621: add support for Netgear WAC104

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -299,6 +299,7 @@ ramips-mt7621
 
   - EX6150 (v1)
   - R6220
+  - WAC104
 
 * TP-Link
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -67,6 +67,10 @@ elseif platform.match('lantiq') then
 			break
 		end
 	end
+elseif platform.match('ramips', 'mt7621', {
+	'netgear,wac104',
+}) then
+	lan_ifname, wan_ifname = 'lan2 lan3 lan4', 'lan1'
 end
 
 if wan_ifname and lan_ifname then

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -20,6 +20,10 @@ device('netgear-r6220', 'netgear_r6220', {
 	factory_ext = '.img',
 })
 
+device('netgear-wac104', 'netgear_wac104', {
+	factory_ext = '.img',
+})
+
 device('netgear-wndr3700-v5', 'netgear_wndr3700-v5', {
 	factory = false,
 	broken = true, -- untested


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [X] Web interface
  - [ ] TFTP
  - [X] Other: nmrpflash
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`