### PR TITLE
ath79-generic: add support for CPE710v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -90,6 +90,7 @@ ath79-generic
   - CPE510 (v1.0, v1.1)
   - CPE510 (v2.0)
   - CPE510 (v3.0)
+  - CPE710 (v1.0)
   - EAP225-Outdoor (v1)
   - TL-WDR3500 (v1)
   - TL-WDR3600 (v1)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -34,6 +34,7 @@ function M.is_outdoor_device()
 		'tplink,cpe510-v1',
 		'tplink,cpe510-v2',
 		'tplink,cpe510-v3',
+		'tplink,cpe710-v1',
 		'tplink,eap225-outdoor-v1',
 		'tplink,wbs210-v1',
 		'tplink,wbs210-v2',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -381,6 +381,8 @@ device('tp-link-cpe510-v1', 'tplink_cpe510-v1', {
 device('tp-link-cpe510-v2', 'tplink_cpe510-v2')
 device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
 
+device('tp-link-cpe710-v1', 'tplink_cpe710-v1')
+
 device('tp-link-eap225-outdoor-v1', 'tplink_eap225-outdoor-v1', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })


### PR DESCRIPTION
Works like a charm, ready to review.

- [x] Must be flashable from vendor firmware
  - ~~Web interface~~ **OpenWrt commit says 'should work' but did not for me**
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence **LAN LED is assigned to do that**
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`