### PR TITLE
openwrt: revert mesh-breaking commit

### DIFF
--- a/patches/openwrt/0004-Revert-mac80211-add-a-bug-fix-for-a-rare-crash.patch
+++ b/patches/openwrt/0004-Revert-mac80211-add-a-bug-fix-for-a-rare-crash.patch
@@ -1,0 +1,53 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 18 Jun 2022 03:01:39 +0200
+Subject: Revert "mac80211: add a bug fix for a rare crash"
+
+This reverts commit 33df033b73365487c5bb5a58b77aed04d4ca6ac1.
+
+This commit was reported to break 11s meshing, thus breaking mesh-links
+upon upgrade.
+
+diff --git a/package/kernel/mac80211/patches/subsys/328-mac80211-do-not-wake-queues-on-a-vif-that-is-being-s.patch b/package/kernel/mac80211/patches/subsys/328-mac80211-do-not-wake-queues-on-a-vif-that-is-being-s.patch
+deleted file mode 100644
+index f0150ddef0ba6082f35c80e4653d6dbf3a1a7c54..0000000000000000000000000000000000000000
+--- a/package/kernel/mac80211/patches/subsys/328-mac80211-do-not-wake-queues-on-a-vif-that-is-being-s.patch
++++ /dev/null
+@@ -1,38 +0,0 @@
+-From: Felix Fietkau <nbd@nbd.name>
+-Date: Sat, 26 Mar 2022 23:58:35 +0100
+-Subject: [PATCH] mac80211: do not wake queues on a vif that is being stopped
+-
+-When a vif is being removed and sdata->bss is cleared, __ieee80211_wake_txqs
+-can still be called on it, which crashes as soon as sdata->bss is being
+-dereferenced.
+-To fix this properly, check for SDATA_STATE_RUNNING before waking queues,
+-and take the fq lock when setting it (to ensure that __ieee80211_wake_txqs
+-observes the change when running on a different CPU
+-
+-Signed-off-by: Felix Fietkau <nbd@nbd.name>
+----
+-
+---- a/net/mac80211/iface.c
+-+++ b/net/mac80211/iface.c
+-@@ -377,7 +377,9 @@ static void ieee80211_do_stop(struct iee
+- 	bool cancel_scan;
+- 	struct cfg80211_nan_func *func;
+- 
+-+	spin_lock_bh(&local->fq.lock);
+- 	clear_bit(SDATA_STATE_RUNNING, &sdata->state);
+-+	spin_unlock_bh(&local->fq.lock);
+- 
+- 	cancel_scan = rcu_access_pointer(local->scan_sdata) == sdata;
+- 	if (cancel_scan)
+---- a/net/mac80211/util.c
+-+++ b/net/mac80211/util.c
+-@@ -301,6 +301,9 @@ static void __ieee80211_wake_txqs(struct
+- 	local_bh_disable();
+- 	spin_lock(&fq->lock);
+- 
+-+	if (!test_bit(SDATA_STATE_RUNNING, &sdata->state))
+-+		goto out;
+-+
+- 	if (sdata->vif.type == NL80211_IFTYPE_AP)
+- 		ps = &sdata->bss->ps;
+- 


### PR DESCRIPTION
This commit reportedly breaks 11s meshing, rendering mesh-only nodes
useless.

Fixes #2559

Signed-off-by: David Bauer <mail@david-bauer.net>