### PR TITLE
Ath79 migrate ubnt loco m5 xw

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -104,7 +104,7 @@ ath79-generic
 * Ubiquiti
 
   - NanoBeam M5 (XW)
-  - NanoStation Loco M2 (XW)
+  - NanoStation Loco M2/M5 (XW)
   - NanoStation M2/M5 (XW)
   - UniFi AC Lite
   - UniFi AC LR

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -429,6 +429,7 @@ device('tp-link-wbs210-v2', 'tplink_wbs210-v2')
 device('ubiquiti-nanostation-loco-m-xw', 'ubnt_nanostation-loco-m-xw', {
 	manifest_aliases = {
 		'ubiquiti-nanostation-loco-m2-xw', -- upgrade from OpenWrt 19.07
+		'ubiquiti-nanostation-loco-m5-xw', -- upgrade from OpenWrt 19.07
 	},
 })
 


### PR DESCRIPTION
@Noodlesalat intends to test this.


- [x] Must be flashable from vendor firmware
  - ~~Web interface~~
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs **do not exist, rssi works**
    - ~~Should map to their respective radio~~
    - ~~Should show activity~~
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`