### PR TITLE
ipq40xx: Add support for GL.iNet GL-AP1300

### DIFF
--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -56,6 +56,13 @@ device('engenius-ens620ext', 'engenius_ens620ext', {
 
 -- GL.iNet
 
+device('gl.inet-gl-ap1300', 'glinet_gl-ap1300', {
+	factory = '-squashfs-nand-factory',
+	factory_ext = '.ubi',
+	sysupgrade = '-squashfs-nand-sysupgrade',
+	sysupgrade_ext = '.bin',
+})
+
 device('gl.inet-gl-b1300', 'glinet_gl-b1300', {
 	factory = false,
 })


### PR DESCRIPTION
[Map Link](https://map.freifunk-nordhessen.de/#!/de/map/9483c41b0051)

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [ ] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios 
  - [ ] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [ ] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - (not applicable) Should map to their respective radio
    - (not applicable)Should show activity
  - Switch port LEDs
    - (not applicable) Should map to their respective port (or switch, if only one led present) 
    - (not applicable) Should show link state and activity
- Outdoor devices only:
  -  (not applicable) Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`


Hi,
this is a draft pull request to track the state.
## Summary
- RAM: 256MB
- FLASH: 4MB NOR + 128MB NAND
- ETH: 1x WAN (PoE) + 1x LAN port
- mini PCIe connector
[Source](https://docs.gl-inet.com/en/3/specification/gl-ap1300/)

## To solve:
- [ ] Primary MAC address does not match label: Is: 94:83:c4:1b:00:8d instead of 94:83:c4:1b:00:8b

## Nice-to-have:
- [ ] Let "World"-LED represent the WAN-Connection-Status