### PR TITLE
mediatek-mt7622: add support for Xiaomi AX3200

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -230,6 +230,10 @@ mediatek-mt7622
 
   - UniFi 6 LR
 
+* Xiaomi
+
+  - AX3200 (RB03)
+
 mpc85xx-p1010
 -------------
 

--- a/targets/mediatek-mt7622
+++ b/targets/mediatek-mt7622
@@ -1,3 +1,10 @@
 device('ubiquiti-unifi-6-lr', 'ubnt_unifi-6-lr', {
 	factory = false,
 })
+
+-- Xiaomi
+
+device('xiaomi-redmi-router-ax6s', 'xiaomi_redmi-router-ax6s', {
+	factory = false,
+})
+


### PR DESCRIPTION
- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: 
                   https://openwrt.org/toh/xiaomi/ax3200#installation
                   https://forum.openwrt.org/t/adding-openwrt-support-for-xiaomi-redmi-router-ax6s-xiaomi-router-ax3200/111085/513
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs (None available)
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) (Only WAN Port)
    - [X] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`