### PR TITLE
Fix make lint

### DIFF
--- a/contrib/actions/run-build.sh
+++ b/contrib/actions/run-build.sh
@@ -6,7 +6,7 @@ export BROKEN=1
 export GLUON_AUTOREMOVE=1
 export GLUON_DEPRECATED=1
 export GLUON_SITEDIR="contrib/ci/minimal-site"
-export GLUON_TARGET=$1
+export GLUON_TARGET="$1"
 export BUILD_LOG=1
 
 make update

--- a/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
+++ b/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
@@ -37,7 +37,7 @@ proto_gluon_bat0_renew() {
 proto_gluon_bat0_setup() {
 	local config="$1"
 
-	local routing_algo=$(lookup_site 'mesh.batman_adv.routing_algo' 'BATMAN_IV')
+	local routing_algo="$(lookup_site 'mesh.batman_adv.routing_algo' 'BATMAN_IV')"
 
 	local gw_mode
 	json_get_vars gw_mode

--- a/package/gluon-setup-mode/files/usr/bin/gluon-enter-setup-mode
+++ b/package/gluon-setup-mode/files/usr/bin/gluon-enter-setup-mode
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -euo pipefail
+set -eu
 
 echo "Entering setup mode and rebooting..."
 uci set gluon-setup-mode.@setup_mode[0].enabled='1'


### PR DESCRIPTION
`make lint` throws three errors, this should fix it.

I think `gluon-enter-setup-mode` never had `pipefail`-support, if we want to change that, I could implement that as well, but I suppose it's not necessary int this case, as its output appears to be not evaluated.