### PR TITLE
gluon-l3roamd: site: make node_client_prefix6 optional+deprecated

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -49,10 +49,13 @@ node_prefix6
 
     node_prefix6 = 'fdca::ffee:babe:2::/64'
 
-node_client_prefix6
-  The ipv6 prefix from which the client-specific IP-address is calculated that
-  is assigned to each node by l3roamd to allow efficient communication when 
-  roaming. This is exclusively useful when running a routing mesh protocol
+node_client_prefix6 \: optional, deprecated
+  DEPRECATED: Don't specify it anymore, this prefix will then
+  automatically be generated from the domain_seed.
+
+  An IPv6 prefix internally used by the l3roamd protocol, used to allow
+  an efficient handover via unicast when a client roamed.
+  This is exclusively useful when running a routing mesh protocol
   like babel. e.g. ::
 
     node_client_prefix6 = 'fdca::ffee:babe:3::/64'

--- a/package/gluon-l3roamd/Makefile
+++ b/package/gluon-l3roamd/Makefile
@@ -6,7 +6,7 @@ include ../gluon.mk
 
 define Package/gluon-l3roamd
   TITLE:=Configure l3roamd for babel
-  DEPENDS:=+gluon-core +l3roamd +uc
+  DEPENDS:=+gluon-core +gluon-mesh-layer3-common +l3roamd +uc
 endef
 
 $(eval $(call BuildPackageGluon,gluon-l3roamd))

--- a/package/gluon-l3roamd/check_site.lua
+++ b/package/gluon-l3roamd/check_site.lua
@@ -1,1 +1,0 @@
-need_string_match(in_domain({'node_client_prefix6'}), '^[%x:]+/64$', false)

--- a/package/gluon-l3roamd/files/etc/init.d/gluon-l3roamd
+++ b/package/gluon-l3roamd/files/etc/init.d/gluon-l3roamd
@@ -43,7 +43,7 @@ start_service () {
 	local prefix4="$(lua -e 'prefix4 = require("gluon.site").prefix4() if prefix4 then print(" -p " .. prefix4) end')"
 	local prefix6="$(lua -e 'print(" -p " .. require("gluon.site").prefix6())')"
 	local localip="$(uci get network.loopback.ip6addr | cut -d/ -f1)"
-	local roamingprefix="$(lua -e 'roamingprefix = require("gluon.site").node_client_prefix6() if roamingprefix then print(" -P " .. roamingprefix) end')"
+	local roamingprefix="$(lua -e 'print(" -P " .. require("gluon.l3").node_client_prefix6())')"
 
 	/sbin/sysctl -w net.ipv6.neigh.default.gc_thresh1=2
 	/sbin/sysctl -w net.ipv4.neigh.default.gc_thresh1=2

--- a/package/gluon-mesh-babel/check_site.lua
+++ b/package/gluon-mesh-babel/check_site.lua
@@ -1,5 +1,4 @@
 need_string_match(in_domain({'node_prefix6'}), '^[%x:]+/64$')
-need_string_match(in_domain({'node_client_prefix6'}), '^[%x:]+/64$')
 
 need_string_match(in_domain({'next_node', 'ip6'}), '^[%x:]+$', false)
 need_string_match(in_domain({'next_node', 'ip4'}), '^%d+.%d+.%d+.%d+$', false)

--- a/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
+++ b/package/gluon-mesh-babel/luasrc/lib/gluon/upgrade/300-gluon-mesh-babel-mkconfig
@@ -1,6 +1,7 @@
 #!/usr/bin/lua
 
 local site = require 'gluon.site'
+local l3 = require 'gluon.l3'
 local uci = require('simple-uci').cursor()
 local nodeip = uci:get('network', 'loopback', 'ip6addr'):match('^[^/]+')
 local babelconf='/etc/gluon-babeld.conf'
@@ -14,7 +15,7 @@ file:write("import-table 254\n")
 file:write("out ip " .. site.next_node.ip6() .. "/128 deny\n")
 file:write("redistribute ip " .. site.next_node.ip6() .. "/128 deny\n")
 file:write("redistribute ip " .. site.prefix6() .. " eq 128  allow\n")
-file:write("redistribute ip " .. site.node_client_prefix6() .. " eq 128  allow\n")
+file:write("redistribute ip " .. l3.node_client_prefix6() .. " eq 128  allow\n")
 file:write("redistribute ip " .. site.node_prefix6() .. " eq 128  allow\n")
 file:write("redistribute ip 2000::/3 allow\n")
 file:write("redistribute local if br-wan deny\n")

--- a/package/gluon-mesh-layer3-common/check_site.lua
+++ b/package/gluon-mesh-layer3-common/check_site.lua
@@ -1,2 +1,2 @@
 need_string_match(in_domain({'node_prefix6'}), '^[%x:]+/64$')
-
+need_string_match(in_domain({'node_client_prefix6'}), '^[%x:]+/64$', false)

--- a/package/gluon-mesh-layer3-common/luasrc/usr/lib/lua/gluon/l3.lua
+++ b/package/gluon-mesh-layer3-common/luasrc/usr/lib/lua/gluon/l3.lua
@@ -1,0 +1,20 @@
+local site = require("gluon.site")
+local util = require("gluon.util")
+
+local M = {}
+
+-- returns a prefix generated from the domain-seed
+-- for l3roamd -P <node-client-prefix>
+function M.node_client_prefix6()
+	local key = "gluon-l3roamd.node_client_prefix6"
+	local prefix = site.node_client_prefix6()
+
+	if not prefix then
+		local prefix_seed = util.domain_seed_bytes(key, 7)
+		prefix = ("fd" .. prefix_seed):gsub(("(%x%x%x%x)"):rep(4), "%1:%2:%3:%4" .. "::/64")
+	end
+
+	return prefix
+end
+
+return M


### PR DESCRIPTION
The site.node_client_prefix6() is only used internally by the l3roamd
protocol. Therefore it is unnecessary to expose it to an administrator.
    
Instead, if node_client_prefix6 is unspecified in the site, generate an
IPv6 Unique Local Address prefix from the site domain_seed.
    
This updates the site documentation as well and marks this setting as
both optional and deprecated.
    
Note: If you had the node_client_prefix6 specified before and want to
use the new autogeneration from the domain_seed instead then this will
break compatibility and will need a gluon-scheduled-domain switch.
    
Signed-off-by: Linus Lüssing \<linus.luessing@c0d3.blue\>