### PR TITLE
lantiq-xrx200: all updates from swconfig to DSA

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -62,16 +62,6 @@ elseif platform.match('ath79', 'generic', {
 	'ubnt,unifiac-pro',
 }) then
 	lan_ifname, wan_ifname = 'eth0.2', 'eth0.1'
-elseif platform.match('lantiq') then
-	local switch_data = board_data.switch or {}
-	local switch0_data = switch_data.switch0 or {}
-	local roles_data = switch0_data.roles or {}
-	for _, role_data in ipairs(roles_data) do
-		if role_data.role == 'wan' then
-			wan_ifname = iface_exists(role_data.device)
-			break
-		end
-	end
 elseif platform.match('ramips', 'mt7621', {
 	'netgear,wac104',
 }) then

--- a/patches/openwrt/0006-lantiq-xrx200-make-DSA-images-swconfig-upgradable.patch
+++ b/patches/openwrt/0006-lantiq-xrx200-make-DSA-images-swconfig-upgradable.patch
@@ -1,0 +1,30 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 5 Jul 2022 23:49:31 +0200
+Subject: lantiq-xrx200: make DSA images swconfig upgradable
+
+diff --git a/target/linux/lantiq/image/tp-link.mk b/target/linux/lantiq/image/tp-link.mk
+index 756105b94c7f844439132ab57837c9ac87d231ca..5563968de9ab3f491fa89d755fcc6e6fff79948f 100644
+--- a/target/linux/lantiq/image/tp-link.mk
++++ b/target/linux/lantiq/image/tp-link.mk
+@@ -1,7 +1,7 @@
+ DEVICE_VARS += TPLINK_FLASHLAYOUT TPLINK_HWID TPLINK_HWREV TPLINK_HWREVADD TPLINK_HVERSION
+ 
+ define Device/dsa-migration
+-  DEVICE_COMPAT_VERSION := 1.1
++  DEVICE_COMPAT_VERSION := 1.0
+   DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
+ endef
+ 
+diff --git a/target/linux/lantiq/image/vr9.mk b/target/linux/lantiq/image/vr9.mk
+index d17045b6db157a878534a28988accd8998ddd572..e83da928e57d827d33bca6bdef96df290bb67347 100644
+--- a/target/linux/lantiq/image/vr9.mk
++++ b/target/linux/lantiq/image/vr9.mk
+@@ -1,7 +1,7 @@
+ DEVICE_VARS += NETGEAR_BOARD_ID NETGEAR_HW_ID
+ 
+ define Device/dsa-migration
+-  DEVICE_COMPAT_VERSION := 1.1
++  DEVICE_COMPAT_VERSION := 1.0
+   DEVICE_COMPAT_MESSAGE := Config cannot be migrated from swconfig to DSA
+ endef
+ 


### PR DESCRIPTION
This PR adds the same workaround to allow older swconfig based Gluon versions to update to OpenWrt 22.03+ based DSA images for the lantiq-xrx200 target.