### PR TITLE
lantiq-xway: remove DSL specific packages

### DIFF
--- a/targets/lantiq-xway
+++ b/targets/lantiq-xway
@@ -1,3 +1,13 @@
+packages {
+	'-kmod-ltq-adsl-ar9-mei',
+	'-kmod-ltq-adsl-ar9',
+	'-kmod-ltq-adsl-ar9-fw-b',
+	'-kmod-ltq-atm-ar9',
+	'-ltq-adsl-app',
+	'-ppp-mod-pppoa',
+	'-kmod-ltq-deu-ar9'
+}
+
 device('avm-fritz-box-7312', 'avm_fritz7312', {
 	factory = false,
 })


### PR DESCRIPTION
Gluon does not support usage of the integrated ADSL modem, thus
DSL-related packages can be removed.

Signed-off-by: David Bauer <mail@david-bauer.net>