### PR TITLE
gluon-core: always store primary MAC address in lowercase hex digits

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -147,7 +147,7 @@ for _, matcher in ipairs(primary_addrs) do
 		if platform.match(unpack(match)) then
 			local addr = f()
 			if addr then
-				sysconfig.primary_mac = addr
+				sysconfig.primary_mac = addr:lower()
 				return
 			end
 		end


### PR DESCRIPTION
Depending on the source of the primary MAC address, uppercase digits
would be used on some devices. Convert the address to lowercase for
consistency.

We only change the case for newly configured nodes to avoid changing the
node ID and derives MAC addresses for existing installations.

The issue was reported in https://github.com/freifunk-gluon/gluon/pull/2406#issuecomment-1094058134.