### PR TITLE
ath79-generic: (re)add Rocket M2/M5 (XM)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -116,6 +116,7 @@ ath79-generic
   - NanoBeam M5 (XW)
   - NanoStation Loco M2/M5 (XW)
   - NanoStation M2/M5 (XW)
+  - Rocket M2/M5 (XM)
   - UniFi AC Lite
   - UniFi AC LR
   - UniFi AC Mesh

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -42,6 +42,7 @@ function M.is_outdoor_device()
 		'ubnt,nanobeam-m5-xw',
 		'ubnt,nanostation-loco-m-xw',
 		'ubnt,nanostation-m-xw',
+		'ubnt,rocket-m',
 		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',
 		'ubnt,unifiac-mesh-pro',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -467,6 +467,14 @@ device('ubiquiti-nanostation-m-xw', 'ubnt_nanostation-m-xw', {
 	},
 })
 
+device('ubiquiti-rocket-m-xm', 'ubnt_rocket-m', {
+	manifest_aliases = {
+		'ubiquiti-rocket-m', -- upgrade from OpenWrt 19.07
+		'ubiquiti-rocket-m2', -- upgrade from OpenWrt 19.07
+		'ubiquiti-rocket-m5', -- upgrade from OpenWrt 19.07
+	},
+})
+
 device('ubiquiti-unifi-ac-lite', 'ubnt_unifiac-lite', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9880,


### PR DESCRIPTION
> Gone due to
> commit 45c84a117bf8 ("ar71xx: drop target")

"nrb" intends to test this device "after sleeping".

- [x] Must be flashable from vendor firmware
  - ~~Web interface~~
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [ ] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity **rssi**
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`