### PR TITLE
ath79-generic: (re)add support for ALFA Network AP121F

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -4,6 +4,10 @@ Supported Devices & Architectures
 ath79-generic
 --------------
 
+* ALFA Network
+
+  - AP121F
+
 * AVM
 
   - FRITZ!WLAN Repeater 300E [#avmflash]_

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S96led
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S96led
@@ -12,6 +12,9 @@ start() {
 	if [ -z $status_led ]; then
 		status_led="$running"
 	fi
+	if [ -z $status_led ]; then
+		status_led="$boot"
+	fi
 
 	status_led_set_timer 1000 300
 }

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -16,6 +16,12 @@ local ATH10K_PACKAGES_QCA9887 = {
 
 local ATH10K_PACKAGES_QCA9888 = {}
 
+-- ALFA NETWORK
+
+device('alfa-network-ap121f', 'alfa-network_ap121f', {
+	factory = false,
+})
+
 -- AVM
 
 device('avm-fritz-box-4020', 'avm_fritz4020', {


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
    - u-boot web based recovery, accepts sysupgrade image: https://openwrt.org/toh/alfa_network/ap121f#recovery_through_u-boot
  - [ ] TFTP
    - should be available, but untested
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [ ] Lit while the device is on
      - N/A, no "led-running" assigned in DTS, LED with "V" icon reserved for VPN status
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
      - Yes, on LED with "V" icon (via led-boot fallback in Gluon)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
    - N/A, indoor, mini USB travel router