### PR TITLE
docs/features/wired-mesh: update to role-based configuration

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -414,6 +414,8 @@ mesh_vpn
       },
     }
 
+.. _user-site-interfaces:
+
 interfaces \: optional
   Default setup for Ethernet ports.
   ::


### PR DESCRIPTION
> - explain what happens on gluon-reconfigure
> - show workflow to alter the wired network config
> - update examples
> - update 'has changed in' section
> 
> resolves #2474 

@herbetom lets take this as a first draft. Let me know what you're missing or'd like to have changed.