### PR TITLE
ramips-mt7620: add support for xiaomi_mi-router-3g-v2

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -359,6 +359,7 @@ ramips-mt7621
 * Xiaomi
 
   - Xiaomi Mi Router 4A (Gigabit Edition)
+  - Xiaomi Mi Wi-Fi Router 3G v2
 
 ramips-mt76x8
 -------------

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -359,7 +359,7 @@ ramips-mt7621
 * Xiaomi
 
   - Xiaomi Mi Router 4A (Gigabit Edition)
-  - Xiaomi Mi Wi-Fi Router 3G v2
+  - Xiaomi Mi Router 3G v2
 
 ramips-mt76x8
 -------------

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -60,6 +60,10 @@ device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {
 	factory = false,
 })
 
+device('xiaomi-mi-router-3g-v2', 'xiaomi_mi-router-3g-v2', {
+	factory = false,
+})
+
 
 -- ZBT
 


### PR DESCRIPTION
The `Xiaomi Mi Wi-Fi Router 3G v2` is basically the same as `Xiaomi Mi Router 4A (Gigabit Edition)`, only the bootloader is different

- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: https://github.com/acecilia/OpenWRTInvasion/blob/master/README.md
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Not available
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`