### PR TITLE
web-admin: always ignore minor compat-version on upgrade

### DIFF
--- a/package/gluon-web-admin/luasrc/lib/gluon/config-mode/controller/admin/upgrade.lua
+++ b/package/gluon-web-admin/luasrc/lib/gluon/config-mode/controller/admin/upgrade.lua
@@ -17,6 +17,7 @@ local unistd = require 'posix.unistd'
 
 local file
 local tmpfile = "/tmp/firmware.img"
+local compat_option = "--ignore-minor-compat-version"
 
 
 local function filehandler(_, chunk, eof)
@@ -64,7 +65,7 @@ local function action_upgrade(http, renderer)
 	end
 
 	local function image_supported(supported_tmpfile)
-		return (os.execute(string.format("exec /sbin/sysupgrade -T %q >/dev/null", supported_tmpfile)) == 0)
+		return (os.execute(string.format("exec /sbin/sysupgrade -T %s %q >/dev/null", compat_option, supported_tmpfile)) == 0)
 	end
 
 	local function storage_size()
@@ -122,7 +123,7 @@ local function action_upgrade(http, renderer)
 		}, 'gluon-web-admin')
 
 	elseif step == 3 then
-		local cmd = {[0] = '/sbin/sysupgrade', tmpfile}
+		local cmd = {[0] = '/sbin/sysupgrade', compat_option, tmpfile}
 		if http:formvalue('keepcfg') ~= '1' then
 			table.insert(cmd, 1, '-n')
 		end


### PR DESCRIPTION
This implements the same behavior as it is used in the autoupdater [1].

This is for example required to allow the manual installation of
firmware upgrades via the config mode on devices which where migrated
from swconfig to DSA. Otherwise the image will always be invalid.

[1] https://github.com/freifunk-gluon/packages/commit/b80428166454d184f356e5a14a144911d9ee11aa