### PR TITLE
ramips-mt76x8: add support for Xiaomi Mi Router 4A (100M International Edition)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -401,6 +401,7 @@ ramips-mt76x8
 * Xiaomi
 
   - Xiaomi Mi Router 4A (100M Edition)
+  - Xiaomi Mi Router 4A (100M International Edition)
   - Xiaomi Mi Router 4C
 
 rockchip-armv8

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -104,6 +104,10 @@ device('xiaomi-mi-router-4a-100m-edition', 'xiaomi_mi-router-4a-100m', {
 	factory = false,
 })
 
+device('xiaomi-mi-router-4a-100m-international-edition', 'xiaomi_mi-router-4a-100m-intl', {
+	factory = false,
+})
+
 device('xiaomi-mi-router-4c', 'xiaomi_mi-router-4c', {
 	factory = false,
 })


### PR DESCRIPTION
The following Tests were done by hdvalentin out of the FFRN community:


- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: via [OpenWRTInvasion](https://github.com/acecilia/OpenWRTInvasion) and then telnet
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [ , x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name: `xiaomi-mi-router-4a-100m-international-edition`
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [ x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on (orange)
    - [x] Should display config mode blink sequence (system LED blinks blue)
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio (system LED turns from orange into blue)
    - [no] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) No leds on the ports, one led shows activity at wan port
    - [x] Should show link state and activity, (only wan)
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`