### PR TITLE
gluon-mesh-vpn-fastd: fix respondd segfault under load

### DIFF
--- a/package/gluon-mesh-vpn-fastd/src/respondd.c
+++ b/package/gluon-mesh-vpn-fastd/src/respondd.c
@@ -65,7 +65,7 @@ static struct json_object * get_fastd_version(void) {
 	}
 
 	const char *version = line;
-	if (strncmp(version, "fastd ", 6) == 0)
+	if (version && strncmp(version, "fastd ", 6) == 0)
 		version += 6;
 
 	struct json_object *ret = gluonutil_wrap_string(version);


### PR DESCRIPTION
When running "fastd -v" fails, line may be NULL, causing a segfault in
strncmp.