### PR TITLE
targets/lantiq-xrx200: add device Arcadyan VGV7510KW22 aka o2 Box 6431

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -238,6 +238,10 @@ ipq806x-generic
 lantiq-xrx200
 -------------
 
+* Arcadyan
+
+  - VGV7510KW22 (o2 Box 6431)
+
 * AVM
 
   - FRITZ!Box 7360 (v1, v2) [#avmflash]_ [#lan_as_wan]_

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -87,6 +87,9 @@ local primary_addrs = {
 		{'ipq806x', 'generic', {
 			'netgear,r7800',
 		}},
+		{'lantiq', 'xrx200', {
+			'arcadyan,vgv7510kw22-nor',
+		}},
 		{'lantiq', 'xway', {
 			'netgear,dgn3500b',
 		}},

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -67,6 +67,10 @@ elseif platform.match('ramips', 'mt7621', {
 	'netgear,wac104',
 }) then
 	lan_ifname, wan_ifname = 'lan2 lan3 lan4', 'lan1'
+elseif platform.match('lantiq', 'xrx200', {
+	'arcadyan,vgv7510kw22-nor',
+}) then
+	lan_ifname, wan_ifname = 'lan1 lan2 lan3 lan4', 'wan'
 elseif platform.match('realtek', 'rtl838x', {
 	'd-link,dgs-1210-10p',
 }) then

--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -47,6 +47,11 @@ device('avm-fritz-box-7412', 'avm_fritz7412', {
 	factory = false,
 })
 
+device('arcadyan-vgv7510kw22', 'arcadyan_vgv7510kw22-nor', {
+	factory = false,
+	aliases = {'o2-box-6431'},
+})
+
 -- TP-Link
 
 -- CAVEAT: These devices don't have a dedicated WAN port.


### PR DESCRIPTION
I have this device working and would like to integrate it into Gluon upstream

- [x] Must be flashable from vendor firmware
  - [x] Web interface (@maurerle - hidden interface on boot - see here https://forum.openwrt.org/t/installing-lede-u-boot-via-brnboot-web-interface-without-rs232/9857/6)
  - [x] Other:  serial (some people connect the serial without opening the case) in combination with tftp worked for @4ludwig4 (updated openwrt wiki for this device: https://openwrt.org/toh/arcadyan/vgv7510kw22) but there are also reports that people got it working without using the serial port.
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - DSL/WAN port works with LED: https://github.com/openwrt/openwrt/pull/11594
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity (https://github.com/openwrt/openwrt/pull/11749)
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
    - this works very good

~~The LEDs for WLAN, Internet, Info are not active. Power-LED and plugged in LAN cables are working correctly, so this seems to be the only open issue.
Of course, if someone has the idea for the LAN-Ports I am all ears but otherwise I'd like to have upstream support for this device :)~~

Original thread: https://github.com/freifunk-gluon/gluon/pull/2006


Update 24.01.2023: as the two OpenWRT PRs are now merged, backported to openwrt-22.03 branch and merged into gluon-master - all open issues are fixed and this device can get proper support :)