### PR TITLE
gluon-core: fix missing ifname for mesh_radio networks in uci

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -129,6 +129,7 @@ local function configure_mesh(config, radio, index, suffix, disabled)
 
 	uci:section('network', 'interface', name, {
 		proto = 'gluon_mesh',
+		ifname = suffix and 'mesh' .. suffix,
 	})
 
 	uci:section('wireless', 'wifi-iface', name, {


### PR DESCRIPTION
Before this comit, the networks in /etc/config/network looked like this:

	config interface 'mesh_radio0'
        	option proto 'gluon_mesh'

After this patch, the networks look like this:

	config interface 'mesh_radio0'
	        option proto 'gluon_mesh'
        	option ifname 'mesh0'

Especially, this fixes a regression bug, that the "wifi" section in the
respondd request type "neighbours" was empty:

	~# gluon-neighbour-info -d ::1 -r neighbours | ffh_pretty_json
	{
	  "wifi": [
	  ],
	  ...
	}

After this commit, the section (correctly) looks like this:

	root@UFU-FWH-A272-Tresckowstr-GemR-vorne:~# gluon-neighbour-info -d ::1 -r neighbours | ffh_pretty_json
	{
	  "wifi": {
	    "ca:38:7e:42:5f:21": {
	      "neighbours": {
	        "fe:9f:4d:01:ea:e1": {
	          "noise": -102,
	          "inactive": 50,
	          "signal": -84
	        },
	        "fe:df:b9:84:37:51": {
	          "noise": -102,
	          "inactive": 20,
	          "signal": -73
	        }
	      }
	    }
	  },
	  ...
	}

The corresponding code can be found here: https://github.com/freifunk-gluon/gluon/blob/master/package/gluon-respondd/src/respondd-neighbours.c#L99-L101