### PR TITLE
gluon-respondd: fix missing section "wifi" for request type "neighbours"

### DIFF
--- a/package/gluon-respondd/src/respondd-neighbours.c
+++ b/package/gluon-respondd/src/respondd-neighbours.c
@@ -82,18 +82,18 @@ static struct json_object * get_wifi(void) {
 	struct json_object *ret = json_object_new_object();
 
 	struct uci_package *p;
-	if (uci_load(ctx, "network", &p))
+	if (uci_load(ctx, "wireless", &p))
 		goto end;
 
 
 	struct uci_element *e;
 	uci_foreach_element(&p->sections, e) {
 		struct uci_section *s = uci_to_section(e);
-		if (strcmp(s->type, "interface"))
+		if (strcmp(s->type, "wifi-iface"))
 			continue;
 
-		const char *proto = uci_lookup_option_string(ctx, s, "proto");
-		if (!proto || strcmp(proto, "gluon_mesh"))
+		const char *proto = uci_lookup_option_string(ctx, s, "mode");
+		if (!proto || strcmp(proto, "mesh"))
 			continue;
 
 		const char *ifname = uci_lookup_option_string(ctx, s, "ifname");


### PR DESCRIPTION
The below mentioned commit introduced a regression, that the "wifi"
section of the request type "neighbours" was empty:

    ~# gluon-neighbour-info -d ::1 -r neighbours | ffh_pretty_json
    {
      "wifi": [
      ],
      ...
    }

After this commit, the section (correctly) looks like this:

    root@UFU-FWH-A272-Tresckowstr-GemR-vorne:~# gluon-neighbour-info -d ::1 -r neighbours | ffh_pretty_json
    {
      "wifi": {
        "ca:38:7e:42:5f:21": {
          "neighbours": {
            "fe:9f:4d:01:ea:e1": {
              "noise": -102,
              "inactive": 50,
              "signal": -84
            },
            "fe:df:b9:84:37:51": {
              "noise": -102,
              "inactive": 20,
              "signal": -73
            }
          }
        }
      },
      ...
    }

The issue was due to the fact, that the iteration over the (mesh) wifi interfaces
was broken. The code was assuming, that the section

    config interface 'mesh_radio0'
            option proto 'gluon_mesh'

in /etc/config/network contains an option "ifname", which it does not.
The ifname property is only stored in the corresponding section in
/etc/config/wireless:

    config wifi-iface 'mesh_radio0'
            option ifname 'mesh0'
            option network 'mesh_radio0'
            option mode 'mesh'
            ...

Therefore, we now iterate over wifi-ifaces in /etc/config/wireless, that
have the mode 'mesh' instead. This resolves the issue.

Fixes 0f1fa243f781ee5eef9ed4bc1b3c5397136ac2da