### PR TITLE
gluon-core: enable bridge port isolation for br-mesh_other interfaces

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/210-interface-mesh
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/210-interface-mesh
@@ -33,6 +33,14 @@ if #mesh_interfaces_other > 0 then
 	else
 		iftype = 'bridge'
 		ifname = mesh_interfaces_other
+
+		for _, iface in ipairs(ifname) do
+			uci:section('network', 'device', nil, {
+				name = iface,
+				isolate = true,
+			})
+		end
+
 	end
 
 	uci:section('network', 'interface', 'mesh_other', {


### PR DESCRIPTION
This is an alternative approach to #2484.

It sets the `isolate` option for all mesh devices via uci and let's netifd handle the low level stuff.

The script is run on every gluon-reconfigure.

### Where it should and shouldn't work:

Isolation should be enabled when there are multiple (non-`uplink`) `mesh` Interfaces.

For devices which were already ported to **DSA** isolation is enabled for all indiviual Ports on that device.

For devices which are still configured via **swconfig** isolation between indivial physical ports isn't possible. 

On all devices isolation should be enabled between `mesh` VLANs and of course between those VLANs and phyiscal `mesh` Ports.

### Commands

Show whether it's activated:

```
grep ^ /sys/devices/virtual/net/br-mesh*/brif/*/isolated
```

1 means it's enabled fo that interface, 0 that it's diabled. 