### PR TITLE
ath79-generic: (re)add support for Ocedo Koala

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -60,6 +60,7 @@ ath79-generic
 
 * OCEDO
 
+  - Koala
   - Raccoon
 
 * Onion

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -175,6 +175,11 @@ device('netgear-wnr2200-16m', 'netgear_wnr2200-16m', {
 
 -- OCEDO
 
+device('ocedo-koala', 'ocedo_koala', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('ocedo-raccoon', 'ocedo_raccoon', {
 	factory = false,
 })


### PR DESCRIPTION
> Gone due to
> commit 45c84a117bf8 ("ar71xx: drop target")

@blocktrron intends to test this device