### PR TITLE
gluon-core: increase ath10k peer limit

### DIFF
--- a/package/gluon-core/files/etc/hotplug.d/firmware/20-gluon-ath10k-fwcfg
+++ b/package/gluon-core/files/etc/hotplug.d/firmware/20-gluon-ath10k-fwcfg
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+[ -e "/lib/firmware/$FIRMWARE" ] && exit 0
+
+case "$FIRMWARE" in
+ath10k/fwcfg*)
+	cp "/lib/gluon/ath10k-fwcfg.txt" "/lib/firmware/$FIRMWARE"
+	;;
+esac

--- a/package/gluon-core/files/lib/gluon/ath10k-fwcfg.txt
+++ b/package/gluon-core/files/lib/gluon/ath10k-fwcfg.txt
@@ -1,0 +1,4 @@
+vdevs = 4
+peers = 96
+active_peers = 96
+stations = 96


### PR DESCRIPTION
Increase the peer limit for ath10k-ct from 32 to 96 STAs like it is set
for the non-ct firmware / driver. In order to make this work with the
memory constraints of the wireless platform, reduce the number of
concurrent vdevs to the maximum Gluon uses (4).

Closes #2604

Signed-off-by: David Bauer <mail@david-bauer.net>