### PR TITLE
gluon-core: provide migration for preserve_channels

### DIFF
--- a/docs/features/wlan-configuration.rst
+++ b/docs/features/wlan-configuration.rst
@@ -19,7 +19,7 @@ During upgrades the wifi channel of the 2.4GHz and 5GHz radio will be restored t
 configured in the site.conf. If you need to preserve a user defined wifi channel during upgrades
 you can configure this via the uci section ``gluon-core.wireless``::
 
-  uci set gluon-core.@wireless[0].preserve_channels='1'
+  uci set gluon.wireless.preserve_channels='1'
 
 When channels should be preserved, toggling the outdoor mode will have no effect on the channel settings.
 Therefore, the Outdoor mode settings won't be displayed in config mode.

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/190-preserve-wireless-channels
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/190-preserve-wireless-channels
@@ -1,0 +1,23 @@
+#!/usr/bin/lua
+
+local wireless = require 'gluon.wireless'
+local uci = require('simple-uci').cursor()
+
+local preserve_channels = wireless.preserve_channels(uci)
+
+-- Migrate preserve channels from pre-2022.01
+local core_wireless = uci:get_first('gluon-core', 'wireless')
+if core_wireless ~= nil then
+	local preserve_legacy = uci:get_bool('gluon-core', core_wireless, 'preserve_channels')
+	if preserve_legacy then
+		preserve_channels = true
+	end
+
+	uci:delete('gluon-core', core_wireless)
+	uci:save('gluon-core')
+end
+
+uci:section('gluon', 'wireless', 'wireless', {
+	preserve_channels = preserve_channels or false,
+})
+uci:save('gluon')

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -123,7 +123,7 @@ function M.foreach_radio(uci, f)
 end
 
 function M.preserve_channels(uci)
-	return uci:get('gluon', 'wireless', 'preserve_channels')
+	return uci:get_bool('gluon', 'wireless', 'preserve_channels')
 end
 
 function M.device_supports_wpa3()


### PR DESCRIPTION
The preserve_channels configuration option was moved to the gluon UCI
package without adding a proper migration.

Closes #2612 

Signed-off-by: David Bauer <mail@david-bauer.net>