### PR TITLE
Add option to hide owner info from statuspage

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -143,7 +143,7 @@
 				<h2><%:Overview%></h2>
 				<dl>
 					<dt><%:Node name%></dt><dd><%| nodeinfo.hostname %></dd>
-					<% if nodeinfo.owner and nodeinfo.owner.contact then -%>
+					<% if nodeinfo.owner and nodeinfo.owner.contact and not nodeinfo.owner.hide_statuspage then -%>
 						<dt><%:Contact%></dt><dd><%| nodeinfo.owner.contact %></dd>
 					<%- end %>
 					<% if nodeinfo.location then -%>


### PR DESCRIPTION
Owner info should not be able to crawl from public ipv6 addresses

This is a first draft to discuss the idea.
Of course, an option in the wizard (or configurable in the site config) would also be needed.