### PR TITLE
Include OpenWrt's target default package lists in config generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ config: $(LUA) FORCE
 		$(call CheckSite,$(conf)); \
 	)
 
+	$(OPENWRTMAKE) prepare-tmpinfo
 	$(GLUON_ENV) $(LUA) scripts/target_config.lua > openwrt/.config
 	$(OPENWRTMAKE) defconfig
 	$(GLUON_ENV) $(LUA) scripts/target_config_check.lua

--- a/scripts/target_config_lib.lua
+++ b/scripts/target_config_lib.lua
@@ -151,49 +151,33 @@ lib.include(target)
 
 lib.check_devices()
 
-if #lib.devices > 0 then
-	handle_target_pkgs(lib.target_packages)
+handle_target_pkgs(lib.target_packages)
 
-	for _, dev in ipairs(lib.devices) do
-		local device_pkgs = {}
-		local function handle_pkgs(pkgs)
-			for _, pkg in ipairs(pkgs) do
-				if string.sub(pkg, 1, 1) ~= '-' then
-					config_package(pkg, nil)
-				end
-				device_pkgs = append_to_list(device_pkgs, pkg)
-			end
-		end
-
-		handle_pkgs(lib.target_packages)
-		handle_pkgs(class_packages(dev.options.class))
-		handle_pkgs(dev.options.packages or {})
-		handle_pkgs(site_packages(dev.image))
-
-		local profile_config = string.format('%s_DEVICE_%s', openwrt_config_target, dev.name)
-		lib.config(
-			'TARGET_DEVICE_' .. profile_config, true,
-			string.format("unable to enable device '%s'", dev.name)
-		)
-		lib.config(
-			'TARGET_DEVICE_PACKAGES_' .. profile_config,
-			table.concat(device_pkgs, ' ')
-		)
-	end
-else
-	-- x86 fallback: no devices
-	local target_pkgs = {}
+for _, dev in ipairs(lib.devices) do
+	local device_pkgs = {}
 	local function handle_pkgs(pkgs)
-		target_pkgs = concat_list(target_pkgs, pkgs)
+		for _, pkg in ipairs(pkgs) do
+			if string.sub(pkg, 1, 1) ~= '-' then
+				config_package(pkg, nil)
+			end
+			device_pkgs = append_to_list(device_pkgs, pkg)
+		end
 	end
 
-	-- Just hardcode the class for device-less targets to 'standard'
-	-- - this is x86 only at the moment, and it will have devices
-	-- in OpenWrt 19.07 + 1 as well
 	handle_pkgs(lib.target_packages)
-	handle_pkgs(class_packages('standard'))
+	handle_pkgs(class_packages(dev.options.class))
+	handle_pkgs(dev.options.packages or {})
+	handle_pkgs(site_packages(dev.image))
 
-	handle_target_pkgs(target_pkgs)
+	local profile_config = string.format('%s_DEVICE_%s', openwrt_config_target, dev.name)
+	lib.config(
+		'TARGET_DEVICE_' .. profile_config, true,
+		string.format("unable to enable device '%s'", dev.name)
+	)
+	lib.config(
+		'TARGET_DEVICE_PACKAGES_' .. profile_config,
+		table.concat(device_pkgs, ' ')
+	)
 end
 
 return lib

--- a/scripts/target_config_lib.lua
+++ b/scripts/target_config_lib.lua
@@ -123,6 +123,14 @@ local enabled_packages = {}
 -- Arguments: package name and config value (true: y, nil: m, false: unset)
 -- Ensures precedence of y > m > unset
 local function config_package(pkg, v)
+	-- HACK: Handle virtual default packages
+	local subst = {
+		nftables = 'nftables-nojson'
+	}
+	if subst[pkg] then
+		pkg = subst[pkg]
+	end
+
 	if v == false then
 		if not enabled_packages[pkg] then
 			lib.try_config('PACKAGE_' .. pkg, false)


### PR DESCRIPTION
See the commit message of patch 3 ("scripts: target_config_lib: prepend target default package list from openwrt/tmp/.targetinfo") for an explanation of the issue.

Patch 1 ("scripts: target_config_lib: remove handling for targets without devices") looks much more complex that it is due to unfortunate diffing - it only removes the obsolete `if #lib.devices > 0` check and the corresponding else branch.

I have diffed the generated `.config` for all targets with BROKEN=1 before and after the change (filtering out `CONFIG_GLUON_VERSION lines) with ~~a minimal site~~ the ffda site to ensure that these patches don't break any devices. The resulting diff looks good: [configs.diff.txt](https://github.com/freifunk-gluon/gluon/files/9410756/configs.diff.txt)

Closes #2619

