### PR TITLE
workflows: fix checkout in backports action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs
         uses: zeebe-io/backport-action@v0.0.8
         with:


### PR DESCRIPTION
The checkout was too limited for the backport action to determine the
proper merge base.