### PR TITLE
ramips-mt76x8: add support for TP-Link RE305 v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -391,6 +391,7 @@ ramips-mt76x8
   - Archer C50 (v3)
   - Archer C50 (v4)
   - RE200 (v2)
+  - RE305 (v1) [#device-class-tiny]
   - TL-MR3020 (v3)
   - TL-MR3420 (v5)
   - TL-WA801ND (v5)

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -452,7 +452,7 @@ Footnotes
 
 .. [#device-class-tiny]
   These devices only support a subset of Gluons capabilities due to flash or memory
-  size constraints. Devices are classified as tiny in they provide less than 7M of usable
+  size constraints. Devices are classified as tiny if they provide less than 7M of usable
   flash space or have a low amount of system memory. For more information, see the
   developer documentation: :ref:`device-class-definition`.
 

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -60,6 +60,10 @@ device('tp-link-archer-c50-v4', 'tplink_archer-c50-v4', {
 
 device('tp-link-re200-v2', 'tplink_re200-v2')
 
+device('tp-link-re305', 'tplink_re305-v1', {
+	class = 'tiny', -- Only 6M of usable Firmware space
+})
+
 device('tp-link-tl-mr3020-v3', 'tplink_tl-mr3020-v3', {
 	factory = false,
 	extra_images = {


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [X] Web interface
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) = tp-link-re305-v1
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN)
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity