### PR TITLE
ipq40xx-generic: add suppot for GL.iNet GL-AP1300

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -185,6 +185,7 @@ ipq40xx-generic
 
 * GL.iNet
 
+  - GL-AP1300
   - GL-B1300
 
 * Linksys

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -56,6 +56,13 @@ device('engenius-ens620ext', 'engenius_ens620ext', {
 
 -- GL.iNet
 
+device('gl.inet-gl-ap1300', 'glinet_gl-ap1300', {
+	factory = '-squashfs-nand-factory',
+	factory_ext = '.ubi',
+	sysupgrade = '-squashfs-nand-sysupgrade',
+	sysupgrade_ext = '.bin',
+})
+
 device('gl.inet-gl-b1300', 'glinet_gl-b1300', {
 	factory = false,
 })


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: Bootloader recovery interface
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs (No LEDs)
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`