### PR TITLE
ath79-nand: add support for ZTE MF281

### DIFF
--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -6,6 +6,8 @@ local ATH10K_PACKAGES_QCA9887 = {
 	'-ath10k-firmware-qca9887-ct',
 }
 
+local ATH10K_PACKAGES_QCA9888 = {}
+
 
 -- GL.iNet
 
@@ -26,4 +28,12 @@ device('netgear-wndr3700-v4', 'netgear_wndr3700-v4', {
 	manifest_aliases = {
 		'netgear-wndr3700v4', -- Upgrade from OpenWrt 19.07
 	},
+})
+
+
+-- ZTE
+
+device('zte-mf281', 'zte_mf281', {
+	broken = true,
+	packages = ATH10K_PACKAGES_QCA9888,
 })


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: Using internal UART header
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`