### PR TITLE
ath79-nand: fix upgrade from 19.07 for GL-AR300M

### DIFF
--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -13,6 +13,9 @@ local ATH10K_PACKAGES_QCA9888 = {}
 
 device('gl.inet-gl-ar300m-nor', 'glinet_gl-ar300m-nor', {
 	factory = false,
+	manifest_aliases = {
+		'gl.inet-gl-ar300m', -- Upgrade from OpenWrt 19.07
+	},
 })
 
 device('gl.inet-gl-ar750s-nor', 'glinet_gl-ar750s-nor', {


### PR DESCRIPTION
Support for the device was (re)added in #2455
(merged as 94e04393b19e843cfe595558839ae0aced075127)

---

https://github.com/freifunk-gluon/gluon/blob/89dc6b203d4d4facd743b1b3f24a5c892bc67499/targets/ar71xx-generic#L118-L121

There also was a `gl-ar300m` alias. I don't know if and when that one could be required.


---

This should be backported to [v2022.1.x](https://github.com/freifunk-gluon/gluon/tree/v2022.1.x).

cc @AiyionPrime 