### PR TITLE
xrx200: ensure the correct version for fritz7360

### DIFF
--- a/patches/openwrt/0009-xrx200-migrate-fritz7360-v2-using-incorrect-image.patch
+++ b/patches/openwrt/0009-xrx200-migrate-fritz7360-v2-using-incorrect-image.patch
@@ -1,0 +1,81 @@
+From: Grische <github@grische.xyz>
+Date: Sun, 18 Sep 2022 14:03:16 +0200
+Subject: xrx200: migrate fritz7360-v2 using incorrect image
+
+Migrate AVM FRITZ!Box 7360 v2 boards flashed with the incorrect v1 image to use
+the newly added v2 target image during the next upgrade.
+Using the v2 target image allows the boards to read the TFFS partition, which
+is misaligned when using the v1 image.
+
+Ref: https://github.com/freifunk-gluon/gluon/pull/2648
+
+Co-authored-by: Jan-Niklas Burfeind <git@aiyionpri.me>
+
+diff --git a/target/linux/lantiq/xrx200/base-files/lib/preinit/01_sysinfo.sh b/target/linux/lantiq/xrx200/base-files/lib/preinit/01_sysinfo.sh
+new file mode 100644
+index 0000000000000000000000000000000000000000..fab50d708e872f819c643cea79327e4f438de524
+--- /dev/null
++++ b/target/linux/lantiq/xrx200/base-files/lib/preinit/01_sysinfo.sh
+@@ -0,0 +1,62 @@
++set_sysinfo_xrx200_for_fritz7360_model() {
++    local board_name=$1
++    local model
++    local urlader_version urlader_memsize urlader_flashsize
++    local hexdump_format='4/1 "%02x""\n"'
++
++    # Values are based on urlader-parser-py
++    # https://github.com/grische/urlader-parser-py/blob/42970bf8dec7962317df4ff734c57ebf36df8905/parser.py#L77-L84
++    urlader_version="$(dd if=/dev/mtd0ro bs=1 skip=$((0x580+0x0)) count=4 | hexdump -e "${hexdump_format}")"
++    if [ "${urlader_version}" != "00000003" ]; then
++        logger -s -p warn -t sysinfo-xrx200 "unexpected urlader version found: ${urlader_version}"
++        return
++    fi
++
++    urlader_memsize="$(dd if=/dev/mtd0ro bs=1 skip=$((0x580+0x4)) count=4 | hexdump -e "${hexdump_format}")"
++    if [ "${urlader_memsize}" != "08000000" ]; then
++        logger -s -p warn -t sysinfo-xrx200 "unexpected memsize found: ${urlader_memsize}"
++        return
++    fi
++
++    urlader_flashsize="$(dd if=/dev/mtd0ro bs=1 skip=$((0x580+0x8)) count=4 | hexdump -e "${hexdump_format}")"
++    case "${urlader_flashsize}" in
++        "02000000")    # 32MB
++            # see vr9_avm_fritz7360-v2.dts
++            board_name="avm,fritz7360-v2"
++            model="AVM FRITZ!Box 7360 V2"
++            ;;
++        "01000000")    # 16MB
++            return
++            ;;
++        *)
++            logger -s -p warn -t sysinfo-xrx200 "unexpected flashsize found: ${urlader_flashsize}"
++            return
++            ;;
++    esac
++
++    logger -s -p notice -t sysinfo-xrx200 "detected ${board_name} from urlader partition /dev/mtd0ro. Enforcing model ${model}."
++    echo "${board_name}" > /tmp/sysinfo/board_name
++    echo "${model}" > /tmp/sysinfo/model
++}
++
++do_sysinfo_xrx200() {
++    local reported_board board_name model
++
++    [ -d /proc/device-tree ] || return
++    reported_board="$(strings /proc/device-tree/compatible | head -1)"
++
++    mkdir -p /tmp/sysinfo
++    # 7360 is notoriously known for not writing "v2" on their labels and many
++    # routers have flashed the wrong firmware with the wrong flash layout.
++    # We ensure that the underlying hardware is reported correctly, so that
++    # future upgrades will use the correct flash layout.
++    # Using 7360v2 hardware, an upgrade from a 7360v1/sl firmware to a 7360v2
++    # is working.
++    case "${reported_board}" in
++        avm,fritz7360sl)
++            set_sysinfo_xrx200_for_fritz7360_model "${reported_board}"
++            ;;
++    esac
++}
++
++boot_hook_add preinit_main do_sysinfo_xrx200


### PR DESCRIPTION
This is a follow-up of https://github.com/freifunk-gluon/gluon/pull/2544 .

With the new Gluon release, there are dedicated images for 7360v1 and 7360v2 that each has their correct flash layouts. The main difference between v1 and v2 (w.r.t. Gluon) is the size of the flash (and not the flash vendor/model, see Details below).

In order to "fix" existing, and wrongly flashed, devices, I created a script that checks AVM's urlader partition (i.e. bootloader partition) and reads the size of the flash. Depending on the size of the flash, either sets the `model` and `board_name` to that of a [7360v1/sl](https://github.com/openwrt/openwrt/blob/v22.03.0/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360sl.dts#L6-L7) or to that of a [7360v2](https://github.com/openwrt/openwrt/blob/v22.03.0/target/linux/lantiq/files/arch/mips/boot/dts/lantiq/vr9_avm_fritz7360-v2.dts#L6-L7).

This will PR allow smooth migration of wrongly flashed 7360v2 devices to use the correct image.

### Details
During the manufacturing process of a specific AVM router model, vendors and model numbers of elements of the board (like the flash chip in this case) are not identical across identical models with different serial numbers. Only the "metadata", like the exact size of the flash, are identical.
For more details on the different versions, I highly recommend Boxmatrix: https://boxmatrix.info/wiki/FRITZ!Box_Fon_WLAN_7360_Versions

An AVM device has usually 2 places for metadata that persists across firmware upgrades, the urlader partition (i.e. bootloader metadata), and the TFFS partitions. When using a "firmware restore" tool from AVM, the TFFS partition is re-generated from the data in the urlader partition. Hence, the "source of truth" is the urlader partition.

For that, I did some reverse engineering to identify the format and data of the urlader partition: https://github.com/grische/urlader-parser-py

Luckily for the migration, we do not need the full logic and only need to read the first few bytes:
* the urlader version (0x580) to make sure we are in the correct position
* the memsize (0x584) to make sure we were not lucky before and confirm we do have a 7360
* the flashsize (0x588) to read the actual size of the flash

### Background
I have been working with @AiyionPrime on trying to fix the flash layout on some 7360 devices that were unable to read the TFFS partitions. It turned out that 7360v2 devices did not have the correct flash layout with Gluon, as the v2 download was actually a v1 image that used the wrong flash layout.

It turns out that the same problem is with OpenWRT as a lot of 7360 devices were incorrectly flashed with the 7360v1/sl image, instead the 7360v2 image. **The label on the back rarely indicates the correct version.** 
This was "fixed" with OpenWRT by [extending the flashing instructions](https://openwrt.org/toh/avm/fritz.box.wlan.7360?do=diff&rev2%5B0%5D=1652087491&rev2%5B1%5D=1656151163&difftype=sidebyside).

### Tests
I tested this migration on a local 7360v2 device.

EDIT:
For reference (and easier readability), that's the actual OpenWRT commit: https://github.com/grische/openwrt/commit/fa3af8c6583b5338499f10aec926f49d399e84ee