### PR TITLE
[v2022.1.x] Backport device support introduced in master

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -416,6 +416,7 @@ rockchip-armv8
 * FriendlyElec
 
   - NanoPi R2S
+  - NanoPi R4S (4GB LPDDR4)
 
 sunxi-cortexa7
 --------------

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -185,6 +185,7 @@ ipq40xx-generic
 
 * GL.iNet
 
+  - GL-AP1300
   - GL-B1300
 
 * Linksys

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -102,6 +102,7 @@ local primary_addrs = {
 		}},
 		{'rockchip', 'armv8', {
 			'friendlyarm,nanopi-r2s',
+			'friendlyarm,nanopi-r4s',
 		}},
 		{'x86'},
 	}},

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -6,6 +6,8 @@ local ATH10K_PACKAGES_QCA9887 = {
 	'-ath10k-firmware-qca9887-ct',
 }
 
+local ATH10K_PACKAGES_QCA9888 = {}
+
 
 -- GL.iNet
 
@@ -29,4 +31,12 @@ device('netgear-wndr3700-v4', 'netgear_wndr3700-v4', {
 	manifest_aliases = {
 		'netgear-wndr3700v4', -- Upgrade from OpenWrt 19.07
 	},
+})
+
+
+-- ZTE
+
+device('zte-mf281', 'zte_mf281', {
+	broken = true,
+	packages = ATH10K_PACKAGES_QCA9888,
 })

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -56,6 +56,13 @@ device('engenius-ens620ext', 'engenius_ens620ext', {
 
 -- GL.iNet
 
+device('gl.inet-gl-ap1300', 'glinet_gl-ap1300', {
+	factory = '-squashfs-nand-factory',
+	factory_ext = '.ubi',
+	sysupgrade = '-squashfs-nand-sysupgrade',
+	sysupgrade_ext = '.bin',
+})
+
 device('gl.inet-gl-b1300', 'glinet_gl-b1300', {
 	factory = false,
 })

--- a/targets/rockchip-armv8
+++ b/targets/rockchip-armv8
@@ -4,3 +4,4 @@ defaults {
 }
 
 device('friendlyelec-nanopi-r2s', 'friendlyarm_nanopi-r2s')
+device('friendlyelec-nanopi-r4s', 'friendlyarm_nanopi-r4s') -- 4GB LPDDR4


### PR DESCRIPTION
Backport device supported added to Gluon after the v2022.1 release. This Gluon release shares the OpenWrt base with current master, so the backport is a mere formality.