### PR TITLE
 hostapd: don't select indoor channel on outdoor operation

### DIFF
--- a/patches/openwrt/0008-hostapd-don-t-select-indoor-channel-on-outdoor-operation.patch
+++ b/patches/openwrt/0008-hostapd-don-t-select-indoor-channel-on-outdoor-operation.patch
@@ -1,0 +1,74 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 10 Sep 2022 01:06:02 +0200
+Subject: hostapd: don't select indoor channel on outdoor operation
+
+Don't select channels designated for exclusive-indoor use when the
+country3 element is set on outdoor operation.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+(cherry picked from commit 5110cf7ebdd5af57f98fe4581ce4c5ddb0a2bf86)
+
+diff --git a/package/network/services/hostapd/patches/800-acs-don-t-select-indoor-channel-on-outdoor-operation.patch b/package/network/services/hostapd/patches/800-acs-don-t-select-indoor-channel-on-outdoor-operation.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..96ebdefae9e710a350fa44a359896071b142af67
+--- /dev/null
++++ b/package/network/services/hostapd/patches/800-acs-don-t-select-indoor-channel-on-outdoor-operation.patch
+@@ -0,0 +1,58 @@
++From 37528a5205cb0b9e2238b7d97fb2ff5457448f1c Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Thu, 8 Sep 2022 01:45:41 +0200
++Subject: [PATCH] acs: don't select indoor channel on outdoor operation
++
++Don't select channels designated for exclusive-indoor use when the
++country3 element is set on outdoor operation.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ src/ap/acs.c | 9 +++++++++
++ src/ap/dfs.c | 3 +++
++ 2 files changed, 12 insertions(+)
++
++--- a/src/ap/acs.c
+++++ b/src/ap/acs.c
++@@ -552,6 +552,9 @@ static void acs_survey_mode_interference
++ 		if (chan->max_tx_power < iface->conf->min_tx_power)
++ 			continue;
++ 
+++		if (chan->flag & HOSTAPD_CHAN_INDOOR_ONLY && iface->conf->country[2] == 0x4f)
+++			continue;
+++
++ 		wpa_printf(MSG_DEBUG, "ACS: Survey analysis for channel %d (%d MHz)",
++ 			   chan->chan, chan->freq);
++ 
++@@ -686,6 +689,9 @@ acs_find_ideal_chan_mode(struct hostapd_
++ 		if (chan->max_tx_power < iface->conf->min_tx_power)
++ 			continue;
++ 
+++		if (chan->flag & HOSTAPD_CHAN_INDOOR_ONLY && iface->conf->country[2] == 0x4f)
+++			continue;
+++
++ 		if (!chan_bw_allowed(chan, bw, 1, 1)) {
++ 			wpa_printf(MSG_DEBUG,
++ 				   "ACS: Channel %d: BW %u is not supported",
++@@ -1065,6 +1071,9 @@ static int * acs_request_scan_add_freqs(
++ 		if (chan->max_tx_power < iface->conf->min_tx_power)
++ 			continue;
++ 
+++		if (chan->flag & HOSTAPD_CHAN_INDOOR_ONLY && iface->conf->country[2] == 0x4f)
+++			continue;
+++
++ 		*freq++ = chan->freq;
++ 	}
++ 
++--- a/src/ap/dfs.c
+++++ b/src/ap/dfs.c
++@@ -282,6 +282,9 @@ static int dfs_find_channel(struct hosta
++ 		if (chan->max_tx_power < iface->conf->min_tx_power)
++ 			continue;
++ 
+++		if (chan->flag & HOSTAPD_CHAN_INDOOR_ONLY && iface->conf->country[2] == 0x4f)
+++			continue;
+++
++ 		if (ret_chan && idx == channel_idx) {
++ 			wpa_printf(MSG_DEBUG, "Selected channel %d (%d)",
++ 				   chan->freq, chan->chan);


### PR DESCRIPTION
Don't select channels designated for exclusive-indoor use when the country3 element is set on outdoor operation.

This effectively prevents from using indoor-only channels in case outdoor-mode is activated. It can be seen as a safeguard from selecting inapprpriate channels in a site outdoor-chanlist.

Signed-off-by: David Bauer <mail@david-bauer.net>