### PR TITLE
ramips-mt7621: add Ubiquiti UniFi Switch Flex

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -355,6 +355,7 @@ ramips-mt7621
   - EdgeRouter X
   - EdgeRouter X-SFP
   - UniFi 6 Lite
+  - UniFi Switch Flex
 
 * ZBT
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -67,6 +67,10 @@ elseif platform.match('ramips', 'mt7621', {
 	'netgear,wac104',
 }) then
 	lan_ifname, wan_ifname = 'lan2 lan3 lan4', 'lan1'
+elseif platform.match('ramips', 'mt7621', {
+	'ubnt,usw-flex',
+}) then
+	lan_ifname, wan_ifname = 'lan2 lan3 lan4 lan5', 'lan1'
 end
 
 if wan_ifname and lan_ifname then

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -59,6 +59,10 @@ function M.is_outdoor_device()
 		'mikrotik,sxtsq-5-ac',
 	}) then
 		return true
+	elseif M.match('ramips', 'mt7621', {
+		'ubnt,usw-flex',
+	}) then
+		return true
 	end
 
 	return false

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -109,3 +109,8 @@ device('ubiquiti-edgerouter-x-sfp', 'ubnt_edgerouter-x-sfp', {
 		'ubnt-erx-sfp',
 	},
 })
+
+device('ubiquiti-unifi-switch-flex', 'ubnt_usw-flex', {
+	factory = false,
+	packages = {'-hostapd-mini', 'poemgr'},
+})


### PR DESCRIPTION
Currently [`poemgr`](https://github.com/blocktrron/poemgr) is included but not enabled. I kinda  think it would be a sensible default to enable it as well as poe on all ports. Or if there would be a Config Mode Page to enable those ports.

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [ ] Must support upgrade mechanism
  - [ ] Must have working sysupgrade
    - [ ] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [ ] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [ ] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios 
  - [ ] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [ ] Lit while the device is on
    - [ ] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`