### PR TITLE
ath79-generic: add LibreRouter v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -57,6 +57,10 @@ ath79-generic
 
   - JT-OR750i
 
+* LibreRouter
+
+  - LibreRouter v1 [#missing_radios]_
+
 * Netgear
 
   - WNDR3700 (v1, v2)
@@ -499,6 +503,10 @@ Footnotes
 
 .. [#lan_as_wan]
   All LAN ports on this device are used as WAN.
+
+.. [#missing_radios]
+  This device contains more than two WLAN radios, which is currently
+  unsupported by Gluon. Only the first two radios will work.
 
 .. [#modular_ethernet]
   These devices follow a modular principle,

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -25,6 +25,7 @@ end
 function M.is_outdoor_device()
 	if M.match('ath79', 'generic', {
 		'devolo,dvl1750x',
+		'librerouter,librerouter-v1',
 		'plasmacloud,pa300',
 		'plasmacloud,pa300e',
 		'tplink,cpe210-v1',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -180,6 +180,12 @@ device('joy-it-jt-or750i', 'joyit_jt-or750i', {
 	factory = false,
 })
 
+-- LibreRouter
+
+-- lacks support for additional radios
+device('librerouter-v1', 'librerouter_librerouter-v1', {
+	factory = false,
+})
 
 -- Netgear
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - ~~TFTP~~ untested
  - [x] Other: sysupgrade
    - *Web interface and TFTP should probably work, too, but were not tested yet.*
    - **edit aiyion**: web interface works as well
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
      **has no label, but at least is not random**
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
    - *only tested 2.4 GHz*
  - [x] Association with 802.11s mesh must work on all radios 
    - *only tested 2.4 GHz*
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~ **are internal**
    - ~~Should map to their respective radio~~
    - ~~Should show activity~~
  - Switch port LEDs
    - ~~Should map to their respective port (or switch, if only one led present)~~
    - ~~Should show link state and activity~~
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

---

We did some rudimentary tests at the Wireless Battlemesh v14, generally the LiberRouter v1 seems to work fine with Gluon v2022.1. I don't have access to the device anymore, so can't complete the checklist right now.

Issues we observed so far though:

* Device reboots every 10min, with no message on the serial. So it looks like the hardware watchdog is not working properly, even though it is configured in DTS.
* The device has 1x 2.4GHz + 2x 5GHz radios, however only one of the 5GHz radios gets configured. The two 5GHz radios are detected though, a radio section is added to /etc/config/wireless for the second one, however without associated wifi-ifaces. Also the config-mode seemed to show both 5GHz radios.