### PR TITLE
ath79: add support for Extreme Networks WS-AP3805i

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -41,6 +41,10 @@ ath79-generic
 
   - WS-AP3705i
 
+* Extreme Networks
+
+  - WS-AP3805i
+
 * GL.iNet
 
   - 6416A

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -114,6 +114,14 @@ device('enterasys-ws-ap3705', 'enterasys_ws-ap3705i', {
 })
 
 
+-- Extreme Networks
+
+device('extreme-networks-ws-ap3805i', 'extreme-networks_ws-ap3805i', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
+
 -- GL.iNet
 
 device('gl.inet-6416', 'glinet_6416', {


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: [Serial Console (UART), ramboot via TFTP and then install sysupgrade](https://github.com/openwrt/openwrt/commit/f8c87aa2d27ab405f284dd4357377ab5c893a345)
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
      It's matching the `WLAN 1` MAC on the device. There also is a `LAN` and `WLAN 2` MAC.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN) - Single Port Device
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio (WLAN 1 LED is 5 GHz, WLAN 2 is 2,4 GHz)
    - [x] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) - no LED for the Ethernet port
    - [ ] Should show link state and activity - no LED for the Ethernet port
- Outdoor devices only:
  - Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`