### PR TITLE
modules: update openwrt

### DIFF
--- a/modules
+++ b/modules
@@ -2,7 +2,7 @@ GLUON_FEEDS='packages routing gluon'
 
 OPENWRT_REPO=https://github.com/openwrt/openwrt.git
 OPENWRT_BRANCH=openwrt-22.03
-OPENWRT_COMMIT=b472753d79ab014c799f28aac99e698e5caf0b19
+OPENWRT_COMMIT=f579b8538b72ed4ea9b53e7ed1cffe651e90ffeb
 
 PACKAGES_PACKAGES_REPO=https://github.com/openwrt/packages.git
 PACKAGES_PACKAGES_BRANCH=openwrt-22.03

--- a/patches/openwrt/0004-ramips-mt7621-make-DSA-images-swconfig-upgradable.patch
+++ b/patches/openwrt/0004-ramips-mt7621-make-DSA-images-swconfig-upgradable.patch
@@ -3,7 +3,7 @@ Date: Sun, 5 Jun 2022 23:43:38 +0200
 Subject: ramips-mt7621: make DSA images swconfig upgradable
 
 diff --git a/target/linux/ramips/image/mt7621.mk b/target/linux/ramips/image/mt7621.mk
-index 8860be11b8c879c067901cf6642a133b27b1e3b2..f8a846cfc67c306fedfbdb2bd2056fa3d6aa1b61 100644
+index c07ab39afdebd38b7e1764b86eaceb4e2108768c..635e1a0b006347197751d8850feed3c30202a1ea 100644
 --- a/target/linux/ramips/image/mt7621.mk
 +++ b/target/linux/ramips/image/mt7621.mk
 @@ -172,7 +172,6 @@ endef
@@ -22,7 +22,7 @@ index 8860be11b8c879c067901cf6642a133b27b1e3b2..f8a846cfc67c306fedfbdb2bd2056fa3
    $(Device/seama)
    SEAMA_SIGNATURE := wrgac13_dlink.2013gui_dir860lb
    LOADER_TYPE := bin
-@@ -1226,7 +1224,6 @@ endef
+@@ -1227,7 +1225,6 @@ endef
  TARGET_DEVICES += mts_wg430223
  
  define Device/netgear_ex6150
@@ -30,7 +30,7 @@ index 8860be11b8c879c067901cf6642a133b27b1e3b2..f8a846cfc67c306fedfbdb2bd2056fa3
    DEVICE_VENDOR := NETGEAR
    DEVICE_MODEL := EX6150
    DEVICE_PACKAGES := kmod-mt76x2
-@@ -1238,7 +1235,6 @@ endef
+@@ -1239,7 +1236,6 @@ endef
  TARGET_DEVICES += netgear_ex6150
  
  define Device/netgear_sercomm_nand
@@ -38,7 +38,7 @@ index 8860be11b8c879c067901cf6642a133b27b1e3b2..f8a846cfc67c306fedfbdb2bd2056fa3
    $(Device/uimage-lzma-loader)
    BLOCKSIZE := 128k
    PAGESIZE := 2048
-@@ -1421,7 +1417,6 @@ endef
+@@ -1422,7 +1418,6 @@ endef
  TARGET_DEVICES += netgear_wax202
  
  define Device/netgear_wndr3700-v5
@@ -46,7 +46,7 @@ index 8860be11b8c879c067901cf6642a133b27b1e3b2..f8a846cfc67c306fedfbdb2bd2056fa3
    $(Device/netgear_sercomm_nor)
    $(Device/uimage-lzma-loader)
    IMAGE_SIZE := 15232k
-@@ -1745,7 +1740,6 @@ endef
+@@ -1746,7 +1741,6 @@ endef
  TARGET_DEVICES += tplink_tl-wpa8631p-v3
  
  define Device/ubnt_edgerouter_common
@@ -54,7 +54,7 @@ index 8860be11b8c879c067901cf6642a133b27b1e3b2..f8a846cfc67c306fedfbdb2bd2056fa3
    $(Device/uimage-lzma-loader)
    DEVICE_VENDOR := Ubiquiti
    IMAGE_SIZE := 256768k
-@@ -2142,7 +2136,6 @@ endef
+@@ -2143,7 +2137,6 @@ endef
  TARGET_DEVICES += zbtlink_zbt-wg2626
  
  define Device/zbtlink_zbt-wg3526-16m
@@ -62,7 +62,7 @@ index 8860be11b8c879c067901cf6642a133b27b1e3b2..f8a846cfc67c306fedfbdb2bd2056fa3
    $(Device/uimage-lzma-loader)
    IMAGE_SIZE := 16064k
    DEVICE_VENDOR := Zbtlink
-@@ -2155,7 +2148,6 @@ endef
+@@ -2156,7 +2149,6 @@ endef
  TARGET_DEVICES += zbtlink_zbt-wg3526-16m
  
  define Device/zbtlink_zbt-wg3526-32m


### PR DESCRIPTION
```
f579b8538b72 ath79: add low_mem to tiny image
4b5bd1509195 ath79: move ubnt-xm to tiny
977f6f36a012 kernel: fix possible mtd NULL pointer dereference
562894b39da3 treewide: fix security issues by bumping all packages using libwolfssl
ce5984366296 wolfssl: fix TLSv1.3 RCE in uhttpd by using 5.5.1-stable (CVE-2022-39173)
3d2be75b0c13 wolfssl: refresh patches
0c8425bf1159 wolfssl: bump to 5.5.0
2c49ad36fbc1 kernel: bump 5.10 to 5.10.146
f04515e7bd44 kernel: bump 5.10 to 5.10.145
a91f391b594f kernel: bump 5.10 to 5.10.144
25747a4c0476 ramips: fix switch setup for ASUS RT-AX53U
23d23038dd02 uboot-mvebu: backport LibreSSL patches for older version of LibreSSL
1ff2993edb89 uboot-mvebu: backport patch to fix compilation on non glibc system
d30ddfbac456 ramips: enable LZMA loader to fix Linksys RE6500 boot
ed905fce5886 tools/meson: backport WSL2 fix
e5ab159fbf99 firmware: intel-microcode: update to 20220809
938ae9267516 toolchain: Include ./include/fortify for external musl toolchain
8f72f5e4c0c3 toolchain: Select USE_SSTRIP with external musl toolchain
4ad6925a9e66 scripts: ext-toolchain: add support for musl
65bd63206900 scripts: ext-toolchain: add support for info.mk in probe_cc
b0622d122128 scripts: ext-toolchain: actually probe libc type on config generation
d1a6c3559142 scripts: ext-toolchain: add option to overwrite config
24cf766dfe80 scripts: ext-toolchain: fix wrong prefix in print_config generation
18a88668b8ed rules_mk: don't include wrapped bin with external toolchains
29927e347a1b rules_mk: use gcc versions for external toolchain
cd117f0596e0 bcm53xx: backport clk driver fix for DT nodes names
9dc46d65494c ath79: fix LibreRouter-v1 watchdog and poe_pass
0cb3a616e425 build: fix warnings from grep
463fe05d9e6e Makefile: fix stray \ warnings with grep-3.8
25d8b9cad6f1 build: fix issues with targets installed via feeds
74eeee1698e8 build: fix including modules.mk for targets pulled in from feeds
dafac183f3c6 mpc85xx: add patch to fix gpio mpc8xxx
7707b47c7277 ramips: fix fw_setsys
f3ffb04a4346 kernel: add missing symbol
2a6346725abd bcm4908: fix -EPROBE_DEFER support in bcm4908_enet
700f5d2990f0 kernel: update U-Boot NVMEM driver
acc78a9cf68b bcm4908: backport mtd parser for Broadcom's U-Boot partition
```