### PR TITLE
ath79-generic: Fix autoupdater for Loco M XW from v2021.1.x to v2022.1.x

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -511,6 +511,7 @@ device('tp-link-wbs510-v1', 'tplink_wbs510-v1', {
 
 device('ubiquiti-nanostation-loco-m-xw', 'ubnt_nanostation-loco-m-xw', {
 	manifest_aliases = {
+		'ubiquiti-loco-m-xw', -- upgrade from OpenWrt 19.07
 		'ubiquiti-nanostation-loco-m2-xw', -- upgrade from OpenWrt 19.07
 		'ubiquiti-nanostation-loco-m5-xw', -- upgrade from OpenWrt 19.07
 	},


### PR DESCRIPTION
Ubiquiti Nanostation Loco M XW was renamed in v2022.1.x, but the alias to the old name was missing, so devices running the old release did not update.

Fixes #2663