### PR TITLE
docs: add Gluon v2022.1.1 Release Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the future development of Gluon.
 
 Please refrain from using the `master` branch for anything else but development purposes!
 Use the most recent release instead. You can list all releases by running `git tag`
-and switch to one by running `git checkout v2022.1 && make update`.
+and switch to one by running `git checkout v2022.1.1 && make update`.
 
 If you're using the autoupdater, do not autoupdate nodes with anything but releases.
 If you upgrade using random master commits the nodes *might break* eventually.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = '2015-2022, Project Gluon'
 author = 'Project Gluon'
 
 # The short X.Y version
-version = '2022.1'
+version = '2022.1.1'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -5,6 +5,7 @@ Release Notes
    :caption: Gluon 2022.1
    :maxdepth: 2
 
+   v2022.1.1
    v2022.1
 
 .. toctree::

--- a/docs/releases/v2022.1.1.rst
+++ b/docs/releases/v2022.1.1.rst
@@ -1,0 +1,84 @@
+Gluon 2022.1.1
+==============
+
+Important notes
+---------------
+
+This release mitigates multiple flaws in the Linux wireless stack fixing RCE and DoS vulnerabilities.
+
+
+Added hardware support
+----------------------
+
+ipq40xx-generic
+~~~~~~~~~~~~~~~
+
+- GL.iNet
+
+  - GL-AP1300
+
+mpc85xx-p1010
+~~~~~~~~~~~~~
+
+- TP-Link
+
+  - TL-WDR4900 (v1)
+
+ramips-mt7621
+~~~~~~~~~~~~~
+
+- ZyXEL
+
+  - NWA50AX
+
+rockchip-armv8
+~~~~~~~~~~~~~~
+
+-  FriendlyElec
+
+   -  NanoPi R4S (4GB LPDDR4)
+
+Bugfixes
+--------
+
+ * Multiple mitigations for (`critical vulnerabilities <https://seclists.org/oss-sec/2022/q4/20>`_) in the Linux kernel WLAN stack. This only concerns Gluon v2022.1, older Gluon versions are unaffected.
+
+   * CVE-2022-41674
+   * CVE-2022-42719
+   * CVE-2022-42720
+   * CVE-2022-42721
+   * CVE-2022-42722
+ * Fixes `security issues in WolfSSL <https://openwrt.org/releases/22.03/notes-22.03.1#security_fixes>`_. People who have installed additional, non-Gluon packages which rely on WolfSSL's TLS 1.3 implementation might be affected. Firmwares using either gluon-mesh-wireless-sae or gluon-wireless-encryption-wpa3 are unaffected by these issues, since only WPA-Enterprise relies on the affected TLS functionality.
+
+   * CVE-2022-38152
+   * CVE-2022-39173
+
+ * Fixes the update path for GL-AR300M and NanoStation Loco M2/M5 (XW) devices.
+
+Known issues
+------------
+
+* A workaround for Android devices not waking up to their MLD subscriptions was removed,
+  potentially breaking IPv6 connectivity for these devices after extended sleep periods
+
+* Upgrading EdgeRouter-X from versions before v2020.1.x may lead to a soft-bricked state due to bad blocks on the NAND flash which the NAND driver before this release does not handle well.
+  (`#1937 <https://github.com/freifunk-gluon/gluon/issues/1937>`_)
+
+* The integration of the BATMAN_V routing algorithm is incomplete.
+
+  - Mesh neighbors don't appear on the status page. (`#1726 <https://github.com/freifunk-gluon/gluon/issues/1726>`_)
+    Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new throughput
+    metric.
+  - Throughput values are not correctly acquired for different interface types.
+    (`#1728 <https://github.com/freifunk-gluon/gluon/issues/1728>`_)
+    This affects virtual interface types like bridges and VXLAN.
+
+* Default TX power on many Ubiquiti devices is too high, correct offsets are unknown
+  (`#94 <https://github.com/freifunk-gluon/gluon/issues/94>`_)
+
+  Reducing the TX power in the Advanced Settings is recommended.
+
+* In configurations without VXLAN, the MAC address of the WAN interface is modified even when Mesh-on-WAN is disabled
+  (`#496 <https://github.com/freifunk-gluon/gluon/issues/496>`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when promiscuous mode is disallowed).

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2022.1
+-- This is an example site configuration for Gluon v2022.1.1
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -8,7 +8,7 @@ Gluon's releases are managed using `Git tags`_. If you are just getting
 started with Gluon we recommend to use the latest stable release of Gluon.
 
 Take a look at the `list of gluon releases`_ and notice the latest release,
-e.g. *v2022.1*. Always get Gluon using git and don't try to download it
+e.g. *v2022.1.1*. Always get Gluon using git and don't try to download it
 as a Zip archive as the archive will be missing version information.
 
 Please keep in mind that there is no "default Gluon" build; a site configuration
@@ -50,7 +50,7 @@ Building the images
 -------------------
 
 To build Gluon, first check out the repository. Replace *RELEASE* with the
-version you'd like to checkout, e.g. *v2022.1*.
+version you'd like to checkout, e.g. *v2022.1.1*.
 
 ::
 


### PR DESCRIPTION
This adds Release Notes for the Gluon v2022.1.1 release.

This is a quick take, I'd say it is kind-of-urgent given the recent publication of flaws in the wireless stack.

Not sure if we should explain the situation for older releases in this specific release notes, given 19.07 based Gluon is not affected.