### PR TITLE
ramips-mt7621: add support for ZyXEL NWA50AX

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -369,6 +369,10 @@ ramips-mt7621
   - WG3526-16M
   - WG3526-32M
 
+* ZyXEL
+
+  - NWA50AX
+
 * Xiaomi
 
   - Xiaomi Mi Router 4A (Gigabit Edition)

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -90,6 +90,11 @@ device('zbtlink-zbt-wg3526-32m', 'zbtlink_zbt-wg3526-32m', {
 })
 
 
+-- ZyXEL
+
+device('zyxel-nwa50ax', 'zyxel_nwa50ax')
+
+
 -- Devices without WLAN
 
 -- Ubiquiti


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [x] Other: TFTP with external serial
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - ~~[ ] Should map to their respective radio~~ has nonc
    - ~~[ ] Should show activity~~
  - Switch port LEDs
    - ~~[ ] Should map to their respective port (or switch, if only one led present)~~ has none 
    - ~~[ ] Should show link state and activity~~
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`