### PR TITLE
ipq40xx-generic: add AVM FRITZBox 7520 explicitely

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -180,6 +180,7 @@ ipq40xx-generic
 * AVM
 
   - FRITZ!Box 4040 [#avmflash]_
+  - FRITZ!Box 7520 (v1) [#eva_ramboot]_
   - FRITZ!Box 7530 [#eva_ramboot]_
   - FRITZ!Repeater 1200 [#eva_ramboot]_
 

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -36,6 +36,7 @@ device('avm-fritz-box-4040', 'avm_fritzbox-4040', {
 
 device('avm-fritz-box-7530', 'avm_fritzbox-7530', {
 	factory = false,
+	aliases = {'avm-fritz-box-7520'},
 })
 
 device('avm-fritz-repeater-1200', 'avm_fritzrepeater-1200', {


### PR DESCRIPTION
AVM Fritz!Box 7520 and Fritz!Box 7530 use the same hardware platform and can only be distinguished by using the urlader partition or the fritz-tffs tools and read the ProductID (Fritz_Box_HW247).