### PR TITLE
contrib: update minimal-site site.conf for v2022.1

### DIFF
--- a/contrib/ci/minimal-site/site.conf
+++ b/contrib/ci/minimal-site/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2018.2+
+-- This is an example site configuration for Gluon v2022.1
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.
@@ -10,7 +10,7 @@
   -- hostname_prefix = 'freifunk-',
 
   -- Name of the community.
-  site_name = 'Continious Integration',
+  site_name = 'Continuous Integration',
 
   -- Shorthand of the community.
   site_code = 'ci',
@@ -42,10 +42,14 @@
     -- Wireless channel.
     channel = 1,
 
-    -- ESSID used for client network.
+    -- ESSIDs used for client network.
     ap = {
       ssid = 'gluon-ci-ssid',
       -- disabled = true, -- (optional)
+
+      -- Configuration for a backward compatible OWE network below.
+      owe_ssid = 'owe.gluon-ci-ssid', -- (optional - SSID for OWE client network)
+      owe_transition_mode = true, -- (optional - enables transition-mode - requires ssid as well as owe_ssid)
     },
 
     mesh = {
@@ -64,8 +68,6 @@
     outdoor_chanlist = '100-140',
     ap = {
       ssid = 'gluon-ci-ssid',
-      owe_ssid = "owe.gluon-ci-ssid",
-      owe_transition_mode = false,
     },
     mesh = {
       -- Adjust these values!
@@ -74,6 +76,12 @@
     },
   },
 
+  mesh = {
+    vxlan = true,
+    batman_adv = {
+      routing_algo = 'BATMAN_IV',
+    },
+  },
 
   -- The next node feature allows clients to always reach the node it is
   -- connected to using a known IP address.
@@ -84,12 +92,16 @@
     ip6 = 'fd::1',
   },
 
-  mesh = {
-    vxlan = true,
-    batman_adv = {
-      routing_algo = 'BATMAN_IV'
-    }
-  },
+  -- Options specific to routing protocols (optional)
+  -- mesh = {
+    -- Options specific to the batman-adv routing protocol (optional)
+    -- batman_adv = {
+      -- Gateway selection class (optional)
+      -- The default class 20 is based on the link quality (TQ) only,
+      -- class 1 is calculated from both the TQ and the announced bandwidth
+      -- gw_sel_class = 1,
+    -- },
+  -- },
 
   mesh_vpn = {
     -- enabled = true,
@@ -113,7 +125,18 @@
           peers = {
           },
 
+          -- Optional: nested peer groups
+          -- groups = {
+            -- backbone_sub = {
+              -- ...
+            -- },
+          -- ...
+          -- },
         },
+        -- Optional: additional peer groups, possibly with other limits
+        -- backbone2 = {
+          -- ...
+        -- },
       },
     },
 
@@ -130,7 +153,8 @@
   },
 
   autoupdater = {
-    -- Default branch. Don't forget to set GLUON_BRANCH when building!
+    -- Default branch (optional), can be overridden by setting GLUON_AUTOUPDATER_BRANCH when building.
+    -- Set GLUON_AUTOUPDATER_ENABLED to enable the autoupdater by default for newly installed nodes.
     branch = 'stable',
 
     -- List of branches. You may define multiple branches.


### PR DESCRIPTION
This updates the `site.conf` used in the CI based on docs/site-example/site.conf for Gluon v2022.1.

This update is mostly cosmetic, changing "ci" to "minimal-site-ci" and rearranging the content to be aligned with the current `docs/site-example/site.conf`.

Please let me know if you are interested in this kind of change.