### PR TITLE
ramips-mt7621: add support for ZyXEL NWA55AXE

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -59,6 +59,11 @@ function M.is_outdoor_device()
 		'mikrotik,sxtsq-5-ac',
 	}) then
 		return true
+
+	elseif M.match('ramips', 'mt7621', {
+		'zyxel,nwa55axe',
+	}) then
+		return true
 	end
 
 	return false

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -93,6 +93,9 @@ device('zbtlink-zbt-wg3526-32m', 'zbtlink_zbt-wg3526-32m', {
 -- ZyXEL
 
 device('zyxel-nwa50ax', 'zyxel_nwa50ax')
+device('zyxel-nwa55axe', 'zyxel_nwa55axe', {
+	broken = true, -- Missing LED / Reset button
+})
 
 
 -- Devices without WLAN


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [x] Other: UART bootloader
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode (No Reset button)
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [ ] Lit while the device is on
    - [ ] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [ ] Added Device to `docs/user/supported_devices.rst`