### PR TITLE
gluon-core: preserve wireless channel width during updates

### DIFF
--- a/docs/features/wlan-configuration.rst
+++ b/docs/features/wlan-configuration.rst
@@ -16,8 +16,8 @@ by the user). This means that it is not possible to enable or disable an existin
 configurations during upgrades.
 
 During upgrades the wifi channel of the 2.4GHz and 5GHz radio will be restored to the channel
-configured in the site.conf. If you need to preserve a user defined wifi channel during upgrades
-you can configure this via the uci section ``gluon-core.wireless``::
+configured in the site.conf. The channel width will be reset to Gluon's default. If you need to preserve
+these settings during upgrades you can configure this via the uci section ``gluon-core.wireless``::
 
   uci set gluon.wireless.preserve_channels='1'
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -66,6 +66,10 @@ local function get_channel(radio, config)
 end
 
 local function get_htmode(radio)
+	if wireless.preserve_channels(uci) then
+		return radio.htmode
+	end
+
 	if radio.band == '5g' and is_outdoor() then
 		local outdoor_htmode = uci:get('gluon', 'wireless', 'outdoor_' .. radio['.name'] .. '_htmode')
 		if outdoor_htmode ~= nil then


### PR DESCRIPTION
This adds the uci option 'gluon.wireless.preserve_htmode'. When set to true the channel width of wireless radios (htmode) is preserved during updates.