### PR TITLE
contrib: remove downloaded *.deb files from OCI container

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ecdsautils \
     lua-check \
     shellcheck \
+  && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
 RUN useradd -d /gluon gluon


### PR DESCRIPTION
`apt-get clean` clears out the local repository of retrieved package files. It removes everything but the lock file from /var/cache/apt/archives/ and /var/cache/apt/archives/partial/.