### PR TITLE
targets/ramips-mt76x8: add device TP-Link RE200 V3

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -402,7 +402,7 @@ ramips-mt76x8
 
   - Archer C20 (v4, v5)
   - Archer C50 (v3, v4)
-  - RE200 (v2)
+  - RE200 (v2, v3)
   - RE305 (v1) [#device-class-tiny]
   - TL-MR3020 (v3)
   - TL-MR3420 (v5)

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -60,6 +60,8 @@ device('tp-link-archer-c50-v4', 'tplink_archer-c50-v4', {
 
 device('tp-link-re200-v2', 'tplink_re200-v2')
 
+device('tp-link-re200-v3', 'tplink_re200-v3')
+
 device('tp-link-re305', 'tplink_re305-v1', {
 	class = 'tiny', -- Only 6M of usable Firmware space
 })


### PR DESCRIPTION
Signed-off-by: Richard Fröhning <misanthropos@gmx.de>

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP
  - ~~Other: <specify>~~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`
