### PR TITLE
openwrt: add patch to expose unset symbols

### DIFF
--- a/patches/openwrt/0010-kconfig-abort-configuration-on-unset-symbol.patch
+++ b/patches/openwrt/0010-kconfig-abort-configuration-on-unset-symbol.patch
@@ -1,0 +1,75 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Fri, 11 Nov 2022 13:37:07 +0100
+Subject: kconfig: abort configuration on unset symbol
+
+This fixes the initial patch to cover all cases where unset symbols are
+handled in the code.
+
+Fixes commit eaa9c94c7574 ("generic: Kconfig: exit on unset symbol")
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/generic/hack-5.10/205-kconfig-abort-configuration-on-unset-symbol.patch b/target/linux/generic/hack-5.10/205-kconfig-abort-configuration-on-unset-symbol.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..bd5c54d4b8b73b36c9f5b809447a8e76fce19e5d
+--- /dev/null
++++ b/target/linux/generic/hack-5.10/205-kconfig-abort-configuration-on-unset-symbol.patch
+@@ -0,0 +1,41 @@
++From 310e8e04a05d9eb43fa9dd7f00143300afcaa37a Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Fri, 11 Nov 2022 13:33:44 +0100
++Subject: [PATCH] kconfig: abort configuration on unset symbol
++
++When a target configuration has unset Kconfig symbols, the build will
++fail when OpenWrt is compiled with V=s and stdin is connected to a tty.
++
++In case OpenWrt is compiled without either of these preconditions, the
++build will succeed with the symbols in question being unset.
++
++Modify the kernel configuration in a way it fails on unset symbols
++regardless of the aforementioned preconditions.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ scripts/kconfig/conf.c | 6 ++++++
++ 1 file changed, 6 insertions(+)
++
++--- a/scripts/kconfig/conf.c
+++++ b/scripts/kconfig/conf.c
++@@ -109,6 +109,9 @@ static int conf_askvalue(struct symbol *
++ 		}
++ 		/* fall through */
++ 	case oldaskconfig:
+++		if (!tty_stdio && getenv("FAIL_ON_UNCONFIGURED")) {
+++			exit(1);
+++		}
++ 		fflush(stdout);
++ 		xfgets(line, sizeof(line), stdin);
++ 		return 1;
++@@ -303,6 +306,9 @@ static int conf_choice(struct menu *menu
++ 			}
++ 			/* fall through */
++ 		case oldaskconfig:
+++			if (!tty_stdio && getenv("FAIL_ON_UNCONFIGURED")) {
+++				exit(1);
+++			}
++ 			fflush(stdout);
++ 			xfgets(line, sizeof(line), stdin);
++ 			strip(line);
+diff --git a/target/linux/generic/hack-5.10/205-kconfig-exit.patch b/target/linux/generic/hack-5.10/205-kconfig-exit.patch
+deleted file mode 100644
+index c3fb7a1f999e56da34b0a15565ce36098cfba7fb..0000000000000000000000000000000000000000
+--- a/target/linux/generic/hack-5.10/205-kconfig-exit.patch
++++ /dev/null
+@@ -1,11 +0,0 @@
+---- a/scripts/kconfig/conf.c
+-+++ b/scripts/kconfig/conf.c
+-@@ -215,6 +215,8 @@ static int conf_sym(struct menu *menu)
+- 				break;
+- 			continue;
+- 		case 0:
+-+			if (!sym_has_value(sym) && !tty_stdio && getenv("FAIL_ON_UNCONFIGURED"))
+-+				exit(1);
+- 			newval = oldval;
+- 			break;
+- 		case '?':


### PR DESCRIPTION
The GitHub actions pipeline is not interrupted for unset symbols due to OpenWrt not failing in all cases of unset symbols.

Adda patch to consistently fail for unset symbols.

Ref #2701 (build process is waiting for user input)

Signed-off-by: David Bauer <mail@david-bauer.net>