### PR TITLE
Wavlink WS-WN572HP3 (4G)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -368,6 +368,10 @@ ramips-mt7621
   - EdgeRouter X-SFP
   - UniFi 6 Lite
 
+* Wavlink
+
+  - WS-WN572HP3 (4G)
+
 * ZBT
 
   - WG3526-16M

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
@@ -50,6 +50,10 @@ elseif platform.match('ipq40xx', 'generic', {
 	'glinet,gl-ap1300',
 }) then
 	setup_ncm_qmi('/dev/cdc-wdm0', 'qmi', 15)
+elseif platform.match('ramips', 'mt7621', {
+	'wavlink,ws-wn572hp3-4g',
+}) then
+	setup_ncm_qmi('/dev/ttyUSB2', 'ncm', 15)
 end
 
 uci:save('network')

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -61,6 +61,7 @@ function M.is_outdoor_device()
 		return true
 
 	elseif M.match('ramips', 'mt7621', {
+		'wavlink,ws-wn572hp3-4g',
 		'zyxel,nwa55axe',
 	}) then
 		return true
@@ -76,6 +77,10 @@ function M.is_cellular_device()
 		return true
 	elseif M.match('ipq40xx', 'generic', {
 		'glinet,gl-ap1300',
+	}) then
+		return true
+	elseif M.match('ramips', 'mt7621', {
+		'wavlink,ws-wn572hp3-4g',
 	}) then
 		return true
 	end

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -59,6 +59,11 @@ device('ubiquiti-unifi-6-lite', 'ubnt_unifi-6-lite', {
 	factory = false,
 })
 
+-- Wavlink
+
+device('wavlink-ws-wn572hp3-4g', 'wavlink_ws-wn572hp3-4g', {
+        factory = false,
+})
 
 -- Xiaomi
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - ~~Web interface~~
  - [x] TFTP
  - [x] Other: Mediatek Webinterface details in OpenWrt commit
  - https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=dce66899bf243d78689afcc693340b891bbf4c2d
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs (only 4G LEDs available, none for wifi)
    - ~~Should map to their respective radio~~
    - ~~Should show activity~~
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`

------------------
  
This PR was intended to show @blocktrron's PR works, and does. 

> Not sure for how long, as the connected data volume is fairly limited; but the device works flawlessly with your code.  
  
_Originally posted by @AiyionPrime in https://github.com/freifunk-gluon/gluon/issues/2631#issuecomment-1336534774_