### PR TITLE
ipq40xx-mikrotik: add mikrotik-hap-ac2

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -56,6 +56,16 @@
     "targets/generic",
     "targets/targets.mk"
   ],
+  "ipq40xx-mikrotik": [
+    "targets/ipq40xx-mikrotik",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk",
+    "targets/mikrotik.inc"
+  ],
   "ipq806x-generic": [
     "targets/ipq806x-generic",
     "modules",

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -223,6 +223,7 @@ ipq40xx-mikrotik
 * Mikrotik
 
   - DISC Lite5 ac (RBDiscG-5acD)
+  - hAP ac2
   - SXTsq 5 ac (RBSXTsqG-5acD)
 
 ipq806x-generic

--- a/targets/ipq40xx-mikrotik
+++ b/targets/ipq40xx-mikrotik
@@ -1,5 +1,11 @@
 include 'mikrotik.inc'
 
+local ATH10K_PACKAGES_IPQ40XX = {}
+
+device('mikrotik-hap-ac2', 'mikrotik_hap-ac2', {
+	packages = ATH10K_PACKAGES_IPQ40XX,
+})
+
 device('mikrotik-sxtsq-5-ac-rbsxtsqg-5acd', 'mikrotik_sxtsq-5-ac', {
 	factory = false,
 	aliases = {'mikrotik-discg-5acd'},


### PR DESCRIPTION
@mkg20001  I just reordered targets/ipq40xx-mikrotik, supersedes #2464 if its compile tests are still okay.
Will merge once this is green.