### PR TITLE
ramips-mt7621: add ASUS RT-AX53U

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -356,6 +356,7 @@ ramips-mt7621
 * ASUS
 
   - RT-AC57U (v1)
+  - RT-AX53U
 
 * Cudy
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -7,6 +7,7 @@ device('asus-rt-ac57u-v1', 'asus_rt-ac57u-v1', {
 	},
 })
 
+device('asus-rt-ax53u', 'asus_rt-ax53u')
 
 -- Cudy
 


### PR DESCRIPTION
Add support for ASUS RT-AX53U

- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other:
    - ssh > mtd-write factory image to Kernel-partition
      [Wiki instructions](https://openwrt.org/toh/asus/rt-ax53u#installation_with_mtd-write)
    - tftp via serial (requires opening the case)
      [Wiki instructions](https://openwrt.org/toh/asus/rt-ax53u#installation_with_tftp)
    - Asus Firmware Restoration Tool on Windows
      Flash OpenWrt Kernel/initramfs first, then sysupgrade to Gluon
      [Asus Instructions](https://www.asus.com/support/FAQ/1000814/)
      [Download Firmware Restoration Tool](https://dlcdnets.asus.com/pub/ASUS/wireless/GT-AX6000/Rescue_2103.zip)
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
        `asus-rt-ax53u`
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
      Device has two MACs:
  - 50:eb:f6:83:2c:14 (2.4GHz and LAN and WAN) < primary and printed on the label
  - 50:eb:f6:83:2c:18 (5GHz)    
  - ~~When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.~~
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - ~~if there are multiple ports but no WAN port~~:
      - ~~the PoE input should be WAN, all other ports LAN~~
      - ~~otherwise the first port should be declared as WAN, all other ports LAN~~
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- Cellular devices only:
  - [ ] ~~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`
 
The device is running Gluon and works ~~but the LEDs have some issues~~

Performance:
110 Download, 38 Upload via Wireguard on a 250/40 VDSL2 connection
VPN performance improved noticeably since I created this PR (typically it reached around 80-100mbit/s Download before)