### PR TITLE
docs: add LAN-AS-WAN label to FB 7520/7530

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -178,8 +178,8 @@ ipq40xx-generic
 * AVM
 
   - FRITZ!Box 4040 [#avmflash]_
-  - FRITZ!Box 7520 (v1) [#eva_ramboot]_
-  - FRITZ!Box 7530 [#eva_ramboot]_
+  - FRITZ!Box 7520 (v1) [#eva_ramboot]_ [#lan_as_wan]_
+  - FRITZ!Box 7530 [#eva_ramboot]_ [#lan_as_wan]_
   - FRITZ!Repeater 1200 [#eva_ramboot]_
 
 * EnGenius


### PR DESCRIPTION
These devices use all LAN ports as a WAN bridge.

Closes #2721

Signed-off-by: David Bauer <mail@david-bauer.net>