### PR TITLE
gluon-web-model: resolve hang when submitting form with disabled element

### DIFF
--- a/package/gluon-web-model/luasrc/usr/lib/lua/gluon/web/model/classes.lua
+++ b/package/gluon-web-model/luasrc/usr/lib/lua/gluon/web/model/classes.lua
@@ -410,11 +410,11 @@ function TextValue:__init__(...)
 end
 
 
-local Element = class(Node)
+local Element = class(AbstractValue)
 M.Element = Element
 
 function Element:__init__(template, kv, ...)
-	Node.__init__(self, ...)
+	AbstractValue.__init__(self, ...)
 
 	self.default   = nil
 	self.size      = nil

--- a/package/gluon-web-private-wifi/i18n/de.po
+++ b/package/gluon-web-private-wifi/i18n/de.po
@@ -49,6 +49,9 @@ msgstr ""
 msgid "WPA3"
 msgstr ""
 
+msgid "Meshing on WAN interface is enabled. This can lead to problems."
+msgstr "Mesh auf WAN ist aktiv. Dies kann zu Problemen führen."
+
 msgid ""
 "Your node can additionally extend your private network by bridging the WAN "
 "interface with a separate WLAN. This feature is completely independent of "

--- a/package/gluon-web-private-wifi/i18n/gluon-web-private-wifi.pot
+++ b/package/gluon-web-private-wifi/i18n/gluon-web-private-wifi.pot
@@ -40,6 +40,9 @@ msgstr ""
 msgid "WPA3"
 msgstr ""
 
+msgid "Meshing on WAN interface is enabled. This can lead to problems."
+msgstr ""
+
 msgid ""
 "Your node can additionally extend your private network by bridging the WAN "
 "interface with a separate WLAN. This feature is completely independent of "

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
@@ -28,7 +28,7 @@ enabled.default = uci:get('wireless', primary_iface) and not uci:get_bool('wirel
 
 local warning = s:element('model/warning', {
 	content = mesh_on_wan and translate(
-		'Meshing on WAN interface is enabled.' ..
+		'Meshing on WAN interface is enabled. ' ..
 		'This can lead to problems.'
 	) or nil,
 }, 'warning')


### PR DESCRIPTION
I was made aware of a bug when submitting the form while the element is
disabled based on it's dependencies

(disable "enabled" in "private wifi", then save, while having mesh on wan enabled)

The fix was to inherit from AbstractValue instead of just node

AbstractValue's AbstractValue:resolve_node_depends() in particular
solves the issue, but it made more sense to just use the full base class

Also includes translations