### PR TITLE
gluon-mmfd: add missing waitforsocket function

### DIFF
--- a/package/gluon-mmfd/files/etc/init.d/mmfd
+++ b/package/gluon-mmfd/files/etc/init.d/mmfd
@@ -5,6 +5,15 @@ START=50
 DAEMON=/usr/sbin/mmfd
 SOCKET=/var/run/mmfd.sock
 
+waitforsocket() {
+	while ! echo "get_neighbours" | uc $SOCKET
+	do
+		sleep 1
+		echo "waiting for successful socket connection for mmfd"
+	done
+}
+
+
 start_service() {
 	local interfaces=$(for dev in $(gluon-list-mesh-interfaces); do echo " -i $dev"; done)
 


### PR DESCRIPTION
This fixes a bug in the gluon-mmfd init script. Waitforsocket() is being called without being specified.
This implements the missing functionality and resolves the problem.