### PR TITLE
docs: remove remaining CSS workaround

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,14 +1,3 @@
 .strike {
 	text-decoration: line-through;
 }
-
-/*
-	This fixes the vertical position of list markers when the first
-	element in the <li> is a <pre> block
-
-	Scrolling inside the <pre> block is still working as expected
-*/
-.rst-content pre.literal-block,
-.rst-content div[class^='highlight'] pre {
-	overflow: visible;
-}


### PR DESCRIPTION
Remove a workaround for a CSS issue in older Firefox versions, which was recently fixed (at some point between Firefox 102 and 108). Firefox 108+ now displays the bullet points at the right vertical position even without the hack in [1].

[1] https://gluon.readthedocs.io/en/latest/releases/v2018.1.html#site-conf

Opening as a draft for now, as the current Extended Support Release is Firefox 102. I propose to merge this as soon as all Firefox versions without the fix are EOL.