### PR TITLE
ramips-mt7621: Add Xiaomi Mi Router 3G

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -376,7 +376,7 @@ ramips-mt7621
 * Xiaomi
 
   - Xiaomi Mi Router 4A (Gigabit Edition)
-  - Xiaomi Mi Router 3G v2
+  - Xiaomi Mi Router 3G (v1, v2)
 
 ramips-mt76x8
 -------------

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -66,10 +66,13 @@ device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {
 	factory = false,
 })
 
-device('xiaomi-mi-router-3g-v2', 'xiaomi_mi-router-3g-v2', {
+device('xiaomi-mi-router-3g', 'xiaomi_mi-router-3g', {
 	factory = false,
 })
 
+device('xiaomi-mi-router-3g-v2', 'xiaomi_mi-router-3g-v2', {
+	factory = false,
+})
 
 -- ZBT
 


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [X] Other: [https://openwrt.org/toh/xiaomi/mir3g#installation](https://openwrt.org/toh/xiaomi/mir3g#installation)
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio (system LED turns from orange into blue)
    - [ ] Should show activity (as no LED for radio is present)
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`