### PR TITLE
gluon-respondd: restart instead of reload - fixes #2733

### DIFF
--- a/package/gluon-respondd/files/etc/init.d/gluon-respondd
+++ b/package/gluon-respondd/files/etc/init.d/gluon-respondd
@@ -24,6 +24,6 @@ service_triggers() {
 	local name=$(basename ${script:-$initscript})
 
 	procd_open_trigger
-	procd_add_raw_trigger "interface.*" 0 "/etc/init.d/$name" reload
+	procd_add_raw_trigger "interface.*" 0 "/etc/init.d/$name" restart
 	procd_close_trigger
 }


### PR DESCRIPTION
respondd has to handle interface changes for re-listening

respondd was being sent sighup by procd previously, but didn't handle it

The easiest way is to just restart respondd to make it re-listen, since it does not carry any important state