### PR TITLE
treewide: fix indentation in .sh files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -37,6 +37,8 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
+[*.sh]
+
 [*.yml]
 indent_style = space
 indent_size = 2

--- a/contrib/run_qemu.sh
+++ b/contrib/run_qemu.sh
@@ -4,12 +4,12 @@
 #       Then you enter the command mode of qemu and can exit by typing "quit".
 
 qemu-system-x86_64 \
-    -d 'cpu_reset' \
-    -enable-kvm \
-    -gdb tcp::1234 \
-    -nographic \
-    -netdev user,id=wan,hostfwd=tcp::2223-10.0.2.15:22 \
-    -device virtio-net-pci,netdev=wan,addr=0x06,id=nic1 \
-    -netdev user,id=lan,hostfwd=tcp::6080-192.168.1.1:80,hostfwd=tcp::2222-192.168.1.1:22,net=192.168.1.100/24 \
-    -device virtio-net-pci,netdev=lan,addr=0x05,id=nic2 \
-    "$@"
+	-d 'cpu_reset' \
+	-enable-kvm \
+	-gdb tcp::1234 \
+	-nographic \
+	-netdev user,id=wan,hostfwd=tcp::2223-10.0.2.15:22 \
+	-device virtio-net-pci,netdev=wan,addr=0x06,id=nic1 \
+	-netdev user,id=lan,hostfwd=tcp::6080-192.168.1.1:80,hostfwd=tcp::2222-192.168.1.1:22,net=192.168.1.100/24 \
+	-device virtio-net-pci,netdev=lan,addr=0x05,id=nic2 \
+	"$@"

--- a/contrib/sign.sh
+++ b/contrib/sign.sh
@@ -29,11 +29,22 @@ lower="$(mktemp)"
 
 trap 'rm -f "$upper" "$lower"' EXIT
 
-awk 'BEGIN    { sep=0 }
-     /^---$/ { sep=1; next }
-              { if(sep==0) print > "'"$upper"'";
-                else       print > "'"$lower"'"}' \
-    "$manifest"
+awk 'BEGIN    {
+	sep = 0
+}
+
+/^---$/ {
+	sep = 1;
+	next
+}
+
+{
+	if(sep == 0) {
+		print > "'"$upper"'"
+	} else {
+		print > "'"$lower"'"
+	}
+}' "$manifest"
 
 ecdsasign "$upper" < "$SECRET" >> "$lower"
 

--- a/contrib/sigtest.sh
+++ b/contrib/sigtest.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ $# -eq 0 ] || [ "-h" = "$1" ] || [ "-help" = "$1" ] || [ "--help" = "$1" ]; then
-    cat <<EOHELP
+	cat <<EOHELP
 Usage: $0 <public> <signed manifest>
 
 sigtest.sh checks if a manifest is signed by the public key <public>. There is
@@ -12,7 +12,7 @@ See also:
  * https://gluon.readthedocs.io/en/latest/features/autoupdater.html
 
 EOHELP
-    exit 1
+	exit 1
 fi
 
 public="$1"
@@ -21,18 +21,29 @@ upper="$(mktemp)"
 lower="$(mktemp)"
 ret=1
 
-awk "BEGIN    { sep=0 }
-    /^---\$/ { sep=1; next }
-              { if(sep==0) print > \"$upper\";
-                else       print > \"$lower\"}" \
-    "$manifest"
+awk 'BEGIN    {
+	sep = 0
+}
+
+/^---$/ {
+	sep = 1;
+	next
+}
+
+{
+	if(sep == 0) {
+		print > "'"$upper"'"
+	} else {
+		print > "'"$lower"'"
+	}
+}' "$manifest"
 
 while read -r line
 do
-    if ecdsaverify -s "$line" -p "$public" "$upper"; then
-        ret=0
-        break
-    fi
+	if ecdsaverify -s "$line" -p "$public" "$upper"; then
+		ret=0
+		break
+	fi
 done < "$lower"
 
 rm -f "$upper" "$lower"

--- a/package/gluon-autoupdater/files/lib/gluon/autoupdater/lib.sh
+++ b/package/gluon-autoupdater/files/lib/gluon/autoupdater/lib.sh
@@ -2,15 +2,15 @@
 
 
 stop() {
-        if [ -x /etc/init.d/"$1" ]; then
-                echo "Stopping $1..."
-                /etc/init.d/"$1" stop
-        fi
+	if [ -x /etc/init.d/"$1" ]; then
+		echo "Stopping $1..."
+		/etc/init.d/"$1" stop
+	fi
 }
 
 start_enabled() {
-        if [ -x /etc/init.d/"$1" ] && /etc/init.d/"$1" enabled; then
-                echo "Starting $1..."
-                /etc/init.d/"$1" start
-        fi
+	if [ -x /etc/init.d/"$1" ] && /etc/init.d/"$1" enabled; then
+		echo "Starting $1..."
+		/etc/init.d/"$1" start
+	fi
 }

--- a/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
+++ b/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
@@ -5,90 +5,90 @@
 init_proto "$@"
 
 proto_gluon_wired_init_config() {
-        proto_config_add_boolean transitive
-        proto_config_add_int index
-        proto_config_add_boolean vxlan
-        proto_config_add_string vxpeer6addr
+	proto_config_add_boolean transitive
+	proto_config_add_int index
+	proto_config_add_boolean vxlan
+	proto_config_add_string vxpeer6addr
 }
 
 xor2() {
-        echo -n "${1:0:1}"
-        echo -n "${1:1:1}" | tr '0123456789abcdef' '23016745ab89efcd'
+	echo -n "${1:0:1}"
+	echo -n "${1:1:1}" | tr '0123456789abcdef' '23016745ab89efcd'
 }
 
 is_layer3_device () {
-        local addrlen="$(cat "/sys/class/net/$1/addr_len")"
-        test "$addrlen" -eq 0
+	local addrlen="$(cat "/sys/class/net/$1/addr_len")"
+	test "$addrlen" -eq 0
 }
 
 # shellcheck disable=SC2086
 interface_linklocal() {
-        if is_layer3_device "$1"; then
-                if ! ubus call network.interface dump | \
-                     jsonfilter -e "@.interface[@.l3_device='$1']['ipv6-address'][*].address" | \
-                     grep -e '^fe[89ab][0-9a-f]' -m 1; then
-                        proto_notify_error "$config" "MISSING_LL_ADDR_ON_LOWER_IFACE"
-                        proto_block_restart "$config"
-                        exit 1
-                fi
-                return
-        fi
+	if is_layer3_device "$1"; then
+		if ! ubus call network.interface dump | \
+		jsonfilter -e "@.interface[@.l3_device='$1']['ipv6-address'][*].address" | \
+		grep -e '^fe[89ab][0-9a-f]' -m 1; then
+			proto_notify_error "$config" "MISSING_LL_ADDR_ON_LOWER_IFACE"
+			proto_block_restart "$config"
+			exit 1
+		fi
+		return
+	fi
 
-        local macaddr="$(ubus call network.device status '{"name": "'"$1"'"}' | jsonfilter -e '@.macaddr')"
-        local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
+	local macaddr="$(ubus call network.device status '{"name": "'"$1"'"}' | jsonfilter -e '@.macaddr')"
+	local oldIFS="$IFS"; IFS=':'; set -- $macaddr; IFS="$oldIFS"
 
-        echo "fe80::$(xor2 "$1")$2:$3ff:fe$4:$5$6"
+	echo "fe80::$(xor2 "$1")$2:$3ff:fe$4:$5$6"
 }
 
 proto_gluon_wired_setup() {
-        local config="$1"
-        local ifname="$2"
+	local config="$1"
+	local ifname="$2"
 
-        local meshif="$config"
+	local meshif="$config"
 
-        local transitive index vxlan vxpeer6addr
-        json_get_vars transitive index vxlan vxpeer6addr
+	local transitive index vxlan vxpeer6addr
+	json_get_vars transitive index vxlan vxpeer6addr
 
-        # default args
-        [ -z "$vxlan" ] && vxlan=1
-        [ -z "$vxpeer6addr" ] && vxpeer6addr='ff02::15c'
+	# default args
+	[ -z "$vxlan" ] && vxlan=1
+	[ -z "$vxpeer6addr" ] && vxpeer6addr='ff02::15c'
 
-        proto_init_update "$ifname" 1
-        proto_send_update "$config"
+	proto_init_update "$ifname" 1
+	proto_send_update "$config"
 
-        if [ "$vxlan" -eq 1 ]; then
-                meshif="vx_$config"
+	if [ "$vxlan" -eq 1 ]; then
+		meshif="vx_$config"
 
-                json_init
-                json_add_string name "$meshif"
-                [ -n "$index" ] && json_add_string macaddr "$(lua -e "print(require('gluon.util').generate_mac($index))")"
-                json_add_string proto 'vxlan6'
-                json_add_string tunlink "$config"
-                # ip6addr (the lower interface ip6) is used by the vxlan.sh proto
-                json_add_string ip6addr "$(interface_linklocal "$ifname")"
-                json_add_string peer6addr "$vxpeer6addr"
-                json_add_int vid "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')"
-                json_add_boolean rxcsum '0'
-                json_add_boolean txcsum '0'
-                json_close_object
-                ubus call network add_dynamic "$(json_dump)"
-        fi
+		json_init
+		json_add_string name "$meshif"
+		[ -n "$index" ] && json_add_string macaddr "$(lua -e "print(require('gluon.util').generate_mac($index))")"
+		json_add_string proto 'vxlan6'
+		json_add_string tunlink "$config"
+		# ip6addr (the lower interface ip6) is used by the vxlan.sh proto
+		json_add_string ip6addr "$(interface_linklocal "$ifname")"
+		json_add_string peer6addr "$vxpeer6addr"
+		json_add_int vid "$(lua -e 'print(tonumber(require("gluon.util").domain_seed_bytes("gluon-mesh-vxlan", 3), 16))')"
+		json_add_boolean rxcsum '0'
+		json_add_boolean txcsum '0'
+		json_close_object
+		ubus call network add_dynamic "$(json_dump)"
+	fi
 
-        json_init
-        json_add_string name "${config}_mesh"
-        json_add_string ifname "@${meshif}"
-        json_add_string proto 'gluon_mesh'
-        json_add_boolean fixed_mtu 1
-        [ -n "$transitive" ] && json_add_boolean transitive "$transitive"
-        json_close_object
-        ubus call network add_dynamic "$(json_dump)"
+	json_init
+	json_add_string name "${config}_mesh"
+	json_add_string ifname "@${meshif}"
+	json_add_string proto 'gluon_mesh'
+	json_add_boolean fixed_mtu 1
+	[ -n "$transitive" ] && json_add_boolean transitive "$transitive"
+	json_close_object
+	ubus call network add_dynamic "$(json_dump)"
 }
 
 proto_gluon_wired_teardown() {
-        local config="$1"
+	local config="$1"
 
-        proto_init_update "*" 0
-        proto_send_update "$config"
+	proto_init_update "*" 0
+	proto_send_update "$config"
 }
 
 add_protocol gluon_wired


### PR DESCRIPTION
> to match the editorconfig
> 
> awk code in `contrib/sign.sh` and `contrib/sigtest.sh` reformatted as gawk does

The awk-code is now formatted the same way for both awk snippets,
I tested `contrib/sigtest.sh` on a manifest generated before this PR, does work as expected.