### PR TITLE
lua indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,6 +23,8 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 
+[*.lua]
+
 [*.md]
 indent_style = space
 indent_size = 4

--- a/package/gluon-authorized-keys/luasrc/lib/gluon/upgrade/100-authorized-keys
+++ b/package/gluon-authorized-keys/luasrc/lib/gluon/upgrade/100-authorized-keys
@@ -6,17 +6,17 @@ local file = '/etc/dropbear/authorized_keys'
 local keys = {}
 
 local function load_keys()
-  for line in io.lines(file) do
-    keys[line] = true
-  end
+	for line in io.lines(file) do
+		keys[line] = true
+	end
 end
 
 pcall(load_keys)
 
 local f = io.open(file, 'a')
 for _, key in ipairs(site.authorized_keys()) do
-  if not keys[key] then
-    f:write(key .. '\n')
-  end
+	if not keys[key] then
+		f:write(key .. '\n')
+	end
 end
 f:close()

--- a/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
+++ b/package/gluon-config-mode-mesh-vpn/luasrc/lib/gluon/config-mode/wizard/0300-mesh-vpn.lua
@@ -10,11 +10,11 @@ return function(form, uci)
 
 	local msg = pkg_i18n.translate(
 		'Your internet connection can be used to establish a ' ..
-	        'VPN connection with other nodes. ' ..
-	        'Enable this option if there are no other nodes reachable ' ..
-	        'over WLAN in your vicinity or you want to make a part of ' ..
-	        'your connection\'s bandwidth available for the network. You can limit how ' ..
-	        'much bandwidth the node will use at most.'
+		'VPN connection with other nodes. ' ..
+		'Enable this option if there are no other nodes reachable ' ..
+		'over WLAN in your vicinity or you want to make a part of ' ..
+		'your connection\'s bandwidth available for the network. You can limit how ' ..
+		'much bandwidth the node will use at most.'
 	)
 
 	local s = form:section(Section, nil, msg)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -131,9 +131,9 @@ function M.get_mesh_devices(uconn)
 	local dump = uconn:call("network.interface", "dump", {})
 	local devices = {}
 	for _, interface in ipairs(dump.interface) do
-	    if ( (interface.proto == "gluon_mesh") and interface.up ) then
+		if ( (interface.proto == "gluon_mesh") and interface.up ) then
 			table.insert(devices, interface.device)
-	    end
+		end
 	end
 	return devices
 end

--- a/package/gluon-mesh-vpn-wireguard/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/package/gluon-mesh-vpn-wireguard/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -6,13 +6,13 @@ local site = require 'gluon.site'
 local private_key = uci:get("network_gluon-old", 'wg_mesh', "private_key")
 
 if not private_key or not private_key:match("^" .. ("[%a%d+/]"):rep(42) .. "[AEIMQUYcgkosw480]=$") then
-  private_key = "generate"
+	private_key = "generate"
 end
 
 uci:section('network', 'interface', 'wg_mesh', {
-  proto = 'wireguard',
-  fwmark = 1,
-  private_key = private_key,
+	proto = 'wireguard',
+	fwmark = 1,
+	private_key = private_key,
 })
 
 uci:section('network', 'interface', 'mesh_wg_mesh', {
@@ -22,17 +22,17 @@ uci:section('network', 'interface', 'mesh_wg_mesh', {
 
 -- Clean up previous configuration
 uci:delete_all('wgpeerselector', 'peer', function(peer)
-  return peer.preserve ~= '1'
+	return peer.preserve ~= '1'
 end)
 
 for name, peer in pairs(site.mesh_vpn.wireguard.peers()) do
-  uci:section("wgpeerselector", "peer", name, {
-    enabled = true,
-    endpoint = peer.endpoint,
-    public_key = peer.public_key,
-    allowed_ips = { "fe80::1/128" },
-    ifname = 'wg_mesh',
-  })
+	uci:section("wgpeerselector", "peer", name, {
+		enabled = true,
+		endpoint = peer.endpoint,
+		public_key = peer.public_key,
+		allowed_ips = { "fe80::1/128" },
+		ifname = 'wg_mesh',
+	})
 end
 
 uci:save("wgpeerselector")

--- a/package/gluon-neighbour-info/luasrc/lib/gluon/upgrade/400-neighbour-info-firewall
+++ b/package/gluon-neighbour-info/luasrc/lib/gluon/upgrade/400-neighbour-info-firewall
@@ -4,28 +4,24 @@ local uci = require('simple-uci').cursor()
 
 -- Allow incoming respondd replies to queries on WAN
 -- If the query was via multicast, the response isn't matched by --state RELATED
-uci:section('firewall', 'rule', 'wan_respondd_reply',
-  {
-    name = 'wan_respondd_reply',
-    src = 'wan',
-    src_ip = 'fe80::/64',
-    src_port = '1001',
-    dest_port = '32768:61000', -- see /proc/sys/net/ipv4/ip_local_port_range
-    proto = 'udp',
-    target = 'ACCEPT',
-  }
-)
+uci:section('firewall', 'rule', 'wan_respondd_reply', {
+	name = 'wan_respondd_reply',
+	src = 'wan',
+	src_ip = 'fe80::/64',
+	src_port = '1001',
+	dest_port = '32768:61000', -- see /proc/sys/net/ipv4/ip_local_port_range
+	proto = 'udp',
+	target = 'ACCEPT',
+})
 
-uci:section('firewall', 'rule', 'mesh_respondd_reply',
-  {
-    name = 'mesh_respondd_reply',
-    src = 'mesh',
-    src_ip = 'fe80::/64',
-    src_port = '1001',
-    dest_port = '32768:61000', -- see /proc/sys/net/ipv4/ip_local_port_range
-    proto = 'udp',
-    target = 'ACCEPT',
-  }
-)
+uci:section('firewall', 'rule', 'mesh_respondd_reply', {
+	name = 'mesh_respondd_reply',
+	src = 'mesh',
+	src_ip = 'fe80::/64',
+	src_port = '1001',
+	dest_port = '32768:61000', -- see /proc/sys/net/ipv4/ip_local_port_range
+	proto = 'udp',
+	target = 'ACCEPT',
+})
 
 uci:save('firewall')

--- a/package/gluon-node-info/luasrc/lib/gluon/upgrade/500-node-info-system
+++ b/package/gluon-node-info/luasrc/lib/gluon/upgrade/500-node-info-system
@@ -5,6 +5,6 @@ local uci = require('simple-uci').cursor()
 local config = 'gluon-node-info'
 
 if not uci:get_first(config, 'system') then
-  uci:section(config, 'system')
-  uci:save(config)
+	uci:section(config, 'system')
+	uci:save(config)
 end

--- a/package/gluon-wan-dnsmasq/luasrc/lib/gluon/wan-dnsmasq/update.lua
+++ b/package/gluon-wan-dnsmasq/luasrc/lib/gluon/wan-dnsmasq/update.lua
@@ -12,63 +12,63 @@ local util = require 'gluon.util'
 local new_servers = ''
 
 local function append_server(server)
-  new_servers = new_servers .. 'nameserver ' .. server .. '\n'
+	new_servers = new_servers .. 'nameserver ' .. server .. '\n'
 end
 
 
 local function handled_interfaces()
-  local interfaces = {}
+	local interfaces = {}
 
-  for _, path in ipairs(util.glob('/lib/gluon/wan-dnsmasq/interface.d/*')) do
-    for interface in io.lines(path) do
-      table.insert(interfaces, interface)
-    end
-  end
+	for _, path in ipairs(util.glob('/lib/gluon/wan-dnsmasq/interface.d/*')) do
+		for interface in io.lines(path) do
+			table.insert(interfaces, interface)
+		end
+	end
 
-  return interfaces
+	return interfaces
 end
 
 
 local function handle_interface(status)
-  local ifname = status.device
-  local servers = status.inactive['dns-server']
+	local ifname = status.device
+	local servers = status.inactive['dns-server']
 
-  for _, server in ipairs(servers) do
-    if server:match('^fe80:') then
-      append_server(server .. '%' .. ifname)
-    else
-      append_server(server)
-    end
-  end
+	for _, server in ipairs(servers) do
+		if server:match('^fe80:') then
+			append_server(server .. '%' .. ifname)
+		else
+			append_server(server)
+		end
+	end
 end
 
 local function append_interface_servers(iface)
-  handle_interface(ubus:call('network.interface.' .. iface, 'status', {}))
+	handle_interface(ubus:call('network.interface.' .. iface, 'status', {}))
 end
 
 
 local static = uci:get_first('gluon-wan-dnsmasq', 'static', 'server')
 
 if type(static) == 'table' and #static > 0 then
-  for _, server in ipairs(static) do
-    append_server(server)
-  end
+	for _, server in ipairs(static) do
+		append_server(server)
+	end
 else
-  for _, interface in ipairs(handled_interfaces()) do
-      pcall(append_interface_servers, interface)
-  end
+	for _, interface in ipairs(handled_interfaces()) do
+		pcall(append_interface_servers, interface)
+	end
 end
 
 
 local old_servers = util.readfile(RESOLV_CONF)
 
 if new_servers ~= old_servers then
-  stat.mkdir('/var/gluon')
-  stat.mkdir('/var/gluon/wan-dnsmasq')
+	stat.mkdir('/var/gluon')
+	stat.mkdir('/var/gluon/wan-dnsmasq')
 
-  local f = io.open(RESOLV_CONF .. '.tmp', 'w')
-  f:write(new_servers)
-  f:close()
+	local f = io.open(RESOLV_CONF .. '.tmp', 'w')
+	f:write(new_servers)
+	f:close()
 
-  os.rename(RESOLV_CONF .. '.tmp', RESOLV_CONF)
+	os.rename(RESOLV_CONF .. '.tmp', RESOLV_CONF)
 end

--- a/package/gluon-web-autoupdater/luasrc/lib/gluon/config-mode/model/admin/autoupdater.lua
+++ b/package/gluon-web-autoupdater/luasrc/lib/gluon/config-mode/model/admin/autoupdater.lua
@@ -1,12 +1,5 @@
---[[
-Copyright 2013 Nils Schneider <nils@nilsschneider.net>
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-        http://www.apache.org/licenses/LICENSE-2.0
-]]--
+-- SPDX-FileCopyrightText: 2013 Nils Schneider <nils@nilsschneider.net>
+-- SPDX-License-Identifier: Apache-2.0
 
 local uci = require("simple-uci").cursor()
 local autoupdater = uci:get_first("autoupdater", "autoupdater")

--- a/package/gluon-web/luasrc/usr/lib/lua/gluon/web/dispatcher.lua
+++ b/package/gluon-web/luasrc/usr/lib/lua/gluon/web/dispatcher.lua
@@ -179,7 +179,7 @@ local function dispatch(config, http, request)
 		renderer.render_layout("error/404", {
 			message =
 				"No page is registered at '/" .. table.concat(request, "/") .. "'.\n" ..
-			        "If this URL belongs to an extension, make sure it is properly installed.\n",
+				"If this URL belongs to an extension, make sure it is properly installed.\n",
 		}, 'gluon-web')
 		return
 	end

--- a/package/gluon-web/luasrc/usr/lib/lua/gluon/web/template.lua
+++ b/package/gluon-web/luasrc/usr/lib/lua/gluon/web/template.lua
@@ -58,7 +58,7 @@ return function(config, env)
 		-- Now finally render the thing
 		local stat, err = pcall(template)
 		assert(stat, "Failed to execute template '" .. name .. "'.\n" ..
-			      "A runtime error occurred: " .. tostring(err or "(nil)"))
+			"A runtime error occurred: " .. tostring(err or "(nil)"))
 	end
 
 	--- Render a certain template.


### PR DESCRIPTION
@tcatm's license text contained spaces for indentation.
Instead of fixing it, I swapped the whole license header to spdx as discussed in

> We have `*.c` files that include a LICENSE header that introduces mixed (space) indentation into files that otherwise use tabs. E.g. `package/libgluonutil/src/libgluonutil.c`. We could use the occasion to migrate to SPDX identifiers, no? @NeoRaider

and

> +1 for migrating to SPDX headers

_Originally posted by @mweinelt and @blocktrron in https://github.com/freifunk-gluon/gluon/issues/2116#issuecomment-691694201 and https://github.com/freifunk-gluon/gluon/issues/2116#issuecomment-695835779_

All other lua files have been indented to tabs. Compiled locally without errors.