### PR TITLE
workflows/docker: bump editorconfig-checker from 2.6.0 to 2.7.0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,7 +40,7 @@ jobs:
         run: sudo apt install curl tar
       - name: Install editorconfig-checker
         env:
-          VERSION: 2.6.0
+          VERSION: 2.7.0
           OS: linux
           ARCH: amd64
         run: |

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /tmp/ec &&\
-    wget -O /tmp/ec/ec-linux-amd64.tar.gz https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.6.0/ec-linux-amd64.tar.gz &&\
+    wget -O /tmp/ec/ec-linux-amd64.tar.gz https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.7.0/ec-linux-amd64.tar.gz &&\
     tar -xvzf /tmp/ec/ec-linux-amd64.tar.gz &&\
     mv bin/ec-linux-amd64 /usr/local/bin/editorconfig-checker &&\
     rm -rf /tmp/ec


### PR DESCRIPTION
> - [Release notes](https://github.com/editorconfig-checker/editorconfig-checker/releases)
> - [Commits](https://github.com/editorconfig-checker/editorconfig-checker/compare/2.6.0...2.7.0)
> 
> Signed-off-by: Jan-Niklas Burfeind <git@aiyionpri.me>