### PR TITLE
ath79-nand: add support for GL.iNet GL-XE300

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -143,6 +143,7 @@ ath79-nand
 
   - GL-AR300M
   - GL-AR750S
+  - GL-XE300
 
 * Netgear
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
@@ -43,6 +43,10 @@ local function setup_ncm_qmi(devpath, control_type, delay)
 end
 
 if platform.match('ath79', 'nand', {
+	'glinet,gl-xe300',
+}) then
+	setup_ncm_qmi('/dev/cdc-wdm0', 'qmi', 15)
+elseif platform.match('ath79', 'nand', {
 	'zte,mf281',
 }) then
 	setup_ncm_qmi('/dev/ttyACM0', 'ncm', 15)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -73,6 +73,7 @@ end
 function M.is_cellular_device()
 	if M.match('ath79', 'nand', {
 		'zte,mf281',
+		'glinet,gl-xe300',
 	}) then
 		return true
 	elseif M.match('ipq40xx', 'generic', {

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S96led
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S96led
@@ -3,17 +3,25 @@
 START=96
 
 start() {
+	local custom_led
+
 	/etc/init.d/led start
 
 	. /etc/diag.sh
 
 	get_status_led 2> /dev/null
 
-	if [ -z $status_led ]; then
+	if [ -z "$status_led" ]; then
 		status_led="$running"
 	fi
-	if [ -z $status_led ]; then
+
+	if [ -z "$status_led" ]; then
 		status_led="$boot"
+	fi
+
+	custom_led="$(lua -e 'print(require("gluon.setup-mode").get_status_led() or "")')"
+	if [ -z "$status_led" ]; then
+		status_led="$custom_led"
 	fi
 
 	status_led_set_timer 1000 300

--- a/package/gluon-setup-mode/luasrc/usr/lib/lua/gluon/setup-mode.lua
+++ b/package/gluon-setup-mode/luasrc/usr/lib/lua/gluon/setup-mode.lua
@@ -1,0 +1,14 @@
+local platform = require 'gluon.platform'
+
+
+local M = {}
+
+function M.get_status_led()
+	if platform.match('ath79', 'nand', {
+		'glinet,gl-xe300',
+	}) then
+		return "green:wlan"
+	end
+end
+
+return M

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -23,6 +23,9 @@ device('gl.inet-gl-ar750s-nor', 'glinet_gl-ar750s-nor', {
 	packages = ATH10K_PACKAGES_QCA9887,
 })
 
+device('gl.inet-gl-xe300', 'glinet_gl-xe300', {
+	factory = false,
+})
 
 -- Netgear
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [x] Other: Bootloader recovery interface
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
  - 3G/4G LED
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`

Related Upstream PRs:
- https://github.com/openwrt/openwrt/pull/11845
- https://github.com/openwrt/openwrt/pull/11870
- https://github.com/openwrt/openwrt/pull/11908