### PR TITLE
gluon-web-model: fix issue with warning blocking save on private-wifi

### DIFF
--- a/package/gluon-web-model/files/lib/gluon/web/view/model/warning.html
+++ b/package/gluon-web-model/files/lib/gluon/web/view/model/warning.html
@@ -1,14 +1,14 @@
-<%- if self.title or self.content then -%>
+<%- if not self.hide then -%>
 <div class="gluon-warning"<%=
 	attr("id", id) ..
 	attr("data-index", self.index) ..
 	attr("data-depends", self:deplist(self.deps))
 %>>
 	<%- if self.content then -%>
-	<%=self.content%>
+	<%= self.content %>
 	<%- else -%>
-	<b><%=self.title%></b><br>
-	<%=self.description%>
+	<b><%= self.title %></b><br>
+	<%= self.description %>
 	<%- end -%>
 </div>
 <%- end -%>

--- a/package/gluon-web-model/luasrc/usr/lib/lua/gluon/web/model/classes.lua
+++ b/package/gluon-web-model/luasrc/usr/lib/lua/gluon/web/model/classes.lua
@@ -429,6 +429,23 @@ function Element:__init__(template, kv, ...)
 	self.error = false
 end
 
+function Element:parse(http)
+	if not self.datatype then
+		self.state = M.FORM_VALID
+		return
+	end
+
+	return AbstractValue:parse(http)
+end
+
+function Element:validate()
+	if not self.datatype then
+		return true
+	end
+
+	AbstractValue:validate()
+end
+
 local Section = class(Node)
 M.Section = Section
 

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
@@ -27,10 +27,11 @@ local enabled = s:option(Flag, "enabled", translate("Enabled"))
 enabled.default = uci:get('wireless', primary_iface) and not uci:get_bool('wireless', primary_iface, "disabled")
 
 local warning = s:element('model/warning', {
-	content = mesh_on_wan and translate(
+	content = translate(
 		'Meshing on WAN interface is enabled. ' ..
 		'This can lead to problems.'
-	) or nil,
+	),
+	hide = not mesh_on_wan,
 }, 'warning')
 warning:depends(enabled, true)
 


### PR DESCRIPTION
The other bugfix which made this element inherit from AbstractValue
caused AbstractValue:validate() to be inherited aswell

Now added an if so validate only runs if a datatype is set
(since Element is meant as a generic way to extend web-model without
modifying web-model - also to add custom inputs - just hiding it behind an if sounds like a sane solution)