### PR TITLE
editorconfig: exclude docs/_built

### DIFF
--- a/.ecrc
+++ b/.ecrc
@@ -1,0 +1,3 @@
+{
+  "Exclude": ["docs/_build"]
+}


### PR DESCRIPTION
> while not present unless built, they are never meant to be checked

currently `cd docs; make html; cd ..; make lint-editorconfig`

results in about

```console
18208 errors found
```
on master.

After merging this, the editorconfig-checker ignores the docs folder properly.