### PR TITLE
sunxi: add devices bananapi m2 ultra and berry

### DIFF
--- a/targets/sunxi-cortexa7
+++ b/targets/sunxi-cortexa7
@@ -15,3 +15,7 @@ device('lemaker-banana-pro', 'lemaker_bananapro', {
 device('lamobo-r1', 'lamobo_lamobo-r1', {
 	broken = true, -- AP+11s not working
 })
+
+device('sinovoip-bananapi-m2-ultra', 'sinovoip_bananapi-m2-ultra')
+
+device('sinovoip-bananapi-m2-berry', 'sinovoip_bananapi-m2-berry')


### PR DESCRIPTION
adds support for the banana pi m2 ultra and banana pi m2 berry