### PR TITLE
extended info when no domain is given

### DIFF
--- a/package/gluon-core/luasrc/usr/bin/gluon-switch-domain
+++ b/package/gluon-core/luasrc/usr/bin/gluon-switch-domain
@@ -16,7 +16,7 @@ end
 local setup_mode = unistd.access('/var/gluon/setup-mode') == 0
 
 if #arg ~= 1 then
-	io.stderr:write('Usage: gluon-switch-domain [--no-reboot] <domain>\n')
+	io.stderr:write('Usage: gluon-switch-domain [--no-reboot] <domain>\n use: uci show gluon.core to view your actual domain')
 	os.exit(1)
 end
 local domain = arg[1]

--- a/package/gluon-core/luasrc/usr/bin/gluon-switch-domain
+++ b/package/gluon-core/luasrc/usr/bin/gluon-switch-domain
@@ -16,7 +16,7 @@ end
 local setup_mode = unistd.access('/var/gluon/setup-mode') == 0
 
 if #arg ~= 1 then
-	io.stderr:write('Usage: gluon-switch-domain [--no-reboot] <domain>\n use: uci show gluon.core to view your actual domain')
+	io.stderr:write('Usage: gluon-switch-domain [--no-reboot] <domain>\nUse: uci show gluon.core to view your actual domain\n')
 	os.exit(1)
 end
 local domain = arg[1]

--- a/package/gluon-core/luasrc/usr/bin/gluon-switch-domain
+++ b/package/gluon-core/luasrc/usr/bin/gluon-switch-domain
@@ -16,7 +16,7 @@ end
 local setup_mode = unistd.access('/var/gluon/setup-mode') == 0
 
 if #arg ~= 1 then
-	io.stderr:write('Usage: gluon-switch-domain [--no-reboot] <domain>\nUse: uci show gluon.core to view your actual domain\n')
+	io.stderr:write('Usage: gluon-switch-domain [--no-reboot] <domain>\nUse: "uci show gluon.core" to view your actual domain\n')
 	os.exit(1)
 end
 local domain = arg[1]


### PR DESCRIPTION
... the easy way ... 
the better way is ... a parameter to get domain status... like gluon-switch-domain status  --> uci get gluon.core.domain ...but... until then... this is helpful...