### PR TITLE
gluon-core:  sleep to wait for device initialisations

### DIFF
--- a/package/gluon-core/files/etc/uci-defaults/zzz-gluon-upgrade
+++ b/package/gluon-core/files/etc/uci-defaults/zzz-gluon-upgrade
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Work around an issue with wifi setup timing by waiting a bit
+# while device initialisation is ongoing.
+# https://github.com/freifunk-gluon/gluon/issues/2779
+sleep 3
+
 gluon-reconfigure
 
 exit 0


### PR DESCRIPTION
workaround for a timing issue during first boot on ath79-generic after sysupgrade from ar71xx-generic image

GitHub Issue: [#2779](https://github.com/freifunk-gluon/gluon/issues/2779)