### PR TITLE
ramips: add support for Cudy WR1300 v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -355,6 +355,7 @@ ramips-mt7621
 
 * Cudy
 
+  - WR1300 (v1)
   - WR2100
 
 * D-Link

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -65,6 +65,7 @@ device('netgear-wndr3700-v5', 'netgear_wndr3700-v5', {
 	},
 })
 
+
 -- TP-Link
 
 device('tp-link-archer-c6-v3', 'tplink_archer-c6-v3', {
@@ -75,17 +76,20 @@ device('tp-link-re500-v1', 'tplink_re500-v1')
 
 device('tp-link-re650-v1', 'tplink_re650-v1')
 
+
 -- Ubiquiti
 
 device('ubiquiti-unifi-6-lite', 'ubnt_unifi-6-lite', {
 	factory = false,
 })
 
+
 -- Wavlink
 
 device('wavlink-ws-wn572hp3-4g', 'wavlink_ws-wn572hp3-4g', {
 	factory = false,
 })
+
 
 -- Xiaomi
 
@@ -100,6 +104,7 @@ device('xiaomi-mi-router-3g', 'xiaomi_mi-router-3g', {
 device('xiaomi-mi-router-3g-v2', 'xiaomi_mi-router-3g-v2', {
 	factory = false,
 })
+
 
 -- ZBT
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -7,6 +7,10 @@ device('asus-rt-ac57u', 'asus_rt-ac57u', {
 
 -- Cudy
 
+device('cudy-wr1300', 'cudy_wr1300', {
+	factory = false,
+})
+
 device('cudy-wr2100', 'cudy_wr2100', {
 	factory = false,
 })


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [X] Web interface (explained below)
  - [ ] TFTP
  - [X] Other: Signed openwrt from vendor can be flashed through web interface, next step: sysupgrade to Gluon
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) cudy-wr1300
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - ~~When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.~~
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - ~~On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.~~
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`