### PR TITLE
[Backport v2022.1.x] ath79-generic: Work around boot hang on Unifi AC-Mesh

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -1,3 +1,7 @@
+-- modify kernel builds slightly to work around a boot hang on various device
+-- based on the QCA9563 SoC - especially the Unifi AC-* devices
+config('KERNEL_AIO', true)
+
 local ATH10K_PACKAGES_QCA9880 = {
 	'kmod-ath10k',
 	'-kmod-ath10k-ct',


### PR DESCRIPTION
It looks like boot hangs on an AC-Mesh for unknown reasons. The last message seen on the console is:

    [    0.000000] Inode-cache hash table entries: 8192 (order: 3, 32768 bytes, linear)

But interestingly, it seems like enabling AIO somehow works around this problem. Changing any off the following options seem to have the same effect at the moment for Linux 5.10.160+5.10.161

    # CONFIG_KERNEL_AIO is not set
    # CONFIG_KERNEL_CGROUPS is not set
    # CONFIG_KERNEL_FANOTIFY is not set
    # CONFIG_KERNEL_FHANDLE is not set
    # CONFIG_KERNEL_IO_URING is not set
    # CONFIG_KERNEL_IPV6_MROUTE is not set
    # CONFIG_KERNEL_IPV6_SEG6_LWTUNNEL is not set
    # CONFIG_KERNEL_IP_MROUTE is not set
    CONFIG_KERNEL_PROC_STRIPPED=y

Just enable CONFIG_AIO until the actual problem was fixed.

Link: https://github.com/freifunk-gluon/gluon/issues/2784

(cherry picked from commit 536c771f3fe56937e516b97c3e233afb02e39b82)

Manual backport to `v2022.1.x`, from #2791.