### PR TITLE
bcm63xx: add support for TP Link TD-W8968 V3

### DIFF
--- a/targets/bcm63xx-generic
+++ b/targets/bcm63xx-generic
@@ -4,6 +4,6 @@ device('tp-link-td-w8968-v3', 'sagem_fast-2704n', {
 	sysupgrade = '-squashfs-cfe', 
 	sysupgrade_ext = '.bin', -- No sysupgrade image available
 
-
+aliases = {'tp-link-td-w8968-v3'},
 	broken = true, -- WiFi chip not supported
 })

--- a/targets/bcm63xx-generic
+++ b/targets/bcm63xx-generic
@@ -4,9 +4,6 @@ device('tp-link-td-w8968-v3', 'sagem_fast-2704n', {
 	sysupgrade = '-squashfs-cfe', 
 	sysupgrade_ext = '.bin', -- No sysupgrade image available
 
-	manifest_aliases = {
-		'FAST2704N', -- Upgrade from OpenWrt 19.07
-	},
 
 	broken = true, -- WiFi chip not supported
 })

--- a/targets/bcm63xx-generic
+++ b/targets/bcm63xx-generic
@@ -1,0 +1,12 @@
+include 'bcm63xx.inc'
+
+device('tp-link-td-w8968-v3', 'sagem_fast-2704n', {
+	sysupgrade = '-squashfs-cfe', 
+	sysupgrade_ext = '.bin', -- No sysupgrade image available
+
+	manifest_aliases = {
+		'FAST2704N', -- Upgrade from OpenWrt 19.07
+	},
+
+	broken = true, -- WiFi chip not supported
+})

--- a/targets/bcm63xx.inc
+++ b/targets/bcm63xx.inc
@@ -1,0 +1,6 @@
+defaults {
+	factory = '-squashfs-cfe',
+	factory_ext = '.bin',
+	sysupgrade = '-squashfs-sysupgrade',
+	sysupgrade_ext = '.bin',
+}

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -25,5 +25,6 @@ $(eval $(call GluonTarget,x86,64))
 
 ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,bcm27xx,bcm2710)) # BROKEN: Untested
+$(eval $(call GluonTarget,bcm63xx,generic)) # BROKEN: Untested
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
 endif

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -25,6 +25,6 @@ $(eval $(call GluonTarget,x86,64))
 
 ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,bcm27xx,bcm2710)) # BROKEN: Untested
-$(eval $(call GluonTarget,bcm63xx,generic)) # BROKEN: Untested
+$(eval $(call GluonTarget,bcm63xx,generic)) # BROKEN: No 11s support
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
 endif


### PR DESCRIPTION
adds support for the tp link td w8968 v3

- [x] Must be flashable from vendor firmware
  - ~[ ] Web interface~
  - [x] TFTP
  - [x] Other: CFE web recovery
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
    - ##### output is "sagem-f-st-2704n"
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - ~[ ] Association with AP must be possible on all radios~
  - ~[ ] Association with 802.11s mesh must work on all radios~
  - ~[ ] AP+mesh mode must work in parallel on all radios~
    - ##### Wifi chip not supported
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [ ] Should display config mode blink sequence
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
      - ##### was not displayed
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
       - ##### Wifi chip not supported
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present)
    - [x] Should show link state and activity
       - ##### only one led is displayed which only shows the activity of the wan port but not the activity of the other lan ports
- Outdoor devices only:
  - ~[ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~
- Docs:
  - ~[ ] Added Device to `docs/user/supported_devices.rst`~

the internet speed, tested with freifunk chemnitz as an example, comes to 10 mbit/s with the tp link td w8968 v3 and that can be a little higher speed via freifunk chemnitz. it is therefore not a very fast router that unfortunately does not have wifi via gluon/openwrt but since it has a total of 4 lan ports (100 mbit/s) it is at least possible as a lan switch for the lan-based use of gluon.