### PR TITLE
[Backport v2022.1.x] Revert "ipq40xx: switch Wave2 firmware to -ct (#2541)"

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -18,7 +18,13 @@ local ATH10K_PACKAGES_QCA9887 = {
 	'-ath10k-firmware-qca9887-ct',
 }
 
-local ATH10K_PACKAGES_QCA9888 = {}
+local ATH10K_PACKAGES_QCA9888 = {
+	'kmod-ath10k',
+	'-kmod-ath10k-ct',
+	'-kmod-ath10k-ct-smallbuffers',
+	'ath10k-firmware-qca9888',
+	'-ath10k-firmware-qca9888-ct',
+}
 
 -- ALFA NETWORK
 

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -1,5 +1,19 @@
-local ATH10K_PACKAGES_IPQ40XX = {}
-local ATH10K_PACKAGES_IPQ40XX_QCA9888 = {}
+local ATH10K_PACKAGES_IPQ40XX = {
+	'kmod-ath10k',
+	'-kmod-ath10k-ct',
+	'-kmod-ath10k-ct-smallbuffers',
+	'ath10k-firmware-qca4019',
+	'-ath10k-firmware-qca4019-ct',
+}
+local ATH10K_PACKAGES_IPQ40XX_QCA9888 = {
+	'kmod-ath10k',
+	'-kmod-ath10k-ct',
+	'-kmod-ath10k-ct-smallbuffers',
+	'ath10k-firmware-qca4019',
+	'-ath10k-firmware-qca4019-ct',
+	'ath10k-firmware-qca9888',
+	'-ath10k-firmware-qca9888-ct',
+}
 
 
 defaults {

--- a/targets/ipq806x-generic
+++ b/targets/ipq806x-generic
@@ -4,7 +4,7 @@
 -- The QCA9984 on the other hand works fine for 11s meshes on both bands.
 
 local QCA9980_PACKAGES = {'-kmod-ath10k', 'kmod-ath10k-ct', '-ath10k-firmware-qca99x0', 'ath10k-firmware-qca99x0-ct'}
-local QCA9984_PACKAGES = {}
+local QCA9984_PACKAGES = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca9984', '-ath10k-firmware-qca9984-ct'}
 
 
 --


### PR DESCRIPTION
> This is a temporary measure that fixes #2692.
> 
> This reverts commit 15ef885836907b27b2c0481f7ea83d1dd504c5d5.
> 
> (cherry picked from commit 22c47df2423e6149c4b37d5f70741adcf3365f5d)

This needed manual cherry-picking, I suggest we wait for the actions to run through, before merging.