### PR TITLE
ramips-mt7621: add GL.iNet MT1300

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -357,6 +357,10 @@ ramips-mt7621
 
   - DIR-860L (B1)
 
+* GL.iNet
+
+  - GL-MT1300
+
 * NETGEAR
 
   - EX6150 (v1)

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -17,6 +17,13 @@ device('cudy-wr2100', 'cudy_wr2100', {
 device('d-link-dir-860l-b1', 'dlink_dir-860l-b1')
 
 
+-- GL.iNet
+
+device('gl.inet-gl-mt1300', 'glinet_gl-mt1300', {
+	factory = false,
+})
+
+
 -- Netgear
 
 device('netgear-ex6150', 'netgear_ex6150', {


### PR DESCRIPTION
Test Device: https://map.chemnitz.freifunk.net/#!v:m;n:9483c41c0a42

- [x] Must be flashable from vendor firmware
  - [x] Web interface
 - [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> gl.inet-gl-mt1300
- [x] Reset button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
  - Radio LEDs (none)
  - Switch port LEDs (none)
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`