### PR TITLE
ath79-generic: fix WS-AP3705i autoupdater name

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -130,7 +130,7 @@ device('d-link-dir825b1', 'dlink_dir-825-b1', {
 
 -- Enterasys
 
-device('enterasys-ws-ap3705', 'enterasys_ws-ap3705i', {
+device('enterasys-ws-ap3705i', 'enterasys_ws-ap3705i', {
 	factory = false,
 })
 


### PR DESCRIPTION
The device was introduced in #2332 and merged in 102a4b9350c925cbbe15fdead43a370c445eacf8.

It appears that the autoupdater name wasn't correct and devices therefore don't receive updates.

```
root@64295-ggw3-20b399bb366f-132:~# lua -e 'print(require("platform_info").get_image_name())'
enterasys-ws-ap3705i
```

cc @blocktrron 