### PR TITLE
actions, docs: fix English typo, wording

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -34,7 +34,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Read back changd targets to create build matrix
+        # Read back changed targets to create build matrix
         target: ${{ fromJSON(needs.changed.outputs.targets) }}
     runs-on: ubuntu-latest
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,8 @@ using other parts or why the proposed change breaks other parts of the system.
 They might even refuse the idea altogether - after all, they have to sleep well
 after merging the changes, too.
 
-The preferred way to discuss in the IRC channel ([#gluon] on irc.hackint.org)
-or on the [mailing list], however, you can also open a new issue on Github to
+The preferred way to discuss is in the IRC channel ([#gluon] on irc.hackint.org)
+or on the [mailing list], however, you can also open a new issue on GitHub to
 discuss there. We maintain a [list of rejected features] and we'd like to
 kindly ask you to review it first. In general, looking for duplicates may save
 you some time.

--- a/docs/user/x86.rst
+++ b/docs/user/x86.rst
@@ -15,7 +15,7 @@ The following targets for x86 images exist:
 
     There are three images:
 
-    * `generic` (compressed "raw" image, can written to a disk directly or booted with qemu)
+    * `generic` (compressed "raw" image, can be written to a disk directly or booted with qemu)
     * `virtualbox` (VDI image)
     * `vmware` (VMDK image)
 


### PR DESCRIPTION
Fix also another sentence in `docs`.