### PR TITLE
gluon-core: set WAN mac from board-data

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/110-network
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/110-network
@@ -4,6 +4,19 @@ local uci = require('simple-uci').cursor()
 
 local sysconfig = require 'gluon.sysconfig'
 local util = require 'gluon.util'
+local json = require 'jsonc'
+
+local function get_network_mac(name)
+	local board_data = json.load('/etc/board.json')
+	local network_data = (board_data or {}).network
+
+	if network_data == nil then
+		return nil
+	end
+
+	local ifdata = network_data[name] or {}
+	return ifdata.macaddr
+end
 
 local wan = uci:get_all('network_gluon-old', 'wan') or {}
 local wan6 = uci:get_all('network_gluon-old', 'wan6') or {}
@@ -27,6 +40,7 @@ uci:section('network', 'interface', 'wan', {
 	ipaddr = wan.ipaddr,
 	netmask = wan.netmask,
 	gateway = wan.gateway,
+	macaddr = get_network_mac('wan'),
 	ifname = util.get_role_interfaces(uci, 'uplink'),
 	type = 'bridge',
 	igmp_snooping = true,


### PR DESCRIPTION
Set the MAC-adress for the WAN interfacce in case it is defined in the board-data.

This commit fixes random MAC-Addresses on reboot in case OpenWrt stores them in the device network configuration.

Fixes #2808