### PR TITLE
gluon-status-page: fix status display of wireless mesh for recent openwrt

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -67,7 +67,7 @@
 			iface = lower:sub(pattern:len())
 		end
 
-		return unistd.access('/sys/class/net/' .. iface .. '/wireless') ~= nil
+		return unistd.access('/sys/class/net/' .. iface .. '/phy80211') ~= nil
 	end
 
 	local uconn = ubus.connect()


### PR DESCRIPTION
Instead of checking for the deprecated sysfs entry `wireless` which no longer exists when running newer versions of openwrt, testing for `phy80211` can be used and works for old and new versions of openwrt.