### PR TITLE
ramips-mt7621: add support for D-Link DAP-X1860 (A1)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -359,6 +359,7 @@ ramips-mt7621
 
 * D-Link
 
+  - DAP-X1860 (A1)
   - DIR-860L (B1)
 
 * GL.iNet

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -14,6 +14,8 @@ device('cudy-wr2100', 'cudy_wr2100', {
 
 -- D-Link
 
+device('d-link-dap-x1860-a1', 'dlink_dap-x1860-a1')
+
 device('d-link-dir-860l-b1', 'dlink_dir-860l-b1')
 
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other:
     - press reset while powering the device
     - connect yourself to the network port, configure ipv4 within 192.168.0.0/24
     - device is reachable via http://192.168.0.50
     - upload factory firmware image
       Caveats:
       - doesn't respond to pings
       - error during uploads from browsers which aren't chromium based (worst case: we'll need some small application in the future which handles the upload in a way the device understands, for now chromium based browsers seem to work)
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode (WPS)
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be delcared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs (None)
    - Should map to their respective port (or switch, if only one led present) 
    - Should show link state and activity
- Outdoor devices only:
  - Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`