### PR TITLE
ramips-mt7621: add support for Mercusys MR70X v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -362,6 +362,10 @@ ramips-mt7621
 
   - GL-MT1300
 
+* Mercusys
+
+  - MR70X (v1)
+
 * NETGEAR
 
   - EX6150 (v1)

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -24,6 +24,11 @@ device('gl.inet-gl-mt1300', 'glinet_gl-mt1300', {
 })
 
 
+-- Mercusys
+
+device('mercusys-mr70x-v1', 'mercusys_mr70x-v1')
+
+
 -- Netgear
 
 device('netgear-ex6150', 'netgear_ex6150', {


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [x] Other: Web recovery
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be delcared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs (NONE)
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`