### PR TITLE
docs: readd TP-Link TD-W8970 v1 

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -254,6 +254,9 @@ lantiq-xrx200
   - FRITZ!Box 7362 SL [#eva_ramboot]_ [#lan_as_wan]_
   - FRITZ!Box 7412 [#eva_ramboot]_
 
+* TP-Link
+  - TD-W8970 (v1) [#lan_as_wan]_
+
 lantiq-xway
 -----------
 


### PR DESCRIPTION
This device is already supported.
It's a lantiq device that was entered as ar71xx
in to the list of supported device and therefore
removed before the release of Gluon 22.
EDIT: https://github.com/freifunk-gluon/gluon/commit/003c90f0b20af7dc0f51893a3931ad8bada725d2