### PR TITLE
docs: readd TP-Link TD-W8970 v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -237,6 +237,9 @@ lantiq-xrx200
   - FRITZ!Box 7362 SL [#eva_ramboot]_ [#lan_as_wan]_
   - FRITZ!Box 7412 [#eva_ramboot]_
 
+* TP-Link
+  - TD-W8970 (v1) [#lan_as_wan]_
+
 lantiq-xway
 -----------
 


### PR DESCRIPTION
This device is already supported.
It's a lantiq device that was entered as ar71xx
in to the list of supported device and therefore
removed before the release of Gluon 22.

This is a backport of
95e5d382ecc65ed68262b90e2fc5f2d8a13d464c