### PR TITLE
[docs] improve build dependencies and docs

### DIFF
--- a/contrib/actions/install-dependencies.sh
+++ b/contrib/actions/install-dependencies.sh
@@ -3,6 +3,6 @@
 set -e
 
 apt-get -y update
-apt-get -y install git subversion build-essential python3 gawk unzip libncurses5-dev zlib1g-dev libssl-dev wget time qemu-utils
+apt-get -y install git build-essential python3 gawk unzip libncurses5-dev zlib1g-dev libssl-dev libelf-dev wget rsync time qemu-utils
 apt-get -y clean
 rm -rf /var/lib/apt/lists/*

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     file \
     git \
-    subversion \
     python3 \
     build-essential \
     gawk \

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -25,18 +25,20 @@ An example configuration can be found in the Gluon repository at *docs/site-exam
 Dependencies
 ------------
 To build Gluon, several packages need to be installed on the system. On a
-freshly installed Debian Stretch system the following packages are required:
+freshly installed Debian Bullseye system the following packages are required:
 
 * `git` (to get Gluon and other dependencies)
-* `subversion`
 * `python3`
 * `build-essential`
+* `ecdsautils` (to sign firmware, see `contrib/sign.sh`)
 * `gawk`
 * `unzip`
 * `libncurses-dev` (actually `libncurses5-dev`)
 * `libz-dev` (actually `zlib1g-dev`)
 * `libssl-dev`
+* `libelf-dev` (to build x86-64)
 * `wget`
+* `rsync`
 * `time` (built-in `time` doesn't work)
 * `qemu-utils`
 


### PR DESCRIPTION
Target x86-64 does not build otherwise and does not show useful messages concerning the missing package either.

This issue was discussed on #gluon on IRC and was found by comparing the install docs to the `contrib/docker/Dockerfile`.

This PR updates the install dependencies and docs
    * add missing libelf-dev dependency (to build x86-64)
    * remove subversion dependency
    * add rsync dependency
    * add ecdsautils to docs (to sign firmware)