### PR TITLE
[v2021.1.x] patches: enable uart for Joy-IT OR750i

### DIFF
--- a/patches/openwrt/0027-ath79-enable-uart-for-Joy-IT-or750i.patch
+++ b/patches/openwrt/0027-ath79-enable-uart-for-Joy-IT-or750i.patch
@@ -1,0 +1,19 @@
+From: Jan-Niklas Burfeind <git@aiyionpri.me>
+Date: Wed, 5 Apr 2023 22:53:59 +0200
+Subject: ath79: enable uart for Joy-IT or750i
+
+diff --git a/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts b/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
+index 042348d82c479c097f534f0bf2bb383ace55e02d..76f863e9d3e92a1edfe4b7351376a7bb0d8e5bf5 100644
+--- a/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
++++ b/target/linux/ath79/dts/qca9531_joyit_jt-or750i.dts
+@@ -116,6 +116,10 @@
+ 	status = "okay";
+ };
+ 
++&uart {
++	status = "okay";
++};
++
+ &wmac {
+ 	status = "okay";
+ 


### PR DESCRIPTION
> resolves silent sysupgrade failure

The missing uart blocks sysupgrade from doing its job.
Why that is, I haven't looked up yet, but @blocktrron confirmed the reason.

master and newer branches are not affected, the issue was a disabled attribute in a backported patch we had in gluon `2021.1.x`.

resolves #2839