### PR TITLE
docs: add known issue on OR750i sysupgrade error

### DIFF
--- a/docs/releases/v2021.1.1.rst
+++ b/docs/releases/v2021.1.1.rst
@@ -40,6 +40,9 @@ Bugfixes
 Known issues
 ------------
 
+* Sysupgrade does not work on JOY-IT OR750i, devices running this release need to be recovered with an image newer than v2021.1.2 manually.
+  (`#2839 <https://github.com/freifunk-gluon/gluon/issues/2839>`_)
+
 * Upgrading EdgeRouter-X from versions before v2020.1.x may lead to a soft-bricked state due to bad blocks on the NAND flash which the NAND driver before this release does not handle well.
   (`#1937 <https://github.com/freifunk-gluon/gluon/issues/1937>`_)
 

--- a/docs/releases/v2021.1.2.rst
+++ b/docs/releases/v2021.1.2.rst
@@ -103,6 +103,9 @@ Other improvements
 Known issues
 ------------
 
+* Sysupgrade does not work on JOY-IT OR750i, devices running this release need to be recovered with an image newer than v2021.1.2 manually.
+  (`#2839 <https://github.com/freifunk-gluon/gluon/issues/2839>`_)
+
 * Upgrading EdgeRouter-X from versions before v2020.1.x may lead to a
   soft-bricked state due to bad blocks on the NAND flash which the NAND driver
   before this release does not handle well.


### PR DESCRIPTION
> affected versions:
> - v2021.1.1
> - v2021.1.2

I think this PR could use a backport to both `v2021.1.x` and `v2022.1.x`.
If you disagree, just remove the labels prior to merging this.

resolves #2839