### PR TITLE
ipq40xx: use ath10k-smallbuffers for ZyXEL WRE6606

### DIFF
--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -14,6 +14,14 @@ local ATH10K_PACKAGES_IPQ40XX_QCA9888 = {
 	'ath10k-firmware-qca9888',
 	'-ath10k-firmware-qca9888-ct',
 }
+local ATH10K_PACKAGES_IPQ40XX_SMALLBUFFERS = {
+	'-kmod-ath10k',
+	'kmod-ath10k-smallbuffers',
+	'-kmod-ath10k-ct',
+	'-kmod-ath10k-ct-smallbuffers',
+	'ath10k-firmware-qca4019',
+	'-ath10k-firmware-qca4019-ct',
+}
 
 
 defaults {
@@ -122,6 +130,7 @@ device('plasma-cloud-pa2200', 'plasmacloud_pa2200', {
 device('zyxel-nbg6617', 'zyxel_nbg6617')
 
 device('zyxel-wre6606', 'zyxel_wre6606', {
+	packages = ATH10K_PACKAGES_IPQ40XX_SMALLBUFFERS,
 	factory = false,
 	class = 'tiny', -- 128M ath10k + ath10k
 })


### PR DESCRIPTION
The WRE6066, has in contrast to other ip40xx devices, has only 128MB system RAM.
This results in OOM situations and instability, to circumvent this we need to use ath10k-smallbuffers.