### PR TITLE
ipq40xx-mikrotik: rename ath10k_packages to smallbuffers

### DIFF
--- a/targets/ipq40xx-mikrotik
+++ b/targets/ipq40xx-mikrotik
@@ -1,9 +1,9 @@
 include 'mikrotik.inc'
 
-local ATH10K_PACKAGES_IPQ40XX = {}
+local ATH10K_PACKAGES_IPQ40XX_SMALLBUFFERS = {}
 
 device('mikrotik-hap-ac2', 'mikrotik_hap-ac2', {
-	packages = ATH10K_PACKAGES_IPQ40XX,
+	packages = ATH10K_PACKAGES_IPQ40XX_SMALLBUFFERS,
 })
 
 device('mikrotik-sxtsq-5-ac-rbsxtsqg-5acd', 'mikrotik_sxtsq-5-ac', {


### PR DESCRIPTION
The only device using the ATH10K_PACKAGES_IPQ40XX variable in ipq40xx-mikrotik (the MikroTik hAP ac2) has little RAM and is using ath10k-ct-smallbuffers by default at the moment. This is just a suggestion to rename the variable in-case the wifi driver ever has to be replaced by ath10k.

Analogue to 4a00b8aebba30cfd4d5aa691fb850cb6ab4152e7