### PR TITLE
v2022.1.x ramips-mt7621 hardware backports

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -344,6 +344,10 @@ ramips-mt7621
 
   - DIR-860L (B1)
 
+* GL.iNet
+
+  - GL-MT1300
+
 * NETGEAR
 
   - EX6150 (v1)

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -342,6 +342,7 @@ ramips-mt7621
 
 * D-Link
 
+  - DAP-X1860 (A1)
   - DIR-860L (B1)
 
 * GL.iNet

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -348,6 +348,10 @@ ramips-mt7621
 
   - GL-MT1300
 
+* Mercusys
+
+  - MR70X (v1)
+
 * NETGEAR
 
   - EX6150 (v1)

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -17,6 +17,13 @@ device('cudy-wr2100', 'cudy_wr2100', {
 device('d-link-dir-860l-b1', 'dlink_dir-860l-b1')
 
 
+-- GL.iNet
+
+device('gl.inet-gl-mt1300', 'glinet_gl-mt1300', {
+	factory = false,
+})
+
+
 -- Netgear
 
 device('netgear-ex6150', 'netgear_ex6150', {

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -24,6 +24,11 @@ device('gl.inet-gl-mt1300', 'glinet_gl-mt1300', {
 })
 
 
+-- Mercusys
+
+device('mercusys-mr70x-v1', 'mercusys_mr70x-v1')
+
+
 -- Netgear
 
 device('netgear-ex6150', 'netgear_ex6150', {

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -14,6 +14,8 @@ device('cudy-wr2100', 'cudy_wr2100', {
 
 -- D-Link
 
+device('d-link-dap-x1860-a1', 'dlink_dap-x1860-a1')
+
 device('d-link-dir-860l-b1', 'dlink_dir-860l-b1')
 
 


### PR DESCRIPTION
this backports three devices:

GL.iNet MT1300
https://github.com/freifunk-gluon/gluon/pull/2813

Mercusys MR70X v1
https://github.com/freifunk-gluon/gluon/pull/2831

D-Link DAP-X1860 (A1)
https://github.com/freifunk-gluon/gluon/pull/2830
( needs #2859 )