### PR TITLE
ipq40xx-generic: add support for Meraki MR33

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -81,6 +81,7 @@ local primary_addrs = {
 		{'brcm2708'},
 		{'ipq40xx', 'generic', {
 			'avm,fritzbox-4040',
+			'meraki,mr33',
 			'plasmacloud,pa1200',
 			'plasmacloud,pa2200',
 		}},

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -96,6 +96,23 @@ device('gl.inet-gl-b1300', 'glinet_gl-b1300', {
 device('linksys-ea6350v3', 'linksys_ea6350v3')
 
 
+-- Meraki
+
+device('meraki-mr33-access-point', 'meraki_mr33', {
+	packages = {
+		-- radio0 is monitoring radio - removed for now
+		-- the -ct firmware does not have working mesh
+		'-ath10k-firmware-qca9887-ct',
+		'-ath10k-board-qca9887',
+	},
+	factory = false,
+	broken = true,
+	-- case must be opened to install
+	-- the board also bricks the SoC on newer bootloader-versions which is irreversible
+	-- third radio not yet working
+})
+
+
 -- NETGEAR
 
 device('netgear-ex6100v2', 'netgear_ex6100v2', {


### PR DESCRIPTION
This device was tested by someone in our community.
This looks good so far, we are still investigating the open issues and see if we can get support for 5GHz Wifi out of the box too.

- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: https://openwrt.org/toh/meraki/mr33#installation
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
        #output is "meraki-mr33-access-point" - added to manifest_aliases
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
      #eth0 MAC matches - set in 010-primary
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be delcared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
  # monitor radio0 driver is disabled, radio1 is 2.4GHz and radio2 is 5GHz
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~ no radio LEDs
      - ~~Should map to their respective radio~~
      - ~~Should show activity~~
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- ~~Outdoor devices only:~~
  - ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- ~~Cellular devices only:~~
  - ~~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - ~~Added Device to `docs/user/supported_devices.rst`~~ <- is broken