### PR TITLE
libbatadv: Update UAPI from kernel 6.2

### DIFF
--- a/package/libbatadv/src/batadv-genl.c
+++ b/package/libbatadv/src/batadv-genl.c
@@ -41,58 +41,206 @@
 
 __attribute__ ((visibility ("default")))
 struct nla_policy batadv_genl_policy[NUM_BATADV_ATTR] = {
-	[BATADV_ATTR_VERSION]		= { .type = NLA_STRING },
-	[BATADV_ATTR_ALGO_NAME]		= { .type = NLA_STRING },
-	[BATADV_ATTR_MESH_IFINDEX]	= { .type = NLA_U32 },
-	[BATADV_ATTR_MESH_IFNAME]	= { .type = NLA_STRING,
-		.maxlen = IFNAMSIZ },
-	[BATADV_ATTR_MESH_ADDRESS]	= { .type = NLA_UNSPEC,
+	[BATADV_ATTR_VERSION] = {
+		.type = NLA_STRING,
+	},
+	[BATADV_ATTR_ALGO_NAME] = {
+		.type = NLA_STRING,
+	},
+	[BATADV_ATTR_MESH_IFINDEX] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_MESH_IFNAME] = {
+		.type = NLA_STRING,
+		.maxlen = IFNAMSIZ,
+	},
+	[BATADV_ATTR_MESH_ADDRESS] = {
+		.type = NLA_UNSPEC,
 		.minlen = ETH_ALEN,
-		.maxlen = ETH_ALEN },
-	[BATADV_ATTR_HARD_IFINDEX]	= { .type = NLA_U32 },
-	[BATADV_ATTR_HARD_IFNAME]	= { .type = NLA_STRING,
-		.maxlen = IFNAMSIZ },
-	[BATADV_ATTR_HARD_ADDRESS]	= { .type = NLA_UNSPEC,
+		.maxlen = ETH_ALEN,
+	},
+	[BATADV_ATTR_HARD_IFINDEX] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_HARD_IFNAME] = {
+		.type = NLA_STRING,
+		.maxlen = IFNAMSIZ,
+	},
+	[BATADV_ATTR_HARD_ADDRESS] = {
+		.type = NLA_UNSPEC,
 		.minlen = ETH_ALEN,
-		.maxlen = ETH_ALEN },
-	[BATADV_ATTR_ORIG_ADDRESS]	= { .type = NLA_UNSPEC,
+		.maxlen = ETH_ALEN,
+	},
+	[BATADV_ATTR_ORIG_ADDRESS] = {
+		.type = NLA_UNSPEC,
 		.minlen = ETH_ALEN,
-		.maxlen = ETH_ALEN },
-	[BATADV_ATTR_TPMETER_RESULT]	= { .type = NLA_U8 },
-	[BATADV_ATTR_TPMETER_TEST_TIME]	= { .type = NLA_U32 },
-	[BATADV_ATTR_TPMETER_BYTES]	= { .type = NLA_U64 },
-	[BATADV_ATTR_TPMETER_COOKIE]	= { .type = NLA_U32 },
-	[BATADV_ATTR_PAD]		= { .type = NLA_UNSPEC },
-	[BATADV_ATTR_ACTIVE]		= { .type = NLA_FLAG },
-	[BATADV_ATTR_TT_ADDRESS]	= { .type = NLA_UNSPEC,
+		.maxlen = ETH_ALEN,
+	},
+	[BATADV_ATTR_TPMETER_RESULT] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_TPMETER_TEST_TIME] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_TPMETER_BYTES] = {
+		.type = NLA_U64,
+	},
+	[BATADV_ATTR_TPMETER_COOKIE] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_PAD] = {
+		.type = NLA_UNSPEC,
+	},
+	[BATADV_ATTR_ACTIVE] = {
+		.type = NLA_FLAG,
+	},
+	[BATADV_ATTR_TT_ADDRESS] = {
+		.type = NLA_UNSPEC,
 		.minlen = ETH_ALEN,
-		.maxlen = ETH_ALEN },
-	[BATADV_ATTR_TT_TTVN]		= { .type = NLA_U8 },
-	[BATADV_ATTR_TT_LAST_TTVN]	= { .type = NLA_U8 },
-	[BATADV_ATTR_TT_CRC32]		= { .type = NLA_U32 },
-	[BATADV_ATTR_TT_VID]		= { .type = NLA_U16 },
-	[BATADV_ATTR_TT_FLAGS]		= { .type = NLA_U32 },
-	[BATADV_ATTR_FLAG_BEST]		= { .type = NLA_FLAG },
-	[BATADV_ATTR_LAST_SEEN_MSECS]	= { .type = NLA_U32 },
-	[BATADV_ATTR_NEIGH_ADDRESS]	= { .type = NLA_UNSPEC,
+		.maxlen = ETH_ALEN,
+	},
+	[BATADV_ATTR_TT_TTVN] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_TT_LAST_TTVN] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_TT_CRC32] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_TT_VID] = {
+		.type = NLA_U16,
+	},
+	[BATADV_ATTR_TT_FLAGS] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_FLAG_BEST] = {
+		.type = NLA_FLAG,
+	},
+	[BATADV_ATTR_LAST_SEEN_MSECS] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_NEIGH_ADDRESS] = {
+		.type = NLA_UNSPEC,
 		.minlen = ETH_ALEN,
-		.maxlen = ETH_ALEN },
-	[BATADV_ATTR_TQ]		= { .type = NLA_U8 },
-	[BATADV_ATTR_THROUGHPUT]	= { .type = NLA_U32 },
-	[BATADV_ATTR_BANDWIDTH_UP]	= { .type = NLA_U32 },
-	[BATADV_ATTR_BANDWIDTH_DOWN]	= { .type = NLA_U32 },
-	[BATADV_ATTR_ROUTER]		= { .type = NLA_UNSPEC,
+		.maxlen = ETH_ALEN,
+	},
+	[BATADV_ATTR_TQ] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_THROUGHPUT] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_BANDWIDTH_UP] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_BANDWIDTH_DOWN] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_ROUTER] = {
+		.type = NLA_UNSPEC,
 		.minlen = ETH_ALEN,
-		.maxlen = ETH_ALEN },
-	[BATADV_ATTR_BLA_OWN]		= { .type = NLA_FLAG },
-	[BATADV_ATTR_BLA_ADDRESS]	= { .type = NLA_UNSPEC,
+		.maxlen = ETH_ALEN,
+	},
+	[BATADV_ATTR_BLA_OWN] = {
+		.type = NLA_FLAG,
+	},
+	[BATADV_ATTR_BLA_ADDRESS] = {
+		.type = NLA_UNSPEC,
 		.minlen = ETH_ALEN,
-		.maxlen = ETH_ALEN },
-	[BATADV_ATTR_BLA_VID]		= { .type = NLA_U16 },
-	[BATADV_ATTR_BLA_BACKBONE]	= { .type = NLA_UNSPEC,
+		.maxlen = ETH_ALEN,
+	},
+	[BATADV_ATTR_BLA_VID] = {
+		.type = NLA_U16,
+	},
+	[BATADV_ATTR_BLA_BACKBONE] = {
+		.type = NLA_UNSPEC,
 		.minlen = ETH_ALEN,
-		.maxlen = ETH_ALEN },
-	[BATADV_ATTR_BLA_CRC]		= { .type = NLA_U16 },
+		.maxlen = ETH_ALEN,
+	},
+	[BATADV_ATTR_BLA_CRC] = {
+		.type = NLA_U16,
+	},
+	[BATADV_ATTR_DAT_CACHE_IP4ADDRESS] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_DAT_CACHE_HWADDRESS] = {
+		.type = NLA_UNSPEC,
+		.minlen = ETH_ALEN,
+		.maxlen = ETH_ALEN,
+	},
+	[BATADV_ATTR_DAT_CACHE_VID] = {
+		.type = NLA_U16,
+	},
+	[BATADV_ATTR_MCAST_FLAGS] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_MCAST_FLAGS_PRIV] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_VLANID] = {
+		.type = NLA_U16,
+	},
+	[BATADV_ATTR_AGGREGATED_OGMS_ENABLED] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_AP_ISOLATION_ENABLED] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_ISOLATION_MARK] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_ISOLATION_MASK] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_BONDING_ENABLED] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_BRIDGE_LOOP_AVOIDANCE_ENABLED] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_DISTRIBUTED_ARP_TABLE_ENABLED] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_FRAGMENTATION_ENABLED] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_GW_BANDWIDTH_DOWN] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_GW_BANDWIDTH_UP] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_GW_MODE] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_GW_SEL_CLASS] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_HOP_PENALTY] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_LOG_LEVEL] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_MULTICAST_FORCEFLOOD_ENABLED] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_NETWORK_CODING_ENABLED] = {
+		.type = NLA_U8,
+	},
+	[BATADV_ATTR_ORIG_INTERVAL] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_ELP_INTERVAL] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_THROUGHPUT_OVERRIDE] = {
+		.type = NLA_U32,
+	},
+	[BATADV_ATTR_MULTICAST_FANOUT] = {
+		.type = NLA_U32,
+	},
 };
 
 /**

--- a/package/libbatadv/src/batman_adv.h
+++ b/package/libbatadv/src/batman_adv.h
@@ -1,25 +1,7 @@
 /* SPDX-License-Identifier: MIT */
-/* Copyright (C) 2016-2017  B.A.T.M.A.N. contributors:
+/* Copyright (C) B.A.T.M.A.N. contributors:
  *
  * Matthias Schiffer
- *
- * Permission is hereby granted, free of charge, to any person obtaining a
- * copy of this software and associated documentation files (the "Software"),
- * to deal in the Software without restriction, including without limitation
- * the rights to use, copy, modify, merge, publish, distribute, sublicense,
- * and/or sell copies of the Software, and to permit persons to whom the
- * Software is furnished to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
- * DEALINGS IN THE SOFTWARE.
  */
 
 #ifndef _UAPI_LINUX_BATMAN_ADV_H_
@@ -27,6 +9,7 @@
 
 #define BATADV_NL_NAME "batadv"
 
+#define BATADV_NL_MCAST_GROUP_CONFIG	"config"
 #define BATADV_NL_MCAST_GROUP_TPMETER	"tpmeter"
 
 /**
@@ -86,9 +69,70 @@ enum batadv_tt_client_flags {
 
 	/**
 	 * @BATADV_TT_CLIENT_TEMP: this global client has been detected to be
-	 * part of the network but no nnode has already announced it
+	 * part of the network but no node has already announced it
 	 */
 	BATADV_TT_CLIENT_TEMP	 = (1 << 11),
+};
+
+/**
+ * enum batadv_mcast_flags_priv - Private, own multicast flags
+ *
+ * These are internal, multicast related flags. Currently they describe certain
+ * multicast related attributes of the segment this originator bridges into the
+ * mesh.
+ *
+ * Those attributes are used to determine the public multicast flags this
+ * originator is going to announce via TT.
+ *
+ * For netlink, if BATADV_MCAST_FLAGS_BRIDGED is unset then all querier
+ * related flags are undefined.
+ */
+enum batadv_mcast_flags_priv {
+	/**
+	 * @BATADV_MCAST_FLAGS_BRIDGED: There is a bridge on top of the mesh
+	 * interface.
+	 */
+	BATADV_MCAST_FLAGS_BRIDGED			= (1 << 0),
+
+	/**
+	 * @BATADV_MCAST_FLAGS_QUERIER_IPV4_EXISTS: Whether an IGMP querier
+	 * exists in the mesh
+	 */
+	BATADV_MCAST_FLAGS_QUERIER_IPV4_EXISTS		= (1 << 1),
+
+	/**
+	 * @BATADV_MCAST_FLAGS_QUERIER_IPV6_EXISTS: Whether an MLD querier
+	 * exists in the mesh
+	 */
+	BATADV_MCAST_FLAGS_QUERIER_IPV6_EXISTS		= (1 << 2),
+
+	/**
+	 * @BATADV_MCAST_FLAGS_QUERIER_IPV4_SHADOWING: If an IGMP querier
+	 * exists, whether it is potentially shadowing multicast listeners
+	 * (i.e. querier is behind our own bridge segment)
+	 */
+	BATADV_MCAST_FLAGS_QUERIER_IPV4_SHADOWING	= (1 << 3),
+
+	/**
+	 * @BATADV_MCAST_FLAGS_QUERIER_IPV6_SHADOWING: If an MLD querier
+	 * exists, whether it is potentially shadowing multicast listeners
+	 * (i.e. querier is behind our own bridge segment)
+	 */
+	BATADV_MCAST_FLAGS_QUERIER_IPV6_SHADOWING	= (1 << 4),
+};
+
+/**
+ * enum batadv_gw_modes - gateway mode of node
+ */
+enum batadv_gw_modes {
+	/** @BATADV_GW_MODE_OFF: gw mode disabled */
+	BATADV_GW_MODE_OFF,
+
+	/** @BATADV_GW_MODE_CLIENT: send DHCP requests to gw servers */
+	BATADV_GW_MODE_CLIENT,
+
+	/** @BATADV_GW_MODE_SERVER: announce itself as gateway server */
+	BATADV_GW_MODE_SERVER,
 };
 
 /**
@@ -272,6 +316,171 @@ enum batadv_nl_attrs {
 	 */
 	BATADV_ATTR_BLA_CRC,
 
+	/**
+	 * @BATADV_ATTR_DAT_CACHE_IP4ADDRESS: Client IPv4 address
+	 */
+	BATADV_ATTR_DAT_CACHE_IP4ADDRESS,
+
+	/**
+	 * @BATADV_ATTR_DAT_CACHE_HWADDRESS: Client MAC address
+	 */
+	BATADV_ATTR_DAT_CACHE_HWADDRESS,
+
+	/**
+	 * @BATADV_ATTR_DAT_CACHE_VID: VLAN ID
+	 */
+	BATADV_ATTR_DAT_CACHE_VID,
+
+	/**
+	 * @BATADV_ATTR_MCAST_FLAGS: Per originator multicast flags
+	 */
+	BATADV_ATTR_MCAST_FLAGS,
+
+	/**
+	 * @BATADV_ATTR_MCAST_FLAGS_PRIV: Private, own multicast flags
+	 */
+	BATADV_ATTR_MCAST_FLAGS_PRIV,
+
+	/**
+	 * @BATADV_ATTR_VLANID: VLAN id on top of soft interface
+	 */
+	BATADV_ATTR_VLANID,
+
+	/**
+	 * @BATADV_ATTR_AGGREGATED_OGMS_ENABLED: whether the batman protocol
+	 *  messages of the mesh interface shall be aggregated or not.
+	 */
+	BATADV_ATTR_AGGREGATED_OGMS_ENABLED,
+
+	/**
+	 * @BATADV_ATTR_AP_ISOLATION_ENABLED: whether the data traffic going
+	 *  from a wireless client to another wireless client will be silently
+	 *  dropped.
+	 */
+	BATADV_ATTR_AP_ISOLATION_ENABLED,
+
+	/**
+	 * @BATADV_ATTR_ISOLATION_MARK: the isolation mark which is used to
+	 *  classify clients as "isolated" by the Extended Isolation feature.
+	 */
+	BATADV_ATTR_ISOLATION_MARK,
+
+	/**
+	 * @BATADV_ATTR_ISOLATION_MASK: the isolation (bit)mask which is used to
+	 *  classify clients as "isolated" by the Extended Isolation feature.
+	 */
+	BATADV_ATTR_ISOLATION_MASK,
+
+	/**
+	 * @BATADV_ATTR_BONDING_ENABLED: whether the data traffic going through
+	 *  the mesh will be sent using multiple interfaces at the same time.
+	 */
+	BATADV_ATTR_BONDING_ENABLED,
+
+	/**
+	 * @BATADV_ATTR_BRIDGE_LOOP_AVOIDANCE_ENABLED: whether the bridge loop
+	 *  avoidance feature is enabled. This feature detects and avoids loops
+	 *  between the mesh and devices bridged with the soft interface
+	 */
+	BATADV_ATTR_BRIDGE_LOOP_AVOIDANCE_ENABLED,
+
+	/**
+	 * @BATADV_ATTR_DISTRIBUTED_ARP_TABLE_ENABLED: whether the distributed
+	 *  arp table feature is enabled. This feature uses a distributed hash
+	 *  table to answer ARP requests without flooding the request through
+	 *  the whole mesh.
+	 */
+	BATADV_ATTR_DISTRIBUTED_ARP_TABLE_ENABLED,
+
+	/**
+	 * @BATADV_ATTR_FRAGMENTATION_ENABLED: whether the data traffic going
+	 *  through the mesh will be fragmented or silently discarded if the
+	 *  packet size exceeds the outgoing interface MTU.
+	 */
+	BATADV_ATTR_FRAGMENTATION_ENABLED,
+
+	/**
+	 * @BATADV_ATTR_GW_BANDWIDTH_DOWN: defines the download bandwidth which
+	 *  is propagated by this node if %BATADV_ATTR_GW_BANDWIDTH_MODE was set
+	 *  to 'server'.
+	 */
+	BATADV_ATTR_GW_BANDWIDTH_DOWN,
+
+	/**
+	 * @BATADV_ATTR_GW_BANDWIDTH_UP: defines the upload bandwidth which
+	 *  is propagated by this node if %BATADV_ATTR_GW_BANDWIDTH_MODE was set
+	 *  to 'server'.
+	 */
+	BATADV_ATTR_GW_BANDWIDTH_UP,
+
+	/**
+	 * @BATADV_ATTR_GW_MODE: defines the state of the gateway features.
+	 * Possible values are specified in enum batadv_gw_modes
+	 */
+	BATADV_ATTR_GW_MODE,
+
+	/**
+	 * @BATADV_ATTR_GW_SEL_CLASS: defines the selection criteria this node
+	 *  will use to choose a gateway if gw_mode was set to 'client'.
+	 */
+	BATADV_ATTR_GW_SEL_CLASS,
+
+	/**
+	 * @BATADV_ATTR_HOP_PENALTY: defines the penalty which will be applied
+	 *  to an originator message's tq-field on every hop and/or per
+	 *  hard interface
+	 */
+	BATADV_ATTR_HOP_PENALTY,
+
+	/**
+	 * @BATADV_ATTR_LOG_LEVEL: bitmask with to define which debug messages
+	 *  should be send to the debug log/trace ring buffer
+	 */
+	BATADV_ATTR_LOG_LEVEL,
+
+	/**
+	 * @BATADV_ATTR_MULTICAST_FORCEFLOOD_ENABLED: whether multicast
+	 *  optimizations should be replaced by simple broadcast-like flooding
+	 *  of multicast packets. If set to non-zero then all nodes in the mesh
+	 *  are going to use classic flooding for any multicast packet with no
+	 *  optimizations.
+	 */
+	BATADV_ATTR_MULTICAST_FORCEFLOOD_ENABLED,
+
+	/**
+	 * @BATADV_ATTR_NETWORK_CODING_ENABLED: whether Network Coding (using
+	 *  some magic to send fewer wifi packets but still the same content) is
+	 *  enabled or not.
+	 */
+	BATADV_ATTR_NETWORK_CODING_ENABLED,
+
+	/**
+	 * @BATADV_ATTR_ORIG_INTERVAL: defines the interval in milliseconds in
+	 *  which batman sends its protocol messages.
+	 */
+	BATADV_ATTR_ORIG_INTERVAL,
+
+	/**
+	 * @BATADV_ATTR_ELP_INTERVAL: defines the interval in milliseconds in
+	 *  which batman emits probing packets for neighbor sensing (ELP).
+	 */
+	BATADV_ATTR_ELP_INTERVAL,
+
+	/**
+	 * @BATADV_ATTR_THROUGHPUT_OVERRIDE: defines the throughput value to be
+	 *  used by B.A.T.M.A.N. V when estimating the link throughput using
+	 *  this interface. If the value is set to 0 then batman-adv will try to
+	 *  estimate the throughput by itself.
+	 */
+	BATADV_ATTR_THROUGHPUT_OVERRIDE,
+
+	/**
+	 * @BATADV_ATTR_MULTICAST_FANOUT: defines the maximum number of packet
+	 * copies that may be generated for a multicast-to-unicast conversion.
+	 * Once this limit is exceeded distribution will fall back to broadcast.
+	 */
+	BATADV_ATTR_MULTICAST_FANOUT,
+
 	/* add attributes above here, update the policy in netlink.c */
 
 	/**
@@ -300,10 +509,14 @@ enum batadv_nl_commands {
 	BATADV_CMD_UNSPEC,
 
 	/**
-	 * @BATADV_CMD_GET_MESH_INFO: Query basic information about batman-adv
-	 * device
+	 * @BATADV_CMD_GET_MESH: Get attributes from softif/mesh
 	 */
-	BATADV_CMD_GET_MESH_INFO,
+	BATADV_CMD_GET_MESH,
+
+	/**
+	 * @BATADV_CMD_GET_MESH_INFO: Alias for @BATADV_CMD_GET_MESH
+	 */
+	BATADV_CMD_GET_MESH_INFO = BATADV_CMD_GET_MESH,
 
 	/**
 	 * @BATADV_CMD_TP_METER: Start a tp meter session
@@ -321,9 +534,15 @@ enum batadv_nl_commands {
 	BATADV_CMD_GET_ROUTING_ALGOS,
 
 	/**
-	 * @BATADV_CMD_GET_HARDIFS: Query list of hard interfaces
+	 * @BATADV_CMD_GET_HARDIF: Get attributes from a hardif of the
+	 *  current softif
 	 */
-	BATADV_CMD_GET_HARDIFS,
+	BATADV_CMD_GET_HARDIF,
+
+	/**
+	 * @BATADV_CMD_GET_HARDIFS: Alias for @BATADV_CMD_GET_HARDIF
+	 */
+	BATADV_CMD_GET_HARDIFS = BATADV_CMD_GET_HARDIF,
 
 	/**
 	 * @BATADV_CMD_GET_TRANSTABLE_LOCAL: Query list of local translations
@@ -360,6 +579,39 @@ enum batadv_nl_commands {
 	 * backbones
 	 */
 	BATADV_CMD_GET_BLA_BACKBONE,
+
+	/**
+	 * @BATADV_CMD_GET_DAT_CACHE: Query list of DAT cache entries
+	 */
+	BATADV_CMD_GET_DAT_CACHE,
+
+	/**
+	 * @BATADV_CMD_GET_MCAST_FLAGS: Query list of multicast flags
+	 */
+	BATADV_CMD_GET_MCAST_FLAGS,
+
+	/**
+	 * @BATADV_CMD_SET_MESH: Set attributes for softif/mesh
+	 */
+	BATADV_CMD_SET_MESH,
+
+	/**
+	 * @BATADV_CMD_SET_HARDIF: Set attributes for hardif of the
+	 *  current softif
+	 */
+	BATADV_CMD_SET_HARDIF,
+
+	/**
+	 * @BATADV_CMD_GET_VLAN: Get attributes from a VLAN of the
+	 *  current softif
+	 */
+	BATADV_CMD_GET_VLAN,
+
+	/**
+	 * @BATADV_CMD_SET_VLAN: Set attributes for VLAN of the
+	 *  current softif
+	 */
+	BATADV_CMD_SET_VLAN,
 
 	/* add new commands above here */
 
@@ -422,5 +674,31 @@ enum batadv_tp_meter_reason {
 	 */
 	BATADV_TP_REASON_TOO_MANY		= 133,
 };
+
+/**
+ * enum batadv_ifla_attrs - batman-adv ifla nested attributes
+ */
+enum batadv_ifla_attrs {
+	/**
+	 * @IFLA_BATADV_UNSPEC: unspecified attribute which is not parsed by
+	 *  rtnetlink
+	 */
+	IFLA_BATADV_UNSPEC,
+
+	/**
+	 * @IFLA_BATADV_ALGO_NAME: routing algorithm (name) which should be
+	 *  used by the newly registered batadv net_device.
+	 */
+	IFLA_BATADV_ALGO_NAME,
+
+	/* add attributes above here, update the policy in soft-interface.c */
+
+	/**
+	 * @__IFLA_BATADV_MAX: internal use
+	 */
+	__IFLA_BATADV_MAX,
+};
+
+#define IFLA_BATADV_MAX (__IFLA_BATADV_MAX - 1)
 
 #endif /* _UAPI_LINUX_BATMAN_ADV_H_ */


### PR DESCRIPTION
`batadv_gw_modes` and `BATADV_ATTR_GW_MODE` were missing from the local version, so update it from upstream.