### PR TITLE
backport-v2022.1.x - xrx200: migrate fritz7360-v2 using incorrect image

### DIFF
--- a/patches/openwrt/0008-xrx200-migrate-fritz7360-v2-using-incorrect-image.patch
+++ b/patches/openwrt/0008-xrx200-migrate-fritz7360-v2-using-incorrect-image.patch
@@ -1,0 +1,81 @@
+From: Grische <github@grische.xyz>
+Date: Sun, 18 Sep 2022 14:03:16 +0200
+Subject: xrx200: migrate fritz7360-v2 using incorrect image
+
+Migrate AVM FRITZ!Box 7360 v2 boards flashed with the incorrect v1 image to use
+the newly added v2 target image during the next upgrade.
+Using the v2 target image allows the boards to read the TFFS partition, which
+is misaligned when using the v1 image.
+
+Ref: https://github.com/freifunk-gluon/gluon/pull/2648
+
+Co-authored-by: Jan-Niklas Burfeind <git@aiyionpri.me>
+
+diff --git a/target/linux/lantiq/xrx200/base-files/lib/preinit/01_sysinfo.sh b/target/linux/lantiq/xrx200/base-files/lib/preinit/01_sysinfo.sh
+new file mode 100644
+index 0000000000000000000000000000000000000000..fab50d708e872f819c643cea79327e4f438de524
+--- /dev/null
++++ b/target/linux/lantiq/xrx200/base-files/lib/preinit/01_sysinfo.sh
+@@ -0,0 +1,62 @@
++set_sysinfo_xrx200_for_fritz7360_model() {
++    local board_name=$1
++    local model
++    local urlader_version urlader_memsize urlader_flashsize
++    local hexdump_format='4/1 "%02x""\n"'
++
++    # Values are based on urlader-parser-py
++    # https://github.com/grische/urlader-parser-py/blob/42970bf8dec7962317df4ff734c57ebf36df8905/parser.py#L77-L84
++    urlader_version="$(dd if=/dev/mtd0ro bs=1 skip=$((0x580+0x0)) count=4 | hexdump -e "${hexdump_format}")"
++    if [ "${urlader_version}" != "00000003" ]; then
++        logger -s -p warn -t sysinfo-xrx200 "unexpected urlader version found: ${urlader_version}"
++        return
++    fi
++
++    urlader_memsize="$(dd if=/dev/mtd0ro bs=1 skip=$((0x580+0x4)) count=4 | hexdump -e "${hexdump_format}")"
++    if [ "${urlader_memsize}" != "08000000" ]; then
++        logger -s -p warn -t sysinfo-xrx200 "unexpected memsize found: ${urlader_memsize}"
++        return
++    fi
++
++    urlader_flashsize="$(dd if=/dev/mtd0ro bs=1 skip=$((0x580+0x8)) count=4 | hexdump -e "${hexdump_format}")"
++    case "${urlader_flashsize}" in
++        "02000000")    # 32MB
++            # see vr9_avm_fritz7360-v2.dts
++            board_name="avm,fritz7360-v2"
++            model="AVM FRITZ!Box 7360 V2"
++            ;;
++        "01000000")    # 16MB
++            return
++            ;;
++        *)
++            logger -s -p warn -t sysinfo-xrx200 "unexpected flashsize found: ${urlader_flashsize}"
++            return
++            ;;
++    esac
++
++    logger -s -p notice -t sysinfo-xrx200 "detected ${board_name} from urlader partition /dev/mtd0ro. Enforcing model ${model}."
++    echo "${board_name}" > /tmp/sysinfo/board_name
++    echo "${model}" > /tmp/sysinfo/model
++}
++
++do_sysinfo_xrx200() {
++    local reported_board board_name model
++
++    [ -d /proc/device-tree ] || return
++    reported_board="$(strings /proc/device-tree/compatible | head -1)"
++
++    mkdir -p /tmp/sysinfo
++    # 7360 is notoriously known for not writing "v2" on their labels and many
++    # routers have flashed the wrong firmware with the wrong flash layout.
++    # We ensure that the underlying hardware is reported correctly, so that
++    # future upgrades will use the correct flash layout.
++    # Using 7360v2 hardware, an upgrade from a 7360v1/sl firmware to a 7360v2
++    # is working.
++    case "${reported_board}" in
++        avm,fritz7360sl)
++            set_sysinfo_xrx200_for_fritz7360_model "${reported_board}"
++            ;;
++    esac
++}
++
++boot_hook_add preinit_main do_sysinfo_xrx200


### PR DESCRIPTION
As mentioned in #2648 this backports the fritz 7360v2 migration to v2022.1.x branch

Migrate AVM FRITZ!Box 7360 v2 boards flashed with the incorrect v1 image to use the newly added v2 target image during the next upgrade. Using the v2 target image allows the boards to read the TFFS partition, which is misaligned when using the v1 image.

Co-authored-by: Jan-Niklas Burfeind <git@aiyionpri.me>
(cherry picked from commit e4ec16d9cd2e43f84ab0253025a7cd91316f5618)