### PR TITLE
scripts/container.sh: support podman on macOS

### DIFF
--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -12,7 +12,7 @@ TAG="gluon:${BRANCH:-latest}"
 if [ "$(command -v podman)" ]
 then
 	podman build -t "${TAG}" contrib/docker
-	podman run -it --rm --userns=keep-id --volume="$(pwd):/gluon" "${TAG}"
+	podman run -it --rm --userns=keep-id:uid=1000,gid=1000 --volume="$(pwd):/gluon" "${TAG}"
 elif [ "$(command -v docker)" ]
 then
 	docker build -t "${TAG}" contrib/docker


### PR DESCRIPTION
The default user and group IDs on macOS are different from those used on Linux, so add the expected ones explicitly.