### PR TITLE
openwrt: backport combination of dual-flash partitions

### DIFF
--- a/patches/openwrt/0011-ath79-combine-OCEDO-dual-firmware-partitions.patch
+++ b/patches/openwrt/0011-ath79-combine-OCEDO-dual-firmware-partitions.patch
@@ -1,0 +1,115 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Tue, 15 Nov 2022 15:25:40 +0100
+Subject: ath79: combine OCEDO dual firmware-partitions
+
+In order to maximize the available space on OCEDO boards using a
+dual-image partition layout, combine the two OS partitions into a single
+partition.
+
+This allows users to access more usable space for additional packages.
+
+Don't limit the usable image size to the size of a single OS partition.
+The initial installation has to be done with an older version of OpenWrt
+in case the generated image exceeds the space of a single OS
+partition in the future.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+(cherry picked from commit eded295cd7fd53bfa5afcb67a1b91cfda0523ba6)
+
+diff --git a/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts b/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
+index 0bbeb2b533b3fbbdcce53e094412d459ee762d85..3ecd20e2aa8fe04164cddbc84e0eb800e049c011 100644
+--- a/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
++++ b/target/linux/ath79/dts/ar9344_ocedo_raccoon.dts
+@@ -91,15 +91,10 @@
+ 			};
+ 
+ 			partition@50000 {
++				/* Dual-Flash layout combined */
+ 				compatible = "denx,uimage";
+ 				label = "firmware";
+-				reg = <0x050000 0x740000>;
+-			};
+-
+-			partition@790000 {
+-				label = "vendor";
+-				reg = <0x790000 0x740000>;
+-				read-only;
++				reg = <0x050000 0xe80000>;
+ 			};
+ 
+ 			partition@ed0000 {
+diff --git a/target/linux/ath79/dts/qca9558_ocedo_koala.dts b/target/linux/ath79/dts/qca9558_ocedo_koala.dts
+index 66f8c6589b20221edc41a2f882b28229ff8633b9..de9e1bc19c4d03707f5b921ee5e9fe7422f461bb 100644
+--- a/target/linux/ath79/dts/qca9558_ocedo_koala.dts
++++ b/target/linux/ath79/dts/qca9558_ocedo_koala.dts
+@@ -88,15 +88,10 @@
+ 			};
+ 
+ 			partition@50000 {
++				/* Dual-Flash layout combined */
+ 				compatible = "denx,uimage";
+ 				label = "firmware";
+-				reg = <0x050000 0x740000>;
+-			};
+-
+-			partition@790000 {
+-				label = "vendor";
+-				reg = <0x790000 0x740000>;
+-				read-only;
++				reg = <0x050000 0xe80000>;
+ 			};
+ 
+ 			partition@ed0000 {
+diff --git a/target/linux/ath79/dts/qca9558_ocedo_ursus.dts b/target/linux/ath79/dts/qca9558_ocedo_ursus.dts
+index 2dc4c07e918c50eb522100eb7f72c8804d5ba5fb..f8b3681bb7f143a498d5cb64897af335b970c43b 100644
+--- a/target/linux/ath79/dts/qca9558_ocedo_ursus.dts
++++ b/target/linux/ath79/dts/qca9558_ocedo_ursus.dts
+@@ -59,15 +59,10 @@
+ 			};
+ 
+ 			partition@50000 {
++				/* Dual-Flash layout combined */
+ 				compatible = "denx,uimage";
+ 				label = "firmware";
+-				reg = <0x050000 0x740000>;
+-			};
+-
+-			partition@790000 {
+-				label = "vendor";
+-				reg = <0x790000 0x740000>;
+-				read-only;
++				reg = <0x050000 0xe80000>;
+ 			};
+ 
+ 			partition@ed0000 {
+diff --git a/target/linux/ath79/image/generic.mk b/target/linux/ath79/image/generic.mk
+index 31d296fb62a1bb3fee4dfaba894f8339c48dd59c..deb5644ef525cf85ab7671d053d4ae6f2ee8e951 100644
+--- a/target/linux/ath79/image/generic.mk
++++ b/target/linux/ath79/image/generic.mk
+@@ -1797,7 +1797,7 @@ define Device/ocedo_koala
+   DEVICE_MODEL := Koala
+   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+   SUPPORTED_DEVICES += koala
+-  IMAGE_SIZE := 7424k
++  IMAGE_SIZE := 14848k
+ endef
+ TARGET_DEVICES += ocedo_koala
+ 
+@@ -1805,7 +1805,7 @@ define Device/ocedo_raccoon
+   SOC := ar9344
+   DEVICE_VENDOR := Ocedo
+   DEVICE_MODEL := Raccoon
+-  IMAGE_SIZE := 7424k
++  IMAGE_SIZE := 14848k
+ endef
+ TARGET_DEVICES += ocedo_raccoon
+ 
+@@ -1814,7 +1814,7 @@ define Device/ocedo_ursus
+   DEVICE_VENDOR := Ocedo
+   DEVICE_MODEL := Ursus
+   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+-  IMAGE_SIZE := 7424k
++  IMAGE_SIZE := 14848k
+ endef
+ TARGET_DEVICES += ocedo_ursus
+ 

--- a/patches/openwrt/0012-ath79-combine-UniFi-AC-dual-firmware-partitions.patch
+++ b/patches/openwrt/0012-ath79-combine-UniFi-AC-dual-firmware-partitions.patch
@@ -1,0 +1,55 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 17 Nov 2022 22:53:33 +0100
+Subject: ath79: combine UniFi AC dual firmware-partitions
+
+In order to maximize the available space on UniFi AC boards using a
+dual-image partition layout, combine the two OS partitions into a single
+partition.
+
+This allows users to access more usable space for additional packages.
+
+Don't limit the usable image size to the size of a single OS partition.
+The initial installation has to be done with an older version of OpenWrt
+in case the generated image exceeds the space of a single kernel
+partition in the future.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+(cherry picked from commit e4a76673ff4f655ba0698d9edb9efbacd0f82fff)
+
+diff --git a/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi b/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
+index 2e407c348642cf5145f79c15288856fa141b0512..6704ec983b0beed5421a59f663cf8db6d650f559 100644
+--- a/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
++++ b/target/linux/ath79/dts/qca9563_ubnt_unifiac.dtsi
+@@ -69,17 +69,12 @@
+ 			};
+ 
+ 			partition@70000 {
++				/* Combine kernel0 & kernel1 */
+ 				label = "firmware";
+-				reg = <0x070000 0x790000>;
++				reg = <0x070000 0xf20000>;
+ 				compatible = "denx,uimage";
+ 			};
+ 
+-			partition@800000 {
+-				label = "kernel1";
+-				reg = <0x800000 0x790000>;
+-				read-only;
+-			};
+-
+ 			partition@f90000 {
+ 				label = "bs";
+ 				reg = <0xf90000 0x020000>;
+diff --git a/target/linux/ath79/image/generic-ubnt.mk b/target/linux/ath79/image/generic-ubnt.mk
+index 7642c59e02848741996d6f9dcaf923d5dbaf6880..d6898c79d6b4d51d19813781e086db8086537318 100644
+--- a/target/linux/ath79/image/generic-ubnt.mk
++++ b/target/linux/ath79/image/generic-ubnt.mk
+@@ -221,7 +221,7 @@ TARGET_DEVICES += ubnt_unifi
+ define Device/ubnt_unifiac
+   DEVICE_VENDOR := Ubiquiti
+   SOC := qca9563
+-  IMAGE_SIZE := 7744k
++  IMAGE_SIZE := 15488k
+   DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca988x-ct
+ endef
+ 


### PR DESCRIPTION
Backport two patches combining dual-flash layouts of OCEDO as well as UniFi AC boards.

The two firmware partitions are already combined on OpenWrt master to prolong the life of these devices. It allows the device to store firmware images up to 14 MB compared to the previous 7 MB.

The intention behind backporting these patches is to allow these devices to have a wide update path to firmware-versions requiring this extra space. Otherwise a device might not be able to install an upgrade which exceeds a single firmware-partition.

For UniFi AC boards it should be noted that factory-installation will not be possible with an image exceeding a single firmware-partition. In this case, an older OpenWrt image that fits in a single partition and supports writing the enlarged partition space is required.

Currently, this is not the case. As these devices are end-of-sale, this will become less of a concern over time.