### PR TITLE
[Backport v2022.1.x] ramips-mt7621: add TP-Link Archer C6 v3

### DIFF
--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -63,6 +63,10 @@ device('netgear-wndr3700-v5', 'netgear_wndr3700-v5', {
 
 -- TP-Link
 
+device('tp-link-archer-c6-v3', 'tplink_archer-c6-v3', {
+	broken = true, -- LAN LED not working - review after resolving #2756
+})
+
 device('tp-link-re500-v1', 'tplink_re500-v1')
 
 device('tp-link-re650-v1', 'tplink_re650-v1')


### PR DESCRIPTION
(cherry picked from commit 7cabc593c7c383a90d65fa6a97110704958cfd6c)