### PR TITLE
docs: use linkcheck_ignore for unreachable links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,13 @@ pygments_style = None
 # Don't highlight code blocks unless requested explicitly
 highlight_language = 'none'
 
+# Ignore links to the config mode, as well as anchors on on hackint, which are
+# used to mark channel names and do not exist. Regular links are not effected.
+linkcheck_ignore = [
+    'http://192.168.1.1',
+    'https://webirc.hackint.org/#'
+]
+
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
> Config Mode
> - http://192.168.1.1
> 
> (not existing) anchors on hackint used to join channels
> - https://webirc.hackint.org/#

Prior to this commit `make linkcheck; echo $?` returns non-zero in `docs/`

This change makes the return code of said command useful again and reduces its execution time drastically, as 192.168.1.1 is not tested until it timeouts after quite a while.