### PR TITLE
Support non default UID/GID for build container

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:bullseye-slim
 
+ARG DUID=1000
+ARG DGID=1000
+
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -30,7 +33,7 @@ RUN mkdir /tmp/ec &&\
     mv bin/ec-linux-amd64 /usr/local/bin/editorconfig-checker &&\
     rm -rf /tmp/ec
 
-RUN useradd -d /gluon gluon
+RUN groupadd -g $DGID gluon && useradd -g $DGID -u $DUID -d /gluon gluon
 USER gluon
 
 VOLUME /gluon

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -11,11 +11,11 @@ TAG="gluon:${BRANCH:-latest}"
 
 if [ "$(command -v podman)" ]
 then
-	podman build -t "${TAG}" contrib/docker
+	podman build --build-arg DGID="$(id -g)" --build-arg DUID="$(id -u)" -t "${TAG}" contrib/docker
 	podman run -it --rm --userns=keep-id --volume="$(pwd):/gluon" "${TAG}"
 elif [ "$(command -v docker)" ]
 then
-	docker build -t "${TAG}" contrib/docker
+	docker build --build-arg DGID="$(id -g)" --build-arg DUID="$(id -u)" -t "${TAG}" contrib/docker
 	docker run -it --rm --volume="$(pwd):/gluon" "${TAG}"
 else
 	1>&2 echo "Please install either podman or docker. Exiting" >/dev/null


### PR DESCRIPTION
Set the current UID and GID of the executing user as build arguments for the build of the container, so that environments with other UIDs and GIDs than 1000 are supported.