### PR TITLE
Dockerfile: don't create gluon user (fixes support for UID != 1000)

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -29,8 +29,5 @@ RUN mkdir /tmp/ec &&\
     mv bin/ec-linux-amd64 /usr/local/bin/editorconfig-checker &&\
     rm -rf /tmp/ec
 
-RUN useradd -d /gluon gluon
-USER gluon
-
 VOLUME /gluon
 WORKDIR /gluon

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -16,7 +16,7 @@ then
 elif [ "$(command -v docker)" ]
 then
 	docker build -t "${TAG}" contrib/docker
-	docker run -it --rm --volume="$(pwd):/gluon" "${TAG}"
+	docker run -it --rm --user "$(id -u):$(id -g)" --volume="$(pwd):/gluon" "${TAG}"
 else
 	1>&2 echo "Please install either podman or docker. Exiting" >/dev/null
 	exit 1


### PR DESCRIPTION
The new user `gluon` gets UID 1000 and GID 1000 and cannot write to the mounted gluon directory unless the calling user has the same UID.

On Linux only the first non admin user gets UID 1000, so docker and podman fail for all other users.

On macOS there is typically no user with UID 1000, so docker and podman fail for all users.

When no `gluon` user is created, a default user with the same UID and GID as the calling user is used and everything works fine.