### PR TITLE
[Backport v2022.1.x] ath79-generic: switch Wave2 firmware to -ct

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -14,13 +14,7 @@ local ATH10K_PACKAGES_QCA9887 = {
 	'-ath10k-firmware-qca9887-ct',
 }
 
-local ATH10K_PACKAGES_QCA9888 = {
-	'kmod-ath10k',
-	'-kmod-ath10k-ct',
-	'-kmod-ath10k-ct-smallbuffers',
-	'ath10k-firmware-qca9888',
-	'-ath10k-firmware-qca9888-ct',
-}
+local ATH10K_PACKAGES_QCA9888 = {}
 
 -- ALFA NETWORK
 


### PR DESCRIPTION
> This partially reverts commit 22c47df2423e6149c4b37d5f70741adcf3365f5d.
> 
> Devices in ath79-generic like the TP-Link EAP225-Outdoor v1 are really unstable with the non -ct Wave2 firmware and regulary crash with 100% memory consumption when only a handful devices are connected via 5 GHz.
> 
> closes freifunk-gluon/gluon#2827
> 
> (cherry picked from commit 4badb2702edd396109038da129227413795f7a49)