### PR TITLE
ramips: add support for Cudy X6 v2

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -360,7 +360,7 @@ ramips-mt7621
 * Cudy
 
   - WR2100
-  - X6 (v1)
+  - X6 (v1, v2)
 
 * D-Link
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -15,6 +15,10 @@ device('cudy-x6-v1', 'cudy_x6-v1', {
 	factory = false,
 })
 
+device('cudy-x6-v2', 'cudy_x6-v2', {
+	factory = false,
+})
+
 
 -- D-Link
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [x] Other: Signed openwrt from vendor can be flashed through web interface, next step: sysupgrade to Gluon
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) cudy-x6-v2
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - ~~When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.~~
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - ~~if there are multiple ports but no WAN port:~~
      - ~~the PoE input should be WAN, all other ports LAN~~
      - ~~otherwise the first port should be declared as WAN, all other ports LAN~~
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] ~~Should map to their respective radio~~
    - [ ] ~~Should show activity~~
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity (only one combined led present per port)
- Outdoor devices only:
  - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- Cellular devices only:
  - [ ] ~~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`

_________

~~Building right now, check list will be filled in tonight.~~ Done :)