### PR TITLE
docs: fix supported_devices (missing newline)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -259,6 +259,7 @@ lantiq-xrx200
   - FRITZ!Box 7412 [#eva_ramboot]_
 
 * TP-Link
+
   - TD-W8970 (v1) [#lan_as_wan]_
 
 lantiq-xway


### PR DESCRIPTION
I made the mistake of never looking at the rendered version
fixes 95e5d382ecc65ed68262b90e2fc5f2d8a13d464c
backport like 8b2cc206d30b7ca52d275b00bcde400102356a05 is optional