### PR TITLE
ath79-generic: add support for TP-Link EAP-225 Outdoor v3

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -115,6 +115,7 @@ ath79-generic
   - CPE510 (v1.0, v1.1, v2.0, v3.0)
   - CPE710 (v1.0)
   - EAP225-Outdoor (v1)
+  - EAP225-Outdoor (v3)
   - RE450 (v1)
   - TL-WDR3500 (v1)
   - TL-WDR3600 (v1)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -37,6 +37,7 @@ function M.is_outdoor_device()
 		'tplink,cpe510-v3',
 		'tplink,cpe710-v1',
 		'tplink,eap225-outdoor-v1',
+		'tplink,eap225-outdoor-v3',
 		'tplink,wbs210-v1',
 		'tplink,wbs210-v2',
 		'tplink,wbs510-v1',

--- a/patches/openwrt/0013-ath79-support-for-TP-Link-EAP225-Outdoor-v3.patch
+++ b/patches/openwrt/0013-ath79-support-for-TP-Link-EAP225-Outdoor-v3.patch
@@ -1,0 +1,150 @@
+From: Paul Maruhn <paulmaruhn@posteo.de>
+Date: Tue, 22 Mar 2022 21:06:42 +0100
+Subject: ath79: support for TP-Link EAP225-Outdoor v3
+
+This model is almost identical to the EAP225-Outdoor v1.
+Major difference is the RTL8211FS PHY Chipset.
+
+Device specifications:
+* SoC: QCA9563 @ 775MHz
+* Memory: 128MiB DDR2
+* Flash: 16MiB SPI-NOR
+* Wireless 2.4GHz (SoC): b/g/n 2x2
+* Wireless 5GHz (QCA9886): a/n/ac 2x2 MU-MIMO
+* Ethernet (RTL8211FS): 1× 1GbE, PoE
+
+Flashing instructions:
+* ssh into target device with recent (>= v1.6.0) firmware
+* run `cliclientd stopcs` on target device
+* upload factory image via web interface
+
+Debricking:
+To recover the device, you need access to the serial port. This requires
+fine soldering to test points, or the use of probe pins.
+* Open the case and solder wires to the test points: RXD, TXD and TPGND4
+  * Use a 3.3V UART, 115200 baud, 8n1
+* Interrupt bootloader by holding ctrl+B during boot
+* upload initramfs via built-in tftp client and perform sysupgrade
+    setenv ipaddr 192.168.1.1 # default, change as required
+    setenv serverip 192.168.1.10 # default, change as required
+    tftp 0x80800000 initramfs.bin
+    bootelf $fileaddr
+
+MAC addresses:
+MAC address (as on device label) is stored in device info partition at
+an offset of 8 bytes. ath9k device has same address as ethernet, ath10k
+uses address incremented by 1.
+From stock ifconfig:
+
+    ath0      Link encap:Ethernet  HWaddr D8:...:2E
+    ath10     Link encap:Ethernet  HWaddr D8:...:2F
+    br0       Link encap:Ethernet  HWaddr D8:...:2E
+    eth0      Link encap:Ethernet  HWaddr D8:...:2E
+
+Signed-off-by: Paul Maruhn <paulmaruhn@posteo.de>
+Co-developed-by: Philipp Rothmann <philipprothmann@posteo.de>
+Signed-off-by: Philipp Rothmann <philipprothmann@posteo.de>
+[Add pre-calibraton nvme-cells]
+Tested-by: Tido Klaassen <tido_ff@4gh.eu>
+Signed-off-by: Nick Hainke <vincent@systemli.org>
+(cherry picked from commit 7e4de89e631aaf56be5375662b7d5ed0f27e26f6)
+
+diff --git a/target/linux/ath79/dts/qca9563_tplink_eap225-outdoor-v3.dts b/target/linux/ath79/dts/qca9563_tplink_eap225-outdoor-v3.dts
+new file mode 100644
+index 0000000000000000000000000000000000000000..e5914c9a55069e5baa5c7b989f3405c762e4d29d
+--- /dev/null
++++ b/target/linux/ath79/dts/qca9563_tplink_eap225-outdoor-v3.dts
+@@ -0,0 +1,59 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "qca9563_tplink_eap2x5-1port.dtsi"
++
++/ {
++	compatible = "tplink,eap225-outdoor-v3", "qca,qca9563";
++	model = "TP-Link EAP225-Outdoor v3";
++
++	aliases {
++		led-boot = &led_status_green;
++		led-failsafe = &led_status_amber;
++		led-running = &led_status_green;
++		led-upgrade = &led_status_amber;
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led_status_green: status_green {
++			label = "green:status";
++			gpios = <&gpio 7 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++		led_status_amber: status_amber {
++			label = "amber:status";
++			gpios = <&gpio 9 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&art {
++	precalibration_ath10k: pre-calibration@5000 {
++		reg = <0x5000 0x2f20>;
++	};
++};
++
++&eth0 {
++	phy-handle = <&phy6>;
++	phy-mode = "sgmii";
++};
++
++&mdio0 {
++	phy6: ethernet-phy@6 {
++		reg = <6>;
++	};
++};
++
++&pcie {
++	wifi@0,0 {
++		compatible = "qcom,ath10k";
++		reg = <0 0 0 0 0>;
++
++		mac-address-increment = <1>;
++
++		nvmem-cells = <&macaddr_info_8>, <&precalibration_ath10k>;
++		nvmem-cell-names = "mac-address", "pre-calibration";
++	};
++};
+diff --git a/target/linux/ath79/generic/base-files/etc/board.d/02_network b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+index 8f9516b8c681fd09c37fb183a63c17cf84f94bfc..b17ef03afcdf12c7a2c51fa8b0eaf3c90ad6fdd9 100644
+--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
++++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+@@ -78,6 +78,7 @@ ath79_setup_interfaces()
+ 	tplink,cpe610-v2|\
+ 	tplink,cpe710-v1|\
+ 	tplink,eap225-outdoor-v1|\
++	tplink,eap225-outdoor-v3|\
+ 	tplink,eap225-v1|\
+ 	tplink,eap225-v3|\
+ 	tplink,eap245-v1|\
+diff --git a/target/linux/ath79/image/generic-tp-link.mk b/target/linux/ath79/image/generic-tp-link.mk
+index fed572c884c75bd21081c7c22dd4652ecefdd993..3d3a45711302b7a73c914d80ec0d309878813149 100644
+--- a/target/linux/ath79/image/generic-tp-link.mk
++++ b/target/linux/ath79/image/generic-tp-link.mk
+@@ -401,6 +401,17 @@ define Device/tplink_eap225-outdoor-v1
+ endef
+ TARGET_DEVICES += tplink_eap225-outdoor-v1
+ 
++define Device/tplink_eap225-outdoor-v3
++  $(Device/tplink-eap2x5)
++  SOC := qca9563
++  IMAGE_SIZE := 13824k
++  DEVICE_MODEL := EAP225-Outdoor
++  DEVICE_VARIANT := v3
++  DEVICE_PACKAGES := kmod-ath10k-ct ath10k-firmware-qca9888-ct
++  TPLINK_BOARD_ID := EAP225-V3
++endef
++TARGET_DEVICES += tplink_eap225-outdoor-v3
++
+ define Device/tplink_eap225-v1
+   $(Device/tplink-eap2x5)
+   SOC := qca9563

--- a/patches/openwrt/0014-ath79-fix-5g-wifi-for-eap225-outdoor-v3-backport.patch
+++ b/patches/openwrt/0014-ath79-fix-5g-wifi-for-eap225-outdoor-v3-backport.patch
@@ -1,0 +1,16 @@
+From: Sebastian Schaper <openwrt@sebastianschaper.net>
+Date: Thu, 9 Mar 2023 23:24:33 +0100
+Subject: ath79: fix 5g wifi for eap225-outdoor v3 backport
+
+diff --git a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+index 712bba76edc86b849bcb9214a9373ec067d66246..5bc4f0a43f0b221b5794e1b1fb95d22027125725 100644
+--- a/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
++++ b/target/linux/ath79/generic/base-files/etc/hotplug.d/firmware/11-ath10k-caldata
+@@ -257,6 +257,7 @@ case "$FIRMWARE" in
+ 			/lib/firmware/ath10k/QCA9888/hw2.0/board.bin
+ 		;;
+ 	tplink,eap225-outdoor-v1|\
++	tplink,eap225-outdoor-v3|\
+ 	tplink,eap225-v3|\
+ 	tplink,eap225-wall-v2)
+ 		caldata_extract "art" 0x5000 0x2f20

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -474,6 +474,11 @@ device('tp-link-eap225-outdoor-v1', 'tplink_eap225-outdoor-v1', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })
 
+device('tp-link-eap225-outdoor-v3', 'tplink_eap225-outdoor-v3', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9888,
+})
+
 device('tp-link-re355-v1', 'tplink_re355-v1', {
 	manifest_aliases = {
 		'tp-link-re355', -- upgrade from OpenWrt 19.07


### PR DESCRIPTION
backport from OpenWrt 7e4de89e631aaf56be5375662b7d5ed0f27e26f6
- don't build factory (needs newer version of tplink-safeloader)
- fix 5g wifi caldata (don't use nvmem-cells in v22.03)
-----------------------------------------------------------
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: https://openwrt.org/toh/tp-link/eap225#installing_openwrt
- [ ] Must support upgrade mechanism
  - [ ] Must have working sysupgrade
    - [ ] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [ ] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [ ] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios 
  - [ ] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [ ] Lit while the device is on
    - [ ] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`