### PR TITLE
readthedocs: specify build-container

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,10 @@ sphinx:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-   version: 3.8
    install:
    - requirements: docs/requirements.txt
+
+build:
+    os: ubuntu-22.04
+    tools:
+        python: "3.8"


### PR DESCRIPTION
Docs builds currently fail with

Could not import extension sphinx.builders.linkcheck (exception: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017.
See: https://github.com/urllib3/urllib3/issues/2168)

The ~~Gluon~~ rtd issuetracker suggests specifying the build-container.

Link: https://github.com/readthedocs/readthedocs.org/issues/10290#issuecomment-1535120995