### PR TITLE
gluon-info: Add domain to gluon-info

### DIFF
--- a/package/gluon-core/luasrc/usr/bin/gluon-info
+++ b/package/gluon-core/luasrc/usr/bin/gluon-info
@@ -26,6 +26,7 @@ local values = {
 		.. ' / ' .. util.trim(util.readfile('/lib/gluon/site-version')) },
 	{ 'Firmware release', util.trim(util.readfile('/lib/gluon/release')) },
 	{ 'Site', site.site_name() },
+	{ 'Domain', uci:get('gluon', 'core', 'domain') or 'n/a' },
 	{ 'Public VPN key', pubkey or 'n/a' },
 }
 


### PR DESCRIPTION
- provides easier information of the currently active domain 
- tested by patching a running node

partially fixes #2790 