### PR TITLE
[Backport v2022.1.x] Backport Cudy WR1300 to v2022.1.x

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -358,6 +358,7 @@ ramips-mt7621
 
 * Cudy
 
+  - WR1300 (v1)
   - WR2100
   - X6 (v1, v2)
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -7,6 +7,10 @@ device('asus-rt-ac57u', 'asus_rt-ac57u', {
 
 -- Cudy
 
+device('cudy-wr1300', 'cudy_wr1300', {
+	factory = false,
+})
+
 device('cudy-wr2100', 'cudy_wr2100', {
         factory = false,
 })

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -73,11 +73,13 @@ device('netgear-wndr3700-v5', 'netgear_wndr3700-v5', {
 	},
 })
 
+
 -- TP-Link
 
 device('tp-link-re500-v1', 'tplink_re500-v1')
 
 device('tp-link-re650-v1', 'tplink_re650-v1')
+
 
 -- Ubiquiti
 
@@ -99,6 +101,7 @@ device('xiaomi-mi-router-3g', 'xiaomi_mi-router-3g', {
 device('xiaomi-mi-router-3g-v2', 'xiaomi_mi-router-3g-v2', {
 	factory = false,
 })
+
 
 -- ZBT
 


### PR DESCRIPTION
Follow up on failed action

> Backport failed for `v2022.1.x`, because it was unable to cherry-pick the commit(s).
> 
> Please cherry-pick the changes locally.
> ```bash
> git fetch origin v2022.1.x
> git worktree add -d .worktree/backport-2794-to-v2022.1.x origin/v2022.1.x
> cd .worktree/backport-2794-to-v2022.1.x
> git checkout -b backport-2794-to-v2022.1.x
> ancref=$(git merge-base 918e3ce78470b6e7ee37ff00809fb2b398490311 e06e555ac22d17ac5c061c3783cc28300e42e68b)
> git cherry-pick -x $ancref..e06e555ac22d17ac5c061c3783cc28300e42e68b
> ```
> 
> 

_Originally posted by @github-actions[bot] in https://github.com/freifunk-gluon/gluon/issues/2794#issuecomment-1541052832_
            