### PR TITLE
openwrt: mask nested A-MSDU support for mesh

### DIFF
--- a/patches/openwrt/0013-mac80211-mask-nested-A-MSDU-support-for-mesh.patch
+++ b/patches/openwrt/0013-mac80211-mask-nested-A-MSDU-support-for-mesh.patch
@@ -1,0 +1,55 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Fri, 8 Oct 2021 00:30:23 +0200
+Subject: mac80211: mask nested A-MSDU support for mesh
+
+mac80211 incorrectly processes A-MSDUs contained in A-MPDU frames. This
+results in dropped packets and severely impacted throughput.
+
+As a workaround, don't indicate support for A-MSDUs contained in
+A-MPDUs. This improves throughput over mesh links by factor 10.
+
+This patch can be dropped after verifying OpenWrt 23.xx fixes do indeed
+fix this issue.
+
+Ref: https://github.com/openwrt/mt76/issues/450
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+(cherry picked from commit f96744ba6b2fd444f4f7575d234c7579bd3030cd)
+
+diff --git a/package/kernel/mac80211/patches/subsys/800-mac80211-mask-nested-A-MSDU-support-for-mesh.patch b/package/kernel/mac80211/patches/subsys/800-mac80211-mask-nested-A-MSDU-support-for-mesh.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..415c6dfb803639cd726ee3f9b35359712b3e075d
+--- /dev/null
++++ b/package/kernel/mac80211/patches/subsys/800-mac80211-mask-nested-A-MSDU-support-for-mesh.patch
+@@ -0,0 +1,31 @@
++From 313d8c18385f10957402b475f9b0c209ceab6c5a Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Fri, 8 Oct 2021 00:25:19 +0200
++Subject: [PATCH] mac80211: mask nested A-MSDU support for mesh
++
++mac80211 incorrectly processes A-MSDUs contained in A-MPDU frames. This
++results in dropped packets and severely impacted throughput.
++
++As a workaround, don't indicate support for A-MSDUs contained in
++A-MPDUs. This improves throughput over mesh links by factor 10.
++
++Ref: https://github.com/openwrt/mt76/issues/450
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ net/mac80211/agg-rx.c | 4 +++-
++ 1 file changed, 3 insertions(+), 1 deletion(-)
++
++--- a/net/mac80211/agg-rx.c
+++++ b/net/mac80211/agg-rx.c
++@@ -251,7 +251,9 @@ static void ieee80211_send_addba_resp(st
++ 	mgmt->u.action.u.addba_resp.action_code = WLAN_ACTION_ADDBA_RESP;
++ 	mgmt->u.action.u.addba_resp.dialog_token = dialog_token;
++ 
++-	capab = u16_encode_bits(amsdu, IEEE80211_ADDBA_PARAM_AMSDU_MASK);
+++	capab = 0;
+++	if (!sta->mesh)
+++		capab = u16_encode_bits(amsdu, IEEE80211_ADDBA_PARAM_AMSDU_MASK);
++ 	capab |= u16_encode_bits(policy, IEEE80211_ADDBA_PARAM_POLICY_MASK);
++ 	capab |= u16_encode_bits(tid, IEEE80211_ADDBA_PARAM_TID_MASK);
++ 	capab |= u16_encode_bits(buf_size, IEEE80211_ADDBA_PARAM_BUF_SIZE_MASK);


### PR DESCRIPTION
This disables A-MSDU support on mesh-links. This restores throughput on mesh-links established between broken (ath10k) and correct (mt76) implementations of mesh A-MSDU.

This patch can be dropped when switching to the next OpenWrt release, as proper fixes have been applied.

Link: https://www.spinics.net/lists/linux-wireless/msg232410.html
Link: https://github.com/openwrt/mt76/issues/450

## iperf3 between ipq4019 and mt7915

### Without this patch

```
root@64367-4040:~# iperf3 -c 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378
Connecting to host 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378, port 5201
[  5] local 2001:67c:2ed8:100e:eadf:70ff:fe79:bbc1 port 43576 connected to 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  86.1 KBytes   705 Kbits/sec   19   2.36 KBytes       
[  5]   1.00-2.00   sec  0.00 Bytes  0.00 bits/sec    8   2.36 KBytes       
[  5]   2.00-3.00   sec  0.00 Bytes  0.00 bits/sec    8   2.36 KBytes       
[  5]   3.00-4.00   sec  0.00 Bytes  0.00 bits/sec    6   2.36 KBytes       
[  5]   4.00-5.00   sec  41.3 KBytes   338 Kbits/sec   10   2.36 KBytes       
[  5]   5.00-6.00   sec  0.00 Bytes  0.00 bits/sec   13   1.18 KBytes       
[  5]   6.00-7.00   sec  42.5 KBytes   348 Kbits/sec   14   2.36 KBytes       
[  5]   7.00-8.00   sec  41.3 KBytes   338 Kbits/sec   10   2.36 KBytes       
[  5]   8.00-9.00   sec  0.00 Bytes  0.00 bits/sec   10   2.36 KBytes       
[  5]   9.00-10.00  sec  0.00 Bytes  0.00 bits/sec   14   2.36 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec   211 KBytes   173 Kbits/sec  112             sender
[  5]   0.00-10.01  sec   189 KBytes   155 Kbits/sec                  receiver

iperf Done.
root@64367-4040:~# iperf3 -c 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378 -R
Connecting to host 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378, port 5201
Reverse mode, remote host 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378 is sending
[  5] local 2001:67c:2ed8:100e:eadf:70ff:fe79:bbc1 port 35896 connected to 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  11.1 MBytes  92.5 Mbits/sec                  
[  5]   1.00-2.00   sec  12.9 MBytes   108 Mbits/sec                  
[  5]   2.00-3.00   sec  12.1 MBytes   102 Mbits/sec                  
[  5]   3.00-4.00   sec  11.7 MBytes  97.9 Mbits/sec                  
[  5]   4.00-5.00   sec  12.5 MBytes   105 Mbits/sec                  
[  5]   5.00-6.00   sec  13.1 MBytes   110 Mbits/sec                  
[  5]   6.00-7.00   sec  12.6 MBytes   105 Mbits/sec                  
[  5]   7.00-8.00   sec  12.7 MBytes   106 Mbits/sec                  
[  5]   8.00-9.00   sec  13.1 MBytes   110 Mbits/sec                  
[  5]   9.00-10.00  sec  12.4 MBytes   104 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-13.55  sec   159 MBytes  98.4 Mbits/sec   31             sender
[  5]   0.00-10.00  sec   124 MBytes   104 Mbits/sec                  receiver

iperf Done.
root@64367-4040:~# 

```

### With this patch

```
root@64367-4040:~# iperf3 -c 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378
Connecting to host 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378, port 5201
[  5] local 2001:67c:2ed8:100e:eadf:70ff:fe79:bbc1 port 35496 connected to 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  4.28 MBytes  35.9 Mbits/sec    0   70.8 KBytes       
[  5]   1.00-2.00   sec  4.03 MBytes  33.8 Mbits/sec    0   60.2 KBytes       
[  5]   2.00-3.00   sec  4.03 MBytes  33.8 Mbits/sec    0   66.1 KBytes       
[  5]   3.00-4.00   sec  4.03 MBytes  33.8 Mbits/sec    0   75.5 KBytes       
[  5]   4.00-5.00   sec  4.15 MBytes  34.8 Mbits/sec    0   75.5 KBytes       
[  5]   5.00-6.00   sec  4.03 MBytes  33.8 Mbits/sec    0   75.5 KBytes       
[  5]   6.00-7.00   sec  4.03 MBytes  33.8 Mbits/sec    0   75.5 KBytes       
[  5]   7.00-8.00   sec  4.15 MBytes  34.8 Mbits/sec    0   81.4 KBytes       
[  5]   8.00-9.00   sec  4.03 MBytes  33.8 Mbits/sec    0   86.1 KBytes       
[  5]   9.00-10.00  sec  4.15 MBytes  34.8 Mbits/sec    0   97.9 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.00  sec  40.9 MBytes  34.3 Mbits/sec    0             sender
[  5]   0.00-10.01  sec  40.6 MBytes  34.1 Mbits/sec                  receiver

iperf Done.
root@64367-4040:~# iperf3 -c 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378 -R
Connecting to host 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378, port 5201
Reverse mode, remote host 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378 is sending
[  5] local 2001:67c:2ed8:100e:eadf:70ff:fe79:bbc1 port 40480 connected to 2001:67c:2ed8:100e:aa63:7dff:fe2e:9378 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  5.91 MBytes  49.5 Mbits/sec                  
[  5]   1.00-2.00   sec  5.66 MBytes  47.4 Mbits/sec                  
[  5]   2.00-3.00   sec  5.56 MBytes  46.6 Mbits/sec                  
[  5]   3.00-4.00   sec  5.39 MBytes  45.2 Mbits/sec                  
[  5]   4.00-5.00   sec  5.84 MBytes  49.0 Mbits/sec                  
[  5]   5.00-6.00   sec  5.28 MBytes  44.3 Mbits/sec                  
[  5]   6.00-7.00   sec  5.28 MBytes  44.3 Mbits/sec                  
[  5]   7.00-8.00   sec  6.01 MBytes  50.4 Mbits/sec                  
[  5]   8.00-9.00   sec  4.70 MBytes  39.4 Mbits/sec                  
[  5]   9.00-10.00  sec  4.50 MBytes  37.8 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.05  sec  54.7 MBytes  45.7 Mbits/sec    4             sender
[  5]   0.00-10.00  sec  54.1 MBytes  45.4 Mbits/sec                  receiver

iperf Done.
root@64367-4040:~# 
```