### PR TITLE
docs: support only for Xiaomi Mi Router 4A Gigabit v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -411,7 +411,7 @@ ramips-mt7621
 
 * Xiaomi
 
-  - Xiaomi Mi Router 4A (Gigabit Edition)
+  - Xiaomi Mi Router 4A (Gigabit Edition v1)
   - Xiaomi Mi Router 3G (v1, v2)
 
 ramips-mt76x8


### PR DESCRIPTION
We support all revisions of v1
Even the one with the new eon/cfeon flash chip (support was added with openwrt 22.03.03)

v2 only exists in master currently and (apparently) has a different 5GHz flash chip (mt7663/mt7615) and a slightly different partition scheme (maybe there are further differences, I didn't notice):
https://github.com/openwrt/openwrt/pull/11803