### PR TITLE
ramips-mt76x8: add support for TP-Link TL-MR6400 v5

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -444,6 +444,7 @@ ramips-mt76x8
   - RE305 (v1) [#device-class-tiny]
   - TL-MR3020 (v3)
   - TL-MR3420 (v5)
+  - TL-MR6400 (v5)
   - TL-WA801ND (v5)
   - TL-WR841N (v13)
   - TL-WR902AC (v3)

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
@@ -58,6 +58,10 @@ elseif platform.match('ramips', 'mt7621', {
 	'wavlink,ws-wn572hp3-4g',
 }) then
 	setup_ncm_qmi('/dev/ttyUSB2', 'ncm', 15)
+elseif platform.match('ramips', 'mt76x8', {
+	'tplink,tl-mr6400-v5',
+}) then
+	setup_ncm_qmi('/dev/cdc-wdm0', 'qmi', 15)
 end
 
 uci:save('network')

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -85,6 +85,10 @@ function M.is_cellular_device()
 		'wavlink,ws-wn572hp3-4g',
 	}) then
 		return true
+	elseif M.match('ramips', 'mt76x8', {
+		'tplink,tl-mr6400-v5',
+	}) then
+		return true
 	end
 
 	return false

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -80,6 +80,13 @@ device('tp-link-tl-mr3420-v5', 'tplink_tl-mr3420-v5', {
 	},
 })
 
+device('tp-link-tl-mr6400-v5', 'tplink_tl-mr6400-v5', {
+	factory = false,
+	extra_images = {
+		{'-squashfs-tftp-recovery', '-bootloader', '.bin'},
+	},
+})
+
 device('tp-link-tl-wa801nd-v5', 'tplink_tl-wa801nd-v5', {
 	factory = false,
 	extra_images = {
@@ -100,6 +107,7 @@ device('tp-link-tl-wr902ac-v3', 'tplink_tl-wr902ac-v3', {
 		{'-squashfs-tftp-recovery', '-bootloader', '.bin'},
 	},
 })
+
 
 -- VoCore 2
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [x] TFTP: place renamed bootloader image (tp_recovery.bin) at tftp root, reachable at 192.168.0.225. Put device into tftp recovery by pressing reset/wps button, plugging in power and holding the button for at least 8 seconds. Device pulls firmware, flashes it and restarts. (see https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=b641eb6ecfbfc2c6a488483332d4b5a6ee4c736c)
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) tp-link-tl-mr6400-v5
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - ~~When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.~~
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - ~~if there are multiple ports but no WAN port:~~
      - ~~the PoE input should be WAN, all other ports LAN~~
      - ~~otherwise the first port should be declared as WAN, all other ports LAN~~
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs (there's one for 2.4GHz)
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs (one wan and one lan led)
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- ~~Outdoor devices only:~~
  - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- Cellular devices only:
  - [x] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [x] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`