### PR TITLE
ipq40xx-generic: add support for ZTE MF289F

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
@@ -53,6 +53,7 @@ elseif platform.match('ath79', 'nand', {
 	setup_ncm_qmi('/dev/ttyACM0', 'ncm', 15)
 elseif platform.match('ipq40xx', 'generic', {
 	'glinet,gl-ap1300',
+	'zte,mf289f',
 }) then
 	setup_ncm_qmi('/dev/cdc-wdm0', 'qmi', 15)
 elseif platform.match('ramips', 'mt7621', {

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -80,6 +80,7 @@ function M.is_cellular_device()
 		return true
 	elseif M.match('ipq40xx', 'generic', {
 		'glinet,gl-ap1300',
+		'zte,mf289f',
 	}) then
 		return true
 	elseif M.match('ramips', 'mt7621', {

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -120,6 +120,14 @@ device('plasma-cloud-pa2200', 'plasmacloud_pa2200', {
 })
 
 
+-- ZTE
+
+device('zte-mf289f', 'zte_mf289f', {
+	broken = true,	-- case must be opened to install
+	factory = false,
+})
+
+
 -- ZyXEL
 
 device('zyxel-nbg6617', 'zyxel_nbg6617')


### PR DESCRIPTION
Also known in Germany as Gigacube CAT20
Added as Broken because you need to open the Device to access the Serial Console for flashing

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: Serial Console, see Commit in OpenWRT https://github.com/openwrt/openwrt/commit/0de6a3339f1aadc1de2c9371435e3de239a00645
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
    Device contains a Status LED inside which blinks in Config Mode. Power LED stays still.
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [x] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [x] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [ ] Added Device to `docs/user/supported_devices.rst`