### PR TITLE
docs: ath79-nand: small adjustments

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -282,7 +282,7 @@ mediatek-mt7622
 
 * Ubiquiti
 
-  - UniFi 6 LR
+  - UniFi 6 LR (v1)
 
 * Xiaomi
 
@@ -411,7 +411,7 @@ ramips-mt7621
 
 * Xiaomi
 
-  - Xiaomi Mi Router 4A (Gigabit Edition)
+  - Xiaomi Mi Router 4A (Gigabit Edition v1)
   - Xiaomi Mi Router 3G (v1, v2)
 
 ramips-mt76x8

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -49,6 +49,6 @@ device('netgear-wndr4300', 'netgear_wndr4300', {
 -- ZTE
 
 device('zte-mf281', 'zte_mf281', {
-	broken = true,
+	broken = true, -- case must be opened to install
 	packages = ATH10K_PACKAGES_QCA9888,
 })


### PR DESCRIPTION
The ZTE MF281 was missing a reason why it is marked as broken.

We only support Unifi 6 LR v1 currently. v2 should work fine with the same image (small led related error in dmesg), but v3 has a different ethernet phy (1gbit/s instead of 2.5gbit/s) the device won't be accessible over ethernet after install (stuck in config mode)
OpenWrt doesn't support v3, yet. v2 could be added to the list but we probably expect people to run the check list again, therefore I'll leave it out.

There is no exact version number silkscreened on the board afaik. But you can still find out whether it's a v3 according to the [wiki](https://openwrt.org/toh/ubiquiti/unifi_6_lr).
> **Important** Devices with manufacturing date 2234 (34rd week of 2022) and later appear to be a version 3 hardware with a different (1 GbE only) Ethernet PHY chip. Flashing v2 firmware to this hardware will result in inoperable Ethernet. See [this forum thread](https://forum.openwrt.org/t/unifi-6-lr-v2-ethernet-not-working/141792/18) for details.