### PR TITLE
Revert "ath79-generic: (re)add Rocket M2/M5 (XM)"

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -130,7 +130,6 @@ ath79-generic
   - NanoBeam M5 (XW)
   - NanoStation Loco M2/M5 (XW)
   - NanoStation M2/M5 (XW)
-  - Rocket M2/M5 (XM)
   - UniFi AC Lite
   - UniFi AC LR
   - UniFi AC Mesh

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -43,7 +43,6 @@ function M.is_outdoor_device()
 		'ubnt,nanobeam-m5-xw',
 		'ubnt,nanostation-loco-m-xw',
 		'ubnt,nanostation-m-xw',
-		'ubnt,rocket-m',
 		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',
 		'ubnt,unifiac-mesh-pro',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -557,14 +557,6 @@ device('ubiquiti-nanostation-m-xw', 'ubnt_nanostation-m-xw', {
 	},
 })
 
-device('ubiquiti-rocket-m-xm', 'ubnt_rocket-m', {
-	manifest_aliases = {
-		'ubiquiti-rocket-m', -- upgrade from OpenWrt 19.07
-		'ubiquiti-rocket-m2', -- upgrade from OpenWrt 19.07
-		'ubiquiti-rocket-m5', -- upgrade from OpenWrt 19.07
-	},
-})
-
 device('ubiquiti-unifi-ac-lite', 'ubnt_unifiac-lite', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9880,


### PR DESCRIPTION
This reverts commit 97efc8abdbd6264a19cbe6c5b95851245f6b798a. (#2580)

Since the commit was drafted the device was moved from ath79-generic to ath79-tiny ([4b5bd15](https://github.com/openwrt/openwrt/commit/4b5bd1509195bc8f19999ebe481b59356b5c3512)).

Therefore the commit breaks builds of the ath79-generic target (`unable to enable device 'ubnt_rocket-m'`).

It might be possible to add support for the ath79-tiny target, and with it the Rocket M2/M5 (XM), in the future.