### PR TITLE
gluon-wan-dnsmasq: use cellular DNS servers

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
@@ -27,6 +27,7 @@ local function setup_ncm_qmi(devpath, control_type, delay)
 		device = devpath,
 		disabled = not uci:get_bool('gluon', 'cellular', 'enabled'),
 		pdptype = pdptype,
+		peerdns = false,
 		apn = uci:get('gluon', 'cellular', 'apn'),
 	})
 

--- a/package/gluon-wan-dnsmasq/files/etc/hotplug.d/iface/50-gluon-wan-dnsmasq
+++ b/package/gluon-wan-dnsmasq/files/etc/hotplug.d/iface/50-gluon-wan-dnsmasq
@@ -1,3 +1,3 @@
-if [ "$INTERFACE" = 'wan' -o "$INTERFACE" = 'wan6' ]; then
+if [ "$INTERFACE" = 'wan' -o "$INTERFACE" = 'wan6' -o "$INTERFACE" = 'cellular_4' -o "$INTERFACE" = 'cellular_6' ]; then
 	/lib/gluon/wan-dnsmasq/update.lua
 fi

--- a/package/gluon-wan-dnsmasq/files/lib/gluon/wan-dnsmasq/interface.d/050-gluon-wan-dnsmasq
+++ b/package/gluon-wan-dnsmasq/files/lib/gluon/wan-dnsmasq/interface.d/050-gluon-wan-dnsmasq
@@ -1,2 +1,4 @@
 wan6
 wan
+cellular_4
+cellular_6


### PR DESCRIPTION
Use DNS servers received from the cellular provider for the WAN dnsmasq instance.
This fixes resolving VPN endpoint DNS requests when using only cellular uplink.

Fixes #2849