### PR TITLE
Dockerfile: update base to debian:bookworm-slim

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -213,6 +213,7 @@
     "targets/targets.mk",
     "targets/x86.inc",
     "contrib/ci/minimal-site/**",
+    "contrib/docker/Dockerfile",
     "package/**"
   ],
   "bcm27xx-bcm2710": [

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Bookworm is now the stable debian version. We should let the CI validate that Gluon can be build there. Currently that does indeed [work for all targets](https://github.com/herbetom/gluon/actions/runs/5803545351).