### PR TITLE
Makefile fixes

### DIFF
--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -24,7 +24,7 @@ $(eval $(call GluonTarget,x86,legacy))
 $(eval $(call GluonTarget,x86,64))
 
 
-ifneq ($(BROKEN),)
+ifeq ($(BROKEN),1)
 $(eval $(call GluonTarget,bcm27xx,bcm2710)) # BROKEN: Untested
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
 endif


### PR DESCRIPTION
_I formatted the less important prosa as quotes to highlight the more important info_

This PR fixes two bugs I encountered while improving our Makefile.
It calls Gluon's Makefile as a submake.

That's kind of relevant for the first commit.

> We reused the variable GLUON_TARGETS for limiting what GLUON_TARGET we build (for loop).
> All without knowing that this environment variable already exists within Gluon. (or FFMUC did, I'm not sure, we basically copied their nice makefile at some point)
> This was fine while MAKE didn't call $(GLUON_MAKE) as a sub make. I fixed this by adding a plus to the shell lines calling another MAKE process.
> Since GLUON_TARGET is a variable set on the command line it takes precendence over all occurences of the variable within all makefiles (atleast for make and it's submakes) no matter what the sub makes set.
> This behavior can also be reproduced by calling GLUON's Makefile directly. (though noone would do so usually since the variable isn't supposed to be set, but we set it unintentionally)

My fix:
Rename `GLUON_TARGETS` to `GLUON_TARGETLIST`
~~use "override" when setting GLUON_TARGETS~~
~~This way the new values always take precedence regardless of what users input.~~
~~The first occurence of `GLUON_TARGETS :=` actually resets it to the empty string. Now it also/actually empties it when set on the command line~~

This mostly prevents confusing output like this, it didn't cause any actual bugs on our end:
```
make download all GLUON_TARGETS="DEADBEEF" GLUON_SITEDIR="contrib/ci/minimal-site"
Please set GLUON_TARGET to a valid target. Gluon supports the following targets:
 * DEADBEEF
make: *** [Makefile:176: config] Error 1
```
(when leaving BROKEN unset, intentionally, to provoke the error message for an existing target)
```
make download all GLUON_TARGETS="bcm27xx-bcm2710" GLUON_SITEDIR="contrib/ci/minimal-site"
Please set GLUON_TARGET to a valid target. Gluon supports the following targets:
 * bcm27xx-bcm2710
make: *** [Makefile:176: config] Error 1
```
_________________

Second commit:
I stumbled across the weird way Gluon handles the environment variable BROKEN:
first of, here are the definitions
[devices](https://github.com/freifunk-gluon/gluon/blob/master/scripts/target_lib.lua#L54-L61)
[targets](https://github.com/freifunk-gluon/gluon/blob/master/targets/targets.mk#L26)

why weird you ask? Well, it's **inconsistent**.

> broken Devices get build, when BROKEN is evaluated to true (by Lua):
> true: 1, 0.1, 0.9, 2, 1000
> false: 0, -1, -4.5, a, b, bullshit
> true meaning: any positive non-zero integer or float
> 
> broken Targets on the other hand, they get build, when BROKEN exists as a (non-empty) variable.
> true is anything from: bullshit, 0, -4.5, word, 1, 0.5, etc.
> 
> I wanted to be able to set `BROKEN=0`
> A because our default is 1, B because `BROKEN=""` is unintuitive for users
> a simple `export BROKEN ?= 1` now works fine with my fix
> 
> Without the fix, I needed to filter the variable MAKEOVERRIDE to remove `BROKEN=0` (or set it to an empty string, I only realized this during writing the PR)
> and I need to `unexport BROKEN` as well
> Better make the behavior consistent, so here's a fix :)

The fix isn't perfect, but it catches the relevant numbers (0 and 1, as well as an empty or unset variable), so it should be fine.
new behavior:
devices stays the same
targets can't (easily) compare numbers (or floats for that matter): only an exact "1" builds BROKEN devices, everything else does nothing

I could adjust Devices so it matches Targets behavior exactly, the decision is up to you
I could also add documentation for `BROKEN` (I think there is none, yet?)