### PR TITLE
docs: supported_devices: add missing 8devices Jalapeno

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -184,6 +184,10 @@ brcm2708-bcm2709
 ipq40xx-generic
 ---------------
 
+* 8devices
+
+  - Jalapeno
+
 * Aruba
 
   - AP-303


### PR DESCRIPTION
Since the device isn't marked as broken it should be mentioned in the docs as a supported device.

https://github.com/freifunk-gluon/gluon/blob/5e9afa33abcb2e7b6f28019b7532055000e43521/targets/ipq40xx-generic#L158-L163