### PR TITLE
ath79-generic: add support for Ubiquiti Rocket 5ac lite

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -132,6 +132,7 @@ ath79-generic
   - NanoBeam M5 (XW)
   - NanoStation Loco M2/M5 (XW)
   - NanoStation M2/M5 (XW)
+  - Rocket 5AC Lite (XC)
   - UniFi AC Lite
   - UniFi AC LR
   - UniFi AC Mesh

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -44,6 +44,7 @@ function M.is_outdoor_device()
 		'ubnt,nanobeam-m5-xw',
 		'ubnt,nanostation-loco-m-xw',
 		'ubnt,nanostation-m-xw',
+		'ubnt,rocket-5ac-lite',
 		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',
 		'ubnt,unifiac-mesh-pro',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -585,6 +585,10 @@ device('ubiquiti-nanobeam-ac-gen1-xc', 'ubnt_nanobeam-ac-xc', {
 
 device('ubiquiti-nanobeam-m5-xw', 'ubnt_nanobeam-m5-xw')
 
+device('ubiquiti-rocket-5ac-lite', 'ubnt_rocket-5ac-lite', {
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('ubiquiti-unifi-ap-outdoor+', 'ubnt_unifi-ap-outdoor-plus', {
 	manifest_aliases = {
 		'ubiquiti-unifiap-outdoor+', -- upgrade from OpenWrt 19.07


### PR DESCRIPTION
The Ubiquiti Rocket 5AC Lite (R5AC-Lite) is an outdoor router.

Specifications:
 - SoC: Qualcomm Atheros QCA9558
 - RAM: 128 MB
 - Flash: 16 MB SPI
 - Ethernet: 1x 10/100/1000 Mbps
 - WiFi 5 GHz: QCA988x
 - Buttons: 1x (reset)
 - LEDs: 1x power, 1x Ethernet, 4x RSSI

Test Device: https://map.chemnitz.freifunk.net/#!v:m;n:784558acb880

Integration Checklist:
- [x] Must be flashable from vendor firmware
  - [x] Other:  https://openwrt.org/toh/ubiquiti/common
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> ubiquiti-rocket-5ac-lite
- [x] Reset button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`
