### PR TITLE
docs: GH use `requirements.txt`

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Dependencies
-        run: sudo pip3 install sphinx-rtd-theme
+        run: sudo pip3 install -r docs/requirements.txt
       - name: Build documentation
         run: make -C docs html
       - name: Archive build output


### PR DESCRIPTION
Replaces hard coded dependency.

Closes #2955