### PR TITLE
gluon-status-page: disallow crawler/robots to index

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/layout.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/layout.html
@@ -6,6 +6,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no">
+		<meta name="robots" content="noindex,nofollow">
 
 		<title><%:Error%></title>
 

--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -125,6 +125,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, user-scalable=no">
+		<meta name="robots" content="noindex,nofollow">
 
 		<title><%| nodeinfo.hostname %> - <%:Status%></title>
 

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/index.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/index.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Pragma" content="no-cache">
 		<meta http-equiv="Expires" content="0">
 		<meta http-equiv="refresh" content="0; URL=/cgi-bin/status">
+		<meta name="robots" content="noindex,nofollow">
 	</head>
 	<body>
 	</body>

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/robots.txt
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
## Changes

Disallow crawlers to crawl and index page.
Crawling causes traffic and high load.
Indexation max cause unintended attention, e.g. spam, ..

Reference:
https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag

## Reference

Closes #2952