### PR TITLE
gluon-status-page: provide empty favicon

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/layout.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/layout.html
@@ -9,6 +9,7 @@
 
 		<title><%:Error%></title>
 
+		<link rel="icon" href="data:,">
 		<link rel="stylesheet" href="/static/status-page.css" type="text/css">
 	</head>
 	<body>

--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -128,6 +128,7 @@
 
 		<title><%| nodeinfo.hostname %> - <%:Status%></title>
 
+		<link rel="icon" href="data:,">
 		<link rel="stylesheet" href="/static/status-page.css" type="text/css">
 	</head>
 	<body data-node-address="<%| http:getenv('SERVER_ADDR') %>"<%=

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/index.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/index.html
@@ -5,6 +5,7 @@
 		<meta http-equiv="Pragma" content="no-cache">
 		<meta http-equiv="Expires" content="0">
 		<meta http-equiv="refresh" content="0; URL=/cgi-bin/status">
+		<link rel="icon" href="data:,">
 	</head>
 	<body>
 	</body>


### PR DESCRIPTION
## Change

Avoids the browser default request to `/favicon.ico` to avoid useless requests.

## Reference

Closes #2951