### PR TITLE
rampis-mt7621: add support for ZyXEL WSM20

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -428,6 +428,7 @@ ramips-mt7621
 * ZyXEL
 
   - NWA50AX
+  - WSM20
 
 * Xiaomi
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -149,6 +149,10 @@ device('zyxel-nwa55axe', 'zyxel_nwa55axe', {
 	broken = true, -- Missing LED / Reset button
 })
 
+device('zyxel-wsm20', 'zyxel_wsm20', {
+	factory = false,
+})
+
 
 -- Devices without WLAN
 


### PR DESCRIPTION
(soory for the spam, same as https://github.com/freifunk-gluon/gluon/pull/2962, thought I lost access to my account)

Better known as ZyXEL Multy M1

logread is full of `daemon.err hostapd: nl80211: kernel reports: integer out of range`, but that should be gone after [this](https://patchwork.ozlabs.org/project/openwrt/patch/20230830161559.10770-3-nbd@nbd.name/) is merged.


<details><summary>There are kernel warnings, I have no idea what they mean.</summary>

```
[  278.192368] WARNING: CPU: 2 PID: 6161 at backports-6.1.24/net/mac80211/mesh_hwmp.c:353 airtime_link_metric_get+0x110/0x724 [mac80211]
[  278.204640] Modules linked in: iptable_nat batman_adv xt_state xt_nat xt_conntrack xt_REDIRECT xt_MASQUERADE xt_CT wireguard nf_nat nf_conntrack mt7915e mt76_connac_lib mt76 mac80211 libchacha20poly1305 ipt_REJECT ebtable_nat ebtable_filter ebtable_broute cfg80211 xt_time xt_tcpudp xt_quota xt_pkttype xt_owner xt_multiport xt_mark xt_mac xt_limit xt_comment xt_addrtype xt_TCPMSS xt_LOG ts_kmp ts_fsm ts_bm poly1305_mips nf_reject_ipv4 nf_log_syslog nf_defrag_ipv6 nf_defrag_ipv4 libcurve25519_generic iptable_mangle iptable_filter ip_tables hwmon ebtables ebt_vlan ebt_stp ebt_snat ebt_redirect ebt_pkttype ebt_mark_m ebt_mark ebt_limit ebt_ip6 ebt_ip ebt_dnat ebt_arpreply ebt_arp ebt_among ebt_802_3 compat chacha_mips sch_teql sch_sfq sch_multiq sch_gred sch_fq sch_dsmark sch_codel em_text em_nbyte em_meta em_cmp act_simple act_pedit act_csum libcrc32c sch_htb sch_hfsc em_u32 cls_u32 cls_route cls_matchall cls_fw cls_flow act_skbedit act_mirred act_gact ip6table_mangle ip6table_filter
[  278.205712]  ip6_tables ip6t_REJECT x_tables nf_reject_ipv6 dummy ip_tunnel veth vxlan udp_tunnel ip6_udp_tunnel sha512_generic seqiv jitterentropy_rng drbg kpp hmac cmac leds_gpio cls_basic sch_tbf sch_ingress gpio_button_hotplug crc32c_generic
[  278.314232] CPU: 2 PID: 6161 Comm: stations Tainted: G        W         5.15.127 #0
[  278.321924] Stack : 80820000 8007c090 00000000 00000004 00000000 00000000 83d57874 809e0000
[  278.330322]         80820000 80751988 84aeb1d8 80826dc3 00000000 00000001 83d57820 8149b980
[  278.338701]         00000000 00000000 80751988 83d576c0 fffffb8f 00000000 ffffffea 00000000
[  278.347070]         83d576cc 00000b8f 8082b8f8 ffffffff 80751988 00000001 00000000 83175f58
[  278.355511]         00000009 83fed548 00000010 830704a0 00000018 803bfa3c 00000008 809e0008
[  278.363957]         ...
[  278.366457] Call Trace:
[  278.368922] [<80007df4>] show_stack+0x28/0xf0
[  278.373357] [<80331880>] dump_stack_lvl+0x60/0x80
[  278.378141] [<8002dcb8>] __warn+0x9c/0x124
[  278.382323] [<8002dd9c>] warn_slowpath_fmt+0x5c/0xac
[  278.387380] [<83175f58>] airtime_link_metric_get+0x110/0x724 [mac80211]
[  278.394308] [<8310ad84>] sta_set_sinfo+0x7d0/0x10a0 [mac80211]
[  278.400281] [<83127b04>] ieee80211_nan_func_match+0x1a70/0x2144 [mac80211]
[  278.407305] [<8302f8dc>] nl80211_put_sta_rate+0x14a0/0x1678 [cfg80211]
[  278.414014] 
[  278.415592] ---[ end trace 28355f69f17fc452 ]---
[  278.488472] ------------[ cut here ]------------
[  278.493203] WARNING: CPU: 0 PID: 315 at backports-6.1.24/net/mac80211/mesh_hwmp.c:353 airtime_link_metric_get+0x110/0x724 [mac80211]
[  278.505476] Modules linked in: iptable_nat batman_adv xt_state xt_nat xt_conntrack xt_REDIRECT xt_MASQUERADE xt_CT wireguard nf_nat nf_conntrack mt7915e mt76_connac_lib mt76 mac80211 libchacha20poly1305 ipt_REJECT ebtable_nat ebtable_filter ebtable_broute cfg80211 xt_time xt_tcpudp xt_quota xt_pkttype xt_owner xt_multiport xt_mark xt_mac xt_limit xt_comment xt_addrtype xt_TCPMSS xt_LOG ts_kmp ts_fsm ts_bm poly1305_mips nf_reject_ipv4 nf_log_syslog nf_defrag_ipv6 nf_defrag_ipv4 libcurve25519_generic iptable_mangle iptable_filter ip_tables hwmon ebtables ebt_vlan ebt_stp ebt_snat ebt_redirect ebt_pkttype ebt_mark_m ebt_mark ebt_limit ebt_ip6 ebt_ip ebt_dnat ebt_arpreply ebt_arp ebt_among ebt_802_3 compat chacha_mips sch_teql sch_sfq sch_multiq sch_gred sch_fq sch_dsmark sch_codel em_text em_nbyte em_meta em_cmp act_simple act_pedit act_csum libcrc32c sch_htb sch_hfsc em_u32 cls_u32 cls_route cls_matchall cls_fw cls_flow act_skbedit act_mirred act_gact ip6table_mangle ip6table_filter
[  278.506079]  ip6_tables ip6t_REJECT x_tables nf_reject_ipv6 dummy ip_tunnel veth vxlan udp_tunnel ip6_udp_tunnel sha512_generic seqiv jitterentropy_rng drbg kpp hmac cmac leds_gpio cls_basic sch_tbf sch_ingress gpio_button_hotplug crc32c_generic
[  278.614821] CPU: 0 PID: 315 Comm: kworker/u8:4 Tainted: G        W         5.15.127 #0
[  278.614959] ------------[ cut here ]------------
[  278.622784] Workqueue: phy0 ieee80211_ibss_leave [mac80211]
[  278.627406] WARNING: CPU: 2 PID: 6161 at backports-6.1.24/net/mac80211/mesh_hwmp.c:353 airtime_link_metric_get+0x110/0x724 [mac80211]
[  278.632938] Stack : 0000000c 8007c090 00000000 00000004 80751988 81c1bb7c 81c21880
[  278.644915] Modules linked in: iptable_nat
[  278.652449]  8004ad84
[  278.652458]  batman_adv
[  278.656528] 
[  278.656539]         80820000 81c1bbb1 00000001 81c1b9c8 8311cd88 00000001
[  278.658839]  xt_state
[  278.661263]  81c1bb88 81456d40
[  278.662749]  xt_nat
[  278.669493] 
[  278.669501]         00000000 00000000 80751988 00000125 205d3400 809e72ff 00000008 0000000d
[  278.671816]  xt_conntrack
[  278.674850]         81c1b9d4 81c1b9e1 ffffffff ffffffff 80751988 00000001 00000000 83175f58
[  278.674921]         00000009 00000001 8319c500
[  278.677022]  xt_REDIRECT
[  278.678493]  8579e042 00000018 803bfa3c
[  278.686855]  xt_MASQUERADE
[  278.689412]  00000000 809e0000
[  278.697788]  xt_CT
[  278.702161]         ...
[  278.704707]  wireguard
[  278.708498] 
[  278.708509] Call Trace:
[  278.708514] [<80007df4>] show_stack+0x28/0xf0
[  278.711205]  nf_nat
[  278.714242] [<80331880>] dump_stack_lvl+0x60/0x80
[  278.714296] [<8002dcb8>] __warn+0x9c/0x124
[  278.714348] [<8002dd9c>] warn_slowpath_fmt+0x5c/0xac
[  278.716346]  nf_conntrack
[  278.718799] [<83175f58>] airtime_link_metric_get+0x110/0x724 [mac80211]
[  278.721135]  mt7915e
[  278.722640] [<83175fc4>] airtime_link_metric_get+0x17c/0x724 [mac80211]
[  278.725097]  mt76_connac_lib
[  278.729534] 
[  278.731487]  mt76
[  278.736362] ---[ end trace 28355f69f17fc453 ]---
[  278.740369]  mac80211 libchacha20poly1305 ipt_REJECT ebtable_nat ebtable_filter ebtable_broute cfg80211 xt_time xt_tcpudp xt_quota xt_pkttype xt_owner xt_multiport xt_mark xt_mac xt_limit xt_comment xt_addrtype xt_TCPMSS xt_LOG ts_kmp ts_fsm ts_bm poly1305_mips nf_reject_ipv4 nf_log_syslog nf_defrag_ipv6 nf_defrag_ipv4 libcurve25519_generic iptable_mangle iptable_filter ip_tables hwmon ebtables ebt_vlan ebt_stp ebt_snat ebt_redirect ebt_pkttype ebt_mark_m ebt_mark ebt_limit ebt_ip6 ebt_ip ebt_dnat ebt_arpreply ebt_arp ebt_among ebt_802_3 compat chacha_mips sch_teql sch_sfq sch_multiq sch_gred sch_fq sch_dsmark sch_codel em_text em_nbyte em_meta em_cmp act_simple act_pedit act_csum libcrc32c sch_htb sch_hfsc em_u32 cls_u32 cls_route cls_matchall cls_fw cls_flow act_skbedit act_mirred act_gact ip6table_mangle ip6table_filter ip6_tables ip6t_REJECT x_tables nf_reject_ipv6 dummy ip_tunnel veth vxlan udp_tunnel ip6_udp_tunnel sha512_generic seqiv jitterentropy_rng drbg kpp hmac cmac
[  278.774977]  leds_gpio cls_basic sch_tbf sch_ingress gpio_button_hotplug crc32c_generic
[  278.869419] CPU: 2 PID: 6161 Comm: stations Tainted: G        W         5.15.127 #0
[  278.877084] Stack : 80820000 8007c090 00000000 00000004 00000000 00000000 83d57874 809e0000
[  278.885487]         80820000 80751988 84aeb1d8 80826dc3 00000000 00000001 83d57820 8149b980
[  278.893886]         00000000 00000000 80751988 83d576c0 fffffbcf 00000000 ffffffea 00000000
[  278.902269]         83d576cc 00000bcf 8082b8f8 ffffffff 80751988 00000001 00000000 83175f58
[  278.910658]         00000009 83fed548 00000010 830704a0 00000018 803bfa3c 00000008 809e0008
[  278.919097]         ...
[  278.921562] Call Trace:
[  278.923992] [<80007df4>] show_stack+0x28/0xf0
[  278.928371] [<80331880>] dump_stack_lvl+0x60/0x80
[  278.933091] [<8002dcb8>] __warn+0x9c/0x124
[  278.937219] [<8002dd9c>] warn_slowpath_fmt+0x5c/0xac
[  278.942210] [<83175f58>] airtime_link_metric_get+0x110/0x724 [mac80211]
[  278.949007] [<8310ad84>] sta_set_sinfo+0x7d0/0x10a0 [mac80211]
[  278.954899] [<83127b04>] ieee80211_nan_func_match+0x1a70/0x2144 [mac80211]
[  278.961835] [<8302f8dc>] nl80211_put_sta_rate+0x14a0/0x1678 [cfg80211]
[  278.968485] 
[  278.970066] ---[ end trace 28355f69f17fc454 ]---
```

</details> 

- [x] Must be flashable from vendor firmware
  - [x] Web interface, sort of
  - ~~[ ] TFTP~~
  - [x] Other: UART
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - ~~[ ] Should map to their respective radio~~
    - ~~[ ] Should show activity~~
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~~[ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- Cellular devices only:
  - ~~[ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - ~~[ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`