### PR TITLE
ramips-mt7621: ZyXEL WSM20 add alias Multy M1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -428,7 +428,7 @@ ramips-mt7621
 * ZyXEL
 
   - NWA50AX
-  - WSM20
+  - WSM20 / Multy M1
 
 * Xiaomi
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -151,6 +151,9 @@ device('zyxel-nwa55axe', 'zyxel_nwa55axe', {
 
 device('zyxel-wsm20', 'zyxel_wsm20', {
 	factory = false,
+	aliases = {
+		'zyxel-multy-m1',
+	},
 })
 
 


### PR DESCRIPTION
This improves upon:
982d8ed7cac1353c24772eb6d91b7a92c4dc6f36

These devices are only sold under the name Multy M1.
I added an alias for the official name :)