### PR TITLE
Revert "x86: switch to EFI-compatible images"

### DIFF
--- a/targets/x86.inc
+++ b/targets/x86.inc
@@ -44,8 +44,8 @@ packages {
 config('TARGET_ROOTFS_EXT4FS', false)
 
 defaults {
-	factory = '-squashfs-combined-efi',
+	factory = '-squashfs-combined',
 	factory_ext = {'.img.gz', '.vmdk', '.vdi'},
-	sysupgrade = '-squashfs-combined-efi',
+	sysupgrade = '-squashfs-combined',
 	sysupgrade_ext = '.img.gz',
 }


### PR DESCRIPTION
This reverts commit 41b8ecd6177f3916ec2ad16bf0f1a1551e77bfd4.

Unbreak upgrades from OpenWrt 19.07 (Gluon 2021.1.x) by undoing the partition table change.

It should be noted that the EFI images generated by OpenWrt are slightly smaller than the non-EFI images for some reason (due to a smaller gap between the boot and root partitions), so upgrading a VM created using a Gluon 2023.1 (EFI) image to a newer non-EFI image will truncate the root partition.

Linux will warn about the truncation on boot ("sda: p2 size 212992 extends beyond EOD, truncated"), but it doesn't cause any other issues, as the root partitions of x86 squashfs images are mostly empty, and the overlay is created in the actual available space after the upgrade. The cosmetic issue will go away as soon as we switch to EFI again (likely with Gluon 2023.2).

Closes #2967

---

This revert is targeted at v2023.1.x only, as we intend to keep EFI enabled in master.

I verified that upgrades from 2021.1.x, 2022.1.x and EFI 2023.1.x images to non-EFI 2023.1.x with this PR all work correctly on x86-64. I assume x86-generic and -legacy behave the same.

Obviously, reverting EFI support will break boot for EFI-only systems without legacy boot support enabled.