### PR TITLE
Fix Dockerfile / container.sh for UID/GID other than 1000

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir /tmp/ec &&\
     mv bin/ec-linux-amd64 /usr/local/bin/editorconfig-checker &&\
     rm -rf /tmp/ec
 
-RUN useradd -d /gluon gluon
+RUN useradd -m -d /gluon gluon
 USER gluon
 
 VOLUME /gluon

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN mkdir /tmp/ec &&\
     mv bin/ec-linux-amd64 /usr/local/bin/editorconfig-checker &&\
     rm -rf /tmp/ec
 
-RUN useradd -m -d /gluon gluon
+RUN useradd -m -d /gluon -u 100 -g 100 gluon
 USER gluon
 
 VOLUME /gluon

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ecdsautils \
     lua-check \
     shellcheck \
+    libnss-unknown \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -30,7 +31,7 @@ RUN mkdir /tmp/ec &&\
     mv bin/ec-linux-amd64 /usr/local/bin/editorconfig-checker &&\
     rm -rf /tmp/ec
 
-RUN useradd -m -d /gluon -u 100 -g 100 gluon
+RUN useradd -m -d /gluon -u 100 -g 100 -o gluon
 USER gluon
 
 VOLUME /gluon

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -12,11 +12,11 @@ TAG="gluon:${BRANCH:-latest}"
 if [ "$(command -v podman)" ]
 then
 	podman build -t "${TAG}" contrib/docker
-	podman run -it --rm --userns=keep-id --volume="$(pwd):/gluon" "${TAG}"
+	podman run -it --rm -u "$(id -u):$(id -g)" --userns=keep-id --volume="$(pwd):/gluon" "${TAG}"
 elif [ "$(command -v docker)" ]
 then
 	docker build -t "${TAG}" contrib/docker
-	docker run -it --rm --volume="$(pwd):/gluon" "${TAG}"
+	docker run -it --rm -u "$(id -u):$(id -g)" --volume="$(pwd):/gluon" -e HOME=/gluon "${TAG}"
 else
 	1>&2 echo "Please install either podman or docker. Exiting" >/dev/null
 	exit 1

--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -18,7 +18,7 @@ then
 	docker build -t "${TAG}" contrib/docker
 	docker run -it --rm -u "$(id -u):$(id -g)" --volume="$(pwd):/gluon" -e HOME=/gluon "${TAG}"
 else
-	1>&2 echo "Please install either podman or docker. Exiting" >/dev/null
+	echo "Please install either podman or docker. Exiting" >&2
 	exit 1
 fi
 


### PR DESCRIPTION
For UIDs/GIDs other than 1000, `scripts/container.sh` was not working correctly, as the owner of the build directory mounted into the container did not match the UID running inside the container. Fix by making them match.

The PR also includes a commit from #2838 by @skorpy2009 with an updated commit message.

Supersedes #2838
Supersedes #2868
Supersedes #2870