### PR TITLE
generic: disable building openvswitch

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -53,6 +53,18 @@ try_config('PACKAGE_dnsmasq_full_noid', false)
 try_config('PACKAGE_dnsmasq_full_broken_rtc', false)
 try_config('PACKAGE_dnsmasq_full_rtc', false)
 
+try_config('PACKAGE_openvswitch', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch-geneve', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch-geneve-intree', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch-gre', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch-gre-intree', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch-intree', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch-lisp-intree', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch-stt-intree', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch-vxlan', false) -- fails to build
+try_config('PACKAGE_kmod-openvswitch-vxlan-intree', false) -- fails to build
+
 try_config('TARGET_SQUASHFS_BLOCK_SIZE', 256)
 
 config('KERNEL_PROC_STRIPPED', true)


### PR DESCRIPTION
openvswitch fails to build with groff v1.23 on the build system.

This groff version hasn't reached a Debian Release yet but is already present with rolling release distros and causes the gluon build to fail.

Since we don't need openvswitch the best temporary fix seems to disable building it by default until this get's resolved upstream.

(Let's see if opening this or even merging this is followed by an coincidental upstream solution. :))

If this is merged it shoud be backported.