### PR TITLE
mediatek-mt7622: add support for Ubiquiti UniFi 6 LR v3

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -301,7 +301,7 @@ mediatek-mt7622
 
 * Ubiquiti
 
-  - UniFi 6 LR (v1)
+  - UniFi 6 LR (v1, v3)
 
 * Xiaomi
 

--- a/targets/mediatek-mt7622
+++ b/targets/mediatek-mt7622
@@ -6,10 +6,18 @@ device('linksys-e8450-ubi', 'linksys_e8450-ubi', {
 })
 
 
+-- Ubiquiti
+
 device('ubiquiti-unifi-6-lr-v1', 'ubnt_unifi-6-lr-v1', {
 	factory = false,
+	-- old name from OpenWrt 22.03.x
 	manifest_aliases = {'ubiquiti-unifi-6-lr'},
 })
+
+device('ubiquiti-unifi-6-lr-v3', 'ubnt_unifi-6-lr-v3', {
+	factory = false,
+})
+
 
 -- Xiaomi
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: ssh
        https://openwrt.org/toh/ubiquiti/unifi_6_lr#installation_steps
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
        ubiquiti-unifi-6-lr-v3
- [x] Reset/~~WPS/...~~ button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
      60:22:32:6a:37:d5
  - ~~When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.~~
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/~~LAN~~)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - ~~otherwise the first port should be declared as WAN, all other ports LAN~~
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~
    - [ ] ~~Should map to their respective radio~~
    - [ ] ~~Should show activity~~
  - ~~Switch port LEDs~~
    - [ ] ~~Should map to their respective port (or switch, if only one led present)~~
    - [ ] ~~Should show link state and activity~~
- Outdoor devices only:
  - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- Cellular devices only:
  - [ ] ~~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`