### PR TITLE
contrib: Dockerfile: install openssh-client

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     lua-check \
     shellcheck \
     libnss-unknown \
+    openssh-client \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Add ssh-client to enable deployment of the build output from CI.