### PR TITLE
workflow: don't push Docker container on PR

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -7,9 +7,6 @@ on:
       - 'master'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'master'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
The docker container on PR action is broken in case the PR is not opened within the Gluon project.

Remove the build on PR so the pipeline does not fail for third party PRs.