### PR TITLE
mpc85xx-p1010: add support for Enterasys WS-AP3715i

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -309,6 +309,10 @@ mediatek-mt7622
 mpc85xx-p1010
 -------------
 
+* Enterasys
+
+  - WS-AP3715i
+
 * Sophos
 
   - RED 15w Rev.1

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -120,6 +120,9 @@ local primary_addrs = {
 			'aerohive,hiveap-330',
 			'ocedo,panda',
 		}},
+		{'mpc85xx', 'p1010', {
+			'enterasys,ws-ap3715i',
+		}},
 		{'ramips', 'mt7620', {
 			'xiaomi,miwifi-mini',
 			'asus,rt-ac51u',

--- a/targets/mpc85xx-p1010
+++ b/targets/mpc85xx-p1010
@@ -1,3 +1,10 @@
+-- Enterasys
+
+device('enterasys-ws-ap3715i', 'enterasys_ws-ap3715i', {
+	factory = false,
+})
+
+
 -- Sophos
 
 device('sophos-red-15w-rev.1', 'sophos_red-15w-rev1', {


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: External serial console
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`