### PR TITLE
actions: run build-gluon for all master* branches

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -2,7 +2,7 @@ name: Build Gluon
 on:
   push:
     branches:
-      - master
+      - master*
       - next*
       - v20*
   pull_request:


### PR DESCRIPTION
This means the build-gluon workflow will also run automatically for master-updates branches.

This allows getting a workflow run inside the own fork on GitHub without having to patch this, opening a PR towards the own Repo or the upstream repo and eating into the limited concurrent worker limit there.