### PR TITLE
[v2023.1.x] patches: openwrt: revert latest mt76 bump

### DIFF
--- a/patches/openwrt/0014-Revert-mt76-update-to-the-latest-version-from-the-22.03-branch.patch
+++ b/patches/openwrt/0014-Revert-mt76-update-to-the-latest-version-from-the-22.03-branch.patch
@@ -1,0 +1,25 @@
+From: Tom Herbers <mail@tomherbers.de>
+Date: Mon, 2 Oct 2023 17:00:58 +0200
+Subject: Revert "mt76: update to the latest version from the 22.03 branch"
+
+This reverts commit 8da4e8fb5687c93091c3759fb983bc59c6312683.
+
+Neccesary because of https://github.com/freifunk-gluon/gluon/issues/3003
+
+diff --git a/package/kernel/mt76/Makefile b/package/kernel/mt76/Makefile
+index 3deeed831589c97f0eee6898dc1ade9644468004..9b10fc3e6fa79a87c14ad3287d3fd155fb63a806 100644
+--- a/package/kernel/mt76/Makefile
++++ b/package/kernel/mt76/Makefile
+@@ -8,9 +8,9 @@ PKG_LICENSE_FILES:=
+ 
+ PKG_SOURCE_URL:=https://github.com/openwrt/mt76
+ PKG_SOURCE_PROTO:=git
+-PKG_SOURCE_DATE:=2023-09-11
+-PKG_SOURCE_VERSION:=bdf8ea71700746c634c064d6477aa143f821d6f6
+-PKG_MIRROR_HASH:=a080a83068abc204d1f563022391625875ef77deda14be49888c179ff78fa8c8
++PKG_SOURCE_DATE:=2023-08-26
++PKG_SOURCE_VERSION:=de38fe7d4cb365312aa570cf37a4c0eff6e15650
++PKG_MIRROR_HASH:=d8b86332060668b36698e3b3703b8735003c09d7dc612327afa9272eead5238d
+ 
+ PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
+ PKG_USE_NINJA:=0

--- a/patches/openwrt/0015-Revert-mt76-update-to-the-latest-version-from-the-22.03-branch.patch
+++ b/patches/openwrt/0015-Revert-mt76-update-to-the-latest-version-from-the-22.03-branch.patch
@@ -1,0 +1,368 @@
+From: Tom Herbers <mail@tomherbers.de>
+Date: Mon, 2 Oct 2023 17:01:05 +0200
+Subject: Revert "mt76: update to the latest version from the 22.03 branch"
+
+This reverts commit 76b1e564d202c09d0035315eb6e958a9b0dd4491.
+
+Neccesary because of https://github.com/freifunk-gluon/gluon/issues/3003
+
+diff --git a/package/kernel/mt76/Makefile b/package/kernel/mt76/Makefile
+index 9b10fc3e6fa79a87c14ad3287d3fd155fb63a806..63d3a480858d7ad74a9ae47283481900c583c8bb 100644
+--- a/package/kernel/mt76/Makefile
++++ b/package/kernel/mt76/Makefile
+@@ -8,9 +8,9 @@ PKG_LICENSE_FILES:=
+ 
+ PKG_SOURCE_URL:=https://github.com/openwrt/mt76
+ PKG_SOURCE_PROTO:=git
+-PKG_SOURCE_DATE:=2023-08-26
+-PKG_SOURCE_VERSION:=de38fe7d4cb365312aa570cf37a4c0eff6e15650
+-PKG_MIRROR_HASH:=d8b86332060668b36698e3b3703b8735003c09d7dc612327afa9272eead5238d
++PKG_SOURCE_DATE:=2022-09-06
++PKG_SOURCE_VERSION:=d70546462b7b51ebc2bcdd5c534fdf3465be62a4
++PKG_MIRROR_HASH:=3d6b68d70a78c0072ed10ab2548344b6b3a70ad99e4edc258fafa16886f4abf9
+ 
+ PKG_MAINTAINER:=Felix Fietkau <nbd@nbd.name>
+ PKG_USE_NINJA:=0
+diff --git a/package/kernel/mt76/patches/100-aggregation-definitions.patch b/package/kernel/mt76/patches/100-aggregation-definitions.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..a88d57133f702e1ea46f2a8346ddef2535107ee4
+--- /dev/null
++++ b/package/kernel/mt76/patches/100-aggregation-definitions.patch
+@@ -0,0 +1,13 @@
++--- a/mt7915/init.c
+++++ b/mt7915/init.c
++@@ -327,8 +327,8 @@ mt7915_init_wiphy(struct ieee80211_hw *h
++ 	struct mt7915_dev *dev = phy->dev;
++ 
++ 	hw->queues = 4;
++-	hw->max_rx_aggregation_subframes = IEEE80211_MAX_AMPDU_BUF;
++-	hw->max_tx_aggregation_subframes = IEEE80211_MAX_AMPDU_BUF;
+++	hw->max_rx_aggregation_subframes = IEEE80211_MAX_AMPDU_BUF_HE;
+++	hw->max_tx_aggregation_subframes = IEEE80211_MAX_AMPDU_BUF_HE;
++ 	hw->netdev_features = NETIF_F_RXCSUM;
++ 
++ 	hw->radiotap_timestamp.units_pos =
+diff --git a/package/kernel/mt76/patches/110-api_update.patch b/package/kernel/mt76/patches/110-api_update.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..27bd6286b02573bba6b92a4816ecef209974dd0a
+--- /dev/null
++++ b/package/kernel/mt76/patches/110-api_update.patch
+@@ -0,0 +1,11 @@
++--- a/tx.c
+++++ b/tx.c
++@@ -325,7 +325,7 @@ mt76_tx(struct mt76_phy *phy, struct iee
++ 	if ((dev->drv->drv_flags & MT_DRV_HW_MGMT_TXQ) &&
++ 	    !(info->flags & IEEE80211_TX_CTL_HW_80211_ENCAP) &&
++ 	    !ieee80211_is_data(hdr->frame_control) &&
++-	    !ieee80211_is_bufferable_mmpdu(hdr->frame_control)) {
+++	    !ieee80211_is_bufferable_mmpdu(skb)) {
++ 		qid = MT_TXQ_PSD;
++ 	}
++ 
+diff --git a/package/kernel/mt76/patches/120-wifi-mt76-ignore-key-disable-commands.patch b/package/kernel/mt76/patches/120-wifi-mt76-ignore-key-disable-commands.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..3ac6cebca8cbf83dd7cb65b4688a9a7702127117
+--- /dev/null
++++ b/package/kernel/mt76/patches/120-wifi-mt76-ignore-key-disable-commands.patch
+@@ -0,0 +1,301 @@
++From: Felix Fietkau <nbd@nbd.name>
++Date: Wed, 22 Mar 2023 10:17:49 +0100
++Subject: [PATCH] wifi: mt76: ignore key disable commands
++
++This helps avoid cleartext leakage of already queued or powersave buffered
++packets, when a reassoc triggers the key deletion.
++
++Cc: stable@vger.kernel.org
++Signed-off-by: Felix Fietkau <nbd@nbd.name>
++---
++
++--- a/mt7603/main.c
+++++ b/mt7603/main.c
++@@ -512,15 +512,15 @@ mt7603_set_key(struct ieee80211_hw *hw,
++ 	    !(key->flags & IEEE80211_KEY_FLAG_PAIRWISE))
++ 		return -EOPNOTSUPP;
++ 
++-	if (cmd == SET_KEY) {
++-		key->hw_key_idx = wcid->idx;
++-		wcid->hw_key_idx = idx;
++-	} else {
+++	if (cmd != SET_KEY) {
++ 		if (idx == wcid->hw_key_idx)
++ 			wcid->hw_key_idx = -1;
++ 
++-		key = NULL;
+++		return 0;
++ 	}
+++
+++	key->hw_key_idx = wcid->idx;
+++	wcid->hw_key_idx = idx;
++ 	mt76_wcid_key_setup(&dev->mt76, wcid, key);
++ 
++ 	return mt7603_wtbl_set_key(dev, wcid->idx, key);
++--- a/mt7615/mac.c
+++++ b/mt7615/mac.c
++@@ -1178,8 +1178,7 @@ EXPORT_SYMBOL_GPL(mt7615_mac_set_rates);
++ static int
++ mt7615_mac_wtbl_update_key(struct mt7615_dev *dev, struct mt76_wcid *wcid,
++ 			   struct ieee80211_key_conf *key,
++-			   enum mt76_cipher_type cipher, u16 cipher_mask,
++-			   enum set_key_cmd cmd)
+++			   enum mt76_cipher_type cipher, u16 cipher_mask)
++ {
++ 	u32 addr = mt7615_mac_wtbl_addr(dev, wcid->idx) + 30 * 4;
++ 	u8 data[32] = {};
++@@ -1188,27 +1187,18 @@ mt7615_mac_wtbl_update_key(struct mt7615
++ 		return -EINVAL;
++ 
++ 	mt76_rr_copy(dev, addr, data, sizeof(data));
++-	if (cmd == SET_KEY) {
++-		if (cipher == MT_CIPHER_TKIP) {
++-			/* Rx/Tx MIC keys are swapped */
++-			memcpy(data, key->key, 16);
++-			memcpy(data + 16, key->key + 24, 8);
++-			memcpy(data + 24, key->key + 16, 8);
++-		} else {
++-			if (cipher_mask == BIT(cipher))
++-				memcpy(data, key->key, key->keylen);
++-			else if (cipher != MT_CIPHER_BIP_CMAC_128)
++-				memcpy(data, key->key, 16);
++-			if (cipher == MT_CIPHER_BIP_CMAC_128)
++-				memcpy(data + 16, key->key, 16);
++-		}
+++	if (cipher == MT_CIPHER_TKIP) {
+++		/* Rx/Tx MIC keys are swapped */
+++		memcpy(data, key->key, 16);
+++		memcpy(data + 16, key->key + 24, 8);
+++		memcpy(data + 24, key->key + 16, 8);
++ 	} else {
+++		if (cipher_mask == BIT(cipher))
+++			memcpy(data, key->key, key->keylen);
+++		else if (cipher != MT_CIPHER_BIP_CMAC_128)
+++			memcpy(data, key->key, 16);
++ 		if (cipher == MT_CIPHER_BIP_CMAC_128)
++-			memset(data + 16, 0, 16);
++-		else if (cipher_mask)
++-			memset(data, 0, 16);
++-		if (!cipher_mask)
++-			memset(data, 0, sizeof(data));
+++			memcpy(data + 16, key->key, 16);
++ 	}
++ 
++ 	mt76_wr_copy(dev, addr, data, sizeof(data));
++@@ -1219,7 +1209,7 @@ mt7615_mac_wtbl_update_key(struct mt7615
++ static int
++ mt7615_mac_wtbl_update_pk(struct mt7615_dev *dev, struct mt76_wcid *wcid,
++ 			  enum mt76_cipher_type cipher, u16 cipher_mask,
++-			  int keyidx, enum set_key_cmd cmd)
+++			  int keyidx)
++ {
++ 	u32 addr = mt7615_mac_wtbl_addr(dev, wcid->idx), w0, w1;
++ 
++@@ -1238,9 +1228,7 @@ mt7615_mac_wtbl_update_pk(struct mt7615_
++ 	else
++ 		w0 &= ~MT_WTBL_W0_RX_IK_VALID;
++ 
++-	if (cmd == SET_KEY &&
++-	    (cipher != MT_CIPHER_BIP_CMAC_128 ||
++-	     cipher_mask == BIT(cipher))) {
+++	if (cipher != MT_CIPHER_BIP_CMAC_128 || cipher_mask == BIT(cipher)) {
++ 		w0 &= ~MT_WTBL_W0_KEY_IDX;
++ 		w0 |= FIELD_PREP(MT_WTBL_W0_KEY_IDX, keyidx);
++ 	}
++@@ -1257,19 +1245,10 @@ mt7615_mac_wtbl_update_pk(struct mt7615_
++ 
++ static void
++ mt7615_mac_wtbl_update_cipher(struct mt7615_dev *dev, struct mt76_wcid *wcid,
++-			      enum mt76_cipher_type cipher, u16 cipher_mask,
++-			      enum set_key_cmd cmd)
+++			      enum mt76_cipher_type cipher, u16 cipher_mask)
++ {
++ 	u32 addr = mt7615_mac_wtbl_addr(dev, wcid->idx);
++ 
++-	if (!cipher_mask) {
++-		mt76_clear(dev, addr + 2 * 4, MT_WTBL_W2_KEY_TYPE);
++-		return;
++-	}
++-
++-	if (cmd != SET_KEY)
++-		return;
++-
++ 	if (cipher == MT_CIPHER_BIP_CMAC_128 &&
++ 	    cipher_mask & ~BIT(MT_CIPHER_BIP_CMAC_128))
++ 		return;
++@@ -1280,8 +1259,7 @@ mt7615_mac_wtbl_update_cipher(struct mt7
++ 
++ int __mt7615_mac_wtbl_set_key(struct mt7615_dev *dev,
++ 			      struct mt76_wcid *wcid,
++-			      struct ieee80211_key_conf *key,
++-			      enum set_key_cmd cmd)
+++			      struct ieee80211_key_conf *key)
++ {
++ 	enum mt76_cipher_type cipher;
++ 	u16 cipher_mask = wcid->cipher;
++@@ -1291,19 +1269,14 @@ int __mt7615_mac_wtbl_set_key(struct mt7
++ 	if (cipher == MT_CIPHER_NONE)
++ 		return -EOPNOTSUPP;
++ 
++-	if (cmd == SET_KEY)
++-		cipher_mask |= BIT(cipher);
++-	else
++-		cipher_mask &= ~BIT(cipher);
++-
++-	mt7615_mac_wtbl_update_cipher(dev, wcid, cipher, cipher_mask, cmd);
++-	err = mt7615_mac_wtbl_update_key(dev, wcid, key, cipher, cipher_mask,
++-					 cmd);
+++	cipher_mask |= BIT(cipher);
+++	mt7615_mac_wtbl_update_cipher(dev, wcid, cipher, cipher_mask);
+++	err = mt7615_mac_wtbl_update_key(dev, wcid, key, cipher, cipher_mask);
++ 	if (err < 0)
++ 		return err;
++ 
++ 	err = mt7615_mac_wtbl_update_pk(dev, wcid, cipher, cipher_mask,
++-					key->keyidx, cmd);
+++					key->keyidx);
++ 	if (err < 0)
++ 		return err;
++ 
++@@ -1314,13 +1287,12 @@ int __mt7615_mac_wtbl_set_key(struct mt7
++ 
++ int mt7615_mac_wtbl_set_key(struct mt7615_dev *dev,
++ 			    struct mt76_wcid *wcid,
++-			    struct ieee80211_key_conf *key,
++-			    enum set_key_cmd cmd)
+++			    struct ieee80211_key_conf *key)
++ {
++ 	int err;
++ 
++ 	spin_lock_bh(&dev->mt76.lock);
++-	err = __mt7615_mac_wtbl_set_key(dev, wcid, key, cmd);
+++	err = __mt7615_mac_wtbl_set_key(dev, wcid, key);
++ 	spin_unlock_bh(&dev->mt76.lock);
++ 
++ 	return err;
++--- a/mt7615/main.c
+++++ b/mt7615/main.c
++@@ -391,18 +391,17 @@ static int mt7615_set_key(struct ieee802
++ 
++ 	if (cmd == SET_KEY)
++ 		*wcid_keyidx = idx;
++-	else if (idx == *wcid_keyidx)
++-		*wcid_keyidx = -1;
++-	else
+++	else {
+++		if (idx == *wcid_keyidx)
+++			*wcid_keyidx = -1;
++ 		goto out;
+++	}
++ 
++-	mt76_wcid_key_setup(&dev->mt76, wcid,
++-			    cmd == SET_KEY ? key : NULL);
++-
+++	mt76_wcid_key_setup(&dev->mt76, wcid, key);
++ 	if (mt76_is_mmio(&dev->mt76))
++-		err = mt7615_mac_wtbl_set_key(dev, wcid, key, cmd);
+++		err = mt7615_mac_wtbl_set_key(dev, wcid, key);
++ 	else
++-		err = __mt7615_mac_wtbl_set_key(dev, wcid, key, cmd);
+++		err = __mt7615_mac_wtbl_set_key(dev, wcid, key);
++ 
++ out:
++ 	mt7615_mutex_release(dev);
++--- a/mt7615/mt7615.h
+++++ b/mt7615/mt7615.h
++@@ -482,11 +482,9 @@ int mt7615_mac_write_txwi(struct mt7615_
++ void mt7615_mac_set_timing(struct mt7615_phy *phy);
++ int __mt7615_mac_wtbl_set_key(struct mt7615_dev *dev,
++ 			      struct mt76_wcid *wcid,
++-			      struct ieee80211_key_conf *key,
++-			      enum set_key_cmd cmd);
+++			      struct ieee80211_key_conf *key);
++ int mt7615_mac_wtbl_set_key(struct mt7615_dev *dev, struct mt76_wcid *wcid,
++-			    struct ieee80211_key_conf *key,
++-			    enum set_key_cmd cmd);
+++			    struct ieee80211_key_conf *key);
++ void mt7615_mac_reset_work(struct work_struct *work);
++ u32 mt7615_mac_get_sta_tid_sn(struct mt7615_dev *dev, int wcid, u8 tid);
++ 
++--- a/mt76x02_util.c
+++++ b/mt76x02_util.c
++@@ -455,20 +455,20 @@ int mt76x02_set_key(struct ieee80211_hw
++ 	msta = sta ? (struct mt76x02_sta *)sta->drv_priv : NULL;
++ 	wcid = msta ? &msta->wcid : &mvif->group_wcid;
++ 
++-	if (cmd == SET_KEY) {
++-		key->hw_key_idx = wcid->idx;
++-		wcid->hw_key_idx = idx;
++-		if (key->flags & IEEE80211_KEY_FLAG_RX_MGMT) {
++-			key->flags |= IEEE80211_KEY_FLAG_SW_MGMT_TX;
++-			wcid->sw_iv = true;
++-		}
++-	} else {
+++	if (cmd != SET_KEY) {
++ 		if (idx == wcid->hw_key_idx) {
++ 			wcid->hw_key_idx = -1;
++ 			wcid->sw_iv = false;
++ 		}
++ 
++-		key = NULL;
+++		return 0;
+++	}
+++
+++	key->hw_key_idx = wcid->idx;
+++	wcid->hw_key_idx = idx;
+++	if (key->flags & IEEE80211_KEY_FLAG_RX_MGMT) {
+++		key->flags |= IEEE80211_KEY_FLAG_SW_MGMT_TX;
+++		wcid->sw_iv = true;
++ 	}
++ 	mt76_wcid_key_setup(&dev->mt76, wcid, key);
++ 
++--- a/mt7915/main.c
+++++ b/mt7915/main.c
++@@ -387,16 +387,15 @@ static int mt7915_set_key(struct ieee802
++ 		mt7915_mcu_add_bss_info(phy, vif, true);
++ 	}
++ 
++-	if (cmd == SET_KEY)
+++	if (cmd == SET_KEY) {
++ 		*wcid_keyidx = idx;
++-	else if (idx == *wcid_keyidx)
++-		*wcid_keyidx = -1;
++-	else
+++	} else {
+++		if (idx == *wcid_keyidx)
+++			*wcid_keyidx = -1;
++ 		goto out;
+++	}
++ 
++-	mt76_wcid_key_setup(&dev->mt76, wcid,
++-			    cmd == SET_KEY ? key : NULL);
++-
+++	mt76_wcid_key_setup(&dev->mt76, wcid, key);
++ 	err = mt76_connac_mcu_add_key(&dev->mt76, vif, &msta->bip,
++ 				      key, MCU_EXT_CMD(STA_REC_UPDATE),
++ 				      &msta->wcid, cmd);
++--- a/mt7921/main.c
+++++ b/mt7921/main.c
++@@ -463,16 +463,15 @@ static int mt7921_set_key(struct ieee802
++ 
++ 	mt7921_mutex_acquire(dev);
++ 
++-	if (cmd == SET_KEY)
+++	if (cmd == SET_KEY) {
++ 		*wcid_keyidx = idx;
++-	else if (idx == *wcid_keyidx)
++-		*wcid_keyidx = -1;
++-	else
+++	} else {
+++		if (idx == *wcid_keyidx)
+++			*wcid_keyidx = -1;
++ 		goto out;
+++	}
++ 
++-	mt76_wcid_key_setup(&dev->mt76, wcid,
++-			    cmd == SET_KEY ? key : NULL);
++-
+++	mt76_wcid_key_setup(&dev->mt76, wcid, key);
++ 	err = mt76_connac_mcu_add_key(&dev->mt76, vif, &msta->bip,
++ 				      key, MCU_UNI_CMD(STA_REC_UPDATE),
++ 				      &msta->wcid, cmd);


### PR DESCRIPTION
The latest mt76 bump results in broken WLAN on the D-Link DAP-X1860 (#3003).

Reverting them works arround this for now.