### PR TITLE
treewide: replace luabitops with lua-bit32

### DIFF
--- a/package/gluon-core/Makefile
+++ b/package/gluon-core/Makefile
@@ -11,7 +11,7 @@ define Package/gluon-core
   TITLE:=Base files of Gluon
   DEPENDS:= \
 	+gluon-site +libgluonutil +libiwinfo-lua +lua-platform-info +lua-simple-uci +lua-hash +lua-jsonc \
-	+luabitop +luaposix +vxlan +odhcp6c +firewall +pretty-hostname
+	+lua-bit32 +luaposix +vxlan +odhcp6c +firewall +pretty-hostname
 endef
 
 define Package/gluon-core/description

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/iputil.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/iputil.lua
@@ -1,4 +1,4 @@
-local bit = require 'bit'
+local bit = require 'bit32'
 
 
 local M = {}

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/util.lua
@@ -1,4 +1,4 @@
-local bit = require 'bit'
+local bit = require 'bit32'
 local posix_fcntl = require 'posix.fcntl'
 local posix_glob = require 'posix.glob'
 local posix_syslog = require 'posix.syslog'

--- a/package/gluon-hoodselector/Makefile
+++ b/package/gluon-hoodselector/Makefile
@@ -6,7 +6,7 @@ include ../gluon.mk
 
 define Package/gluon-hoodselector
   TITLE:=Automatically migrate nodes between domains.
-  DEPENDS:=+luaposix +libgluonutil +lua-math-polygon +libjson-c +gluon-site +micrond +luabitop @GLUON_MULTIDOMAIN
+  DEPENDS:=+luaposix +libgluonutil +lua-math-polygon +libjson-c +gluon-site +micrond +lua-bit32 @GLUON_MULTIDOMAIN
   CONFLICTS:=+gluon-config-mode-domain-select
 endef
 

--- a/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
+++ b/package/gluon-hoodselector/luasrc/usr/sbin/hoodselector
@@ -1,6 +1,6 @@
 #!/usr/bin/lua
 
-local bit = require('bit')
+local bit = require('bit32')
 local util = require ('gluon.util')
 local unistd = require('posix.unistd')
 local fcntl = require('posix.fcntl')

--- a/package/gluon-mesh-babel/Makefile
+++ b/package/gluon-mesh-babel/Makefile
@@ -9,7 +9,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-babel
   TITLE:=Babel mesh
-  DEPENDS:=+gluon-core +babeld +gluon-mesh-layer3-common +libiwinfo +libgluonutil +firewall +libjson-c +libnl-tiny +libubus +libubox +libblobmsg-json +libbabelhelper +luabitop
+  DEPENDS:=+gluon-core +babeld +gluon-mesh-layer3-common +libiwinfo +libgluonutil +firewall +libjson-c +libnl-tiny +libubus +libubox +libblobmsg-json +libbabelhelper
   PROVIDES:=gluon-mesh-provider
 endef
 


### PR DESCRIPTION
`lua-bit32` is pulled in by `luaposix` anyways, and for our purposes these libraries can be used interchangeably. Get rid of the unneeded dependency.