### PR TITLE
CI: Fix target filters, add CI check

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -222,7 +222,6 @@
     "targets/targets.mk",
     "targets/x86.inc",
     "contrib/ci/minimal-site/**",
-    "contrib/docker/Dockerfile",
     "package/**"
   ],
   "bcm27xx-bcm2710": [

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -1,0 +1,22 @@
+name: Check generated CI
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+
+jobs:
+  check-ci:
+    name: Check generated CI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install example site
+        run: ln -s ./docs/site-example ./site
+      - name: Update CI
+        run: make update-ci
+      - name: Show diff
+        run: git status; git diff
+      - name: Patch status
+        run: git diff-files --quiet


### PR DESCRIPTION
The filters generated by `generate-target-filters.py` did not match the actual filters, but the extraneous entry (added in c418b7bb16d54090e468cfb8a89d20655bd466a6) did not do what it was supposed to (as our CI builds do not use the Docker image).

Revert the change and introduce a CI check to prevent future inconsistencies.