### PR TITLE
lantiq-xrx200: mark target as broken

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -75,15 +75,6 @@
     "targets/generic",
     "targets/targets.mk"
   ],
-  "lantiq-xrx200": [
-    "targets/lantiq-xrx200",
-    "modules",
-    "Makefile",
-    "patches/**",
-    "scripts/**",
-    "targets/generic",
-    "targets/targets.mk"
-  ],
   "lantiq-xway": [
     "targets/lantiq-xway",
     "modules",
@@ -234,6 +225,15 @@
     "targets/generic",
     "targets/targets.mk",
     "targets/bcm27xx.inc"
+  ],
+  "lantiq-xrx200": [
+    "targets/lantiq-xrx200",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk"
   ],
   "mvebu-cortexa9": [
     "targets/mvebu-cortexa9",

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -6,7 +6,6 @@ $(eval $(call GluonTarget,bcm27xx,bcm2709))
 $(eval $(call GluonTarget,ipq40xx,generic))
 $(eval $(call GluonTarget,ipq40xx,mikrotik))
 $(eval $(call GluonTarget,ipq806x,generic))
-$(eval $(call GluonTarget,lantiq,xrx200))
 $(eval $(call GluonTarget,lantiq,xway))
 $(eval $(call GluonTarget,mediatek,filogic))
 $(eval $(call GluonTarget,mediatek,mt7622))
@@ -26,5 +25,6 @@ $(eval $(call GluonTarget,x86,64))
 
 ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,bcm27xx,bcm2710)) # BROKEN: Untested
+$(eval $(call GluonTarget,lantiq,xrx200)) # BROKEN: Switch driver broken on Linux 5.15
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
 endif


### PR DESCRIPTION
lantiq-xrx200 is currently marked as source-only in OpenWrt 23.05, as the switch driver does not work correctly on Linux 5.15. Mark as broken in Gluon as well until the issue is fixed.

Upstream PR: https://github.com/openwrt/openwrt/pull/13200