### PR TITLE
Prefer packages from Gluon feeds to upstream feeds

### DIFF
--- a/modules
+++ b/modules
@@ -1,8 +1,11 @@
-GLUON_FEEDS='packages routing gluon'
+GLUON_FEEDS='gluon packages routing'
 
 OPENWRT_REPO=https://github.com/openwrt/openwrt.git
 OPENWRT_BRANCH=openwrt-23.05
 OPENWRT_COMMIT=86e852bcd01c4e43423c03984ee431118d57f855
+
+PACKAGES_GLUON_REPO=https://github.com/freifunk-gluon/packages.git
+PACKAGES_GLUON_COMMIT=ce2e6ac1937af9a4c5c54181ab00781a0bf0097c
 
 PACKAGES_PACKAGES_REPO=https://github.com/openwrt/packages.git
 PACKAGES_PACKAGES_BRANCH=openwrt-23.05
@@ -11,6 +14,3 @@ PACKAGES_PACKAGES_COMMIT=0da9f622975aa1e4efe452da4acbae15479bee63
 PACKAGES_ROUTING_REPO=https://github.com/openwrt/routing.git
 PACKAGES_ROUTING_BRANCH=openwrt-23.05
 PACKAGES_ROUTING_COMMIT=2272106e0839ee06957e88e3596489e1b510d3c2
-
-PACKAGES_GLUON_REPO=https://github.com/freifunk-gluon/packages.git
-PACKAGES_GLUON_COMMIT=ce2e6ac1937af9a4c5c54181ab00781a0bf0097c

--- a/scripts/modules.sh
+++ b/scripts/modules.sh
@@ -2,7 +2,7 @@
 [ ! -f "$GLUON_SITEDIR"/modules ] || . "$GLUON_SITEDIR"/modules
 
 # shellcheck disable=SC2086
-FEEDS="$(echo $GLUON_FEEDS $GLUON_SITE_FEEDS | tr ' ' '\n')"
+FEEDS="$(echo $GLUON_SITE_FEEDS $GLUON_FEEDS | tr ' ' '\n')"
 
 GLUON_MODULES=openwrt
 


### PR DESCRIPTION
In Gluon v2023.1, our tunneldigger package in freifunk-gluon/packages got replaced with a new package in openwrt/packages, causing multiple bugs. To prevent similar issues in the future, reorder the list of feeds, resulting in the following order of precedence:

- OpenWrt base
- Gluon base
- (Site feeds)
- Gluon packages
- OpenWrt packages
- OpenWrt routing

Should be backported to v2023.1.x.