### PR TITLE
actions: improve docker image build-process

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'v202[0-9].[0-9].x'
     tags:
       - 'v*'
 

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@b4bedf8053341df3b5a9f9e0f2cf4e79e27360c6
+        if: ${{ github.repository_owner == 'freifunk-gluon' }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,6 +35,6 @@ jobs:
         uses: docker/build-push-action@4c1b68d83ad20cc1a09620ca477d5bbbb5fa14d0
         with:
           context: ./contrib/docker
-          push: true
+          push: ${{ github.repository_owner == 'freifunk-gluon' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -8,6 +8,7 @@ on:
       - 'v202[0-9].[0-9].x'
     tags:
       - 'v*'
+  pull_request:
 
 env:
   REGISTRY: ghcr.io
@@ -22,7 +23,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Log in to the Container registry
         uses: docker/login-action@b4bedf8053341df3b5a9f9e0f2cf4e79e27360c6
-        if: ${{ github.repository_owner == 'freifunk-gluon' }}
+        if: ${{ github.repository_owner == 'freifunk-gluon' && github.event_name == 'push' }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -36,6 +37,6 @@ jobs:
         uses: docker/build-push-action@4c1b68d83ad20cc1a09620ca477d5bbbb5fa14d0
         with:
           context: ./contrib/docker
-          push: ${{ github.repository_owner == 'freifunk-gluon' }}
+          push: ${{ github.repository_owner == 'freifunk-gluon' && github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Improve the build-process for the Docker container

 - Only push to GitHub container registry when executed for the `freifunk-gluon` organization
 - Build and tag docker container not only for master but also for release branches
 - Enable building of the docker-container on pull-requests again