### PR TITLE
new target: armsr

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,4 +1,24 @@
 {
+  "armsr-armv7": [
+    "targets/armsr-armv7",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk",
+    "targets/armsr.inc"
+  ],
+  "armsr-armv8": [
+    "targets/armsr-armv8",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk",
+    "targets/armsr.inc"
+  ],
   "ath79-generic": [
     "targets/ath79-generic",
     "modules",

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -1,6 +1,16 @@
 Supported Devices & Architectures
 =================================
 
+armsr-armv7
+-----------
+
+* Arm SystemReady (EFI) 32-bit
+
+armsr-armv8
+-----------
+
+* Arm SystemReady (EFI) 64-bit
+
 ath79-generic
 --------------
 

--- a/targets/armsr-armv7
+++ b/targets/armsr-armv7
@@ -1,0 +1,3 @@
+include 'armsr.inc'
+
+device('armsr-armv7', 'generic')

--- a/targets/armsr-armv8
+++ b/targets/armsr-armv8
@@ -1,0 +1,3 @@
+include 'armsr.inc'
+
+device('armsr-armv8', 'generic')

--- a/targets/armsr.inc
+++ b/targets/armsr.inc
@@ -1,0 +1,9 @@
+-- We do not use the ext4 images, so we do not want to build them.
+config('TARGET_ROOTFS_EXT4FS', false)
+
+defaults {
+	factory = '-squashfs-combined',
+	factory_ext = '.img.gz',
+	sysupgrade = '-squashfs-combined',
+	sysupgrade_ext = '.img.gz',
+}

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -1,3 +1,5 @@
+$(eval $(call GluonTarget,armsr,armv7))
+$(eval $(call GluonTarget,armsr,armv8))
 $(eval $(call GluonTarget,ath79,generic))
 $(eval $(call GluonTarget,ath79,nand))
 $(eval $(call GluonTarget,ath79,mikrotik))


### PR DESCRIPTION
This target supports Arm SystemReady compatible machines and allows to run an offloader on any EFI compatible ARM machine or especially on QEMU on ARM.

This depends on https://github.com/openwrt/openwrt/pull/13719, resp. its backport.

I'm testing the armv8 image on a x86 host.

- [X] Must be flashable from vendor firmware
  - ~[ ] Web interface~
  - ~[ ] TFTP~
  - [X] Other: dd image to disk
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- ~[ ] Reset/WPS/... button must return device into config mode~
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - ~[ ] Association with AP must be possible on all radios~
  - ~[ ] Association with 802.11s mesh must work on all radios~ 
  - ~[ ] AP+mesh mode must work in parallel on all radios~
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - ~[ ] Should display config mode blink sequence~
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - ~[ ] Should map to their respective radio~
    - ~[ ] Should show activity~
  - Switch port LEDs
    - ~[ ] Should map to their respective port (or switch, if only one led present)~
    - ~[ ] Should show link state and activity~
- Outdoor devices only:
  - ~[ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~
- Cellular devices only:
  - ~[ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~
  - ~[ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`