### PR TITLE
ci: update branch-pattern matching

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -1,6 +1,7 @@
 {
   "ath79-generic": [
     "targets/ath79-generic",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -10,6 +11,7 @@
   ],
   "ath79-nand": [
     "targets/ath79-nand",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -19,6 +21,7 @@
   ],
   "ath79-mikrotik": [
     "targets/ath79-mikrotik",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -29,6 +32,7 @@
   ],
   "bcm27xx-bcm2708": [
     "targets/bcm27xx-bcm2708",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -39,6 +43,7 @@
   ],
   "bcm27xx-bcm2709": [
     "targets/bcm27xx-bcm2709",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -49,6 +54,7 @@
   ],
   "ipq40xx-generic": [
     "targets/ipq40xx-generic",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -58,6 +64,7 @@
   ],
   "ipq40xx-mikrotik": [
     "targets/ipq40xx-mikrotik",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -68,6 +75,7 @@
   ],
   "ipq806x-generic": [
     "targets/ipq806x-generic",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -77,6 +85,7 @@
   ],
   "lantiq-xway": [
     "targets/lantiq-xway",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -86,6 +95,7 @@
   ],
   "mediatek-filogic": [
     "targets/mediatek-filogic",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -95,6 +105,7 @@
   ],
   "mediatek-mt7622": [
     "targets/mediatek-mt7622",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -104,6 +115,7 @@
   ],
   "mpc85xx-p1010": [
     "targets/mpc85xx-p1010",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -113,6 +125,7 @@
   ],
   "mpc85xx-p1020": [
     "targets/mpc85xx-p1020",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -122,6 +135,7 @@
   ],
   "ramips-mt7620": [
     "targets/ramips-mt7620",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -131,6 +145,7 @@
   ],
   "ramips-mt7621": [
     "targets/ramips-mt7621",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -140,6 +155,7 @@
   ],
   "ramips-mt76x8": [
     "targets/ramips-mt76x8",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -149,6 +165,7 @@
   ],
   "realtek-rtl838x": [
     "targets/realtek-rtl838x",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -158,6 +175,7 @@
   ],
   "rockchip-armv8": [
     "targets/rockchip-armv8",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -167,6 +185,7 @@
   ],
   "sunxi-cortexa7": [
     "targets/sunxi-cortexa7",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -176,6 +195,7 @@
   ],
   "x86-generic": [
     "targets/x86-generic",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -186,6 +206,7 @@
   ],
   "x86-geode": [
     "targets/x86-geode",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -195,6 +216,7 @@
   ],
   "x86-legacy": [
     "targets/x86-legacy",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -205,6 +227,7 @@
   ],
   "x86-64": [
     "targets/x86-64",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -217,6 +240,7 @@
   ],
   "bcm27xx-bcm2710": [
     "targets/bcm27xx-bcm2710",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -227,6 +251,7 @@
   ],
   "lantiq-xrx200": [
     "targets/lantiq-xrx200",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",
@@ -236,6 +261,7 @@
   ],
   "mvebu-cortexa9": [
     "targets/mvebu-cortexa9",
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",

--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -3,8 +3,8 @@ on:
   push:
     branches:
       - master
-      - next*
-      - v20*
+      - next
+      - 'v20[2-9][0-9].[0-9].x'
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -7,6 +7,7 @@ on:
       - 'v20[2-9][0-9].[0-9].x'
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/contrib/actions/generate-target-filters.py
+++ b/contrib/actions/generate-target-filters.py
@@ -10,6 +10,7 @@ import json
 
 # these changes trigger rebuilds on all targets
 common = [
+    ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",
     "patches/**",


### PR DESCRIPTION
## [github: restrict branch-triggers on specific branches](https://github.com/freifunk-gluon/gluon/commit/b59048742300142aedca8ba0e36482564477f7d6)

In https://github.com/freifunk-gluon/gluon/pull/2997 it was pointed out the current branch-trigger matches more
branches than the release-branches. Retrict the match-pattern to only
cover release-branches

Also only trigger builds on the next-branch and not branches prefixed
with this name.

Link: https://github.com/freifunk-gluon/gluon/pull/2997#issuecomment-1771076385

---

## [github: add workflow-dispatch trigger for build workflow](https://github.com/freifunk-gluon/gluon/commit/6fee38e372906a9e892f16bf5df89da4922f28d8)

Add a workflow-dispatch trigger to the build-workflow to enable
triggering build-tests on branches not covered from the match
pattern.

---

## [github: trigger ci-build when altering ci](https://github.com/freifunk-gluon/gluon/pull/3030/commits/ae758117ab5fae995307d36493ee5afd3ee734a1)

It makes sense to run CI build-tests in case the CI itself is altered.