### PR TITLE
build: fix duplicate building of host-tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,8 @@ $(LUA):
 
 	scripts/module_check.sh
 
-	[ -e openwrt/.config ] || $(OPENWRTMAKE) defconfig
+	$(GLUON_ENV) scripts/basic_openwrt_config.sh > openwrt/.config
+	$(OPENWRTMAKE) defconfig
 	$(OPENWRTMAKE) tools/install
 	$(OPENWRTMAKE) package/lua/host/compile
 

--- a/scripts/basic_openwrt_config.sh
+++ b/scripts/basic_openwrt_config.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "CONFIG_DEVEL=y"
+if [ "$GLUON_AUTOREMOVE" != "0" ]; then
+	echo "CONFIG_AUTOREMOVE=y"
+else
+	echo "# CONFIG_AUTOREMOVE is not set"
+fi


### PR DESCRIPTION
Upstream introduced two different methods for determining the state of a package within the OpenWrt buildsystem. While both are based around the md5 hash-function, one taks filename & mtime into account while the other one uses the actual md5 hash of the file-content.

Ever wondered why Gluon suddenly took considerably longer to build? The messy part is how the build-system chooses which method to use. This is based around the AUTOREMOVE configuration. Gluon sets this variable conditionally when built with GLUON_AUTOREMOVE set to 1.

Enter the Gluon build-system. It first compiles Lua, without the AUTOREMOVE configuration passed to OpenWrt. This compiles the packages with the old hash-method based around filename & mtime. Afterwards, it builds with AUTOREMOVE enabled, changing the hash-function and rebuilding all host-packages.

Fix this by setting AUTOREMOVE for both build-processes according to the setting of GLUON_AUTOREMOVE.

Link: https://github.com/openwrt/openwrt/commit/53a08e37437972ba0a8fbf953a93a70a6b784ef4