### PR TITLE
ath79-generic: add support for TP-Link EAP225-Outdoor v3

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -114,7 +114,7 @@ ath79-generic
   - CPE220 (v3.0)
   - CPE510 (v1.0, v1.1, v2.0, v3.0)
   - CPE710 (v1.0)
-  - EAP225-Outdoor (v1)
+  - EAP225-Outdoor (v1, v3)
   - TL-WDR3500 (v1)
   - TL-WDR3600 (v1)
   - TL-WDR4300 (v1)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -37,6 +37,7 @@ function M.is_outdoor_device()
 		'tplink,cpe510-v3',
 		'tplink,cpe710-v1',
 		'tplink,eap225-outdoor-v1',
+		'tplink,eap225-outdoor-v3',
 		'tplink,wbs210-v1',
 		'tplink,wbs210-v2',
 		'tplink,wbs510-v1',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -468,6 +468,10 @@ device('tp-link-eap225-outdoor-v1', 'tplink_eap225-outdoor-v1', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })
 
+device('tp-link-eap225-outdoor-v3', 'tplink_eap225-outdoor-v3', {
+	packages = ATH10K_PACKAGES_QCA9888,
+})
+
 device('tp-link-tl-wdr3500-v1', 'tplink_tl-wdr3500-v1')
 device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
 device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
   * Note: direct vendor firmware to Gluon untested, device was originally flashed from vendor fw to vanilla OpenWrt
  - [ ] TFTP: untested
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - ~~if there are multiple ports but no WAN port:~~
      - ~~the PoE input should be WAN, all other ports LAN~~
      - ~~otherwise the first port should be declared as WAN, all other ports LAN~~
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~ No radio LED available
    - [ ] ~~Should map to their respective radio~~
    - [ ] ~~Should show activity~~
  - ~~Switch port LEDs~~ No switch LED available
    - [ ] ~~Should map to their respective port (or switch, if only one led present)~~
    - [ ] ~~Should show link state and activity~~
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- ~~Cellular devices only:~~
  - [ ] ~~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`