### PR TITLE
ath79-generic: (re)add support for archer-c60

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -110,6 +110,7 @@ ath79-generic
   - Archer C6 (v2 EU/RU/JP)
   - Archer C7 (v2, v4, v5)
   - Archer C59 (v1)
+  - Archer C60 (v1)
   - CPE210 (v1.0, v1.1, v2.0, v3.0, v3.1, v3.20)
   - CPE220 (v3.0)
   - CPE510 (v1.0, v1.1, v2.0, v3.0)

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -428,6 +428,11 @@ device('tp-link-archer-c59-v1', 'tplink_archer-c59-v1', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })
 
+device('tp-link-archer-c60-v1', 'tplink_archer-c60-v1', {
+	packages = ATH10K_PACKAGES_SMALLBUFFERS_QCA9880,
+	factory = false,
+})
+
 device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
 	packages = ATH10K_PACKAGES_SMALLBUFFERS_QCA9880,
 	factory = false,


### PR DESCRIPTION
This device was gone. I tried to use it with the smallbuffers wifi firmware and the device remained suprisingly stable. I whould also consider to add this at least with the broken flag, because I do not have a crowded test environment.
Test device: https://map.chemnitz.freifunk.net/#!v:m;n:50c7bf2cf5c8

- [x] Must be flashable from vendor firmware
  - [x] Web interface
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> tp-link-archer-c60-v1
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`