### PR TITLE
gluon-radv-filterd: replace malloc with calloc

### DIFF
--- a/package/gluon-radv-filterd/src/gluon-radv-filterd.c
+++ b/package/gluon-radv-filterd/src/gluon-radv-filterd.c
@@ -306,16 +306,13 @@ static struct router *router_find_orig(const struct ether_addr *orig) {
 static struct router *router_add(const struct ether_addr *mac) {
 	struct router *router;
 
-	router = malloc(sizeof(*router));
+	router = calloc(1, sizeof(*router));
 	if (!router)
 		return NULL;
 
 	router->src = *mac;
 	router->next = G.routers;
 	G.routers = router;
-	router->eol.tv_sec = 0;
-	router->eol.tv_nsec = 0;
-	memset(&router->originator, 0, sizeof(router->originator));
 
 	return router;
 }


### PR DESCRIPTION
Allocation of the router structure for newly detected router advertisements was done using malloc and selectively clearing some of the structure fields. However the redirect boolean was never set to 0, which means that during update_redirect, we would depend on the random initialization value of the structure.

This means that sometimes ebtables-tiny wouldn't add the correct rules for the advertised routes.