### PR TITLE
docs: add GLUON_FEATURES_standard to multidomain site example

### DIFF
--- a/docs/multidomain-site-example/site.mk
+++ b/docs/multidomain-site-example/site.mk
@@ -17,17 +17,19 @@ GLUON_FEATURES := \
 	web-advanced \
 	web-wizard
 
+GLUON_FEATURES_standard := \
+  wireless-encryption-wpa3
+
 ##	GLUON_MULTIDOMAIN
 #		Build gluon with multidomain support.
 
 GLUON_MULTIDOMAIN=1
 
 ##	GLUON_SITE_PACKAGES
-#		Specify additional Gluon/LEDE packages to include here;
+#		Specify additional Gluon/OpenWrt packages to include here;
 #		A minus sign may be prepended to remove a packages from the
 #		selection that would be enabled by default or due to the
 #		chosen feature flags
-
 
 GLUON_SITE_PACKAGES := iwinfo
 

--- a/docs/multidomain-site-example/site.mk
+++ b/docs/multidomain-site-example/site.mk
@@ -18,7 +18,7 @@ GLUON_FEATURES := \
 	web-wizard
 
 GLUON_FEATURES_standard := \
-  wireless-encryption-wpa3
+	wireless-encryption-wpa3
 
 ##	GLUON_MULTIDOMAIN
 #		Build gluon with multidomain support.


### PR DESCRIPTION
This commit adds the `GLUON_FEATURES_standard` variable to the multidomain site example.

