### PR TITLE
gluon-mesh-vpn: depend on simple-tc in implementation

### DIFF
--- a/package/gluon-mesh-vpn-core/Makefile
+++ b/package/gluon-mesh-vpn-core/Makefile
@@ -6,7 +6,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-vpn-core
   TITLE:=Basic support for connecting meshes via VPN tunnels
-  DEPENDS:=+gluon-core +gluon-wan-dnsmasq +iptables-zz-legacy +iptables-mod-extra +simple-tc
+  DEPENDS:=+gluon-core +gluon-wan-dnsmasq +iptables-zz-legacy +iptables-mod-extra
   USERID:=:gluon-mesh-vpn=800
 endef
 

--- a/package/gluon-mesh-vpn-fastd/Makefile
+++ b/package/gluon-mesh-vpn-fastd/Makefile
@@ -6,7 +6,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-vpn-fastd
   TITLE:=Support for connecting meshes via fastd
-  DEPENDS:=+gluon-core +libgluonutil +gluon-mesh-vpn-core +fastd
+  DEPENDS:=+gluon-core +libgluonutil +gluon-mesh-vpn-core +fastd +simple-tc
 endef
 
 $(eval $(call BuildPackageGluon,gluon-mesh-vpn-fastd))

--- a/package/gluon-mesh-vpn-tunneldigger/Makefile
+++ b/package/gluon-mesh-vpn-tunneldigger/Makefile
@@ -6,7 +6,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-vpn-tunneldigger
   TITLE:=Support for connecting meshes via tunneldigger/L2TPv3 pseudowire
-  DEPENDS:=+gluon-core +gluon-mesh-vpn-core +tunneldigger
+  DEPENDS:=+gluon-core +gluon-mesh-vpn-core +tunneldigger +simple-tc
 endef
 
 $(eval $(call BuildPackageGluon,gluon-mesh-vpn-tunneldigger))

--- a/package/gluon-mesh-vpn-wireguard/Makefile
+++ b/package/gluon-mesh-vpn-wireguard/Makefile
@@ -6,7 +6,7 @@ include ../gluon.mk
 
 define Package/gluon-mesh-vpn-wireguard
   TITLE:=Support for connecting meshes via wireguard
-  DEPENDS:=+gluon-core +libgluonutil +gluon-mesh-vpn-core +wireguard-tools +wgpeerselector +libubox +libubus
+  DEPENDS:=+gluon-core +libgluonutil +gluon-mesh-vpn-core +wireguard-tools +wgpeerselector +libubox +libubus +simple-tc
 endef
 
 define Package/gluon-mesh-vpn-wireguard/install


### PR DESCRIPTION
The vpn-core package does not utilize simple-tc anymore. This is now up to the VPN implementations.