### PR TITLE
target: remove package-removal NOPs

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -98,8 +98,6 @@ packages {
 	'-kmod-ipt-offload',
 	'-kmod-nft-offload',
 	'-libustream-mbedtls',
-	'-libustream-wolfssl',
-	'-libwolfssl',
 	'-mbedtls',
 	'-nftables',
 	'-odhcpd-ipv6only',


### PR DESCRIPTION
OpenWrt does not ship with WolfSSL anymore. Instead mbedTLS is shipped by default.

We can remove the default removal of WolfSSL packages, as they are not included by default anymore.