### PR TITLE
ath79-generic: add support for AVM Fritz!Repeater 1750e

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -57,6 +57,13 @@ device('avm-fritz-wlan-repeater-450e', 'avm_fritz450e', {
 	factory = false,
 })
 
+device('avm-fritz-wlan-repeater-1750e', 'avm_fritz1750e', {
+	packages = ATH10K_PACKAGES_SMALLBUFFERS_QCA9880,
+	factory = false,
+	broken = true, -- OOM with 5GHz enabled in most environments
+	class = 'tiny', -- 64M ath9k + ath10k
+})
+
 -- Buffalo
 
 device('buffalo-wzr-hp-ag300h', 'buffalo_wzr-hp-ag300h')


### PR DESCRIPTION
This device has been successfully tested by @J0chn1
It works fine, but due to the small size I think it can only get BROKEN support due to smallbuffers?

- [X] Must be flashable from vendor firmware
  - [ ] Web interface
  - [X] TFTP (easily with https://github.com/maurerle/fritz-tools/blob/master/fritzflash.py )
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
  - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
    - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
    - [X] should support all network ports on the device
    - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
    - [X] Association with AP must be possible on all radios
    - [X] Association with 802.11s mesh must work on all radios 
    - [X] AP+mesh mode must work in parallel on all radios
	
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio - not applicable, only one, RSSI leds do not work
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- ~~Outdoor devices only:~~
    - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- ~~Cellular devices only:~~
    - [ ] ~~Added board name to `is_cellular_device` function in  `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
    - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
    - [ ] Added Device to `docs/user/supported_devices.rst` (broken)