### PR TITLE
mediatek-filogic: add support for GL.iNet GL-MT3000

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -285,6 +285,10 @@ mediatek-filogic
 
   - WR3000 (v1)
 
+* GL.iNet
+
+  - GL-MT3000
+
 * NETGEAR
 
   - WAX220

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -13,6 +13,13 @@ device('cudy-wr3000-v1', 'cudy_wr3000-v1', {
 })
 
 
+-- GL.iNet
+
+device('gl.inet-gl-mt3000', 'glinet_gl-mt3000', {
+	factory = false,
+})
+
+
 -- NETGEAR
 
 device('netgear-wax220', 'netgear_wax220', {


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP: untested
  - [x] Other: SSH from vendor firmware
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - ~~if there are multiple ports but no WAN port:~~
      - ~~the PoE input should be WAN, all other ports LAN~~
      - ~~otherwise the first port should be declared as WAN, all other ports LAN~~
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~ No radio LED available
    - [ ] ~~Should map to their respective radio~~
    - [ ] ~~Should show activity~~
  - ~~Switch port LEDs~~ No switch LED available
    - [ ] ~~Should map to their respective port (or switch, if only one led present)~~
    - [ ] ~~Should show link state and activity~~
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- ~~Cellular devices only:~~
  - [ ] ~~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`