### PR TITLE
generic: fix removal of mbedtls

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -98,7 +98,7 @@ packages {
 	'-kmod-ipt-offload',
 	'-kmod-nft-offload',
 	'-libustream-mbedtls',
-	'-mbedtls',
+	'-libmbedtls',
 	'-nftables',
 	'-odhcpd-ipv6only',
 	'-ppp',


### PR DESCRIPTION
Package name of mbedtls is not 'mbedtls' but 'libmbedtls'.