### PR TITLE
gluon-mesh-vpn-core: remove old migration code

### DIFF
--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
@@ -1,7 +1,6 @@
 #!/usr/bin/lua
 
 local site = require 'gluon.site'
-local users = require 'gluon.users'
 local util = require 'gluon.util'
 
 local uci = require('simple-uci').cursor()
@@ -20,10 +19,6 @@ uci:section('network', 'interface', 'mesh_vpn', {
 
 uci:save('network')
 
-
--- The previously used user and group are removed, we now have a generic group
-users.remove_user('gluon-fastd')
-users.remove_group('gluon-fastd')
 
 uci:section('firewall', 'include', 'mesh_vpn_dns', {
 	type = 'restore',


### PR DESCRIPTION
This code was added way back in 2017. We don't support updates from those old versions, so we can remove it.