### PR TITLE
ipq40xx-generic: add support for AVM Fritz!Repeater 3000

### DIFF
--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -57,6 +57,22 @@ device('avm-fritz-repeater-1200', 'avm_fritzrepeater-1200', {
 	factory = false,
 })
 
+device('avm-fritz-repeater-3000', 'avm_fritzrepeater-3000', {
+	factory = false,
+	packages = { -- exclude until Gluon supports third radio
+	'kmod-ath10k',
+	'-kmod-ath10k-ct',
+	'-kmod-ath10k-ct-smallbuffers',
+	'ath10k-firmware-qca4019',
+	'-ath10k-firmware-qca4019-ct',
+	'-ath10k-firmware-qca9984-ct',
+	'-ath10k-board-qca9984',
+	},
+	broken = true,
+	-- 3rd WiFi radio not supported (5GHz DFS channels 100+)
+	-- outdoor mode is broken due to 5GHz being limited to channels 36-64
+})
+
 
 -- GL.iNet
 


### PR DESCRIPTION
@j0chn1 tested this device.

Eventually, the device can get full support if the third radio is used instead of the second.
But I don't know how we want to handle this.

- [X] Must be flashable from vendor firmware
  - [ ] Web interface
  - [X] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
  - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
	
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs (none)
	The RSSI Led, does not work, others are not present
    - [ ] ~~Should map to their respective radio~~
    - [ ] ~~Should show activity~~
  - Switch port LEDs
	No switch port LEDs available
    - [ ] ~~Should map to their respective port (or switch, if only one led present)~~ 
    - [ ] ~~Should show link state and activity~~
- ~~Outdoor devices only:~~
  - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- ~~Cellular devices only:~~
  - [ ] ~~Added board name to `is_cellular_device` function in~~
 `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [ ] Added Device to `docs/user/supported_devices.rst` - broken?