### PR TITLE
ci: dynamically set thread-count 

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -41,6 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Show system information
+        run: contrib/actions/show-system-info.sh
+
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
 

--- a/contrib/actions/run-build.sh
+++ b/contrib/actions/run-build.sh
@@ -9,5 +9,9 @@ export GLUON_SITEDIR="contrib/ci/minimal-site"
 export GLUON_TARGET="$1"
 export BUILD_LOG=1
 
+BUILD_THREADS="$(($(nproc) + 1))"
+
+echo "Building Gluon with $BUILD_THREADS threads"
+
 make update
-make -j2 V=s
+make -j$BUILD_THREADS V=s

--- a/contrib/actions/show-system-info.sh
+++ b/contrib/actions/show-system-info.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "-- CPU --"
+cat /proc/cpuinfo
+
+echo "-- Memory --"
+cat /proc/meminfo
+
+echo "-- Disk --"
+df -h
+
+echo "-- Kernel --"
+uname -a
+
+echo "-- Network --"
+ip addr


### PR DESCRIPTION
Despite what GitHub states in their documentation, the runners feature a
different core count. Automatically set the build thread-count by the
amount of available CPU cores.

Link: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

---

Collect some basic system information about the runners the CI jobs
run on. This is done iwth the intention to have diagnostics information
in advance in case builds fail spuriously in some instances.