### PR TITLE
ath79-generic: add support for D-Link DAP-3662

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -33,6 +33,7 @@ ath79-generic
   - DAP-1330 A1 [#lan_as_wan]_
   - DAP-1365 A1 [#lan_as_wan]_
   - DAP-2660 A1 [#lan_as_wan]_
+  - DAP-3662 A1 [#lan_as_wan]_
   - DIR-505 A1 [#lan_as_wan]_
   - DIR-505 A2 [#lan_as_wan]_
   - DIR-825 B1

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -43,6 +43,10 @@ local lan_ifname = iface_exists(lan_interfaces)
 local wan_ifname = iface_exists(wan_interfaces)
 
 if platform.match('ath79', 'generic', {
+	'dlink,dap-3662-a1',
+}) then
+	lan_ifname, wan_ifname = 'eth0.1', 'eth1.2'
+elseif platform.match('ath79', 'generic', {
 	'tplink,cpe210-v1',
 	'tplink,cpe210-v2',
 	'tplink,cpe510-v1',

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -25,6 +25,7 @@ end
 function M.is_outdoor_device()
 	if M.match('ath79', 'generic', {
 		'devolo,dvl1750x',
+		'dlink,dap-3662-a1',
 		'librerouter,librerouter-v1',
 		'plasmacloud,pa300',
 		'plasmacloud,pa300e',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -118,6 +118,11 @@ device('d-link-dap-2660-a1', 'dlink_dap-2660-a1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })
 
+device('d-link-dap-3662-a1', 'dlink_dap-3662-a1', {
+	factory_ext = '.img',
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('d-link-dir-505', 'dlink_dir-505', {
 	factory = false,
 	manifest_aliases = {


### PR DESCRIPTION
```
Specifications:
 * QCA9557, 16 MiB Flash, 128 MiB RAM, 802.11n 2T2R
 * QCA9882, 802.11ac 2T2R
 * 2x Gigabit LAN (1x 802.11af PoE)
 * IP68 pole-mountable outdoor case
```

This device has both switch ports declared as LAN in OpenWrt, which results in no VLAN configuration being generated.
As a result, the automagical assignment of the first LAN port as WAN in gluon would cause both ports to be WAN.
To prevent this, an OpenWrt patch is introduced to set the PoE input port to WAN manually. Is there a better way to fix this in gluon without using a patch here? 

The device has been running fine so far: https://hannover.freifunk.net/karte/#/de/map/e46f134b1500

----------------------------------------------------------------------------

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [*see above] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`
