### PR TITLE
bcm27xx: add support for Pi4 and switch bcm27xx from ext4 to squashfs

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -281,6 +281,17 @@
     "targets/targets.mk",
     "targets/bcm27xx.inc"
   ],
+  "bcm27xx-bcm2711": [
+    "targets/bcm27xx-bcm2711",
+    ".github/workflows/build-gluon.yml",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk",
+    "targets/bcm27xx.inc"
+  ],
   "mvebu-cortexa9": [
     "targets/mvebu-cortexa9",
     ".github/workflows/build-gluon.yml",

--- a/targets/bcm27xx-bcm2711
+++ b/targets/bcm27xx-bcm2711
@@ -1,0 +1,11 @@
+include 'bcm27xx.inc'
+
+device('raspberrypi-4-model-b', 'rpi-4', {
+	manifest_aliases = {
+		-- from Gluon 2023.1 and older
+		'raspberry-pi-4-model-b-rev-1.1',
+		'raspberry-pi-4-model-b-rev-1.2', -- untested
+		'raspberry-pi-4-model-b-rev-1.4', -- untested
+		'raspberry-pi-4-model-b-rev-1.5', -- untested
+	},
+})

--- a/targets/bcm27xx.inc
+++ b/targets/bcm27xx.inc
@@ -1,6 +1,7 @@
+-- We do not use the ext4 images, so we do not want to build them.
+config('TARGET_ROOTFS_EXT4FS', false)
+
 defaults {
-	factory = '-ext4-factory',
 	factory_ext = '.img.gz',
-	sysupgrade = '-ext4-sysupgrade',
 	sysupgrade_ext = '.img.gz',
 }

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -28,5 +28,6 @@ $(eval $(call GluonTarget,x86,64))
 
 ifeq ($(BROKEN),1)
 $(eval $(call GluonTarget,bcm27xx,bcm2710)) # BROKEN: Untested
+$(eval $(call GluonTarget,bcm27xx,bcm2711)) # BROKEN: No 11s support, no reset button, sys LED issues
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
 endif


### PR DESCRIPTION
- [ ] ~~Must be flashable from vendor firmware:~~ N/A, no vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: unpack image to microSD 
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
  - no buttons available (however with physical access the SD card can be updated on another device to reenable the config mode)
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-
  - no lable available, but MAC seems fixed/stable upon `firstboot -y` (here: dc:a6:32:0c:6f:25)
packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN): N/A, single port
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios: 11s/mesh radio unsupported by driver
  - [ ] AP+mesh mode must work in parallel on all radios: 11s/mesh radio unsupported by driver
- LED mapping
  - Power/system LED
    - [ ] Lit while the device is on: unstable, sometimes not lit
    - [ ] Should display config mode blink sequence: not working, is either persistenly lit or persistently not lit after booting into config-mode
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs:~~ no radio LED available (secondary, green LED is mapped to SD card activity)
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- ~~Outdoor devices only:~~ not an outdoor device
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- ~~Cellular devices only:~~ not a cellular device
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [ ] Added Device to `docs/user/supported_devices.rst`