### PR TITLE
ath79-mikrotik: add support for MikroTik wAPR-2nD (wAP R)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -170,6 +170,7 @@ ath79-mikrotik
 * Mikrotik
 
   - RB951Ui-2nD (hAP)
+  - RBwAPR-2nD (wAP R)
 
 brcm2708-bcm2708
 ----------------

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -51,6 +51,11 @@ function M.is_outdoor_device()
 	}) then
 		return true
 
+	elseif M.match('ath79', 'mikrotik', {
+		'mikrotik,routerboard-wapr-2nd',
+	}) then
+		return true
+
 	elseif M.match('ipq40xx', 'generic', {
 		'aruba,ap-365',
 		'engenius,ens620ext',

--- a/targets/ath79-mikrotik
+++ b/targets/ath79-mikrotik
@@ -1,3 +1,4 @@
 include 'mikrotik.inc'
 
 device('mikrotik-routerboard-951ui-2nd-hap', 'mikrotik_routerboard-951ui-2nd')
+device('mikrotik-routerboard-wapr-2nd', 'mikrotik_routerboard-wapr-2nd')

--- a/targets/ath79-mikrotik
+++ b/targets/ath79-mikrotik
@@ -1,4 +1,5 @@
 include 'mikrotik.inc'
 
 device('mikrotik-routerboard-951ui-2nd-hap', 'mikrotik_routerboard-951ui-2nd')
+
 device('mikrotik-routerboard-wapr-2nd', 'mikrotik_routerboard-wapr-2nd')


### PR DESCRIPTION
 [X] Must be flashable from vendor firmware
  - [ ] Web interface
  - [X] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - [X] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`