### PR TITLE
ci: workflow_dispatch: allow usage of a custom site

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -8,6 +8,19 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
+    inputs:
+      site_url:
+        description: 'Gluon Site Repo to use'
+        type: string
+      site_branch:
+        description: 'Gluon Site Branch to use'
+        type: string
+      autoupdater_enabled:
+        description: 'Gluon autoupdater activation State'
+        type: boolean
+      autoupdater_branch:
+        description: 'Gluon autoupdater default branch'
+        type: string
 
 permissions:
   contents: read
@@ -47,8 +60,17 @@ jobs:
       - name: Install Dependencies
         run: sudo contrib/actions/install-dependencies.sh
 
+      - name: Checkout Site
+        run: contrib/actions/checkout-site.sh
+        env:
+          GLUON_SITE_URL: ${{ inputs.site_url }}
+          GLUON_SITE_BRANCH: ${{ inputs.site_branch }}
+
       - name: Build
         run: contrib/actions/run-build.sh ${{ matrix.target }}
+        env:
+          GLUON_AUTOUPDATER_ENABLED: ${{ inputs.autoupdater_enabled }}
+          GLUON_AUTOUPDATER_BRANCH: ${{ inputs.autoupdater_branch }}
 
       - name: Archive build logs
         if: ${{ !cancelled() }}

--- a/contrib/actions/checkout-site.sh
+++ b/contrib/actions/checkout-site.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+set -e
+
+GLUON_SITEDIR=site
+
+if [ -n "${GLUON_SITE_URL}" ]; then
+
+	echo "cloning ${GLUON_SITE_URL}"
+
+	git clone "${GLUON_SITE_URL}" "${GLUON_SITEDIR}"
+
+	if [ -n "$GLUON_SITE_BRANCH" ]; then
+		echo "checking \"${GLUON_SITE_BRANCH}\" out"
+		git -C "${GLUON_SITEDIR}" checkout "${GLUON_SITE_BRANCH}"
+	fi
+
+	echo "GLUON_SITEDIR=${GLUON_SITEDIR}" >> "$GITHUB_ENV"
+
+	echo "site: $(git -C "${GLUON_SITEDIR}" describe)"
+
+fi

--- a/contrib/actions/run-build.sh
+++ b/contrib/actions/run-build.sh
@@ -5,13 +5,19 @@ set -e
 export BROKEN=1
 export GLUON_AUTOREMOVE=1
 export GLUON_DEPRECATED=1
-export GLUON_SITEDIR="contrib/ci/minimal-site"
+export GLUON_SITEDIR="${GLUON_SITEDIR:-contrib/ci/minimal-site}"
 export GLUON_TARGET="$1"
 export BUILD_LOG=1
 
 BUILD_THREADS="$(($(nproc) + 1))"
 
 echo "Building Gluon with $BUILD_THREADS threads"
+
+echo "${GLUON_SITEDIR}"
+tree "${GLUON_SITEDIR}"
+
+echo "GLUON_AUTOUPDATER_ENABLED: ${GLUON_AUTOUPDATER_ENABLED}"
+echo "GLUON_AUTOUPDATER_BRANCH: ${GLUON_AUTOUPDATER_BRANCH}"
 
 make update
 make -j$BUILD_THREADS V=s


### PR DESCRIPTION
The intention is to offer an easy way to build useful gluon images via GitHub Actions.

This should lower the barrier towards testing PRs a bit.