### PR TITLE
mediatek-filogic: remove broken flag for TUF AX4200

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -281,6 +281,10 @@ lantiq-xway
 mediatek-filogic
 ----------------
 
+* ASUS
+
+  - TUF AX4200
+
 * Cudy
 
   - WR3000 (v1)

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -2,7 +2,6 @@
 
 device('asus-tuf-ax4200', 'asus_tuf-ax4200', {
 	factory = false,
-	broken = true, -- Installation requires internal serial
 })
 
 


### PR DESCRIPTION
There is a new way to flash OpenWrt on the ASUS TUF AX4200 which does not require to open the device.

Link: https://github.com/blocktrron/openwrt-asus-filogic-factory/releases/tag/filogic-v1