### PR TITLE
docs: move wifi channels in multi domain site example

### DIFF
--- a/docs/multidomain-site-example/domains/alpha_centauri.conf
+++ b/docs/multidomain-site-example/domains/alpha_centauri.conf
@@ -22,9 +22,9 @@
   },
 
   wifi24 = {
+    channel = 1,
     ap = {
       ssid = "alpha-centauri.example.org",
-      channel = 1,
     },
     mesh = {
       id = 'ueH3uXjdp', -- usually you don't want users to connect to this mesh-SSID, so use a cryptic id that no one will accidentally mistake for the client WiFi
@@ -32,9 +32,9 @@
   },
 
   wifi5 = {
+    channel = 44,
     ap = {
       ssid = "alpha-centauri.example.org",
-      channel = 44,
     },
     mesh = {
       id = 'ueH3uXjdp',


### PR DESCRIPTION
The wifi channels in the multi domain example are somehow in the wrong section