### PR TITLE
lantiq-xrx200: remove BROKEN target-flag

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -83,6 +83,16 @@
     "targets/generic",
     "targets/targets.mk"
   ],
+  "lantiq-xrx200": [
+    "targets/lantiq-xrx200",
+    ".github/workflows/build-gluon.yml",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk"
+  ],
   "lantiq-xway": [
     "targets/lantiq-xway",
     ".github/workflows/build-gluon.yml",
@@ -248,16 +258,6 @@
     "targets/generic",
     "targets/targets.mk",
     "targets/bcm27xx.inc"
-  ],
-  "lantiq-xrx200": [
-    "targets/lantiq-xrx200",
-    ".github/workflows/build-gluon.yml",
-    "modules",
-    "Makefile",
-    "patches/**",
-    "scripts/**",
-    "targets/generic",
-    "targets/targets.mk"
   ],
   "mvebu-cortexa9": [
     "targets/mvebu-cortexa9",

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -6,6 +6,7 @@ $(eval $(call GluonTarget,bcm27xx,bcm2709))
 $(eval $(call GluonTarget,ipq40xx,generic))
 $(eval $(call GluonTarget,ipq40xx,mikrotik))
 $(eval $(call GluonTarget,ipq806x,generic))
+$(eval $(call GluonTarget,lantiq,xrx200))
 $(eval $(call GluonTarget,lantiq,xway))
 $(eval $(call GluonTarget,mediatek,filogic))
 $(eval $(call GluonTarget,mediatek,mt7622))
@@ -25,6 +26,5 @@ $(eval $(call GluonTarget,x86,64))
 
 ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,bcm27xx,bcm2710)) # BROKEN: Untested
-$(eval $(call GluonTarget,lantiq,xrx200)) # BROKEN: Switch driver broken on Linux 5.15
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
 endif


### PR DESCRIPTION
This removes the BROKEN flag from the lantiq-xrx200 target. The issues with the switch-driver have been resolved upstream

Link: https://github.com/openwrt/openwrt/pull/13638