### PR TITLE
ath79-generic: remove Ubiquiti AirMax targets

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -128,10 +128,6 @@ ath79-generic
 
 * Ubiquiti
 
-  - NanoBeam 5AC 19 (XC)
-  - NanoBeam M5 (XW)
-  - NanoStation Loco M2/M5 (XW)
-  - NanoStation M2/M5 (XW)
   - UniFi AC Lite
   - UniFi AC LR
   - UniFi AC Mesh

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -541,21 +541,6 @@ device('tp-link-wbs510-v1', 'tplink_wbs510-v1', {
 
 -- Ubiquiti
 
-device('ubiquiti-nanostation-loco-m-xw', 'ubnt_nanostation-loco-m-xw', {
-	manifest_aliases = {
-		'ubiquiti-loco-m-xw', -- upgrade from OpenWrt 19.07
-		'ubiquiti-nanostation-loco-m2-xw', -- upgrade from OpenWrt 19.07
-		'ubiquiti-nanostation-loco-m5-xw', -- upgrade from OpenWrt 19.07
-	},
-})
-
-device('ubiquiti-nanostation-m-xw', 'ubnt_nanostation-m-xw', {
-	manifest_aliases = {
-		'ubiquiti-nanostation-m2-xw', -- upgrade from OpenWrt 19.07
-		'ubiquiti-nanostation-m5-xw', -- upgrade from OpenWrt 19.07
-	},
-})
-
 device('ubiquiti-unifi-ac-lite', 'ubnt_unifiac-lite', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9880,
@@ -589,12 +574,6 @@ device('ubiquiti-unifi-ap', 'ubnt_unifi-ap', {
 		'ubiquiti-unifi',
 	},
 })
-
-device('ubiquiti-nanobeam-ac-gen1-xc', 'ubnt_nanobeam-ac-xc', {
-	packages = ATH10K_PACKAGES_QCA9880,
-})
-
-device('ubiquiti-nanobeam-m5-xw', 'ubnt_nanobeam-m5-xw')
 
 device('ubiquiti-unifi-ap-outdoor+', 'ubnt_unifi-ap-outdoor-plus', {
 	manifest_aliases = {


### PR DESCRIPTION
Remove due to ticket #2939

These devices risk being bricked in a way that can not be recovered without running full TFTP or serial recovery, as the flash ends up in a read-only state with no way of upgrading to a fixed version.

Thus, remove the support for the time being. Don't just flag them as BROKEN, as this would deliberately brick these boards when installating such an image.