### PR TITLE
gluon-core: drop removed devices

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -49,7 +49,6 @@ if platform.match('ath79', 'generic', {
 	'tplink,wbs210-v1',
 	'tplink,wbs210-v2',
 	'tplink,wbs510-v1',
-	'ubnt,nanostation-m-xw',
 	'ubnt,unifi-ap-pro',
 }) then
 	lan_ifname, wan_ifname = wan_ifname, lan_ifname

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -41,10 +41,6 @@ function M.is_outdoor_device()
 		'tplink,wbs210-v1',
 		'tplink,wbs210-v2',
 		'tplink,wbs510-v1',
-		'ubnt,nanobeam-ac-xc',
-		'ubnt,nanobeam-m5-xw',
-		'ubnt,nanostation-loco-m-xw',
-		'ubnt,nanostation-m-xw',
 		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',
 		'ubnt,unifiac-mesh-pro',
@@ -58,7 +54,6 @@ function M.is_outdoor_device()
 
 	elseif M.match('ipq40xx', 'generic', {
 		'aruba,ap-365',
-		'engenius,ens620ext',
 		'plasmacloud,pa1200',
 	}) then
 		return true


### PR DESCRIPTION
The support for NanaStations was removed in v2022.1 https://gluon.readthedocs.io/en/latest/releases/v2022.1.html#removed-devices

The NanoBeam devices and the EnGenius device are missing in master. 