### PR TITLE
github: fix typos in label paths and names

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@
 "3. topic: batman-adv":
   - docs/package/gluon-mesh-batman-adv*
   - package/gluon-alfred/**
-  - package/gluon-cient-bridge/**
+  - package/gluon-client-bridge/**
   - package/gluon-mesh-batman-adv/**
   - package/libbatadv/**
 "3. topic: build":
@@ -15,7 +15,7 @@
 "3. topic: config-mode":
   - docs/dev/web/config-mode.rst
   - docs/package/gluon-config-mode-*
-  - packge/gluon-config-mode-*/**
+  - package/gluon-config-mode-*/**
   - package/gluon-web*/**
 "3. topic: continous integration":
   - .github/workflows/*
@@ -56,4 +56,4 @@
   - package/gluon-private-wifi/**
   - package/gluon-web-private-wifi/**
   - package/gluon-web-wifi-config/**
-  - package/gluon-wireless-encryption/**
+  - package/gluon-wireless-encryption-wpa3/**


### PR DESCRIPTION
There is a typo in the CI label. Also some paths are outdated or have typos, too.

CI label with typo: https://github.com/freifunk-gluon/gluon/pulls?q=is%3Apr+label%3A%223.+topic%3A+continous+integration%22+