### PR TITLE
targets: add bcm27xx-bcm2711 for raspberry pi 4

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -259,6 +259,17 @@
     "targets/targets.mk",
     "targets/bcm27xx.inc"
   ],
+  "bcm27xx-bcm2711": [
+    "targets/bcm27xx-bcm2711",
+    ".github/workflows/build-gluon.yml",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk",
+    "targets/bcm27xx.inc"
+  ],
   "mvebu-cortexa9": [
     "targets/mvebu-cortexa9",
     ".github/workflows/build-gluon.yml",

--- a/targets/bcm27xx-bcm2711
+++ b/targets/bcm27xx-bcm2711
@@ -1,0 +1,11 @@
+include 'bcm27xx.inc'
+
+device('raspberrypi-4-model-b', 'rpi-4', {
+	manifest_aliases = {
+		-- from Gluon 2019.1 and older
+		'raspberry-pi-4-model-b',
+		'raspberry-pi-4-model-b-rev-1.1',
+		'raspberry-pi-4-model-b-rev-1.2',
+		'raspberry-pi-4-model-b-rev-1.4',
+	},
+})

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -26,5 +26,6 @@ $(eval $(call GluonTarget,x86,64))
 
 ifneq ($(BROKEN),)
 $(eval $(call GluonTarget,bcm27xx,bcm2710)) # BROKEN: Untested
+$(eval $(call GluonTarget,bcm27xx,bcm2711)) # BROKEN: Untested
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
 endif


### PR DESCRIPTION
Upstreaming our patches for raspberry pi 4. The devices have been in use since Gluon v2019 (as offloaders).