### PR TITLE
ci: build Gluon in own Docker image

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -44,11 +44,11 @@ jobs:
       - name: Show system information
         run: contrib/actions/show-system-info.sh
 
-      - name: Install Dependencies
-        run: sudo contrib/actions/install-dependencies.sh
+      - name: Build Docker container
+        run: docker build -t gluon-ci-container contrib/docker
 
-      - name: Build
-        run: contrib/actions/run-build.sh ${{ matrix.target }}
+      - name: Build Gluon
+        run: docker run --rm -v $PWD:/gluon-ci -w /gluon-ci --user "$(id -u):$(id -g)" gluon-ci-container contrib/actions/run-build.sh ${{ matrix.target }}
 
       - name: Archive build logs
         if: ${{ !cancelled() }}

--- a/contrib/actions/install-dependencies.sh
+++ b/contrib/actions/install-dependencies.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-set -e
-
-apt-get -y update
-apt-get -y install git build-essential python3 gawk unzip libncurses5-dev zlib1g-dev libssl-dev libelf-dev wget rsync time qemu-utils
-apt-get -y clean
-rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Build the CI integration test in our own docker container. This way, we can make sure Gluon builds actually succeed there.

This also has the advantage of becoming independent from the host version of GitHubs CI runners.