### PR TITLE
ci: pin runner version to Ubuntu 22.04

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,7 +9,7 @@ jobs:
   backport:
     name: Backport Pull Request
     if: github.repository_owner == 'freifunk-gluon' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Create backport PRs

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions: write-all
     steps:
       - name: Checkout repository

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   build-documentation:
     name: docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies

--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       contents: read  # for dorny/paths-filter to fetch a list of changed files
       pull-requests: read  # for dorny/paths-filter to read pull requests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       targets: ${{ steps.filter.outputs.changes }}
     steps:
@@ -37,7 +37,7 @@ jobs:
       matrix:
         # Read back changed targets to create build matrix
         target: ${{ fromJSON(needs.changed.outputs.targets) }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/check-ci.yml
+++ b/.github/workflows/check-ci.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   check-ci:
     name: Check generated CI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install example site

--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   check-patches:
     name: Check patches
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Refresh patches

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read  # for actions/labeler to determine modified files
       pull-requests: write  # for actions/labeler to add labels to PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository_owner == 'freifunk-gluon'
     steps:
     - uses: actions/labeler@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   lua:
     name: Lua
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies
@@ -21,7 +21,7 @@ jobs:
 
   sh:
     name: Shell
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies
@@ -33,7 +33,7 @@ jobs:
 
   editorconfig:
     name: Editorconfig
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Install Dependencies


### PR DESCRIPTION
Pin the GitHub runner version used to Ubuntu 22.04.

This endures stability in the runner behavior once GitHub switches to the next Ubuntu release for the latest tag.