### PR TITLE
ci: pin runner version to Ubuntu 20.04

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build-documentation:
     name: docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Install Dependencies

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install Dependencies
-        run: sudo pip3 install sphinx-rtd-theme
+        run: sudo pip3 install -r docs/requirements.txt
       - name: Build documentation
         run: make -C docs html
       - name: Archive build output

--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -33,7 +33,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [ar71xx-generic, ar71xx-tiny, ar71xx-nand, ath79-generic, brcm2708-bcm2708, brcm2708-bcm2709, ipq40xx-generic, ipq806x-generic, lantiq-xrx200, lantiq-xway, mpc85xx-generic, mpc85xx-p1020, ramips-mt7620, ramips-mt7621, ramips-mt76x8, ramips-rt305x, sunxi-cortexa7, x86-generic, x86-geode, x86-legacy, x86-64, ar71xx-mikrotik, brcm2708-bcm2710, mvebu-cortexa9]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Install Dependencies

--- a/.github/workflows/check-patches.yml
+++ b/.github/workflows/check-patches.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   check-patches:
     name: Check patches
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Refresh patches

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   labels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository_owner == 'freifunk-gluon'
     steps:
     - uses: actions/labeler@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   lua:
     name: Lua
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Install Dependencies
@@ -18,7 +18,7 @@ jobs:
 
   sh:
     name: Shell
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Install Dependencies

--- a/contrib/actions/generate-actions.py
+++ b/contrib/actions/generate-actions.py
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         target: [{matrix}]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
       - name: Install Dependencies

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-sphinx-rtd-theme
+sphinx-rtd-theme==0.5.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 sphinx-rtd-theme==0.5.2
+sphinx==3.5.4


### PR DESCRIPTION
GitHub updated the runner version of the latest tag to Ubuntu 22.04 while this CI was built for Ubuntu 20.04.