### PR TITLE
mac80211: avoid crashing on invalid band info

### DIFF
--- a/patches/openwrt/0007-mac80211-avoid-crashing-on-invalid-band-info.patch
+++ b/patches/openwrt/0007-mac80211-avoid-crashing-on-invalid-band-info.patch
@@ -1,0 +1,39 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 30 Nov 2023 07:32:52 +0100
+Subject: mac80211: avoid crashing on invalid band info
+
+Frequent crashes have been observed on MT7916 based platforms. While the
+root of these crashes are currently unknown, they happen when decoding
+rate information of connected STAs in AP mode. The rate-information is
+associated with a band which is not available on the PHY.
+
+Check for this condition in order to avoid crashing the whole system.
+This patch should be removed once the roout cause has been found and
+fixed.
+
+Link: https://github.com/freifunk-gluon/gluon/issues/2980
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/package/kernel/mac80211/patches/subsys/780-avoid-crashing-missing-band.patch b/package/kernel/mac80211/patches/subsys/780-avoid-crashing-missing-band.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..1847b2fe8defd67ec17a1b760ce03c0db1065f8c
+--- /dev/null
++++ b/package/kernel/mac80211/patches/subsys/780-avoid-crashing-missing-band.patch
+@@ -0,0 +1,16 @@
++--- a/net/mac80211/sta_info.c
+++++ b/net/mac80211/sta_info.c
++@@ -2422,6 +2422,13 @@ static void sta_stats_decode_rate(struct
++ 
++ 		sband = local->hw.wiphy->bands[band];
++ 
+++		if (!sband) {
+++			wiphy_debug(local->hw.wiphy,
+++				    "Invalid band %d\n",
+++				    band);
+++			break;
+++		}
+++
++ 		if (WARN_ON_ONCE(!sband->bitrates))
++ 			break;
++ 


### PR DESCRIPTION
Frequent crashes have been observed on MT7916 based platforms. While the root of these crashes are currently unknown, they happen when decoding rate information of connected STAs in AP mode. The rate-information is associated with a band which is not available on the PHY.

Check for this condition in order to avoid crashing the whole system. This patch should be removed once the roout cause has been found and fixed.

Closes: #2980
Link: https://github.com/freifunk-gluon/gluon/issues/2980