### PR TITLE
build: allow overriding GLUON_SITE_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,9 @@ $(eval $(call mkabspath,GLUON_TARGETSDIR))
 $(eval $(call mkabspath,GLUON_PATCHESDIR))
 
 GLUON_VERSION := $(shell scripts/getversion.sh '.')
-GLUON_SITE_VERSION := $(shell scripts/getversion.sh '$(GLUON_SITEDIR)')
+
+# Set default SITE_VERSION if not set by user
+GLUON_SITE_VERSION ?= $(shell scripts/getversion.sh '$(GLUON_SITEDIR)')
 
 GLUON_MULTIDOMAIN ?= 0
 GLUON_AUTOREMOVE ?= 0

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -239,7 +239,7 @@ GLUON_RELEASE
 
 GLUON_SITE_VERSION
   Version of the site configuration. This string is displayed in the config mode
-  and `gluon-info`. If not set, Gluon generates a version-string using `git describe`
+  and `gluon-info`. If unset, Gluon generates a version string using `git describe`
   on the site folder.
 
 GLUON_TARGET

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -237,6 +237,11 @@ GLUON_RELEASE
   is available. The same GLUON_RELEASE has to be passed to ``make`` and ``make manifest``
   to generate a correct manifest.
 
+GLUON_SITE_VERSION
+  Version of the site configuration. This string is displayed in the config mode
+  and `gluon-info`. If not set, Gluon generates a version-string using `git describe`
+  on the site folder.
+
 GLUON_TARGET
   Target architecture to build.
 


### PR DESCRIPTION
In case a community does not use Git for versioning it's site or using a different versioning scheme that do not have annotated tags on the master branch.