### PR TITLE
x86: add MediaTek drivers

### DIFF
--- a/targets/x86.inc
+++ b/targets/x86.inc
@@ -37,7 +37,9 @@ packages {
 	'kmod-mt76x0e',
 	'kmod-mt76x2',
 	'kmod-mt7603',
-	'kmod-mt7615e',
+	'kmod-mt7615-firmware',
+	'kmod-mt7915-firmware',
+	'kmod-mt7921-firmware',
 }
 
 -- We do not use the ext4 images, so we do not want to build them.


### PR DESCRIPTION
Add MediaTek driver packages for MT7915 as well as MT7921 WiFi 6 cards.

In addition, fix the mt7615 package name, as the driver was separated into kernel and firmware packages.