### PR TITLE
[v2023.1.x] gluon-core: dont fail on unset interface role

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/021-interface-roles
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/021-interface-roles
@@ -68,6 +68,10 @@ end
 uci:foreach('gluon', 'interface', function(interface)
 
 	local function has_role(role)
+		if interface.role == nil then
+			return false
+		end
+
 		return util.contains(interface.role, role)
 	end
 


### PR DESCRIPTION
In case no interface role was selected for a given interface, gluon-reconfigure currently fails with

```
Configuring: 021-interface-roles
/usr/bin/lua: /usr/lib/lua/gluon/util.lua:25: bad argument #1 to 'pairs' (table expected, got nil) stack traceback:
	[C]: in function '?'
	/usr/lib/lua/simple-uci.lua:22: in function 'foreach'
	./021-interface-roles:47: in main chunk
	[C]: ?
```

Check we actually have a role set before accessing the table.

Signed-off-by: David Bauer <mail@david-bauer.net>
(cherry picked from commit c4d370367ed66ad05f596c0ffafcf813afd76809)

---

Backport of #3050

Haven't tested it (yet). Will do that once Github has created some images. But i don't expect issues.