### PR TITLE
gluon-core: preserve interface MAC-address configuration

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -90,8 +90,15 @@ else
 	sysconfig.single_ifname = lan_ifname or wan_ifname
 end
 
+-- Delete all UCI device esctions of type 'bridge'
+-- as well as the ones starting with 'br-'.
+-- Preserve all others to apply MAC address stored in UCI
+uci:foreach('network', 'device',function(s)
+	if s.type == 'bridge' or s.name:match('^br-') then
+		uci:delete('network', s['.name'])
+	end
+end)
 
-uci:delete_all('network', 'device')
 uci:delete_all('network', 'interface')
 
 uci:save('network')

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -90,7 +90,7 @@ else
 	sysconfig.single_ifname = lan_ifname or wan_ifname
 end
 
--- Delete all UCI device esctions of type 'bridge'
+-- Delete all UCI device sections of type 'bridge'
 -- as well as the ones starting with 'br-'.
 -- Preserve all others to apply MAC address stored in UCI
 uci:foreach('network', 'device',function(s)


### PR DESCRIPTION
This preserve configuration of MAC-addresses for each interface in case OpenWrt sets them using netifd.

This is done by preserving all device-configuration which does not define a bridge or the MAC-address of a bridge.

Closes ##3100