### PR TITLE
[v2023.1.x] ipq40xx-generic: remove support for AVM FRITZ!Box 7520+7530

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -196,8 +196,6 @@ ipq40xx-generic
 * AVM
 
   - FRITZ!Box 4040 [#avmflash]_
-  - FRITZ!Box 7520 (v1) [#eva_ramboot]_ [#lan_as_wan]_
-  - FRITZ!Box 7530 [#eva_ramboot]_ [#lan_as_wan]_
   - FRITZ!Repeater 1200 [#eva_ramboot]_
 
 * EnGenius

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -56,11 +56,6 @@ device('avm-fritz-box-4040', 'avm_fritzbox-4040', {
 	},
 })
 
-device('avm-fritz-box-7530', 'avm_fritzbox-7530', {
-	factory = false,
-	aliases = {'avm-fritz-box-7520'},
-})
-
 device('avm-fritz-repeater-1200', 'avm_fritzrepeater-1200', {
 	factory = false,
 })


### PR DESCRIPTION
remove due to issue https://github.com/freifunk-gluon/gluon/issues/3023

There seem to be issues hindering an updated 7520/7530 to boot properly.

As far as we know the issue only affects openwrt-22.03.

Since the issue results in an unusable device remove support entirely for now and don't just mark it as broken.

---

Should be merged before the next v2023.1.x release at the latest if there is no solution by then.

cc @maurerle @grische