### PR TITLE
gluon-core: use delete_all instead of iterated delete

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -93,10 +93,8 @@ end
 -- Delete all UCI device sections of type 'bridge'
 -- as well as the ones starting with 'br-'.
 -- Preserve all others to apply MAC address stored in UCI
-uci:foreach('network', 'device',function(s)
-	if s.type == 'bridge' or s.name:match('^br-') then
-		uci:delete('network', s['.name'])
-	end
+uci:delete_all('network', 'device', function(dev)
+	return (dev.type == 'bridge' or dev.name:match('^br-'))
 end)
 
 uci:delete_all('network', 'interface')


### PR DESCRIPTION
Use a delete_call with a boolean parameter function instead of manually iterating over all devices.

Link: https://github.com/freifunk-gluon/gluon/pull/3102