### PR TITLE
bcm27xx: update manifest aliases

### DIFF
--- a/targets/bcm27xx-bcm2708
+++ b/targets/bcm27xx-bcm2708
@@ -5,7 +5,8 @@ device('raspberrypi-model-b', 'rpi', {
 		'raspberrypi-model-b-plus',
 		'raspberrypi-model-b-rev2',
 
-		-- from Gluon 2019.1 and older
+		-- from Gluon 2023.1 and older
+		'raspberry-pi-model-b-rev-1',
 		'raspberry-pi-model-b-rev-2',
 		'raspberry-pi-model-b-plus-rev-1.2',
 	},

--- a/targets/bcm27xx-bcm2709
+++ b/targets/bcm27xx-bcm2709
@@ -2,7 +2,7 @@ include 'bcm27xx.inc'
 
 device('raspberrypi-2-model-b', 'rpi-2', {
 	manifest_aliases = {
-		-- from Gluon 2019.1 and older
+		-- from Gluon 2023.1 and older
 		'raspberry-pi-2-model-b-rev-1.1',
 	},
 })

--- a/targets/bcm27xx-bcm2710
+++ b/targets/bcm27xx-bcm2710
@@ -4,7 +4,8 @@ device('raspberrypi-3-model-b', 'rpi-3', {
 	manifest_aliases = {
 		'raspberrypi-3-model-b-plus',
 
-		-- from Gluon 2019.1 and older
+		-- from Gluon 2023.1 and older
 		'raspberry-pi-3-model-b-rev-1.2',
+		'raspberry-pi-3-model-b-plus-rev-1.3',
 	},
 })


### PR DESCRIPTION
As the boardname-based image name setting was broken for bcm27xx due to the target rename, we need to keep the model-based names updated for now.

Add all model strings currently seen on the Multimeshviewer and update the comments accordingly.

---

Corresponding libplatforminfo fix: https://github.com/freifunk-gluon/packages/pull/270