### PR TITLE
add package gluon-libustream-tls

### DIFF
--- a/package/gluon-tls/Makefile
+++ b/package/gluon-tls/Makefile
@@ -1,0 +1,12 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-tls
+
+include ../gluon.mk
+
+define Package/gluon-tls
+  DEPENDS:=+libustream-mbedtls +ca-bundle
+  TITLE:=Dummy Package to select the current TLS implementation
+endef
+
+$(eval $(call BuildPackageGluon,gluon-tls))


### PR DESCRIPTION
This package allows to easily select the correct libustream implementation without all communities having the need to manually change their included packages.