### PR TITLE
github: build-gluon: cancel obsolete in progress workflows for PRs

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   changed:
     permissions:


### PR DESCRIPTION
Goal is to cancel Worfklows for Pull Request if they become obsolte due to new changes.
Without this workflows will continue running, wasting resources and delaying the run of relevant workflows.
This situation will typically occour if a author of a PR notices an error/typo/missing bit and pushes new changes to the branch.

This won't affect concurrent workflows for otherwise triggered workflows (push, workflow_dispatch, tag, ...).

Relevant Links:
- https://docs.github.com/en/actions/using-jobs/using-concurrency
- https://docs.github.com/en/actions/learn-github-actions/contexts#github-context