### PR TITLE
ath79-generic: add support for Sophos AP55

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -112,6 +112,7 @@ ath79-generic
 * Sophos
 
   - AP100c
+  - AP55
   - AP55c
 
 * Teltonika

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -385,6 +385,11 @@ device('sophos-ap100c', 'sophos_ap100c', {
 	factory = false,
 })
 
+device('sophos-ap55', 'sophos_ap55', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 device('sophos-ap55c', 'sophos_ap55c', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
Device is very similar to Devolo Wifi Pro series of devices.

This is the first Device of the Series, i have tested. Sophos AP55c, AP100 and AP100c will follow soonish.

- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: Vendor Software, or TFTP+Serial
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
  -  Device does not have a reset button, however the serial port is directly accessible 
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`