### PR TITLE
ath79-generic: add support for Sophos AP100

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -111,6 +111,7 @@ ath79-generic
 
 * Sophos
 
+  - AP100
   - AP100c
   - AP55c
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -380,6 +380,11 @@ device('siemens-ws-ap3610', 'siemens_ws-ap3610', {
 
 -- Sophos
 
+device('sophos-ap100', 'sophos_ap100', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 device('sophos-ap100c', 'sophos_ap100c', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
Basically the same device as an Sophos AP55, except for the radio being 3x3 instead of 2x2

- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: Vendor Software, or TFTP+Serial
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
  -  Device does not have a reset button, however the serial port is directly accessible 
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`