### PR TITLE
ramips-mt7621: add dlink-dap-1620-b1

### DIFF
--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -34,6 +34,10 @@ device('cudy-x6-v2', 'cudy_x6-v2', {
 
 -- D-Link
 
+device('d-link-dap-1620-b1', 'dlink_dap-1620-b1', {
+	broken = true, -- mt76 driver issue - See #3124
+})
+
 device('d-link-covr-x1860-a1', 'dlink_covr-x1860-a1', {
 	extra_images = {
 		{'-squashfs-recovery', '-recovery', '.bin'}


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface -- should theoretically work, didn't work for me; used u-boot web recovery instead
  - [ ] TFTP
  - [x] Other: Bootloader web recovery
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
  - Doesnt have MAC printed on label or packaging
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [ ] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios 
  - [ ] AP+mesh mode must work in parallel on all radios
  --> marked as broken
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [n/a] Should map to their respective radio
    - [ ] Should show activity --> Same as with the DAP-X1860
  - Switch port LEDs
    - [n/a] Should map to their respective port (or switch, if only one led present) 
    - [n/a] Should show link state and activity
- Outdoor devices only:
  - [n/a] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [n/a] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [n/a] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`