### PR TITLE
ath79-generic: add support for Sophos AP15

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -380,6 +380,12 @@ device('siemens-ws-ap3610', 'siemens_ws-ap3610', {
 
 -- Sophos
 
+device('sophos-ap15', 'sophos_ap15', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+	broken = true, -- no button and no external console port
+})
+
 device('sophos-ap100', 'sophos_ap100', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
Basically the same device as a Sophos AP55

- [X] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [X] Other: Vendor software, theoretically TFTP+UART, but UART header is not accessible externally
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
  - Device does _not_ have any buttons. 
  Warning: Make sure to set up SSH remote access, otherwise the only option is to open up the case and use the UART header for console access.
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`