### PR TITLE
docs: remove an unrelated/misleading link and fix headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Gluon is a firmware framework to build preconfigured OpenWrt images for public m
 
 Gluon provides an easy-to-use firmware for a public, decentral WLAN and/or wire based mesh network.
 Common network capable devices, like smartphones, laptops or desktop PCs can connect to the mesh network and communicate over it, without the need of passwords for access and without the need of installing special software.
-Additionally, internet access and [merging mesh clouds](https://www.open-mesh.org/projects/batman-adv/wiki/Connecting-Batman-adv-clouds) can be accomplished over a WAN through VPN connected gateways.
+Additionally, internet access and merging mesh clouds can be accomplished over a WAN through VPN connected gateways.
 
 Gluon's features include:
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Gluon is a firmware framework to build preconfigured OpenWrt images for public mesh networks.
 
-## Getting started
+## Overview
 
 Gluon provides an easy-to-use firmware for a public, decentral WLAN and/or wire based mesh network.
 Common network capable devices, like smartphones, laptops or desktop PCs can connect to the mesh network and communicate over it, without the need of passwords for access and without the need of installing special software.
@@ -35,6 +35,7 @@ Supported protocols for node-to-node connections:
 * WAN: VPNs via fastd and Wireguard
 * LAN: via VXLAN
 
+## Getting started
 
 We have a huge amount of documentation over at https://gluon.readthedocs.io/.
 


### PR DESCRIPTION
This removes the recently added link to the README again that was supposed to explain the the "merging of meshes" as it is very misleading concerning what Gluon can do.

And adjusts / tidies up the headings.