### PR TITLE
Image customization: add include() function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ ifneq ($(GLUON_BRANCH),)
 endif
 
 ifneq ($(GLUON_FEATURES)$(GLUON_FEATURES_standard)$(GLUON_FEATURES_tiny),)
-  $(error *** Warning: GLUON_FEATURES has been obsolete, please use the image-customization.lua file instead.)
+  $(error GLUON_FEATURES is obsolete, please use the image-customization.lua file instead)
 endif
 
 ifneq ($(GLUON_SITE_PACKAGES)$(GLUON_SITE_PACKAGES_standard)$(GLUON_SITE_PACKAGES_tiny),)
-  $(error *** Warning: GLUON_SITE_PACKAGES has been obsolete, please use the image-customization.lua file instead.)
+  $(error GLUON_SITE_PACKAGES is obsolete, please use the image-customization.lua file instead)
 endif
 
 GLUON_AUTOUPDATER_ENABLED ?= 0

--- a/docs/site-example/image-customization.lua
+++ b/docs/site-example/image-customization.lua
@@ -10,11 +10,11 @@ features {
 	'respondd',
 	'status-page',
 	'web-advanced',
-	'web-wizard'
+	'web-wizard',
 }
 
 if not device_class('tiny') then
 	features {
-		'wireless-encryption-wpa3'
+		'wireless-encryption-wpa3',
 	}
 end

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -790,6 +790,39 @@ disable_factory()
       disable_factory()
     end
 
+include(path)
+  Includes another image customization file. Relative paths are interpreted relative to the site
+  repository root.
+
+  .. code-block:: lua
+    :caption: target-settings.lua
+
+    features {'wireless-encryption-wpa3'}
+
+  .. code-block:: lua
+    :caption: image-customization.lua
+
+    if target('x86', '64') then
+      include 'target-settings.lua'
+    end
+
+  Values returned from the included file become the return value of ``include``:
+
+  .. code-block:: lua
+    :caption: matches-device.lua
+
+    return device {
+      'openmesh-a40',
+      'openmesh-a60',
+    }
+
+  .. code-block:: lua
+    :caption: image-customization.lua
+
+    if include('matches-device.lua') then
+      packages {'iperf3'}
+    end
+
 Technically, the image customization file is evaluated once for each device, allowing
 to make use of regular Lua *if* statements for device-specific configuration as
 can be seen in the examples.

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -701,39 +701,98 @@ setup and a device-specific alteration.
 The following functions are available:
 
 device(device_name_list)
-  Returns true in case the current device is in the list of devices specified in ``device_name_list``.
+  Returns true for devices listed in ``device_name_list``.
   ``device_name_list`` is a table of strings.
 
+  .. code-block:: lua
+
+    if device {
+      'openmesh-a40',
+      'openmesh-a60',
+    } then
+      packages {'iperf3'}
+    end
+
 target(openwrt_target, openwrt_subtarget)
-  Returns true in case the current device is of the specified OpenWrt target and subtarget.
-  The parameter ```openwrt_subtarget``` is optional. If it is not specified, only the target is matched.
+  Returns true for devices of the specified OpenWrt target and subtarget.
+  The parameter ``openwrt_subtarget`` is optional. If it is not specified,
+  the function matches all subtargets of the given target.
+
+  .. code-block:: lua
+
+    if target('x86', '64') then
+      features {'wireless-encryption-wpa3'}
+    end
 
 device_class(dev_class)
   Returns true in case the current device is of the specified device class.
+
+  .. code-block:: lua
+
+    if not device_class('tiny') then
+      features {'wireless-encryption-wpa3'}
+    end
+
 
 features(feature_table)
   Includes the specified list of features in the image. ``feature_table`` is a table of strings.
   These strings can be prefixed with a dash to exclude features included earlier in the file.
 
+  .. code-block:: lua
+
+    features {
+      'autoupdater',
+      'ebtables-filter-multicast',
+      'ebtables-filter-ra-dhcp',
+      'ebtables-limit-arp',
+      'mesh-batman-adv-15',
+      'mesh-vpn-fastd',
+      'respondd',
+      'status-page',
+      'web-advanced',
+      'web-wizard',
+    }
+
 packages(package_table)
   Includes the specified list of packages in the image. ``package_table`` is a table of strings.
   These strings can be prefixed with a dash to exclude packages included earlier in the file.
+
+  .. code-block:: lua
+
+    packages {'iwinfo'}
 
 broken(broken_state)
   Overrides the broken state specified by Gluon. Can be used to mark a device as broken or
   remove the pre-defined broken state.
 
+  .. code-block:: lua
+
+    if device {'meraki-mr33-access-point'} then
+      broken(false)
+    end
+
 disable()
   Disables image generation.
+
+  .. code-block:: lua
+
+    if device {'tp-link-cpe220-v3'} then
+      disable()
+    end
 
 disable_factory()
   Disables factory image generation. Sysupgrade images are still generated and stored in the image
   output directory.
 
+  .. code-block:: lua
+
+    if device {'tp-link-cpe220-v3'} then
+      disable_factory()
+    end
+
 Technically, the image customization file is evaluated once for each device, allowing
 to make use of regular Lua *if* statements for device-specific configuration as
-can be seen in the example.
-
+can be seen in the examples.
 
 .. _site-config-mode-texts:
 

--- a/scripts/image_customization_lib.lua
+++ b/scripts/image_customization_lib.lua
@@ -99,6 +99,22 @@ local function evaluate_device(env, dev)
 		return dev.options.class == class
 	end
 
+	function funcs.include(path)
+		assert(
+			type(path) == 'string',
+			'incorrect use of include(): path expected as first argument')
+
+		if string.sub(path, 1, 1) ~= '/' then
+			assert(
+				string.find(path, '/') == nil,
+				'incorrect use of include(): including files from subdirectories is unsupported')
+			path = env.GLUON_SITEDIR .. '/' .. path
+		end
+		local f = assert(loadfile(path))
+		setfenv(f, funcs)
+		return f()
+	end
+
 	-- Evaluate the feature definition files
 	setfenv(M.customization_file, funcs)
 	M.customization_file()

--- a/scripts/image_customization_lib.lua
+++ b/scripts/image_customization_lib.lua
@@ -11,9 +11,15 @@ local function evaluate_device(env, dev)
 	local device_overrides = {}
 
 	local function add_elements(element_type, element_list)
+		local error_msg = string.format(
+			'incorrect use of %s(): list of %s expected as argument',
+			element_type, element_type)
+		assert(type(element_list) == 'table', error_msg)
+
 		-- We depend on the fact both feature and package
 		-- are already initialized as empty tables
 		for _, element in ipairs(element_list) do
+			assert(type(element) == 'string', error_msg)
 			table.insert(selections[element_type], element)
 		end
 	end
@@ -33,7 +39,7 @@ local function evaluate_device(env, dev)
 	function funcs.broken(broken)
 		assert(
 			type(broken) == 'boolean',
-			'Incorrect use of broken(): has to be a boolean value')
+			'incorrect use of broken(): boolean argument expected')
 		add_override('broken', broken)
 	end
 
@@ -48,9 +54,13 @@ local function evaluate_device(env, dev)
 	function funcs.device(device_names)
 		assert(
 			type(device_names) == 'table',
-			'Incorrect use of device(): pass a list of device names as argument')
+			'incorrect use of device(): list of device names expected as argument')
 
 		for _, device_name in ipairs(device_names) do
+			assert(
+				type(device_name) == 'string',
+				'incorrect use of device(): list of device names expected as argument')
+
 			if device_name == dev.image then
 				return true
 			end
@@ -62,20 +72,30 @@ local function evaluate_device(env, dev)
 	function funcs.target(target, subtarget)
 		assert(
 			type(target) == 'string',
-			'Incorrect use of target(): pass a target name as first argument')
+			'incorrect use of target(): target name expected as first argument')
 
 		if target ~= env.BOARD then
 			return false
 		end
 
-		if subtarget and subtarget ~= env.SUBTARGET then
-			return false
+		if subtarget then
+			assert(
+				type(subtarget) == 'string',
+				'incorrect use of target(): subtarget name expected as first argument')
+
+			if subtarget ~= env.SUBTARGET then
+				return false
+			end
 		end
 
 		return true
 	end
 
 	function funcs.device_class(class)
+		assert(
+			type(class) == 'string',
+			'incorrect use of device_class(): class name expected as first argument')
+
 		return dev.options.class == class
 	end
 


### PR DESCRIPTION
Add a simple way to include image customization Lua snippets.
Can be used to split long files, to include the same options multiple
times in different conditional branches, or even to pass values back to
the including file using return.
    
Relative paths are interpreted relative to the site root (where
image-customization.lua is located). Relative includes would become
confusing when subdirectories are involved (as they are still interpreted
relative to the site root, and proper tracking of current directory for
each include seems fairly complex for a very niche use case), so we simply
reject this case for now; this way, we can implement this however we
want in the future if deemed necessary, without a breaking change.

Suggested by @T-X