### PR TITLE
 ath79-generic: add support for Ubiquiti UniFi Swiss Army Knife Ultra 

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -154,6 +154,7 @@ ath79-generic
   - UniFi AP LR
   - UniFi AP Outdoor+
   - UniFi AP PRO
+  - UniFi Swiss Army Knife Ultra
 
 ath79-mikrotik
 --------------

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -41,6 +41,7 @@ function M.is_outdoor_device()
 		'tplink,wbs210-v1',
 		'tplink,wbs210-v2',
 		'tplink,wbs510-v1',
+		'ubnt,uk-ultra',
 		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',
 		'ubnt,unifiac-mesh-pro',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -610,3 +610,9 @@ device('ubiquiti-unifi-ap-outdoor+', 'ubnt_unifi-ap-outdoor-plus', {
 })
 
 device('ubiquiti-unifi-ap-pro', 'ubnt_unifi-ap-pro')
+
+
+device('ubiquiti-unifi-swiss-army-knife-ultra', 'ubnt_uk-ultra', {
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9880,
+})


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: SSH from Ubiquiti Firmware
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`