### PR TITLE
contrib: drop Gluon version from CI site

### DIFF
--- a/contrib/ci/minimal-site/site.conf
+++ b/contrib/ci/minimal-site/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2023.2
+-- This is an example site configuration
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.

--- a/contrib/ci/olsr-site/site.conf
+++ b/contrib/ci/olsr-site/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2023.2
+-- This is an example site configuration
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.


### PR DESCRIPTION
Drop the Gluon version reference from the site configuration used for the CI builds.

These version indicators were most likely just copied from the example site in the docs, where the version information makes sense. However, the CI site is always built for a specific Gluon version and therefor commit.

This avoids editing the version for each release.