### PR TITLE
labeler: update "continuous integration" label name

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,7 +17,7 @@
   - docs/package/gluon-config-mode-*
   - package/gluon-config-mode-*/**
   - package/gluon-web*/**
-"3. topic: continous integration":
+"3. topic: continuous integration":
   - .github/workflows/*
   - contrib/actions/**
   - contrib/ci/**


### PR DESCRIPTION
The typo in the label name has been fixed, update the labeler config.

Previously suggested in #3072 I think? But this time I actually relabeled all old issues/PRs to use the fixed version of the label.