### PR TITLE
ramips-mt7621: add support for D-Link COVR-X1860 a1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -417,6 +417,7 @@ ramips-mt7621
 
 * D-Link
 
+  - COVR-X1860 (A1)
   - DAP-X1860 (A1)
   - DIR-860L (B1)
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -33,6 +33,12 @@ device('cudy-x6-v2', 'cudy_x6-v2', {
 
 -- D-Link
 
+device('d-link-covr-x1860-a1', 'dlink_covr-x1860-a1', {
+	extra_images = {
+		{'-squashfs-recovery', '-recovery', '.bin'}
+	},
+})
+
 device('d-link-dap-x1860-a1', 'dlink_dap-x1860-a1')
 
 device('d-link-dir-860l-b1', 'dlink_dir-860l-b1')


### PR DESCRIPTION
The COVR-X1860 is a wifi6 device quite similar to the DAP-X1860, which is not wall-plugged and has two Gigabit LAN ports.
It is already well tested with ~40 devices in FFAC.

- [x] Must be flashable from vendor firmware
  - [x] Web interface (recovery when holding the reset button while booting or signed factory image when using D-Link interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~ (none)
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - ~~Switch port LEDs~~ (none)
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- ~~Outdoor devices only~~:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- ~~Cellular devices only~~:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`