### PR TITLE
[v2023.1.x] modules: update openwrt

### DIFF
--- a/modules
+++ b/modules
@@ -2,7 +2,7 @@ GLUON_FEEDS='gluon packages routing'
 
 OPENWRT_REPO=https://github.com/openwrt/openwrt.git
 OPENWRT_BRANCH=openwrt-22.03
-OPENWRT_COMMIT=05f74354bd43efe9d08c0ce0db3fb0ef37ada94e
+OPENWRT_COMMIT=a08553b3b36cc309d3f112208f8451ad85d240eb
 
 PACKAGES_GLUON_REPO=https://github.com/freifunk-gluon/packages.git
 PACKAGES_GLUON_COMMIT=53ea3b89771fc7d7a80f1800ce25e98dfe1633aa


### PR DESCRIPTION
This fixes #2904  on the v2023.1.x branch too

```
a08553b3b3 ath79: read back reset register
debf4b56cd kernel: bump 5.10 to 5.10.206
6121581765 kernel: bump 5.10 to 5.10.203
17ee3e0b20 raimps: mtk_eth_soc: drop rst_esw from ESW driver
5ef01117b7 ramips: dts: mt7628an: reset FE and ESW cores together
b80c17b093 ramips: dts: rt5350: reset FE and ESW cores together
0c84a15288 ramips: dts: rt3050: reset FE and ESW cores together
37ed4c0ec2 ramips: dts: rt3352: reset FE and ESW cores together
8b4b924b85 ramips: mtk_eth_soc: wait longer after FE core reset to settle
ca942a5910 ramips: mtk_eth_soc: allow multiple resets
```