### PR TITLE
gluon-ebtables-limit-arp: stop for autoupdater

### DIFF
--- a/package/gluon-ebtables-limit-arp/files/usr/lib/autoupdater/abort.d/15start-arp-limiter
+++ b/package/gluon-ebtables-limit-arp/files/usr/lib/autoupdater/abort.d/15start-arp-limiter
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. /lib/gluon/autoupdater/lib.sh
+
+# Start after network
+start_enabled gluon-arp-limiter

--- a/package/gluon-ebtables-limit-arp/files/usr/lib/autoupdater/upgrade.d/05stop-arp-limiter
+++ b/package/gluon-ebtables-limit-arp/files/usr/lib/autoupdater/upgrade.d/05stop-arp-limiter
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. /lib/gluon/autoupdater/lib.sh
+
+# Stop before network
+stop gluon-arp-limiter


### PR DESCRIPTION
Stop and start the gluon-arp-limiter service before the network is brought down when commencing update.

Start the service after the network is brought back up when aborting.