### PR TITLE
tools flex: disable parallel build

### DIFF
--- a/patches/openwrt/0008-tools-flex-disable-parallel-build.patch
+++ b/patches/openwrt/0008-tools-flex-disable-parallel-build.patch
@@ -1,0 +1,25 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sun, 21 Jan 2024 02:03:56 +0100
+Subject: tools flex: disable parallel build
+
+Sometimes the build of flex fails with erros like these:
+
+./build-aux/config.sub: line 63: opying: command not found
+
+Disable the parallel build of flex in order to avoid these issues from
+occuring.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/tools/flex/Makefile b/tools/flex/Makefile
+index 86ba5a4415d3a82aaf5e9897736b465cc7e30c42..f3b6d0b1495b30c278e5bf0d2b322b5ade79ec4f 100644
+--- a/tools/flex/Makefile
++++ b/tools/flex/Makefile
+@@ -15,7 +15,6 @@ PKG_SOURCE_URL:=https://github.com/westes/flex/releases/download/v$(PKG_VERSION)
+ PKG_HASH:=e87aae032bf07c26f85ac0ed3250998c37621d95f8bd748b31f15b33c45ee995
+ 
+ HOST_FIXUP:=autoreconf
+-HOST_BUILD_PARALLEL:=1
+ 
+ include $(INCLUDE_DIR)/host-build.mk
+ 


### PR DESCRIPTION
SOmetimes the build of flex fails with erros like these:

./build-aux/config.sub: line 63: opying: command not found

Disable the parallel build of flex in order to avoid these issues from occuring.

This patch will be upstreamed once it did resolve our issue for some weeks.