### PR TITLE
docs, readme: backport v2023.1.2 / v2023.2.1 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the future development of Gluon.
 
 Please refrain from using the `master` branch for anything else but development purposes!
 Use the most recent release instead. You can list all releases by running `git tag`
-and switch to one by running `git checkout v2023.2 && make update`.
+and switch to one by running `git checkout v2023.2.1 && make update`.
 
 If you're using the autoupdater, do not autoupdate nodes with anything but releases.
 If you upgrade using random master commits the nodes *might break* eventually.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = 'Project Gluon'
 author = 'Project Gluon'
 
 # The short X.Y version
-version = '2023.2'
+version = '2023.2.1'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -11,6 +11,7 @@ Release Notes
   :caption: Gluon 2023.1
   :maxdepth: 2
 
+  v2023.1.2
   v2023.1.1
   v2023.1
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -5,6 +5,7 @@ Release Notes
   :caption: Gluon 2023.2
   :maxdepth: 2
 
+  v2023.2.1
   v2023.2
 
 .. toctree::

--- a/docs/releases/v2023.1.2.rst
+++ b/docs/releases/v2023.1.2.rst
@@ -1,0 +1,58 @@
+Gluon 2023.1.2
+==============
+
+Minor changes
+-------------
+
+- Update latest OpenWRT 22.03 version and the corresponding modules
+
+- Always prefer Gluon feeds over upstream feeds while building (`#3026 <https://github.com/freifunk-gluon/gluon/pull/3026>`_)
+
+
+Bugfixes
+--------
+
+- Fixed Raspberry Pi 3 and 4 naming (`#3099 <https://github.com/freifunk-gluon/gluon/issues/3099>`_)
+
+- Fixed inconsistent usage of env variable BROKEN (`#3103 <https://github.com/freifunk-gluon/gluon/issues/3103>`_)
+
+- Fixed gluon-reconfigure failures when no interface role was selected for an interface (`#3095 <https://github.com/freifunk-gluon/gluon/issues/3095>`_)
+
+- Fixed unexpected WiFi shutdowns on TP-Link Archer C7 (`#3049 <https://github.com/freifunk-gluon/gluon/issues/3049>`_)
+
+- Fixed unintentional CPU downclocks of ipq40xx devices (`#3049 <https://github.com/freifunk-gluon/gluon/issues/3049>`_)
+
+- Fixed bandwidth downstream (ingress) limit (`#3017 <https://github.com/freifunk-gluon/gluon/issues/3017>`_)
+
+- Fixed occasional reboot issues on some TP-Link WDR3600 and WDR4300 devices
+  (`Upstream <https://github.com/openwrt/openwrt/issues/13043>`_)
+  (`#2904 <https://github.com/freifunk-gluon/gluon/issues/2904>`_)
+
+
+Known issues
+------------
+
+* The integration of the BATMAN_V routing algorithm is incomplete.
+
+  - Mesh neighbors don't appear on the status page. (`#1726 <https://github.com/freifunk-gluon/gluon/issues/1726>`_)
+    Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new throughput
+    metric.
+  - Throughput values are not correctly acquired for different interface types.
+    (`#1728 <https://github.com/freifunk-gluon/gluon/issues/1728>`_)
+    This affects virtual interface types like bridges and VXLAN.
+
+* Default TX power on many Ubiquiti devices is too high, correct offsets are unknown
+  (`#94 <https://github.com/freifunk-gluon/gluon/issues/94>`_)
+
+  Reducing the TX power in the Advanced Settings is recommended.
+
+* In configurations without VXLAN, the MAC address of the WAN interface is modified even when Mesh-on-WAN is disabled
+  (`#496 <https://github.com/freifunk-gluon/gluon/issues/496>`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when promiscuous mode is disallowed).
+
+* EFI only systems won't boot due to removed EFI support (introduced in v2023.1). This was necessary to work around a bug that
+  causes a config loss during direct upgrades from v2021.1.x to v2023.1.x with the *x86-64*, *x86-generic* and *x86-legacy* targets
+  (`#2967 <https://github.com/freifunk-gluon/gluon/issues/2967>`_).
+
+  Gluon v2023.2 reintroduced EFI support.

--- a/docs/releases/v2023.2.1.rst
+++ b/docs/releases/v2023.2.1.rst
@@ -1,0 +1,64 @@
+Gluon 2023.2.1
+==============
+
+Added hardware support
+----------------------
+
+ath79-generic
+~~~~~~~~~~~~~
+
+- Ubiquiti
+
+  - UniFi Swiss Army Knife Ultra
+
+
+ramips-mt7621
+~~~~~~~~~~~~~
+
+- D-Link
+
+  - COVR-X1860 (A1)
+
+
+Minor changes
+-------------
+
+* Nodes using a fastd VPN connection now report the negotiated method on the status page
+  (`#2465 <https://github.com/freifunk-gluon/gluon/issues/2465>`_)
+
+
+Bugfixes
+--------
+
+* Fixed hostapd being unable to start an AP when selecting channel 116/120 with HT40
+  (`#3165 <https://github.com/freifunk-gluon/gluon/issues/3165>`_)
+
+* Fixed occasional reboot issues on some TP-Link WDR3600 and WDR4300 devices
+  (`Upstream <https://github.com/openwrt/openwrt/issues/13043>`_)
+  (`#2904 <https://github.com/freifunk-gluon/gluon/issues/2904>`_)
+  
+
+
+Known issues
+------------
+
+* Unstable wireless with certain MediaTek devices (`#3154 <https://github.com/freifunk-gluon/gluon/issues/3154>`_)
+
+* The integration of the BATMAN_V routing algorithm is incomplete.
+
+  - Mesh neighbors don't appear on the status page. (`#1726 <https://github.com/freifunk-gluon/gluon/issues/1726>`_)
+    Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new throughput
+    metric.
+  - Throughput values are not correctly acquired for different interface types.
+    (`#1728 <https://github.com/freifunk-gluon/gluon/issues/1728>`_)
+    This affects virtual interface types like bridges and VXLAN.
+
+* Default TX power on many Ubiquiti devices is too high, correct offsets are unknown
+  (`#94 <https://github.com/freifunk-gluon/gluon/issues/94>`_)
+
+  Reducing the TX power in the Advanced Settings is recommended.
+
+* In configurations without VXLAN, the MAC address of the WAN interface is modified even when Mesh-on-WAN is disabled
+  (`#496 <https://github.com/freifunk-gluon/gluon/issues/496>`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when promiscuous mode is disallowed).

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2023.2
+-- This is an example site configuration for Gluon v2023.2.1
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -8,7 +8,7 @@ Gluon's releases are managed using `Git tags`_. If you are just getting
 started with Gluon we recommend to use the latest stable release of Gluon.
 
 Take a look at the `list of gluon releases`_ and notice the latest release,
-e.g. *v2023.2*. Always get Gluon using git and don't try to download it
+e.g. *v2023.2.1*. Always get Gluon using git and don't try to download it
 as a Zip archive as the archive will be missing version information.
 
 Please keep in mind that there is no "default Gluon" build; a site configuration
@@ -53,7 +53,7 @@ Building the images
 -------------------
 
 To build Gluon, first check out the repository. Replace *RELEASE* with the
-version you'd like to checkout, e.g. *v2023.2*.
+version you'd like to checkout, e.g. *v2023.2.1*.
 
 ::
 


### PR DESCRIPTION
Backport Release-Notes for the Releases

 - v2023.1.2
 - v2023.2.1

Update the docs to refer to the release with the most recent major release of the two.