### PR TITLE
github: bump paths-filter version

### DIFF
--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
 
       # Filter targets based on changed files
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: .github/filters.yml


### PR DESCRIPTION
Get rid of Node deprecation warnings.

Link: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/