### PR TITLE
Omit obsolete manifest-aliases / cleanups

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -71,7 +71,7 @@ ath79-generic
 
   - LibreRouter v1 [#missing_radios]_
 
-* Netgear
+* NETGEAR
 
   - WNDR3700 (v1, v2)
   - WNDR3800
@@ -177,7 +177,7 @@ ath79-nand
   - GL-AR750S
   - GL-XE300
 
-* Netgear
+* NETGEAR
 
   - WNDR3700 (v4)
   - WNDR4300 (v1)
@@ -244,7 +244,7 @@ ipq40xx-generic
   - PA1200
   - PA2200
 
-* ZyXEL
+* Zyxel
 
   - NBG6617
 
@@ -316,7 +316,7 @@ mediatek-filogic
 
   - UniFi 6 Plus
 
-* ZyXEL
+* Zyxel
 
   - NWA50AX Pro
 
@@ -426,7 +426,7 @@ ramips-mt7621
 
   - GL-MT1300
 
-* Mercusys
+* MERCUSYS
 
   - MR70X (v1)
 
@@ -459,12 +459,12 @@ ramips-mt7621
   - Xiaomi Mi Router 3G (v1, v2)
   - Xiaomi Mi Router 4A (Gigabit Edition v1)
 
-* ZBT
+* Zbtlink
 
   - WG3526-16M
   - WG3526-32M
 
-* ZyXEL
+* Zyxel
 
   - NWA50AX
   - WSM20

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -69,11 +69,8 @@ device('avm-fritz-wlan-repeater-1750e', 'avm_fritz1750e', {
 device('buffalo-wzr-hp-ag300h', 'buffalo_wzr-hp-ag300h')
 device('buffalo-wzr-600dhp', 'buffalo_wzr-600dhp')
 
-device('buffalo-wzr-hp-g300nh-rtl8366s', 'buffalo_wzr-hp-g300nh-s', {
-	manifest_aliases = {
-		'buffalo-wzr-hp-g300nh', -- Upgrade from OpenWrt 19.07
-	},
-})
+device('buffalo-wzr-hp-g300nh-rtl8366s', 'buffalo_wzr-hp-g300nh-s')
+
 
 -- devolo
 
@@ -120,18 +117,11 @@ device('d-link-dap-2660-a1', 'dlink_dap-2660-a1', {
 
 device('d-link-dir-505', 'dlink_dir-505', {
 	factory = false,
-	manifest_aliases = {
-		'd-link-dir-505-rev-a1', -- Upgrade from OpenWrt 19.07
-		'd-link-dir-505-rev-a2', -- Upgrade from OpenWrt 19.07
-	},
 })
 
 device('d-link-dir825b1', 'dlink_dir-825-b1', {
 	factory = false,
 	class = 'tiny', -- Only 6M of usable Firmware space
-	manifest_aliases = {
-		'd-link-dir-825-rev-b1', -- Upgrade from OpenWrt 19.07
-	},
 })
 
 
@@ -154,9 +144,6 @@ device('extreme-networks-ws-ap3805i', 'extreme-networks_ws-ap3805i', {
 
 device('gl.inet-6416', 'glinet_6416', {
 	factory = false,
-	manifest_aliases = {
-		'gl-inet-6416a-v1', -- Upgrade from OpenWrt 19.07
-	},
 })
 
 device('gl.inet-gl-ar150', 'glinet_gl-ar150', {
@@ -197,9 +184,6 @@ device('netgear-wndr3700', 'netgear_wndr3700', {
 })
 
 device('netgear-wndr3700-v2', 'netgear_wndr3700-v2', {
-	manifest_aliases = {
-		'netgear-wndr3700v2', -- Upgrade from OpenWrt 19.07
-	},
 	factory_ext = '.img',
 })
 
@@ -209,13 +193,9 @@ device('netgear-wndr3800', 'netgear_wndr3800', {
 
 device('netgear-wndr3800ch', 'netgear_wndr3800ch', {
 	factory_ext = '.img',
-	manifest_aliases = {'netgear-wndr3800chmychart'},  -- Upgrade from OpenWrt 19.07
 })
 
 device('netgear-wnr2200-8m', 'netgear_wnr2200-8m', {
-	manifest_aliases = {
-		'netgear-wnr2200', -- Upgrade from OpenWrt 19.07
-	},
 	factory_ext = '.img',
 })
 
@@ -256,86 +236,56 @@ device('openmesh-a60', 'openmesh_a60', {
 
 device('openmesh-mr600-v1', 'openmesh_mr600-v1', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-mr600'},
 })
 
 device('openmesh-mr600-v2', 'openmesh_mr600-v2', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-mr600v2'},
 })
 
 device('openmesh-mr900-v1', 'openmesh_mr900-v1', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-mr900'},
 })
 
 device('openmesh-mr900-v2', 'openmesh_mr900-v2', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-mr900v2'},
 })
 
 device('openmesh-mr1750-v1', 'openmesh_mr1750-v1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-mr1750'},
 })
 
 device('openmesh-mr1750-v2', 'openmesh_mr1750-v2', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-mr1750v2'},
 })
 
 device('openmesh-om2p-v1', 'openmesh_om2p-v1', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-om2p'},
 })
 
 device('openmesh-om2p-v2', 'openmesh_om2p-v2', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x; deacticated at the moment because
-	-- the physical ethernet port for this device changed between 19.07
-	-- and 21.02. And automated update could therefore "break" the
-	-- device until someone physically changed the ethernet cable.
-	-- See https://github.com/freifunk-gluon/gluon/pull/2325#issuecomment-940749284
-	--manifest_aliases = {'openmesh-om2pv2'},
 })
 
 device('openmesh-om2p-v4', 'openmesh_om2p-v4', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-om2pv4'},
 })
 
 device('openmesh-om2p-hs-v1', 'openmesh_om2p-hs-v1', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-om2p-hs'},
 })
 
 device('openmesh-om2p-hs-v2', 'openmesh_om2p-hs-v2', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-om2p-hsv2'},
 })
 
 device('openmesh-om2p-hs-v3', 'openmesh_om2p-hs-v3', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-om2p-hsv3'},
 })
 
 device('openmesh-om2p-hs-v4', 'openmesh_om2p-hs-v4', {
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-om2p-hsv4'},
 })
 
 device('openmesh-om2p-lc', 'openmesh_om2p-lc', {
@@ -349,15 +299,11 @@ device('openmesh-om5p', 'openmesh_om5p', {
 device('openmesh-om5p-ac-v1', 'openmesh_om5p-ac-v1', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-om5p-ac'},
 })
 
 device('openmesh-om5p-ac-v2', 'openmesh_om5p-ac-v2', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,
-	-- old name from OpenWrt 19.07.x
-	manifest_aliases = {'openmesh-om5p-acv2'},
 })
 
 device('openmesh-om5p-an', 'openmesh_om5p-an', {
@@ -442,9 +388,6 @@ device('tp-link-archer-c58-v1', 'tplink_archer-c58-v1', {
 
 device('tp-link-archer-c6-v2-eu-ru-jp', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
-	manifest_aliases = {
-		'tp-link-archer-c6-v2', -- Upgrade from OpenWrt 19.07
-	},
 })
 
 device('tp-link-archer-c7-v2', 'tplink_archer-c7-v2', {
@@ -474,31 +417,16 @@ device('tp-link-archer-d50-v1', 'tplink_archer-d50-v1', {
 	broken = true, -- 64M ath9k + ath10k & power LED not working
 })
 
-device('tp-link-cpe210-v1', 'tplink_cpe210-v1', {
-	manifest_aliases = {
-		'tp-link-cpe210-v1.0', -- Upgrade from OpenWrt 19.07
-		'tp-link-cpe210-v1.1', -- Upgrade from OpenWrt 19.07
-	},
-})
-device('tp-link-cpe210-v2', 'tplink_cpe210-v2', {
-	manifest_aliases = {
-		'tp-link-cpe210-v2.0', -- Upgrade from OpenWrt 19.07
-	},
-})
-device('tp-link-cpe210-v3', 'tplink_cpe210-v3', {
-	manifest_aliases = {
-		'tp-link-cpe210-v3.0', -- Upgrade from OpenWrt 19.07
-		'tp-link-cpe210-v3.1', -- Upgrade from OpenWrt 19.07
-		'tp-link-cpe210-v3.20', -- Upgrade from OpenWrt 19.07
-	},
-})
+device('tp-link-cpe210-v1', 'tplink_cpe210-v1')
+
+device('tp-link-cpe210-v2', 'tplink_cpe210-v2')
+
+device('tp-link-cpe210-v3', 'tplink_cpe210-v3')
+
 device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
-device('tp-link-cpe510-v1', 'tplink_cpe510-v1', {
-	manifest_aliases = {
-		'tp-link-cpe510-v1.0', -- upgrade from OpenWrt 19.07
-		'tp-link-cpe510-v1.1', -- upgrade from OpenWrt 19.07
-	},
-})
+
+device('tp-link-cpe510-v1', 'tplink_cpe510-v1')
+
 device('tp-link-cpe510-v2', 'tplink_cpe510-v2')
 device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
 
@@ -518,11 +446,7 @@ device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
 
 device('tp-link-tl-wr810n-v1', 'tplink_tl-wr810n-v1')
 
-device('tp-link-tl-wr842n-v3', 'tplink_tl-wr842n-v3', {
-	manifest_aliases = {
-		'tp-link-tl-wr842n-nd-v3', -- upgrade from OpenWrt 19.07
-	},
-})
+device('tp-link-tl-wr842n-v3', 'tplink_tl-wr842n-v3')
 
 device('tp-link-tl-wr902ac-v1', 'tplink_tl-wr902ac-v1', {
 	packages = ATH10K_PACKAGES_SMALLBUFFERS_QCA9887,
@@ -530,42 +454,22 @@ device('tp-link-tl-wr902ac-v1', 'tplink_tl-wr902ac-v1', {
 	class = 'tiny', -- 64M ath9k + ath10k
 })
 
-device('tp-link-tl-wr1043nd-v2', 'tplink_tl-wr1043nd-v2', {
-	manifest_aliases = {
-		'tp-link-tl-wr1043n-nd-v2', -- upgrade from OpenWrt 19.07
-	},
-})
-device('tp-link-tl-wr1043nd-v3', 'tplink_tl-wr1043nd-v3', {
-	manifest_aliases = {
-		'tp-link-tl-wr1043n-nd-v3', -- upgrade from OpenWrt 19.07
-	},
-})
-device('tp-link-tl-wr1043nd-v4', 'tplink_tl-wr1043nd-v4', {
-	manifest_aliases = {
-		'tp-link-tl-wr1043n-nd-v4', -- upgrade from OpenWrt 19.07
-	},
-})
+device('tp-link-tl-wr1043nd-v2', 'tplink_tl-wr1043nd-v2')
+
+device('tp-link-tl-wr1043nd-v3', 'tplink_tl-wr1043nd-v3')
+
+device('tp-link-tl-wr1043nd-v4', 'tplink_tl-wr1043nd-v4')
+
 device('tp-link-tl-wr1043n-v5', 'tplink_tl-wr1043n-v5')
 
-device('tp-link-tl-wr2543n-nd', 'tplink_tl-wr2543-v1', {
-	manifest_aliases = {
-		'tp-link-tl-wr2543n-nd-v1', -- upgrade from OpenWrt 19.07
-	},
-})
+device('tp-link-tl-wr2543n-nd', 'tplink_tl-wr2543-v1')
 
-device('tp-link-wbs210-v1', 'tplink_wbs210-v1', {
-	manifest_aliases = {
-		'tp-link-wbs210-v1.20', -- upgrade from OpenWrt 19.07
-	},
-})
+device('tp-link-wbs210-v1', 'tplink_wbs210-v1')
 
 device('tp-link-wbs210-v2', 'tplink_wbs210-v2')
 
-device('tp-link-wbs510-v1', 'tplink_wbs510-v1', {
-	manifest_aliases = {
-		'tp-link-wbs510-v1.20', -- upgrade from OpenWrt 19.07
-	},
-})
+device('tp-link-wbs510-v1', 'tplink_wbs510-v1')
+
 
 -- Ubiquiti
 
@@ -599,15 +503,11 @@ device('ubiquiti-unifi-ap', 'ubnt_unifi-ap', {
 		'ubiquiti-unifi-ap-lr',
 	},
 	manifest_aliases = {
-		'ubiquiti-unifi',
+		'ubiquiti-unifi', -- Upgrade from OpenWrt 22.03
 	},
 })
 
-device('ubiquiti-unifi-ap-outdoor+', 'ubnt_unifi-ap-outdoor-plus', {
-	manifest_aliases = {
-		'ubiquiti-unifiap-outdoor+', -- upgrade from OpenWrt 19.07
-	},
-})
+device('ubiquiti-unifi-ap-outdoor+', 'ubnt_unifi-ap-outdoor-plus')
 
 device('ubiquiti-unifi-ap-pro', 'ubnt_unifi-ap-pro')
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -37,11 +37,13 @@ local ATH10K_PACKAGES_SMALLBUFFERS_QCA9887 = {
 
 local ATH10K_PACKAGES_QCA9888 = {}
 
--- ALFA NETWORK
+
+-- ALFA Network
 
 device('alfa-network-ap121f', 'alfa-network_ap121f', {
 	factory = false,
 })
+
 
 -- AVM
 
@@ -64,9 +66,11 @@ device('avm-fritz-wlan-repeater-1750e', 'avm_fritz1750e', {
 	class = 'tiny', -- 64M ath9k + ath10k
 })
 
+
 -- Buffalo
 
 device('buffalo-wzr-hp-ag300h', 'buffalo_wzr-hp-ag300h')
+
 device('buffalo-wzr-600dhp', 'buffalo_wzr-600dhp')
 
 device('buffalo-wzr-hp-g300nh-rtl8366s', 'buffalo_wzr-hp-g300nh-s')
@@ -108,6 +112,7 @@ device('devolo-wifi-pro-1750x', 'devolo_dvl1750x', {
 -- D-Link
 
 device('d-link-dap-1330-a1', 'dlink_dap-1330-a1')
+
 device('d-link-dap-1365-a1', 'dlink_dap-1365-a1')
 
 device('d-link-dap-2660-a1', 'dlink_dap-2660-a1', {
@@ -163,12 +168,14 @@ device('gl.inet-gl-usb150', 'glinet_gl-usb150', {
 	factory = false,
 })
 
--- JOY-IT
+
+-- Joy-IT
 
 device('joy-it-jt-or750i', 'joyit_jt-or750i', {
 	packages = ATH10K_PACKAGES_QCA9887,
 	factory = false,
 })
+
 
 -- LibreRouter
 
@@ -177,7 +184,8 @@ device('librerouter-v1', 'librerouter_librerouter-v1', {
 	factory = false,
 })
 
--- Netgear
+
+-- NETGEAR
 
 device('netgear-wndr3700', 'netgear_wndr3700', {
 	factory_ext = '.img',
@@ -214,6 +222,7 @@ device('ocedo-koala', 'ocedo_koala', {
 device('ocedo-raccoon', 'ocedo_raccoon', {
 	factory = false,
 })
+
 
 -- Onion
 
@@ -324,6 +333,7 @@ device('siemens-ws-ap3610', 'siemens_ws-ap3610', {
 	factory = false,
 })
 
+
 -- Sophos
 
 device('sophos-ap15', 'sophos_ap15', {
@@ -428,6 +438,7 @@ device('tp-link-cpe220-v3', 'tplink_cpe220-v3')
 device('tp-link-cpe510-v1', 'tplink_cpe510-v1')
 
 device('tp-link-cpe510-v2', 'tplink_cpe510-v2')
+
 device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
 
 device('tp-link-cpe710-v1', 'tplink_cpe710-v1')
@@ -441,7 +452,9 @@ device('tp-link-eap225-outdoor-v3', 'tplink_eap225-outdoor-v3', {
 })
 
 device('tp-link-tl-wdr3500-v1', 'tplink_tl-wdr3500-v1')
+
 device('tp-link-tl-wdr3600-v1', 'tplink_tl-wdr3600-v1')
+
 device('tp-link-tl-wdr4300-v1', 'tplink_tl-wdr4300-v1')
 
 device('tp-link-tl-wr810n-v1', 'tplink_tl-wr810n-v1')
@@ -510,7 +523,6 @@ device('ubiquiti-unifi-ap', 'ubnt_unifi-ap', {
 device('ubiquiti-unifi-ap-outdoor+', 'ubnt_unifi-ap-outdoor-plus')
 
 device('ubiquiti-unifi-ap-pro', 'ubnt_unifi-ap-pro')
-
 
 device('ubiquiti-unifi-swiss-army-knife-ultra', 'ubnt_uk-ultra', {
 	factory = false,

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -38,7 +38,7 @@ device('gl.inet-gl-xe300', 'glinet_gl-xe300', {
 })
 
 
--- Netgear
+-- NETGEAR
 
 device('netgear-wndr3700-v4', 'netgear_wndr3700-v4', {
 	factory_ext = '.img',

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -26,9 +26,6 @@ device('aerohive-hiveap-121', 'aerohive_hiveap-121')
 
 device('gl.inet-gl-ar300m-nor', 'glinet_gl-ar300m-nor', {
 	factory = false,
-	manifest_aliases = {
-		'gl.inet-gl-ar300m', -- Upgrade from OpenWrt 19.07
-	},
 })
 
 device('gl.inet-gl-ar750s-nor', 'glinet_gl-ar750s-nor', {
@@ -45,9 +42,6 @@ device('gl.inet-gl-xe300', 'glinet_gl-xe300', {
 
 device('netgear-wndr3700-v4', 'netgear_wndr3700-v4', {
 	factory_ext = '.img',
-	manifest_aliases = {
-		'netgear-wndr3700v4', -- Upgrade from OpenWrt 19.07
-	},
 })
 
 device('netgear-wndr4300', 'netgear_wndr4300', {

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -128,7 +128,7 @@ device('zte-mf289f', 'zte_mf289f', {
 })
 
 
--- ZyXEL
+-- Zyxel
 
 device('zyxel-nbg6617', 'zyxel_nbg6617')
 

--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -12,6 +12,8 @@ packages {
 }
 
 
+-- AVM
+
 device('avm-fritz-box-3370-rev-2-hynix-nand', 'avm_fritz3370-rev2-hynix', {
 	factory = false,
 	extra_images = {
@@ -51,6 +53,7 @@ device('arcadyan-vgv7510kw22', 'arcadyan_vgv7510kw22-nor', {
 	factory = false,
 	aliases = {'o2-box-6431'},
 })
+
 
 -- TP-Link
 

--- a/targets/lantiq-xway
+++ b/targets/lantiq-xway
@@ -8,9 +8,15 @@ packages {
 	'-kmod-ltq-deu-ar9'
 }
 
+
+-- AVM
+
 device('avm-fritz-box-7312', 'avm_fritz7312', {
 	factory = false,
 })
+
+
+-- NETGEAR
 
 device('netgear-dgn3500b', 'netgear_dgn3500b', {
 	factory_ext = '.img',

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -33,6 +33,6 @@ device('ubiquiti-unifi-6-plus', 'ubnt_unifi-6-plus', {
 })
 
 
--- ZyXEL
+-- Zyxel
 
 device('zyxel-nwa50ax-pro', 'zyxel_nwa50ax-pro')

--- a/targets/mediatek-mt7622
+++ b/targets/mediatek-mt7622
@@ -8,7 +8,7 @@ device('linksys-e8450-ubi', 'linksys_e8450-ubi', {
 
 device('ubiquiti-unifi-6-lr-v1', 'ubnt_unifi-6-lr-v1', {
 	factory = false,
-	manifest_aliases = {'ubiquiti-unifi-6-lr'},
+	manifest_aliases = {'ubiquiti-unifi-6-lr'}, -- Upgrade from OpenWrt 22.03
 })
 
 -- Xiaomi

--- a/targets/mediatek-mt7622
+++ b/targets/mediatek-mt7622
@@ -6,14 +6,16 @@ device('linksys-e8450-ubi', 'linksys_e8450-ubi', {
 })
 
 
+-- Ubiquiti
+
 device('ubiquiti-unifi-6-lr-v1', 'ubnt_unifi-6-lr-v1', {
 	factory = false,
 	manifest_aliases = {'ubiquiti-unifi-6-lr'}, -- Upgrade from OpenWrt 22.03
 })
+
 
 -- Xiaomi
 
 device('xiaomi-redmi-router-ax6s', 'xiaomi_redmi-router-ax6s', {
 	factory = false,
 })
-

--- a/targets/mpc85xx-p1010
+++ b/targets/mpc85xx-p1010
@@ -15,4 +15,3 @@ device('sophos-red-15w-rev.1', 'sophos_red-15w-rev1', {
 -- TP-Link
 
 device('tp-link-tl-wdr4900-v1', 'tplink_tl-wdr4900-v1')
-

--- a/targets/mpc85xx-p1020
+++ b/targets/mpc85xx-p1020
@@ -6,6 +6,7 @@ local ATH10K_PACKAGES_QCA9880 = {
 	'-ath10k-firmware-qca988x-ct',
 }
 
+
 -- Aerohive
 
 device('aerohive-hiveap-330', 'aerohive_hiveap-330', {
@@ -33,4 +34,3 @@ device('extreme-networks-ws-ap3825i', 'extreme-networks_ws-ap3825i', {
 device('ocedo-panda', 'ocedo_panda', {
 	factory = false,
 })
-

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -58,7 +58,6 @@ device('tp-link-archer-c20i', 'tplink_archer-c20i')
 
 device('tp-link-archer-c50-v1', 'tplink_archer-c50-v1', {
 	factory = '-squashfs-factory' .. tplink_region_suffix,
-	manifest_aliases = {'tp-link-archer-c50'},
 })
 
 

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -19,7 +19,8 @@ device('gl-mt750', 'glinet_gl-mt750', {
 	factory = false,
 })
 
--- Netgear
+
+-- NETGEAR
 
 device('netgear-ex3700', 'netgear_ex3700', {
 	aliases = {
@@ -28,6 +29,7 @@ device('netgear-ex3700', 'netgear_ex3700', {
 	manifest_aliases = {'netgear-ex3700-ex3800'},
 	factory_ext = '.chk',
 })
+
 
 -- Nexx
 
@@ -38,6 +40,7 @@ device('nexx-wt3020-8m', 'nexx_wt3020-8m', {
 		'nexx-wt3020h',
 	},
 })
+
 
 -- TP-Link
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -9,6 +9,7 @@ device('asus-rt-ac57u-v1', 'asus_rt-ac57u-v1', {
 
 device('asus-rt-ax53u', 'asus_rt-ax53u')
 
+
 -- Cudy
 
 device('cudy-wr1300-v1', 'cudy_wr1300-v1', {
@@ -51,12 +52,12 @@ device('gl.inet-gl-mt1300', 'glinet_gl-mt1300', {
 })
 
 
--- Mercusys
+-- MERCUSYS
 
 device('mercusys-mr70x-v1', 'mercusys_mr70x-v1')
 
 
--- Netgear
+-- NETGEAR
 
 device('netgear-ex6150', 'netgear_ex6150', {
 	factory_ext = '.chk',
@@ -126,7 +127,7 @@ device('xiaomi-mi-router-3g-v2', 'xiaomi_mi-router-3g-v2', {
 })
 
 
--- ZBT
+-- Zbtlink
 
 device('zbtlink-zbt-wg3526-16m', 'zbtlink_zbt-wg3526-16m', {
 	factory = false,
@@ -137,9 +138,10 @@ device('zbtlink-zbt-wg3526-32m', 'zbtlink_zbt-wg3526-32m', {
 })
 
 
--- ZyXEL
+-- Zyxel
 
 device('zyxel-nwa50ax', 'zyxel_nwa50ax')
+
 device('zyxel-nwa55axe', 'zyxel_nwa55axe', {
 	broken = true, -- Missing LED / Reset button
 })

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -81,9 +81,6 @@ device('netgear-wax202', 'netgear_wax202', {
 device('netgear-wndr3700-v5', 'netgear_wndr3700-v5', {
 	factory = false,
 	broken = true, -- untested
-	manifest_aliases = {
-		'netgear-wndr3700v5',
-	},
 })
 
 
@@ -133,18 +130,10 @@ device('xiaomi-mi-router-3g-v2', 'xiaomi_mi-router-3g-v2', {
 
 device('zbtlink-zbt-wg3526-16m', 'zbtlink_zbt-wg3526-16m', {
 	factory = false,
-	manifest_aliases = {
-		'zbt-wg3526',
-		'zbt-wg3526-16m',
-	},
 })
 
 device('zbtlink-zbt-wg3526-32m', 'zbtlink_zbt-wg3526-32m', {
 	factory = false,
-	manifest_aliases = {
-		'zbt-wg3526-32m',
-	},
-
 })
 
 
@@ -167,15 +156,9 @@ device('zyxel-wsm20', 'zyxel_wsm20', {
 device('ubiquiti-edgerouter-x', 'ubnt_edgerouter-x', {
 	factory = false,
 	packages = {'-hostapd-mini'},
-	manifest_aliases = {
-		'ubnt-erx',
-	},
 })
 
 device('ubiquiti-edgerouter-x-sfp', 'ubnt_edgerouter-x-sfp', {
 	factory = false,
 	packages = {'-hostapd-mini'},
-	manifest_aliases = {
-		'ubnt-erx-sfp',
-	},
 })

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -18,7 +18,7 @@ device('gl.inet-vixmini', 'glinet_vixmini', {
 })
 
 
--- Netgear
+-- NETGEAR
 
 device('netgear-r6020', 'netgear_r6020', {
 	factory_ext = '.img',

--- a/targets/x86-generic
+++ b/targets/x86-generic
@@ -11,8 +11,4 @@ device('x86-generic', 'generic', {
 		{'-kernel', '-kernel', '.bin'},
 		{'-squashfs-rootfs', '-rootfs', '.img.gz'},
 	},
-	manifest_aliases = {
-		'x86-kvm',
-		'x86-xen_domu',
-	},
 })


### PR DESCRIPTION
This PR is mostly about some cleanups.
I propose dropping manifest aliases for unsupported upgrade paths (devices running pre OpenWrt 22.03)
This makes target files better to read and makes the manifests smaller.

I also make OEM naming a bit more consistent across targets and documentation and add a few new lines here and there.
And I gave two existing manifest-aliases their respective code comment (last OpenWrt release with that model name).
There were further manifest-aliases without code comments but I was able to drop those. (introduced for OpenWrt 21 or prior)