### PR TITLE
Drop vdsl packages

### DIFF
--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -51,6 +51,22 @@ device('avm-fritz-box-4040', 'avm_fritzbox-4040', {
 device('avm-fritz-box-7530', 'avm_fritzbox-7530', {
 	factory = false,
 	aliases = {'avm-fritz-box-7520'},
+	packages = {
+		-- same as ATH10K_PACKAGES_IPQ40XX
+		'kmod-ath10k',
+		'-kmod-ath10k-ct',
+		'-kmod-ath10k-ct-smallbuffers',
+		'ath10k-firmware-qca4019',
+		'-ath10k-firmware-qca4019-ct',
+
+		-- VDSL modem
+		'-kmod-ltq-vdsl-vr11',
+		'-kmod-ltq-vdsl-vr11-mei',
+		'-ltq-vdsl-vr11-app',
+		'-ltq-dsl-base',
+		'-kmod-atm',
+		'-linux-atm',
+	},
 })
 
 device('avm-fritz-repeater-1200', 'avm_fritzrepeater-1200', {

--- a/targets/lantiq-xrx200
+++ b/targets/lantiq-xrx200
@@ -5,10 +5,11 @@ packages {
 	'-kmod-ltq-atm-vr9',
 	'-kmod-ltq-ptm-vr9',
 	'-kmod-ltq-deu-vr9',
-	'-ltq-vdsl-app',
+	'-ltq-vdsl-vr9-app',
 	'-dsl-vrx200-firmware-xdsl-a',
 	'-dsl-vrx200-firmware-xdsl-b-patch',
 	'-ppp-mod-pppoa',
+	'-ltq-dsl-base',
 }
 
 


### PR DESCRIPTION
I just noticed that lantiq removes dsl related packages. Let's do the same for the Fritz!Box 7520/7530.
And correct one package name for lantiq-xrx200 that was changed due to introduction of the vr11 modem.
And drop the new package ltq-dsl-base.

This PR hasn't been run-tested, yet.



_____
## Resolved:
~~I removed `ltq-dsl-base` on my own accord. I have no clue whether removing this as well is a good idea or not. (EDIT: actually lantiq-xrx200 also has this package since 23.05; 22.03 didn't have this package)~~
https://github.com/freifunk-gluon/gluon/blob/d5a8f662d2d608097c3870b78a38acbd0e1bb332/targets/ipq40xx-generic#L66

~~should we also drop these?~~
```
kmod-atm - 5.15.146-1
linux-atm - 2.5.2-7
```