### PR TITLE
generic: disable kernel SWAP support

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -64,6 +64,7 @@ config('KERNEL_CGROUPS', false)
 config('KERNEL_IP_MROUTE', false)
 config('KERNEL_IPV6_MROUTE', false)
 config('KERNEL_IPV6_SEG6_LWTUNNEL', false)
+config('KERNEL_SWAP', false)
 config('SECCOMP', false)
 config('KERNEL_SECCOMP', false)
 -- kmod-mt7915e pulls in CONFIG_KERNEL_RELAY


### PR DESCRIPTION
We don't employ swap using zram anymore with Gluon. Thus, we can disable SWAP in the kernel.