### PR TITLE
ath79-generic: add support for D-Link DAP-2680

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -43,6 +43,7 @@ ath79-generic
   - DAP-1330 A1 [#lan_as_wan]_
   - DAP-1365 A1 [#lan_as_wan]_
   - DAP-2660 A1 [#lan_as_wan]_
+  - DAP-2680 A1 [#lan_as_wan]_
   - DIR-505 A1 [#lan_as_wan]_
   - DIR-505 A2 [#lan_as_wan]_
   - DIR-825 B1

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -17,6 +17,14 @@ local ATH10K_PACKAGES_QCA9887 = {
 	'-ath10k-firmware-qca9887-ct',
 }
 
+local ATH10K_PACKAGES_QCA9984 = {
+	'kmod-ath10k',
+	'-kmod-ath10k-ct',
+	'-kmod-ath10k-ct-smallbuffers',
+	'ath10k-firmware-qca9984',
+	'-ath10k-firmware-qca9984-ct',
+}
+
 -- enforce mainline ath10k-smallbuffers kmod, fixes 5GHz-OOM for low memory devices
 
 local ATH10K_PACKAGES_SMALLBUFFERS_QCA9880 = {
@@ -116,6 +124,11 @@ device('d-link-dap-1365-a1', 'dlink_dap-1365-a1')
 device('d-link-dap-2660-a1', 'dlink_dap-2660-a1', {
 	factory_ext = '.img',
 	packages = ATH10K_PACKAGES_QCA9880,
+})
+
+device('d-link-dap-2680-a1', 'dlink_dap-2680-a1', {
+	factory_ext = '.img',
+	packages = ATH10K_PACKAGES_QCA9984,
 })
 
 device('d-link-dir-505', 'dlink_dir-505', {


### PR DESCRIPTION
The DAP-2680 is an AC1750 Wave 2 business Access Point (not previously added along with DAP-2660 since there was an issue with ath10k firmware package choice, meanwhile gluon points to a version of OpenWrt [that includes the fix](https://git.openwrt.org/?p=openwrt/openwrt.git;a=commit;h=0dc056eb66e1b3a4a6797bdf91f7362df6ced9c3)).

```
Specifications:
 * QCA9558, 16 MiB Flash, 256 MiB RAM, 802.11n 3T3R
 * QCA9984, 802.11ac Wave 2 3T3R
 * Gigabit LAN Port (AR8035), 802.3at PoE
```


https://hannover.freifunk.net/karte/#!/de/map/f48ceb8a2cb0


- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [-] TFTP
  - [x] Other: recovery webinterface (keep reset button pressed during power-on, until upload started)
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [-] Should map to their respective radio
    - [- Should show activity
  - Switch port LEDs
    - [-] Should map to their respective port (or switch, if only one led present)
    - [-] Should show link state and activity
- Outdoor devices only:
  - [-] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

