### PR TITLE
docs: add preferred English to guidelines

### DIFF
--- a/docs/dev/basics.rst
+++ b/docs/dev/basics.rst
@@ -83,3 +83,6 @@ To that end we provide a ``.editorconfig`` configuration, which is supported by 
 of the editors out there.
 
 If you add Lua scripts to gluon, check formatting with ``luacheck``.
+
+Only English should be used for naming, comments, documentation and so on.
+The use of American English is preferred.

--- a/docs/dev/web/i18n.rst
+++ b/docs/dev/web/i18n.rst
@@ -6,6 +6,7 @@ General guidelines
 
 * All config mode packages must be fully translatable, with complete English and German texts.
 * All new expert mode packages must be fully translatable. English texts are required.
+* American English should be used. English texts shouldn't mix American and British English.
 * German translations are recommended. Other supported languages, especially French, are
   nice-to-have, but not required. If you don't know a language well, rather leave the translation
   blank, so it is obvious that there is no proper translation yet.


### PR DESCRIPTION
After several chats about the preferred English (American or British) used in Gluon I decided to add it to the documentation.

My suggestion is to add American or British English as preferred English language to the documentation.

My commit adds American English as the preferred one because of the feedback I received from the chats.