### PR TITLE
ath79-generic: add support for D-Link DAP-2695

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -44,6 +44,7 @@ ath79-generic
   - DAP-1365 A1 [#lan_as_wan]_
   - DAP-2660 A1 [#lan_as_wan]_
   - DAP-2680 A1 [#lan_as_wan]_
+  - DAP-2695 A1 [#lan_as_wan]_
   - DIR-505 A1 [#lan_as_wan]_
   - DIR-505 A2 [#lan_as_wan]_
   - DIR-825 B1

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -43,6 +43,7 @@ local lan_ifname = iface_exists(lan_interfaces)
 local wan_ifname = iface_exists(wan_interfaces)
 
 if platform.match('ath79', 'generic', {
+	'dlink,dap-2695-a1',
 	'tplink,cpe210-v1',
 	'tplink,cpe210-v2',
 	'tplink,cpe510-v1',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -133,6 +133,11 @@ device('d-link-dap-2680-a1', 'dlink_dap-2680-a1', {
 	packages = ATH10K_PACKAGES_QCA9984,
 })
 
+device('d-link-dap-2695-a1', 'dlink_dap-2695-a1', {
+	factory_ext = '.img',
+	packages = ATH10K_PACKAGES_QCA9880,
+})
+
 device('d-link-dir-505', 'dlink_dir-505', {
 	factory = false,
 })


### PR DESCRIPTION
split from #3190 

The DAP-2695 (better late than never) is an AC1750 Wave 1 Access Point in a plenum-rated metal case with RJ45 serial console port and six detachable antennas (single band, labelled accordingly).

```
DAP-2695 Specifications:
* SoC: Qualcomm Atheros QCA9558, 256 MiB RAM, 16 MiB SPI NOR
* Ethernet: 2x 10/100/1000 (1x 802.3at PoE-PD)
* WiFi 2.4GHz: Qualcomm Atheros QCA9558
* WiFi 5GHz: Qualcomm Ahteros QCA9880-2R4E
* LEDS: 1x 5GHz, 1x 2.4GHz, 1x LAN1(POE), 1x LAN2, 1x POWER
* UART: 1x RJ45 RS-232 Console port
* Plenum-rated metal case
```

https://hannover.freifunk.net/karte/#!/de/map/9cd6432cac70
https://hannover.freifunk.net/karte/#!/de/map/0cb6d2fd1570

Checklist (Tested for DAP-2695 A1 and A2) 

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [-] TFTP
  - [x] Other: recovery webinterface (keep reset button pressed during power-on, until upload started)
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#notes)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - On devices supplied via PoE, there is usually no explicit WAN/LAN labeling on the hardware.
      The PoE input should be the WAN port in this case.
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present)
    - [x] Should show link state and activity
- Outdoor devices only:
  - [-] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`

