### PR TITLE
scripts/container.sh: fix rootless Podman on systems with SELinux

### DIFF
--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -12,7 +12,7 @@ TAG="gluon:${BRANCH:-latest}"
 if [ "$(command -v podman)" ]
 then
 	podman build -t "${TAG}" contrib/docker
-	podman run -it --rm -u "$(id -u):$(id -g)" --userns=keep-id --volume="$(pwd):/gluon" "${TAG}"
+	podman run -it --rm -u "$(id -u):$(id -g)" --userns=keep-id --volume="$(pwd):/gluon:z" "${TAG}"
 elif [ "$(command -v docker)" ]
 then
 	docker build -t "${TAG}" contrib/docker


### PR DESCRIPTION
We need to pass the `z` option with the volume mount so it gets labeled correctly and access is possible on SELinux-enabled systems. On systems without SELinux, the flag is a no-op.

Fixes #3199