### PR TITLE
kernel net l2tp: drop flow hash on forward

### DIFF
--- a/patches/openwrt/0010-net-l2tp-drop-flow-hash-on-forward.patch
+++ b/patches/openwrt/0010-net-l2tp-drop-flow-hash-on-forward.patch
@@ -1,0 +1,49 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Mon, 26 Feb 2024 14:43:09 +0100
+Subject: net l2tp: drop flow hash on forward
+
+Drop the flow-hash of the skb when forwarding to the L2TP netdev.
+
+This avoids from the L2TP qdisc using the flow-hash from the outer
+packet.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/generic/pending-5.15/987-net-l2tp-drop-flow-hash-on-forward.patch b/target/linux/generic/pending-5.15/987-net-l2tp-drop-flow-hash-on-forward.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..6627ec70cf01efefded8561bda2a3166a915f098
+--- /dev/null
++++ b/target/linux/generic/pending-5.15/987-net-l2tp-drop-flow-hash-on-forward.patch
+@@ -0,0 +1,32 @@
++From 4a44a52f16ccd3d03e0cb5fb437a5eb31a5f9f05 Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Mon, 26 Feb 2024 14:39:34 +0100
++Subject: [PATCH] net l2tp: drop flow hash on forward
++
++Drop the flow-hash of the skb when forwarding to the L2TP netdev.
++
++This avoids from the L2TP qdisc using the flow-hash from the outer
++packet.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ net/l2tp/l2tp_eth.c | 3 +++
++ 1 file changed, 3 insertions(+)
++
++diff --git a/net/l2tp/l2tp_eth.c b/net/l2tp/l2tp_eth.c
++index 6cd97c75445c..9a36e174984c 100644
++--- a/net/l2tp/l2tp_eth.c
+++++ b/net/l2tp/l2tp_eth.c
++@@ -136,6 +136,9 @@ static void l2tp_eth_dev_recv(struct l2tp_session *session, struct sk_buff *skb,
++ 	/* checksums verified by L2TP */
++ 	skb->ip_summed = CHECKSUM_NONE;
++ 
+++	/* drop outer flow-hash */
+++	skb_clear_hash(skb);
+++
++ 	skb_dst_drop(skb);
++ 	nf_reset_ct(skb);
++ 
++-- 
++2.43.0
++


### PR DESCRIPTION
Drop the flow-hash of the skb when forwarding to the L2TP netdev.

This avoids from the L2TP qdisc using the flow-hash from the outer packet, which is in case of a VPN connection always identical.

This allows queuing mechanisms to correctly identify flows within the mesh-vpn on platforms which include L4 into the flow-hash receives from hardware. This is (at least) the case for MediaTek Filogic platforms.