### PR TITLE
docs: fix AVM Recovery Tool url in v2023.1.1 release notes

### DIFF
--- a/docs/releases/v2023.1.1.rst
+++ b/docs/releases/v2023.1.1.rst
@@ -12,14 +12,14 @@ Upgrades to this version are only supported from releases v2021.1 and later.
 **Note:**
 This release was found to be soft-bricking AVM Fritz!Box 7520 and 7530.
 We advice to not offer the release for these two devices until this gets fixed.
-Affected devices can be recovered to Fritz!OS and then reinstalled by using the (`AVM Recovery Tool <http://ftp.avm.de/fritzbox/fritzbox-7530/other/recover/>`_)
+Affected devices can be recovered to Fritz!OS and then reinstalled by using the (`AVM Recovery Tool <https://download.avm.de/fritzbox/fritzbox-7530/other/recover/>`_)
 
 Bugfixes
 --------
 
-- x86: fix config loss during direct upgrades from v2021.1.x to v2023.1.x  (`#2972 <https://github.com/freifunk-gluon/gluon/pull/2972>`_)
+- x86: fix config loss during direct upgrades from v2021.1.x to v2023.1.x (`#2972 <https://github.com/freifunk-gluon/gluon/pull/2972>`_)
 
-- tunneldigger: fix regression in v2023.1 caused by a always failing watchdog script resulting in endless restarts (`#2987 <https://github.com/freifunk-gluon/gluon/pull/2987>`_)
+- tunneldigger: fix regression in v2023.1 caused by an always failing watchdog script resulting in endless restarts (`#2987 <https://github.com/freifunk-gluon/gluon/pull/2987>`_)
 
 - tunneldigger: fix regression in v2023.1 with DNS lookups not using the wan-dnsmasq (`#3001 <https://github.com/freifunk-gluon/gluon/pull/3001>`_)
 


### PR DESCRIPTION
`http://ftp.avm.de` seems to be unavailable. Update the url to the new (?) address.