### PR TITLE
ath79-generic: dir-825-b1 drop class tiny

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -144,7 +144,6 @@ device('d-link-dir-505', 'dlink_dir-505', {
 
 device('d-link-dir825b1', 'dlink_dir-825-b1', {
 	factory = false,
-	class = 'tiny', -- Only 6M of usable Firmware space
 })
 
 


### PR DESCRIPTION
upstream increased partition size to 7.625 MiB in openwrt-23.05
https://github.com/openwrt/openwrt/commit/aca8bb5cc332f0ffdf4249e76b0a56716f98bef0

I suggest removing class tiny for now.
This should be backported to v2023.2.x