### PR TITLE
ath79-nand: drop broken manifest alias

### DIFF
--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -45,9 +45,6 @@ device('gl.inet-gl-xe300', 'glinet_gl-xe300', {
 
 device('netgear-wndr3700-v4', 'netgear_wndr3700-v4', {
 	factory_ext = '.img',
-	manifest_aliases = {
-		'netgear-wndr3700v4', -- Upgrade from OpenWrt 19.07
-	},
 })
 
 device('netgear-wndr4300', 'netgear_wndr4300', {


### PR DESCRIPTION
fix 5deb3aaeffbd27880906e6b33ebc9cc39d2c4a23

This upgrade path never worked due to increase of the kernel partition size.
They dropped this name from SUPPORTED_DEVICES upstream to prevent devices from breaking: https://github.com/openwrt/openwrt/commit/0d28e5d6440d2a37841a207f943e6e5a23172883

Drop this, so devices stop trying to update every hour.
Devices need to be reinstalled manually with a factory image with tools like nmrpflash.
[instructions on the forum](https://forum.openwrt.org/t/updating-wndr3700v4-from-v17-lede/185510/14)