### PR TITLE
re-add: ath79 NETGEAR WNDRMAC v2

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -78,6 +78,7 @@ ath79-generic
   - WNDR3700 (v1, v2)
   - WNDR3800
   - WNR2200 (8M, 16M)
+  - WNDRMAC (v2)
 
 * OCEDO
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -228,7 +228,7 @@ device('netgear-wnr2200-16m', 'netgear_wnr2200-16m', {
 	factory_ext = '.img',
 })
 
-device('netgear-wndrmacv2', 'wndrmacv2', {
+device('netgear-wndrmac-v2', 'netgear_wndrmac-v2', {
 	factory_ext = '.img',
 })
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -228,6 +228,9 @@ device('netgear-wnr2200-16m', 'netgear_wnr2200-16m', {
 	factory_ext = '.img',
 })
 
+device('netgear-wndrmacv2', 'wndrmacv2', {
+	factory_ext = '.img',
+})
 
 -- OCEDO
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [ ] Other:
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
  - Doesnt have MAC printed on label or packaging
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [n/a] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [n/a] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [n/a] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`