### PR TITLE
Wifi-related code cleanup

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -36,11 +36,7 @@ local function get_wlan_mac_from_driver(radio, vif)
 		return nil
 	end
 
-	for i, addr in ipairs(addresses) do
-		if i == vif then
-			return addr
-		end
-	end
+	return addresses[vif]
 end
 
 function M.get_wlan_mac(_, radio, index, vif)

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -161,7 +161,7 @@ if wireless.device_uses_11a(uci) and not wireless.preserve_channels(uci) then
 			return
 		end
 
-		local phy = wireless.find_phy(uci:get_all('wireless', radio))
+		local phy = wireless.find_phy(config)
 
 		local ht = r:option(ListValue, 'outdoor_htmode', translate('HT Mode') .. ' (' .. radio .. ')')
 		ht:depends(outdoor, true)


### PR DESCRIPTION
Two simple improvements I noticed when I implemented #3223.

Other refactoring like passing around only section names instead of whole radio config tables turned out to be not worthwhile, as we usually have the full config object from a `uci:foreach()` call anyways,