### PR TITLE
kirkwood: add support for Linksys E4200 v2

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -292,6 +292,16 @@
     "targets/targets.mk",
     "targets/bcm27xx.inc"
   ],
+  "kirkwood-generic": [
+    "targets/kirkwood-generic",
+    ".github/workflows/build-gluon.yml",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk"
+  ],
   "mvebu-cortexa9": [
     "targets/mvebu-cortexa9",
     ".github/workflows/build-gluon.yml",

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -120,6 +120,9 @@ local primary_addrs = {
 			'openmesh,a42',
 			'openmesh,a62',
 		}},
+		{'kirkwood', 'generic', {
+			'linksys,e4200-v2',
+		}},
 		{'mpc85xx', 'p1020', {
 			'aerohive,hiveap-330',
 			'ocedo,panda',

--- a/targets/kirkwood-generic
+++ b/targets/kirkwood-generic
@@ -1,0 +1,5 @@
+-- Linksys
+
+device('linksys-e4200-v2', 'linksys_e4200-v2', {
+	broken = true, -- 802.11s untested
+})

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -29,5 +29,6 @@ $(eval $(call GluonTarget,x86,64))
 ifeq ($(BROKEN),1)
 $(eval $(call GluonTarget,bcm27xx,bcm2710)) # BROKEN: Untested
 $(eval $(call GluonTarget,bcm27xx,bcm2711)) # BROKEN: No 11s support, no reset button, sys LED issues
+$(eval $(call GluonTarget,kirkwood,generic)) # BROKEN: 11s support untested
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
 endif


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios 
  - [ ] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
    - [x] No Radio LEDs available
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`