### PR TITLE
ramips/mt7621: add D-Link Exo AC2600 DIR-882

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -425,6 +425,7 @@ ramips-mt7621
   - COVR-X1860 (A1)
   - DAP-X1860 (A1)
   - DIR-860L (B1)
+  - DIR-882 (A1)
 
 * GL.iNet
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -44,6 +44,8 @@ device('d-link-dap-x1860-a1', 'dlink_dap-x1860-a1')
 
 device('d-link-dir-860l-b1', 'dlink_dir-860l-b1')
 
+device('d-link-dir-882-a1', 'dlink_dir-882-a1')
+
 
 -- GL.iNet
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP (according to openwrt)

- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity

- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`
