### PR TITLE
docs: site: pubkey_privacy works for wireguard

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -297,7 +297,7 @@ mesh_vpn
   data; this prevents malicious ISPs from correlating VPN sessions with specific mesh
   nodes via public respondd data. If this is of no concern in your threat model,
   this behaviour can be disabled (and thus announcing the public key be enabled) by
-  setting `pubkey_privacy` to `false`. At the moment, this option only affects fastd.
+  setting `pubkey_privacy` to `false`.
 
   The `fastd` section configures settings specific to the *fastd* VPN
   implementation.


### PR DESCRIPTION
I removed a comment from the site documentation citing, that fastd is the only vpn where `pubkey_privacy` has an effect.
I just verified by editing /lib/gluon/site.json and running gluon-reconfigure and reboot, that this settings also works for wireguard VPNs.

I'm not sure whether it works for **Tunneldigger**, so this documentation change requires further feedback.
Is there a fourth VPN provider we support?