### PR TITLE
mesh-vpn-wireguard: actually set the mtu from the site.conf on the wireguard interface

### DIFF
--- a/package/gluon-mesh-vpn-wireguard/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/package/gluon-mesh-vpn-wireguard/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -60,7 +60,8 @@ uci:section('network', 'interface', 'wg_mesh', {
 	proto = 'wireguard',
 	fwmark = 1,
 	private_key = wg_private_key,
-	mtu = active_vpn.mtu(),
+	-- Add 70 bytes for IPv6 VXLAN overhead
+	mtu = active_vpn.mtu() + 70,
 })
 
 uci:section('network', 'interface', 'mesh_wg_mesh', {

--- a/package/gluon-mesh-vpn-wireguard/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
+++ b/package/gluon-mesh-vpn-wireguard/luasrc/lib/gluon/upgrade/400-mesh-vpn-wireguard
@@ -6,6 +6,8 @@ local util = require('gluon.util')
 local site = require 'gluon.site'
 local sp = util.subprocess
 local wait = require 'posix.sys.wait'
+local vpn_core = require('gluon.mesh-vpn')
+local _, active_vpn = vpn_core.get_active_provider()
 
 local wg_private_key = uci:get("network_gluon-old", 'wg_mesh', "private_key")
 
@@ -58,6 +60,7 @@ uci:section('network', 'interface', 'wg_mesh', {
 	proto = 'wireguard',
 	fwmark = 1,
 	private_key = wg_private_key,
+	mtu = active_vpn.mtu(),
 })
 
 uci:section('network', 'interface', 'mesh_wg_mesh', {


### PR DESCRIPTION
Before, we did only set the MTU on mesh-vpn (the vxlan interface), which has to be smaller than the set value on the wg_mesh (wireguard interface).

On WAN interfaces with an MTU of 1500, the default wireguard MTU of 1420 is optimal (as wireguard takes 80 Bytes).
Though it would be better for PPPoE interfaces (which typically have a MTU of 1496) to use a MTU of 1416 or less (1406 being a typical value, currently used by FFMUC, FFH and FFAC).

[The documentation](https://gluon.readthedocs.io/en/latest/user/mtu.html) mentions an optimal wireguard MTU of 1376.
This would then also work on WAN-interfaces with an MTU of 1436 on IPv4 respective 1462 for IPv6).

This PR changes the behavior for mesh-vpn-wireguard to set the correct MTU from the site.conf.

Curiously, this did never lead to any known problems in one of the stated communities, and was found when debugging a fragmentation problem.

Eventually, one should also set the MTU on the wireguard gateway/supernode to something less than 1420..?