### PR TITLE
ath79-generic: TP-Link Archer C7 v2: Fix region selection for factory image

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -390,6 +390,11 @@ device('teltonika-rut230-v1', 'teltonika_rut230-v1')
 
 -- TP-Link
 
+local tplink_region_suffix = ''
+if (env.GLUON_REGION or '') ~= '' then
+	tplink_region_suffix = '-' .. env.GLUON_REGION
+end
+
 device('tp-link-archer-a7-v5', 'tplink_archer-a7-v5', {
 	packages = ATH10K_PACKAGES_QCA9880,
 })
@@ -422,6 +427,7 @@ device('tp-link-archer-c6-v2-eu-ru-jp', 'tplink_archer-c6-v2', {
 
 device('tp-link-archer-c7-v2', 'tplink_archer-c7-v2', {
 	packages = ATH10K_PACKAGES_QCA9880,
+	factory = '-squashfs-factory' .. tplink_region_suffix,
 })
 
 device('tp-link-archer-c7-v4', 'tplink_archer-c7-v4', {


### PR DESCRIPTION
The Archer C7 v2 needs a different factory image depending on the region (EU or US); this got lost during the ar71xx -> ath79 migration.

The OpenWrt factory image without a region suffix is only installable on very old TP-Link firmwares from before the region split was introduced. The region-specific firmware works for both old and new TP-Link firmwares.

Fixes: 8fdda51f9801 ("ath79-generic: (re)add support for archer-c7-v2 (#2437)")