### PR TITLE
mt76: work around dropped TX status reporting

### DIFF
--- a/patches/openwrt/0010-mt76-include-fixes-for-MT7603-MT7612.patch
+++ b/patches/openwrt/0010-mt76-include-fixes-for-MT7603-MT7612.patch
@@ -1,0 +1,175 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 14 Mar 2024 09:39:22 +0100
+Subject: mt76: include fixes for MT7603 / MT7612
+
+diff --git a/package/kernel/mt76/patches/0001-tx-add-limit-for-TXS-ack-override.patch b/package/kernel/mt76/patches/0001-tx-add-limit-for-TXS-ack-override.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..568c590f24c251dda70522865af32b3753cd5beb
+--- /dev/null
++++ b/package/kernel/mt76/patches/0001-tx-add-limit-for-TXS-ack-override.patch
+@@ -0,0 +1,79 @@
++From a95c23b2c2e923ed293eb794b74735c7d6c5b272 Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Fri, 1 Mar 2024 17:41:33 +0100
++Subject: [PATCH 1/2] tx: add limit for TXS ack override
++
++Add an upper limit for overriding missing TX status for each client.
++
++This avoids clients, which to mac80211 still appear as if they are
++connected when in fact they are not reachable for the AP anymore.
++
++This can happen, as the radio (observed on MT7603 in particular) might
++skip TX status-reporting which the host will then mark as acked. This
++prevents the client from timing out and become "sticky" on the AP.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ mt76.h |  2 ++
++ tx.c   | 20 +++++++++++++++++++-
++ 2 files changed, 21 insertions(+), 1 deletion(-)
++
++diff --git a/mt76.h b/mt76.h
++index fd527649..6d9b7028 100644
++--- a/mt76.h
+++++ b/mt76.h
++@@ -330,6 +330,8 @@ struct mt76_wcid {
++ 	u8 rx_key_pn[IEEE80211_NUM_TIDS + 1][6];
++ 	u16 cipher;
++ 
+++	u8 txs_failed_cnt;
+++
++ 	u32 tx_info;
++ 	bool sw_iv;
++ 
++diff --git a/tx.c b/tx.c
++index 1809b032..65d6104f 100644
++--- a/tx.c
+++++ b/tx.c
++@@ -91,6 +91,7 @@ __mt76_tx_status_skb_done(struct mt76_dev *dev, struct sk_buff *skb, u8 flags,
++ {
++ 	struct ieee80211_tx_info *info = IEEE80211_SKB_CB(skb);
++ 	struct mt76_tx_cb *cb = mt76_tx_skb_cb(skb);
+++	struct mt76_wcid *wcid;
++ 	u8 done = MT_TX_CB_DMA_DONE | MT_TX_CB_TXS_DONE;
++ 
++ 	flags |= cb->flags;
++@@ -98,12 +99,29 @@ __mt76_tx_status_skb_done(struct mt76_dev *dev, struct sk_buff *skb, u8 flags,
++ 
++ 	if ((flags & done) != done)
++ 		return;
+++	
+++	wcid = rcu_dereference(dev->wcid[cb->wcid]);
++ 
++ 	/* Tx status can be unreliable. if it fails, mark the frame as ACKed */
++ 	if (flags & MT_TX_CB_TXS_FAILED) {
+++		/* Increment station counter */
+++		if (wcid && wcid->sta)
+++			wcid->txs_failed_cnt++;
+++
++ 		info->status.rates[0].count = 0;
++ 		info->status.rates[0].idx = -1;
++-		info->flags |= IEEE80211_TX_STAT_ACK;
+++
+++		/**
+++		 * Check if station counter exceeds the limit for
+++		 * implicit acks. If not, mark the frame as ACKed.
+++		 */
+++		if (!wcid || wcid->txs_failed_cnt < 25) {
+++			info->flags |= IEEE80211_TX_STAT_ACK;
+++		}
+++	} else if (info->flags & IEEE80211_TX_STAT_ACK) {
+++		/* Reset station counter */
+++		if (wcid && wcid->sta)
+++			wcid->txs_failed_cnt = 0;
++ 	}
++ 
++ 	__skb_queue_tail(list, skb);
++-- 
++2.43.0
++
+diff --git a/package/kernel/mt76/patches/0002-mt76x02-avoid-action-ghost-ack.patch b/package/kernel/mt76/patches/0002-mt76x02-avoid-action-ghost-ack.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..0910ed99ef473db9cf4129f88017912b5d63267d
+--- /dev/null
++++ b/package/kernel/mt76/patches/0002-mt76x02-avoid-action-ghost-ack.patch
+@@ -0,0 +1,80 @@
++From 3c9ecc0c77e85d9ff91faddde59764fbc9316b7c Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Sat, 2 Mar 2024 13:14:49 +0100
++Subject: [PATCH 2/2] mt76x02: avoid action ghost-ack
++
++On PMF enabled networks, chip reports ACTION frames always as acked.
++
++In case a roaming-assistant sens link-measurements periodically,
++this results in the station never becoming inactive and not being removed
++from the AP's station list.
++
++Avoid this from happening by marking action frames sent on a PMF enabled
++network as no-ack.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ mt76x02_mac.c | 27 +++++++++++++++++++++++++++
++ mt76x02_mac.h |  1 +
++ 2 files changed, 28 insertions(+)
++
++diff --git a/mt76x02_mac.c b/mt76x02_mac.c
++index d5db6ffd..672e01ec 100644
++--- a/mt76x02_mac.c
+++++ b/mt76x02_mac.c
++@@ -544,6 +544,7 @@ void mt76x02_send_tx_status(struct mt76x02_dev *dev,
++ 	struct ieee80211_tx_status status = {
++ 		.info = &info
++ 	};
+++	struct ieee80211_hdr *hdr;
++ 	static const u8 ac_to_tid[4] = {
++ 		[IEEE80211_AC_BE] = 0,
++ 		[IEEE80211_AC_BK] = 1,
++@@ -619,6 +620,32 @@ void mt76x02_send_tx_status(struct mt76x02_dev *dev,
++ 		*update = 1;
++ 	}
++ 
+++	if (msta && status.skb &&
+++	    (status.info->flags & IEEE80211_TX_STAT_ACK)) {
+++		hdr = (struct ieee80211_hdr *)status.skb->data;
+++
+++		if (ieee80211_has_protected(hdr->frame_control) &&
+++		    ieee80211_is_robust_mgmt_frame(status.skb)) {
+++			/**
+++			 * On PMF enabled networks, chip reports ACTION frames
+++			 * always as acked.
+++			 *
+++			 * In case a roaming-assistant sends link-measurements
+++			 * periodically, this results in the station never
+++			 * becoming inactive and not being removed from the
+++			 * AP's station list.
+++			 */
+++
+++			if (msta->n_enc_mgmt >= 25) {
+++				status.info->flags &= ~IEEE80211_TX_STAT_ACK;
+++			} else {
+++				msta->n_enc_mgmt++;
+++			}
+++		} else {
+++			msta->n_enc_mgmt = 0;
+++		}
+++	}
+++
++ 	if (status.skb) {
++ 		info = *status.info;
++ 		len = status.skb->len;
++diff --git a/mt76x02_mac.h b/mt76x02_mac.h
++index 5dc6c834..1bd2288f 100644
++--- a/mt76x02_mac.h
+++++ b/mt76x02_mac.h
++@@ -39,6 +39,7 @@ struct mt76x02_sta {
++ 	struct mt76x02_vif *vif;
++ 	struct mt76x02_tx_status status;
++ 	int n_frames;
+++	u8 n_enc_mgmt;
++ 
++ 	struct ewma_pktlen pktlen;
++ };
++-- 
++2.43.0
++


### PR DESCRIPTION
These fixes were developed for MT7603 and MT7612. Originally, we've discovered the TX-status reporting mishandles cases where continuous action frames are sent over a mesh-link but no actual data traffic is transmitted over the link.

This leads to a client "sticking" to the AP even if it already left the covered area.

In the process, we've discovered this patchset might(!) also help mitigate issues seen on MT7916 based platforms. Therefore, i think it is a good idea to open this PR as a draft to serve as a starting point for discussions on this matter.

I've rebased this patchset on current master, build testing by the CI runners now. We've tested fixes with the mt76 patches based on v2023.2.1 releases.

## MT7612 affected node

### First example

![image](https://github.com/freifunk-gluon/gluon/assets/16539439/3a833ce1-e651-4e40-b577-d9a9df56a248)

Dashboard: https://stats.darmstadt.freifunk.net/d/000000021/router-meshviewer-export?var-node=3894edf5ff9b&orgId=1&from=1708931806122&to=1711420462467

This Node was the one we've originally diagnosed the issue. You can see the devices accumulating on the OWE VAP for the 5 GHz radio, as the driver incorrectly marks all action-frames sent to the device as acked. They are dropped after 24h for rekeying.

You can observe a sticky client on the 2.4 GHz radio (MT7603). This does not matter if it happens on the OWE or unencrypted VAP. The node will in this case pollute the airtime and be unavailable to other clients.

### Second example

I have no access to this node, but it shows the same symptoms:

![image](https://github.com/freifunk-gluon/gluon/assets/16539439/206e90f5-5470-4efd-b335-c0033362449a)

Dashboard: https://stats.darmstadt.freifunk.net/d/000000021/router-meshviewer-export?var-node=3894edf70c46&orgId=1&from=1713058330554&to=1715097473774


## MT7986 Nodes

We've seen cases where MT7986 and MT7981 radios might experience degraded performance. Coincidentally, this patchset seems to mitigate similar issues as well (We only have some days of testing on this hypothesis).

![image](https://github.com/freifunk-gluon/gluon/assets/16539439/3e9c9d53-7390-476a-b36b-444ef9fb2658)

![image](https://github.com/freifunk-gluon/gluon/assets/16539439/dc36b000-b451-4e6d-9c61-1f0f836c1c74)

Dashboard: https://stats.darmstadt.freifunk.net/d/000000021/router-meshviewer-export?var-node=c87f54231ad8&orgId=1&from=1713058547177&to=1715642058103


