### PR TITLE
docs: vpn: Add documentation for evaluation of vpn protocols

### DIFF
--- a/docs/user/mtu.rst
+++ b/docs/user/mtu.rst
@@ -1,3 +1,5 @@
+.. _mtu:
+
 MTU for Mesh-VPN
 ================
 


### PR DESCRIPTION
T-X created a pretty cool table to evaluate VPN uplink protocols used in gluon on this hedgedoc: 
https://md.chaotikum.org/zRkW6JXXQs-8WCnwdtig5w?view

To give it more visibility, I would like to add it to the docs as suggested somewhere.

I hope this is fine for you @T-X and @rotanid ?