### PR TITLE
docs: add Gluon v2023.2.3 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the future development of Gluon.
 
 Please refrain from using the `master` branch for anything else but development purposes!
 Use the most recent release instead. You can list all releases by running `git tag`
-and switch to one by running `git checkout v2023.2.2 && make update`.
+and switch to one by running `git checkout v2023.2.3 && make update`.
 
 If you're using the autoupdater, do not autoupdate nodes with anything but releases.
 If you upgrade using random master commits the nodes *might break* eventually.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = 'Project Gluon'
 author = 'Project Gluon'
 
 # The short X.Y version
-version = '2023.2.2'
+version = '2023.2.3'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -5,6 +5,7 @@ Release Notes
   :caption: Gluon 2023.2
   :maxdepth: 2
 
+  v2023.2.3
   v2023.2.2
   v2023.2.1
   v2023.2

--- a/docs/releases/v2023.2.3.rst
+++ b/docs/releases/v2023.2.3.rst
@@ -1,0 +1,59 @@
+Gluon 2023.2.3
+==============
+
+Added hardware support
+----------------------
+
+ath79-generic
+~~~~~~~~~~~~~
+
+- NETGEAR
+
+  - WNDRMAC v2
+
+
+mpc85xx-p1020
+~~~~~~~~~~~~~
+
+- Hewlett-Packard
+
+  - MSM460
+
+
+Bugfixes
+--------
+
+* Factory images for TP-Link Archer C7 v2 now contain the correct region code
+  (`#3260 <https://github.com/freifunk-gluon/gluon/issues/3260>`_)
+
+* Fixed an issue where some bootloader versions of the NETGEAR EX6150 v2 failed
+  to boot Gluon images in rare cases
+  (`Upstream <https://github.com/openwrt/openwrt/commit/de59fc45402ff03e320264c8204f6928090534ad>`_)  
+
+* Fixed boot procedure becoming stuck on Enterasys WS-AP3710i devices
+  (`#3248 <https://github.com/freifunk-gluon/gluon/issues/3248>`_)
+
+
+Known issues
+------------
+
+* Unstable wireless with certain MediaTek devices (`#3154 <https://github.com/freifunk-gluon/gluon/issues/3154>`_)
+
+* The integration of the BATMAN_V routing algorithm is incomplete.
+
+  - Mesh neighbors don't appear on the status page. (`#1726 <https://github.com/freifunk-gluon/gluon/issues/1726>`_)
+    Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new throughput
+    metric.
+  - Throughput values are not correctly acquired for different interface types.
+    (`#1728 <https://github.com/freifunk-gluon/gluon/issues/1728>`_)
+    This affects virtual interface types like bridges and VXLAN.
+
+* Default TX power on many Ubiquiti devices is too high, correct offsets are unknown
+  (`#94 <https://github.com/freifunk-gluon/gluon/issues/94>`_)
+
+  Reducing the TX power in the Advanced Settings is recommended.
+
+* In configurations without VXLAN, the MAC address of the WAN interface is modified even when Mesh-on-WAN is disabled
+  (`#496 <https://github.com/freifunk-gluon/gluon/issues/496>`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when promiscuous mode is disallowed).

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2023.2.2
+-- This is an example site configuration for Gluon v2023.2.3
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -8,7 +8,7 @@ Gluon's releases are managed using `Git tags`_. If you are just getting
 started with Gluon we recommend to use the latest stable release of Gluon.
 
 Take a look at the `list of gluon releases`_ and notice the latest release,
-e.g. *v2023.2.2*. Always get Gluon using git and don't try to download it
+e.g. *v2023.2.3*. Always get Gluon using git and don't try to download it
 as a Zip archive as the archive will be missing version information.
 
 Please keep in mind that there is no "default Gluon" build; a site configuration
@@ -53,7 +53,7 @@ Building the images
 -------------------
 
 To build Gluon, first check out the repository. Replace *RELEASE* with the
-version you'd like to checkout, e.g. *v2023.2.2*.
+version you'd like to checkout, e.g. *v2023.2.3*.
 
 ::
 


### PR DESCRIPTION
There were some fixes since the last v2023.2.x release in Gluon as well as upstream OpenWrt regarding device compatibility. Let's do another minor release.

## Changes up to `068cca0e`
```
068cca0e mpc85xx-p1020: add support for Hewlett-Packard MSM460 (#3275)
d0226591 Merge pull request #3273 from blocktrron/v2023.2.x-updates
71c91b9c modules: update routing
75c6d44b modules: update packages
bee44b93 modules: update openwrt
34b1eed7 ath79-generic: TP-Link Archer C7 v2: Fix region selection for factory image (#3260)
82822a56 Merge pull request #3256 from blocktrron/v2023.2.x-updates
fefdbd74 modules: update routing
e19f183c modules: update packages
32ebeb0e modules: update openwrt
00160f5b gluon-core: lua: wireless: use libiwinfo-lua for find_phy() (#3239)
83fb430e ath79-generic: add support for NETGEAR WNDRMAC v2 (#3232)
```

## Dependencies
Depends on #3278