### PR TITLE
treewide: Update main branch name

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'next'
       - 'v202[0-9].[0-9].x'
     tags:

--- a/.github/workflows/build-gluon.yml
+++ b/.github/workflows/build-gluon.yml
@@ -2,7 +2,7 @@ name: Build Gluon
 on:
   push:
     branches:
-      - master
+      - main
       - next
       - 'v20[2-9][0-9].[0-9].x'
   pull_request:

--- a/.github/workflows/bump-gluon.yml
+++ b/.github/workflows/bump-gluon.yml
@@ -7,7 +7,7 @@ on:
       branch:
         description: "Branch to create update for"
         required: true
-        default: "master"
+        default: "main"
 
 jobs:
   update-openwrt:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,13 +29,13 @@ discuss there. We maintain a [list of rejected features] and we'd like to
 kindly ask you to review it first. In general, looking for duplicates may save
 you some time.
 
-Develop on top of master
-------------------------
+Develop on top of main
+----------------------
 If you are not developing something specific to a release (like for example a
 security fix to a feature that got completely rewritten since the release),
-develop it on top of the master branch. New features and even feature changes
+develop it on top of the main branch. New features and even feature changes
 aren't usually backported to old releases, but will be included in the upcoming
-release, which will be built from master.
+release, which will be built from main.
 
 Use descriptive commit messages
 -------------------------------

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Gluon](https://github.com/freifunk-gluon/gluon/actions/workflows/build-gluon.yml/badge.svg?branch=master)](https://github.com/freifunk-gluon/gluon/actions/workflows/build-gluon.yml)
+[![Build Gluon](https://github.com/freifunk-gluon/gluon/actions/workflows/build-gluon.yml/badge.svg?branch=main)](https://github.com/freifunk-gluon/gluon/actions/workflows/build-gluon.yml)
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](https://opensource.org/license/bsd-2-clause/)
 [![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/freifunk-gluon/gluon?sort=semver)](https://github.com/freifunk-gluon/gluon/releases/latest)
 
@@ -57,12 +57,12 @@ the future development of Gluon.
 
 ## Use a release!
 
-Please refrain from using the `master` branch for anything else but development purposes!
+Please refrain from using the `main` branch for anything else but development purposes!
 Use the most recent release instead. You can list all releases by running `git tag`
 and switch to one by running `git checkout v2023.2.2 && make update`.
 
 If you're using the autoupdater, do not autoupdate nodes with anything but releases.
-If you upgrade using random master commits the nodes *might break* eventually.
+If you upgrade using random main commits the nodes *might break* eventually.
 
 ## Mailinglist
 

--- a/docs/features/monitoring.rst
+++ b/docs/features/monitoring.rst
@@ -135,5 +135,5 @@ Adding a data provider
 ----------------------
 
 To add a provider, you need to install a shared object into ``/lib/gluon/respondd``.
-For more information, refer to the `respondd README <https://github.com/freifunk-gluon/packages/blob/master/net/respondd/README.md>`_
+For more information, refer to the `respondd README <https://github.com/freifunk-gluon/packages/blob/main/net/respondd/README.md>`_
 and have a look the existing providers.

--- a/docs/features/vpn.rst
+++ b/docs/features/vpn.rst
@@ -167,7 +167,7 @@ gateway, tries to establish a connection, and if it fails, tries to connect
 to the next gateway. This approach has several advantages, such as load
 balancing VPN connection attempts and avoiding problems with offline gateways.
 More information about the wgpeerselector and its algorithm can be found
-`here <https://github.com/freifunk-gluon/packages/blob/master/net/wgpeerselector/README.md>`__.
+`here <https://github.com/freifunk-gluon/packages/blob/main/net/wgpeerselector/README.md>`__.
 
 On the gluon node both VXLAN and the wgpeerselector are well integrated and no
 explicit configuration of those tools is necessary, once the general WireGuard

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,7 +86,7 @@ License
 
 See LICENCE_
 
-.. _LICENCE: https://github.com/freifunk-gluon/gluon/blob/master/LICENSE
+.. _LICENCE: https://github.com/freifunk-gluon/gluon/blob/main/LICENSE
 
 Indices and tables
 ==================

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -809,7 +809,7 @@ PACKAGES_${feed}_COMMIT
 
 PACKAGES_${feed}_BRANCH
   Optional: The branch of the repository the given commit ID can be found in.
-  Defaults to the default branch of the repository (usually ``master``)
+  Defaults to the default branch of the repository (usually ``main`` or ``master``)
 
 These variables are always all uppercase, so for an entry ``foo`` in GLUON_SITE_FEEDS,
 the corresponding configuration variables would be ``PACKAGES_FOO_REPO``,


### PR DESCRIPTION
Following the rename of master to main, update everything that references the branch.