### PR TITLE
kirkwood-generic: fix device name of Linksys E4200 v2

### DIFF
--- a/targets/kirkwood-generic
+++ b/targets/kirkwood-generic
@@ -1,5 +1,5 @@
 -- Linksys
 
-device('linksys-e4200-v2', 'linksys_e4200-v2', {
+device('linksys-e4200-v2-viper', 'linksys_e4200-v2', {
 	broken = true, -- 802.11s untested
 })


### PR DESCRIPTION
The model name has a codename suffix:
https://git.openwrt.org/?p=openwrt/openwrt.git;a=blob;f=target/linux/kirkwood/files/arch/arm/boot/dts/kirkwood-e4200-v2.dts;h=bfd708a677c96a9f3bdf80ead2db4498487ac5f8;hb=refs/heads/openwrt-23.05#l6

See also: https://github.com/freifunkMUC/site-ffm/issues/415#issuecomment-2187154401