### PR TITLE
ramips-mt7621: add support for Xiaomi Mi Router 4a Gigabit Edition v2

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -467,7 +467,7 @@ ramips-mt7621
 * Xiaomi
 
   - Xiaomi Mi Router 3G (v1, v2)
-  - Xiaomi Mi Router 4A (Gigabit Edition v1)
+  - Xiaomi Mi Router 4A (Gigabit Edition v1, v2)
 
 * Zbtlink
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -126,7 +126,6 @@ device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {
 	factory = false,
 })
 
-
 device('xiaomi-mi-router-4a-gigabit-edition-v2', 'xiaomi_mi-router-4a-gigabit-v2', {
 	factory = false,
 })

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -126,6 +126,12 @@ device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {
 	factory = false,
 })
 
+
+device('xiaomi-mi-router-4a-gigabit-edition-v2', 'xiaomi_mi-router-4a-gigabit-v2', {
+	factory = false,
+})
+
+
 device('xiaomi-mi-router-3g', 'xiaomi_mi-router-3g', {
 	factory = false,
 })

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -130,7 +130,6 @@ device('xiaomi-mi-router-4a-gigabit-edition-v2', 'xiaomi_mi-router-4a-gigabit-v2
 	factory = false,
 })
 
-
 device('xiaomi-mi-router-3g', 'xiaomi_mi-router-3g', {
 	factory = false,
 })


### PR DESCRIPTION
Closes #3291

- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: <First: Set Password for WLAN and System in Original Web interface. Second: Install Exploit as described at OpenWRT, Third: Copy sysupgrade image to /tmp via FTP, Forth: Open Telnet Session to go to /tmp directory to call mtd -e OS1 -r write name-of-your-sysupgrade-image.bin OS1  >
https://openwrt.org/inbox/toh/xiaomi/xiaomi_mi_router_4a_gigabit_edition#notes_on_firmware_exploit_procedure
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
xiaomi-mi-router-4a-gigabit-edition-v2
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`
