### PR TITLE
private-wifi: rename ifname to wan_wifiX to not collide with openwrt devices with more than one wan port

### DIFF
--- a/package/gluon-private-wifi/luasrc/lib/gluon/upgrade/325-gluon-private-wifi
+++ b/package/gluon-private-wifi/luasrc/lib/gluon/upgrade/325-gluon-private-wifi
@@ -12,7 +12,7 @@ wireless.foreach_radio(uci, function(radio)
 		return
 	end
 
-	uci:set('wireless', name, 'ifname', suffix and 'wan' .. suffix)
+	uci:set('wireless', name, 'ifname', suffix and 'wl-wan' .. suffix)
 end)
 
 uci:save('wireless')

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
@@ -81,7 +81,7 @@ function f:write()
 				ssid       = ssid.data,
 				key        = key.data,
 				macaddr    = macaddr,
-				ifname     = suffix and 'wan' .. suffix,
+				ifname     = suffix and 'wl-wan' .. suffix,
 				disabled   = false,
 			})
 


### PR DESCRIPTION
Currently, no device is affected, though it makes sense to improve the current situation by giving more meaningful ifnames anyway.

closes #3290