### PR TITLE
build: extend GLUON_DEBUG with values 0, 1 and 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ GLUON_SITE_VERSION ?= $(shell scripts/getversion.sh '$(GLUON_SITEDIR)')
 
 GLUON_MULTIDOMAIN ?= 0
 GLUON_AUTOREMOVE ?= 0
-GLUON_DEBUG ?= 0
+GLUON_DEBUG ?= 1
 GLUON_MINIFY ?= 1
 
 # Can be overridden via environment/command line/... to use the Gluon

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -239,7 +239,7 @@ GLUON_RELEASE
 
 GLUON_SITE_VERSION
   Version of the site configuration. This string is displayed in the config mode
-  and `gluon-info`. If unset, Gluon generates a version string using `git describe`
+  and ``gluon-info``. If unset, Gluon generates a version string using ``git describe``
   on the site folder.
 
 GLUON_TARGET

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -255,8 +255,17 @@ GLUON_AUTOREMOVE
   as it significantly increases incremental build times.
 
 GLUON_DEBUG
-  Setting ``GLUON_DEBUG=1`` will provide firmware images including debugging symbols usable with GDB or
-  similar tools. Requires a device or target with at least 16 MB of flash space, e.g. `x86-64`. Unset by default.
+  The following values are supported:
+
+  - ``0``: Remove symbol tables and debug information as well as most section and other
+    information not strictly necessary for execution using ``sstrip``. This saves a small amount
+    of flash space over the default ``strip`` command (roughly 70kiB for ath79), but makes any
+    kind of binary analysis much more difficult, as common tools like objdump and gdb can't
+    handle such files at all.
+  - ``1``: Remove symbol tables and debug information from binaries using the standard ``strip``
+    command. This is the default.
+  - ``2``:  Include debugging symbols usable with GDB or similar tools in all binaries of the image.
+    Requires a device or target with at least 16 MB of flash space, e.g. ``x86-64``.
 
 GLUON_MINIFY
   Setting ``GLUON_MINIFY=0`` will omit the minification of scripts during the build process. By

--- a/targets/generic
+++ b/targets/generic
@@ -84,13 +84,16 @@ config('GLUON_MULTIDOMAIN', istrue(env.GLUON_MULTIDOMAIN))
 
 config('AUTOREMOVE', istrue(env.GLUON_AUTOREMOVE))
 
-if istrue(env.GLUON_DEBUG) then
+if (tonumber(env.GLUON_DEBUG) or 0) > 1 then
 	config('DEBUG', true)
 	config('NO_STRIP', true)
 	config('USE_STRIP', false)
 	config('USE_SSTRIP', false)
 
 	try_config('TARGET_ROOTFS_PARTSIZE', 500)
+elseif istrue(env.GLUON_DEBUG) then
+	config('USE_STRIP', true)
+	config('USE_SSTRIP', false)
 end
 
 config('GLUON_MINIFY', istrue(env.GLUON_MINIFY))


### PR DESCRIPTION
Debugging binaries in images that are built with sstrip is extremely
annoying, as not even objdump will work on them.

Switching from sstrip to standard strip increases the ath79 image size
(for some usual Archer C7 v2 configuration I used for testing) by ~70KiB,
or 1.3% of the rootfs size (~1% of the total image size), which is
rarely worth the decreased debuggability.

Extend GLUON_DEBUG to not only distinguish 0 and 1, such that:

- 0 uses sstrip same as before
- 1 switches to regular strip; this is the new default
- 2 includes all debug info, like GLUON_DEBUG=1 did before
