### PR TITLE
scripts: enable checks for unassigned uppercase

### DIFF
--- a/scripts/container.sh
+++ b/scripts/container.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck enable=check-unassigned-uppercase
 
 set -euo pipefail
 
@@ -21,4 +22,3 @@ else
 	echo "Please install either podman or docker. Exiting" >&2
 	exit 1
 fi
-

--- a/scripts/patch.sh
+++ b/scripts/patch.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck enable=check-unassigned-uppercase
 
 set -e
 shopt -s nullglob

--- a/scripts/update-modules.sh
+++ b/scripts/update-modules.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck enable=check-unassigned-uppercase
 
 set -eo pipefail
 
@@ -66,4 +67,3 @@ for MODULE in "OPENWRT" "PACKAGES_PACKAGES" "PACKAGES_ROUTING" "PACKAGES_GLUON";
 	# remove the checkout
 	rm -fr "${CHECKOUT}"
 done
-

--- a/scripts/update-patches.sh
+++ b/scripts/update-patches.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck enable=check-unassigned-uppercase
 
 set -e
 shopt -s nullglob


### PR DESCRIPTION
As almost all variables are upper-case and do not follow the intention of https://github.com/koalaman/shellcheck/issues/1037#issuecomment-341288433 include checks for unassigned upper-case variables.