### PR TITLE
scripts: remove scripts-wide shellcheck excludes

### DIFF
--- a/scripts/default_feeds.sh
+++ b/scripts/default_feeds.sh
@@ -1,2 +1,5 @@
+#!/bin/sh
+
 # list feeds which don't start with #
 DEFAULT_FEEDS="$(awk '!/^#/ {print $2}' openwrt/feeds.conf.default)"
+export DEFAULT_FEEDS

--- a/scripts/lint-sh.sh
+++ b/scripts/lint-sh.sh
@@ -24,5 +24,5 @@ find scripts -type f | while read -r file; do
 	is_scriptfile "$file" || continue
 
 	echo "Checking $file"
-	shellcheck -f gcc -x -e SC2154,SC1090,SC2181,SC2155,SC2148,SC2034,SC2148 "$file"
+	shellcheck -f gcc -x "$file"
 done

--- a/scripts/module_check.sh
+++ b/scripts/module_check.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2154
 
 set -e
 

--- a/scripts/module_check.sh
+++ b/scripts/module_check.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2154
 
 set -e
 
@@ -15,8 +14,10 @@ fi
 need_sync=false
 
 for module in $GLUON_MODULES; do
-	var=$(echo "$module" | tr '[:lower:]/' '[:upper:]_')
-	eval 'commit_expected=${'"${var}"'_COMMIT}'
+	echo "Checking module '$module'"
+	var=${module//\//_}
+	_remote_commit=${var^^}_COMMIT
+	commit_expected=${!_remote_commit}
 
 	prefix=invalid
 	cd "$GLUONDIR/$module" 2>/dev/null && prefix="$(git rev-parse --show-prefix 2>/dev/null)"

--- a/scripts/modules.sh
+++ b/scripts/modules.sh
@@ -1,4 +1,8 @@
+#!/bin/sh
+
+# shellcheck source=./modules
 . ./modules
+
 [ ! -f "$GLUON_SITEDIR"/modules ] || . "$GLUON_SITEDIR"/modules
 
 # shellcheck disable=SC2086

--- a/scripts/sha256sum.sh
+++ b/scripts/sha256sum.sh
@@ -15,6 +15,7 @@ else
 	exit 1
 fi
 
+# shellcheck disable=SC2181
 [ "$?" -eq 0 ] || exit 1
 
 echo "$ret" | awk '{ print $1 }'

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2154
 
 set -e
 

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# shellcheck disable=SC2154
 
 set -e
 
@@ -10,10 +9,14 @@ GLUONDIR="$(pwd)"
 
 for module in $GLUON_MODULES; do
 	echo "--- Updating module '$module' ---"
-	var=$(echo "$module" | tr '[:lower:]/' '[:upper:]_')
-	eval 'repo=${'"${var}"'_REPO}'
-	eval 'branch=${'"${var}"'_BRANCH}'
-	eval 'commit=${'"${var}"'_COMMIT}'
+	var=${module//\//_}
+	_remote_url=${var^^}_REPO
+	_remote_branch=${var^^}_BRANCH
+	_remote_commit=${var^^}_COMMIT
+
+	repo=${!_remote_url}
+	branch=${!_remote_branch}
+	commit=${!_remote_commit}
 
 	mkdir -p "$GLUONDIR/$module"
 	cd "$GLUONDIR/$module"


### PR DESCRIPTION
This removes script-wide shellcheck excludes to avoid unintentional errors and moves the excludes to the scripts where they are necessary.