### PR TITLE
gluon-web-cellular: add auth option to GUI

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
@@ -21,6 +21,7 @@ local function setup_ncm_qmi(devpath, control_type, delay)
 	local pincode = uci:get('gluon', 'cellular', 'pin')
 	local username = uci:get('gluon', 'cellular', 'username')
 	local password = uci:get('gluon', 'cellular', 'password')
+	local auth = uci:get('gluon', 'cellular', 'auth')
 
 	uci:section('network', 'interface', 'cellular', {
 		proto = control_type,
@@ -40,6 +41,7 @@ local function setup_ncm_qmi(devpath, control_type, delay)
 	set_or_delete('network', 'cellular', 'pincode', pincode)
 	set_or_delete('network', 'cellular', 'username', username)
 	set_or_delete('network', 'cellular', 'password', password)
+	set_or_delete('network', 'cellular', 'auth', auth)
 	set_or_delete('network', 'cellular', 'delay', delay)
 end
 

--- a/package/gluon-web-cellular/i18n/de.po
+++ b/package/gluon-web-cellular/i18n/de.po
@@ -47,3 +47,18 @@ msgstr ""
 "Du kannst den Uplink über einen Mobilfunk Service aktivieren. Wenn du "
 "dich dafür entscheidest, wird die VPN-Verbindung über das integrierte "
 "Mobilfunk-Modem hergestellt."
+
+msgid "Authentication"
+msgstr "Authentifizierung"
+
+msgid "None"
+msgstr "Keine"
+
+msgid "PAP"
+msgstr ""
+
+msgid "CHAP"
+msgstr ""
+
+msgid "Both"
+msgstr "Beide"

--- a/package/gluon-web-cellular/i18n/gluon-web-cellular.pot
+++ b/package/gluon-web-cellular/i18n/gluon-web-cellular.pot
@@ -35,3 +35,18 @@ msgid ""
 "You can enable uplink via cellular service. If you decide so, the VPN "
 "connection is established using the integrated WWAN modem."
 msgstr ""
+
+msgid "Authentication"
+msgstr ""
+
+msgid "None"
+msgstr ""
+
+msgid "PAP"
+msgstr ""
+
+msgid "CHAP"
+msgstr ""
+
+msgid "Both"
+msgstr ""

--- a/package/gluon-web-cellular/luasrc/lib/gluon/config-mode/model/admin/cellular.lua
+++ b/package/gluon-web-cellular/luasrc/lib/gluon/config-mode/model/admin/cellular.lua
@@ -33,6 +33,14 @@ local password = s:option(Value, "password", translate("Password"))
 password:depends(enabled, true)
 password.default = uci:get('gluon', 'cellular', 'password')
 
+local auth = s:option(ListValue, "auth", translate("Authentication"))
+auth:depends(enabled, true)
+auth:value("none", translate("None"))
+auth:value("pap", translate("PAP"))
+auth:value("chap", translate("CHAP"))
+auth:value("both", translate("Both"))
+auth.default = uci:get('gluon', 'cellular', 'auth') or "none"
+
 function f:write()
 	local cellular_enabled = false
 	if enabled.data then
@@ -46,6 +54,7 @@ function f:write()
 		pin = pin.data,
 		username = username.data,
 		password = password.data,
+		auth = auth.data,
 	})
 
 	uci:commit('gluon')


### PR DESCRIPTION
this should fixes #2750 by adding a dropdown menu for the auth methods.

atm it is untested, but we believe that this can be tested soon by someone from [ffmuc](https://github.com/freifunkMUC/site-ffm/pull/456).

More Infos:
https://openwrt.org/docs/guide-user/network/wan/wwan/ltedongle#qmi_protocol_configuration_parameters