### PR TITLE
modules: update openwrt

### DIFF
--- a/modules
+++ b/modules
@@ -2,7 +2,7 @@ GLUON_FEEDS='gluon packages routing'
 
 OPENWRT_REPO=https://github.com/openwrt/openwrt.git
 OPENWRT_BRANCH=openwrt-23.05
-OPENWRT_COMMIT=4c03fe22b7c4228595ed5903631402dc7f4874d0
+OPENWRT_COMMIT=3fcf619e76b9ce5c3d43501923e5f4e11334c600
 
 PACKAGES_GLUON_REPO=https://github.com/freifunk-gluon/packages.git
 PACKAGES_GLUON_COMMIT=3d08b0fee8dc5d96d8bcdb985fad1d5564de4022


### PR DESCRIPTION
mt76 PKG_MIRROR_HASH fixup

```
3fcf619e76 ramips: mt76x8: sync Cudy TR1200 v1 naming
7be58ccacc ramips: mt76x8: add support for Cudy TR1200 v1
e1eac53f74 mt76: Fix PKG_MIRROR_HASH
323e249ce8 mac80211: Update to version 6.1.97-1
e0837a1257 iw: sync nl80211.h
```