### PR TITLE
gluon-core: fix swconfig detection in ethernet module

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/ethernet.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/ethernet.lua
@@ -16,11 +16,11 @@ end
 local function is_swconfig()
 	local has = false
 
-	uci:foreach("system", "switch", function()
+	uci:foreach("network", "switch", function()
 		has = true
 	end)
 
-	uci:foreach("system", "switch_vlan", function()
+	uci:foreach("network", "switch_vlan", function()
 		has = true
 	end)
 


### PR DESCRIPTION
Switch config for swconfig can be found in the network, not the system config.

This resulted in `Switch type: none` beeing reported for swconfig devices.


cc @mkg20001