### PR TITLE
scripts: add --tags to git describe in getversion.sh to include lightweighted tags

### DIFF
--- a/scripts/getversion.sh
+++ b/scripts/getversion.sh
@@ -8,6 +8,6 @@ fi
 cd "$1" || exit 1
 
 cat .scmversion 2>/dev/null && exit 0
-git --git-dir=.git describe --always --abbrev=7 --dirty=+ 2>/dev/null && exit 0
+git --git-dir=.git describe --tags --always --abbrev=7 --dirty=+ 2>/dev/null && exit 0
 
 echo unknown


### PR DESCRIPTION
This flag allows to get the latest non annotated tag in e.g. site repositories.