### PR TITLE
fritzbox-7530/7520: utilize lan1 as wan, others as lan 

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -63,6 +63,10 @@ elseif platform.match('ath79', 'generic', {
 	'ubnt,unifiac-pro',
 }) then
 	lan_ifname, wan_ifname = 'eth0.2', 'eth0.1'
+elseif platform.match('ipq40xx', 'generic', {
+	'avm,fritzbox-7530',
+}) then
+	lan_ifname, wan_ifname = 'lan2 lan3 lan4', 'lan1'
 elseif platform.match('ramips', 'mt7621', {
 	'netgear,wac104',
 }) then

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/021-interface-roles
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/021-interface-roles
@@ -43,6 +43,7 @@ if uci:get('gluon', 'iface_wan') then
 end
 if uci:get('gluon', 'iface_single') then
 	roles.wan = uci:get_list('gluon', 'iface_single', 'role')
+	roles.lan = uci:get_list('gluon', 'iface_single', 'role')
 end
 
 -- Non-existing interfaces are nil, so they will not be added to the table


### PR DESCRIPTION
> With the switch to DSA on this device in openwrt 23.05, we can now utilize the ports of a 7520/7530 better, by splitting them according to their usage.
> Before, they had all LAN ports used as WAN - a behavior which can also be easily configured in config mode nowadays.
> 
> If I remember correctly, this also changes an existing configuration to LAN1 -> WAN and LAN2,3,4 -> LAN
> Therefore, the existing router owner need to make sure to plug the cable into Port1.
> 
> This patch has been tested with latest gluon and already is deployed on all affected FB7520/7530 in FFAC.

This is a new version of #3118 that includes a uci migration path for devices that were configured pre-DSA.

cc @maurerle 