### PR TITLE
[v2023.2.x] treewide: pending devices and bugfixes from master

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -462,7 +462,7 @@ ramips-mt7621
 * Xiaomi
 
   - Xiaomi Mi Router 3G (v1, v2)
-  - Xiaomi Mi Router 4A (Gigabit Edition v1)
+  - Xiaomi Mi Router 4A (Gigabit Edition v1, v2)
 
 * ZBT
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -391,6 +391,7 @@ ramips-mt7620
 
   - EX3700
   - EX3800
+  - EX6130
 
 * Nexx
 

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -500,7 +500,7 @@ ramips-mt76x8
 
   - Archer C20 (v4, v5)
   - Archer C50 (v3, v4)
-  - RE200 (v2, v3)
+  - RE200 (v2, v3, v4)
   - TL-MR3020 (v3)
   - TL-MR3420 (v5)
   - TL-MR6400 (v5)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/ethernet.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/ethernet.lua
@@ -16,11 +16,11 @@ end
 local function is_swconfig()
 	local has = false
 
-	uci:foreach("system", "switch", function()
+	uci:foreach("network", "switch", function()
 		has = true
 	end)
 
-	uci:foreach("system", "switch_vlan", function()
+	uci:foreach("network", "switch_vlan", function()
 		has = true
 	end)
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -383,6 +383,12 @@ device('siemens-ws-ap3610', 'siemens_ws-ap3610', {
 
 -- Sophos
 
+device('sophos-ap15', 'sophos_ap15', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+	broken = true, -- no button and no external console port
+})
+
 device('sophos-ap100', 'sophos_ap100', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -29,6 +29,11 @@ device('netgear-ex3700', 'netgear_ex3700', {
 	factory_ext = '.chk',
 })
 
+device('netgear-ex6130', 'netgear_ex6130', {
+	factory_ext = '.chk',
+})
+
+
 -- Nexx
 
 device('nexx-wt3020-8m', 'nexx_wt3020-8m', {

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -120,6 +120,10 @@ device('xiaomi-mi-router-4a-gigabit-edition', 'xiaomi_mi-router-4a-gigabit', {
 	factory = false,
 })
 
+device('xiaomi-mi-router-4a-gigabit-edition-v2', 'xiaomi_mi-router-4a-gigabit-v2', {
+	factory = false,
+})
+
 device('xiaomi-mi-router-3g', 'xiaomi_mi-router-3g', {
 	factory = false,
 })

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -62,6 +62,8 @@ device('tp-link-re200-v2', 'tplink_re200-v2')
 
 device('tp-link-re200-v3', 'tplink_re200-v3')
 
+device('tp-link-re200-v4', 'tplink_re200-v4')
+
 device('tp-link-tl-mr3020-v3', 'tplink_tl-mr3020-v3', {
 	factory = false,
 	extra_images = {


### PR DESCRIPTION
This PR collects multiple backports of added device support and bugfixes for v2023.2.x from Gluons master branch.