### PR TITLE
Update getting_started.rst

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -29,7 +29,7 @@ freshly installed Debian Bullseye system the following packages are required:
 
 * `git` (to get Gluon and other dependencies)
 * `python3`
-* `python3-distutils`
+* `python3-setuptools`
 * `build-essential`
 * `ecdsautils` (to sign firmware, see `contrib/sign.sh`)
 * `gawk`


### PR DESCRIPTION
Changed entry "python3-distutils" that is outdated to "python3-setuptools" (new version that is supported in modern linux distributions)