### PR TITLE
ath79-generic: add support for DLAN (pro) 1200+ WiFi ac

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -86,6 +86,12 @@ device('buffalo-wzr-hp-g300nh-rtl8366s', 'buffalo_wzr-hp-g300nh-s')
 
 -- devolo
 
+device('devolo-dlan-pro-1200+-wifi-ac', 'devolo_dlan-pro-1200plus-ac', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+	broken = true, -- no power led
+})
+
 device('devolo-wifi-pro-1200e', 'devolo_dvl1200e', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
The DLAN pro 1200+ WiFi ac is the same as the DLAN 1200+ WiFi ac (non-pro).
It is a wall plug device which still exposes the wall plug.

The powerline functionality does not work without additional firmware, which can not be shipped due to licensing issues - yet someone from our community wanted to use this device for FF and did test it.

Looks fine to me, except that there is no Power LED, just the House-LED (used for powerline) and the WIFI-LED (which works as expected)

- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [x] TFTP see: https://openwrt.org/toh/devolo/dlan_pro_1200_wifi_ac#oem_installation_using_the_tftp_method
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
        `devolo-dlan-pro-1200+-wifi-ac`
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED (non exists)
    - [ ] Lit while the device is on
    - [ ] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs (only 1 wifi LED)
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs (non)
    ~~- [ ] Should map to their respective port (or switch, if only one led present)~~
    ~~- [ ] Should show link state and activity~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`