### PR TITLE
docs: add v2023.2.4 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the future development of Gluon.
 
 Please refrain from using the `master` branch for anything else but development purposes!
 Use the most recent release instead. You can list all releases by running `git tag`
-and switch to one by running `git checkout v2023.2.3 && make update`.
+and switch to one by running `git checkout v2023.2.4 && make update`.
 
 If you're using the autoupdater, do not autoupdate nodes with anything but releases.
 If you upgrade using random master commits the nodes *might break* eventually.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ copyright = 'Project Gluon'
 author = 'Project Gluon'
 
 # The short X.Y version
-version = '2023.2.3'
+version = '2023.2.4'
 # The full version, including alpha/beta/rc tags
 release = version
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -5,6 +5,7 @@ Release Notes
   :caption: Gluon 2023.2
   :maxdepth: 2
 
+  v2023.2.4
   v2023.2.3
   v2023.2.2
   v2023.2.1

--- a/docs/releases/v2023.2.4.rst
+++ b/docs/releases/v2023.2.4.rst
@@ -1,0 +1,64 @@
+Gluon 2023.2.4
+==============
+
+Added hardware support
+----------------------
+
+ramips-mt7620
+~~~~~~~~~~~~~
+
+- NETGEAR
+
+  - EX6130
+
+
+ramips-mt7621
+~~~~~~~~~~~~~
+
+- Xiaomi
+
+  - Mi Router 4A (Gigabit Edition v2)
+
+
+ramips-mt76x8
+~~~~~~~~~~~~~
+
+- TP-Link
+
+  - RE200 (v4)
+
+
+Bugfixes
+--------
+
+* Fixed an issue where Enterasys WS-AP3710i devices regularly boot with all-zero MAC-addresses in previous releases
+
+* Detection of `swconfig` based switch architecture has been fixed (`#3309 <https://github.com/freifunk-gluon/gluon/pull/3309>`_)
+
+* Fixed an issue where the AVM FRITZ!Box 4040 used an incorrect primary MAC address
+  (`Upstream <https://github.com/openwrt/openwrt/commit/87fbb5085d7e290b0ba536ad7d0876c4224723a6>`_)
+
+
+Known issues
+------------
+
+* Unstable wireless with certain MediaTek devices (`#3154 <https://github.com/freifunk-gluon/gluon/issues/3154>`_)
+
+* The integration of the BATMAN_V routing algorithm is incomplete.
+
+  - Mesh neighbors don't appear on the status page. (`#1726 <https://github.com/freifunk-gluon/gluon/issues/1726>`_)
+    Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new throughput
+    metric.
+  - Throughput values are not correctly acquired for different interface types.
+    (`#1728 <https://github.com/freifunk-gluon/gluon/issues/1728>`_)
+    This affects virtual interface types like bridges and VXLAN.
+
+* Default TX power on many Ubiquiti devices is too high, correct offsets are unknown
+  (`#94 <https://github.com/freifunk-gluon/gluon/issues/94>`_)
+
+  Reducing the TX power in the Advanced Settings is recommended.
+
+* In configurations without VXLAN, the MAC address of the WAN interface is modified even when Mesh-on-WAN is disabled
+  (`#496 <https://github.com/freifunk-gluon/gluon/issues/496>`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when promiscuous mode is disallowed).

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2023.2.3
+-- This is an example site configuration for Gluon v2023.2.4
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -8,7 +8,7 @@ Gluon's releases are managed using `Git tags`_. If you are just getting
 started with Gluon we recommend to use the latest stable release of Gluon.
 
 Take a look at the `list of gluon releases`_ and notice the latest release,
-e.g. *v2023.2.3*. Always get Gluon using git and don't try to download it
+e.g. *v2023.2.4*. Always get Gluon using git and don't try to download it
 as a Zip archive as the archive will be missing version information.
 
 Please keep in mind that there is no "default Gluon" build; a site configuration
@@ -53,7 +53,7 @@ Building the images
 -------------------
 
 To build Gluon, first check out the repository. Replace *RELEASE* with the
-version you'd like to checkout, e.g. *v2023.2.3*.
+version you'd like to checkout, e.g. *v2023.2.4*.
 
 ::
 


### PR DESCRIPTION
Based on the work done in https://md.darmstadt.ccc.de/gluon-v2023.2.4-rn

A preview can be found here: https://gluon--3345.org.readthedocs.build/en/3345/releases/v2023.2.4.html

Contains the following changes: https://github.com/freifunk-gluon/gluon/compare/v2023.2.3...8d04b5e4961e7c0a779bc8755142b65cca19f72e