### PR TITLE
kirkwood-generic: update BROKEN reason, add Linksys EA4500

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -122,6 +122,7 @@ local primary_addrs = {
 		}},
 		{'kirkwood', 'generic', {
 			'linksys,e4200-v2',
+			'linksys,ea4500',
 		}},
 		{'mpc85xx', 'p1020', {
 			'aerohive,hiveap-330',

--- a/targets/kirkwood-generic
+++ b/targets/kirkwood-generic
@@ -1,5 +1,5 @@
 -- Linksys
 
 device('linksys-e4200-v2-viper', 'linksys_e4200-v2', {
-	broken = true, -- 802.11s untested
+	broken = true, -- no 802.11s support
 })

--- a/targets/kirkwood-generic
+++ b/targets/kirkwood-generic
@@ -3,3 +3,7 @@
 device('linksys-e4200-v2-viper', 'linksys_e4200-v2', {
 	broken = true, -- no 802.11s support
 })
+
+device('linksys-ea4500-viper', 'linksys_ea4500', {
+	broken = true, -- no 802.11s support
+})

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -29,6 +29,6 @@ $(eval $(call GluonTarget,x86,64))
 ifeq ($(BROKEN),1)
 $(eval $(call GluonTarget,bcm27xx,bcm2710)) # BROKEN: Untested
 $(eval $(call GluonTarget,bcm27xx,bcm2711)) # BROKEN: No 11s support, no reset button, sys LED issues
-$(eval $(call GluonTarget,kirkwood,generic)) # BROKEN: 11s support untested
+$(eval $(call GluonTarget,kirkwood,generic)) # BROKEN: No devices with 11s support
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
 endif


### PR DESCRIPTION
The hardware is identical to the E4200 v2, and it's broken, so only minimal testing was done - this is added mostly because I have one lying around and its good to have some "supported" device for testing ARMv5.