### PR TITLE
[v2023.2.x] scripts: add --tags to git describe in getversion.sh to include lightweighted tags (#3310)

### DIFF
--- a/scripts/getversion.sh
+++ b/scripts/getversion.sh
@@ -8,6 +8,6 @@ fi
 cd "$1" || exit 1
 
 cat .scmversion 2>/dev/null && exit 0
-git --git-dir=.git describe --always --abbrev=7 --dirty=+ 2>/dev/null && exit 0
+git --git-dir=.git describe --tags --always --abbrev=7 --dirty=+ 2>/dev/null && exit 0
 
 echo unknown


### PR DESCRIPTION
Backport of https://github.com/freifunk-gluon/gluon/pull/3310

As this has been bothering us on our end with the latest "show version" commands, we would like to see this backported at least to v2023.2.x
![image](https://github.com/user-attachments/assets/5cce22d4-c656-4dd3-8bac-d46dc0e7946e)
