### PR TITLE
docs readme: update hackint webchat URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,6 @@ existing commit messages to get the idea.
 
 
 [packages]: https://gluon.readthedocs.io/en/latest/user/site.html#packages
-[#gluon]: https://webirc.hackint.org/#gluon
+[#gluon]: https://chat.hackint.org/?join=gluon
 [mailing list]: mailto:gluon@luebeck.freifunk.net
 [list of rejected features]: https://github.com/freifunk-gluon/gluon/issues?q=label%3A%222.+status%3A+rejected%22

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ If you're new to Gluon and ready to get your feet wet, have a look at the
 [Getting Started Guide](https://gluon.readthedocs.io/en/latest/user/getting_started.html).
 
 Gluon's developers frequent an IRC chatroom at [#gluon](ircs://irc.hackint.org/#gluon)
-on [hackint](https://hackint.org/). There is also a [webchat](https://webirc.hackint.org/#irc://irc.hackint.org/#gluon)
+on [hackint](https://hackint.org/). There is also a [webchat](https://chat.hackint.org/?join=gluon)
 that allows for uncomplicated access from within your browser. This channel is also available as a bridged Matrix Room at [#gluon:hackint.org](https://matrix.to/#/#gluon:hackint.org).
 
 ## Issues & Feature requests

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ highlight_language = 'none'
 # used to mark channel names and do not exist. Regular links are not effected.
 linkcheck_ignore = [
     'http://192.168.1.1',
-    'https://webirc.hackint.org/#'
+    'https://chat.hackint.org'
 ]
 
 

--- a/docs/dev/basics.rst
+++ b/docs/dev/basics.rst
@@ -21,7 +21,7 @@ web browser. You're welcome to join us!
 
 .. _#gluon: ircs://irc.hackint.org/#gluon
 .. _hackint: https://hackint.org/
-.. _webchat: https://webirc.hackint.org/#irc://irc.hackint.org/#gluon
+.. _webchat: https://chat.hackint.org/?join=gluon
 
 .. _working-with-repositories:
 


### PR DESCRIPTION
> [Network Notice] major - We will be transitioning from our current webchat (KiwiIRC) at webirc.hackint.org to The Lounge, accessible at chat.hackint.org. The old webchat will remain available until November 20, 2024. For more information, please visit our documentation at https://hackint.org/webchat.
