### PR TITLE
ipq806x-generic: add Ubiquiti UniFi AC HD

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -267,6 +267,10 @@ ipq806x-generic
 
   - R7800
 
+* Ubiquiti
+
+  - UniFi AC HD
+
 lantiq-xrx200
 -------------
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/020-interfaces
@@ -67,6 +67,10 @@ elseif platform.match('ipq40xx', 'generic', {
 	'avm,fritzbox-7530',
 }) then
 	lan_ifname, wan_ifname = 'lan2 lan3 lan4', 'lan1'
+elseif platform.match('ipq806x', 'generic', {
+	'ubnt,unifi-ac-hd',
+}) then
+	lan_ifname, wan_ifname = 'eth1', 'eth0'
 elseif platform.match('ramips', 'mt7621', {
 	'netgear,wac104',
 }) then

--- a/targets/ipq806x-generic
+++ b/targets/ipq806x-generic
@@ -26,3 +26,9 @@ device('netgear-nighthawk-x4s-r7800', 'netgear_r7800', {
 	factory_ext = '.img',
 	packages = QCA9984_PACKAGES,
 })
+
+-- Ubiquiti
+device('ubiquiti-unifi-ac-hd', 'ubnt_unifi-ac-hd', {
+	packages = QCA9984_PACKAGES,
+	factory = false,
+})


### PR DESCRIPTION
- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: SSH

- Install was executed on 6.6.73 (worked fine)
- use pitch's [acProFlashtool](https://codeberg.org/pitch/firmwareloader_uap_ac_pro)
- Give your device
> static ip: 192.168.1.xxx (xxx being a number between 1 and 254 but not 20)
> net mask 255.255.255.0
> gateway 192.168.1.20 (optional)

- on linux: `chmod +x firmwareloader-linux`
- `./firmwareloader-linux -f sysupgrade-file-name.bin`

- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
        ubiquiti-unifi-ac-hd
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
      It the same as the one silkscreened onto the device: E063DA59853E
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~
    - [ ] ~~Should map to their respective radio~~
    - [ ] ~~Should show activity~~
  - ~~Switch port LEDs~~
    - [ ] ~~Should map to their respective port (or switch, if only one led present)~~ 
    - [ ] ~~Should show link state and activity~~
- ~~Outdoor devices only:~~
  - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- ~~Cellular devices only:~~
  - [ ] ~~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`