### PR TITLE
ramips-mt7621: add Ubiquiti UniFi nanoHD

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -460,6 +460,7 @@ ramips-mt7621
   - EdgeRouter X
   - EdgeRouter X-SFP
   - UniFi 6 Lite
+  - UniFi nanoHD
 
 * Wavlink
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -112,6 +112,10 @@ device('ubiquiti-unifi-6-lite', 'ubnt_unifi-6-lite', {
 	factory = false,
 })
 
+device('ubiquiti-unifi-nanohd', 'ubnt_unifi-nanohd', {
+	factory = false,
+})
+
 
 -- Wavlink
 


### PR DESCRIPTION
- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: SSH
        Downgrade to [3.9.27](https://community.ui.com/releases/FIRMWARE-3-9-27-8537-for-UAP-USW-has-been-released-3-9-27-8537/e41acf46-de72-4336-8104-f6996c8d04d8) first (6.6.73 was tested and didn't work, it automatically reboots into tftp recovery) using this procedure [UniFi Recovery Mode > Access Points](https://help.ui.com/hc/en-us/articles/360043360253-UniFi-Recovery-Mode)
        use pitch's [acProFlashtool](https://codeberg.org/pitch/firmwareloader_uap_ac_pro)
          Give your device
            static ip: 192.168.1.xxx (xxx being a number between 1 and 254 but not 20)
            net mask 255.255.255.0
            gateway 192.168.1.20 (optional)
          on linux: chmod +x firmwareloader-linux
          ./firmwareloader-linux -f sysupgrade-file-name.bin
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
        ubiquiti-unifi-nanohd
- [x] Reset~~/WPS/...~~ button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
      It the same as the one silkscreened onto the device: E063DA25D25D
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~
    - [ ] ~~Should map to their respective radio~~
    - [ ] ~~Should show activity~~
  - ~~Switch port LEDs~~
    - [ ] ~~Should map to their respective port (or switch, if only one led present)~~ 
    - [ ] ~~Should show link state and activity~~
- ~~Outdoor devices only:~~
  - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- ~~Cellular devices only:~~
  - [ ] ~~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`