### PR TITLE
generic: add gluon grub title

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -82,6 +82,8 @@ config('TARGET_PER_DEVICE_ROOTFS', true)
 
 config('GLUON_MULTIDOMAIN', istrue(env.GLUON_MULTIDOMAIN))
 
+try_config('GRUB_TITLE', 'Gluon')
+
 config('AUTOREMOVE', istrue(env.GLUON_AUTOREMOVE))
 
 if (tonumber(env.GLUON_DEBUG) or 0) > 1 then


### PR DESCRIPTION
change the "OpenWrt" grub title to "Gluon"


![image](https://github.com/user-attachments/assets/a06995cc-3117-47c0-ad3a-f151ef1acb31)
https://github.com/freifunkMUC/site-ffm/pull/512