### PR TITLE
scripts: target_config_lib: make opkg a device-specific package

### DIFF
--- a/scripts/target_config_lib.lua
+++ b/scripts/target_config_lib.lua
@@ -173,7 +173,11 @@ lib.include(target)
 
 lib.check_devices()
 
-handle_target_pkgs(concat_list(get_default_pkgs(), lib.target_packages))
+-- Hack: opkg is added removed from the target packages and instead added
+-- to the devices packages to make it removable via image-customization
+local target_packages = concat_list(get_default_pkgs(), lib.target_packages)
+target_packages = concat_list(target_packages, {'-opkg'})
+handle_target_pkgs(target_packages)
 
 for _, dev in ipairs(lib.devices) do
 	local device_pkgs = {}
@@ -187,6 +191,7 @@ for _, dev in ipairs(lib.devices) do
 	end
 
 	handle_pkgs(lib.target_packages)
+	handle_pkgs({'opkg'})
 	handle_pkgs(dev.options.packages or {})
 	handle_pkgs(site_specific_packages(dev))
 


### PR DESCRIPTION
If a package is installed target-wide, but removed for specific devices (or through image-customization), it is first installed during target rootfs generation, and then uninstalled again for the derived device rootfs.

For packages that are marked as essential, removal of the package will be refused by default, which is usually the correct thing to do to avoid building broken images.

For opkg, we know that it is not required for regular operation of Gluon, and removing it may be desirable for devices with small flash. By never adding opkg to the target list of packages and instead only installing it as a device-specific package, the uninstall issue can be avoided.

Removing opkg saves ~38KiB of the squashfs on mips_24kc. Stripping the opkg database is not supported however, as there is no device-specific flag for that.

---

I'm undecided if 38KiB are worth a hack like this... but at least the change is very simple.

cc @rotanid 

Fixes #3365