### PR TITLE
ath79: Add support for Sophos AP15C

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -114,6 +114,7 @@ ath79-generic
 
 * Sophos
 
+  - AP15C
   - AP100
   - AP100c
   - AP55

--- a/patches/openwrt/0010-ath79-add-support-for-sophos-ap15c.patch
+++ b/patches/openwrt/0010-ath79-add-support-for-sophos-ap15c.patch
@@ -1,0 +1,224 @@
+From 591162a4fc435b5369de11c4c1d3d3c6b6981e69 Mon Sep 17 00:00:00 2001
+From: David Lutz <kpanic@hirnduenger.de>
+Date: Tue, 5 Nov 2024 10:55:43 +0100
+Subject: [PATCH] ath79: Add support for Sophos AP15C
+
+---
+ package/boot/uboot-envtools/files/ath79       |   1 +
+ .../linux/ath79/dts/qca9557_sophos_ap15c.dts  | 159 ++++++++++++++++++
+ .../generic/base-files/etc/board.d/02_network |   1 +
+ target/linux/ath79/image/generic.mk           |   8 +
+ 4 files changed, 169 insertions(+)
+ create mode 100644 target/linux/ath79/dts/qca9557_sophos_ap15c.dts
+
+diff --git a/package/boot/uboot-envtools/files/ath79 b/package/boot/uboot-envtools/files/ath79
+index 1d9d3bcfaa..c6d23ce73d 100644
+--- a/package/boot/uboot-envtools/files/ath79
++++ b/package/boot/uboot-envtools/files/ath79
+@@ -163,6 +163,7 @@ ruckus,zf7372)
+ 	ubootenv_add_uci_config "/dev/mtd2" "0x0" "0x40000" "0x10000"
+ 	;;
+ sophos,ap15|\
++sophos,ap15c|\
+ sophos,ap55|\
+ sophos,ap55c|\
+ sophos,ap100|\
+diff --git a/target/linux/ath79/dts/qca9557_sophos_ap15c.dts b/target/linux/ath79/dts/qca9557_sophos_ap15c.dts
+new file mode 100644
+index 0000000000..68d02e97a5
+--- /dev/null
++++ b/target/linux/ath79/dts/qca9557_sophos_ap15c.dts
+@@ -0,0 +1,159 @@
++// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
++
++#include "qca955x.dtsi"
++
++#include <dt-bindings/gpio/gpio.h>
++#include <dt-bindings/input/input.h>
++#include <dt-bindings/leds/common.h>
++
++/ {
++	compatible = "sophos,ap15c", "qca,qca9557";
++	model = "Sophos AP15C";
++
++	aliases {
++		led-boot = &led_status_green;
++		led-failsafe = &led_status_yellow;
++		led-running = &led_status_green;
++		led-upgrade = &led_status_yellow;
++		label-mac-device = &eth0;
++	};
++
++	chosen {
++		bootargs = "console=ttyS0,115200n8";
++	};
++
++	keys {
++		compatible = "gpio-keys";
++
++		reset {
++			label = "reset";
++			linux,code = <KEY_RESTART>;
++			gpios = <&gpio 18 GPIO_ACTIVE_LOW>;
++			debounce-interval = <60>;
++		};
++	};
++
++	leds {
++		compatible = "gpio-leds";
++
++		led_status_green: status_green {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_GREEN>;
++			gpios = <&gpio 13 GPIO_ACTIVE_LOW>;
++			default-state = "on";
++		};
++
++		led_status_yellow: status_yellow {
++			function = LED_FUNCTION_STATUS;
++			color = <LED_COLOR_ID_YELLOW>;
++			gpios = <&gpio 14 GPIO_ACTIVE_LOW>;
++		};
++	};
++};
++
++&spi {
++	status = "okay";
++
++	flash@0 {
++		compatible = "jedec,spi-nor";
++		reg = <0>;
++		spi-max-frequency = <25000000>;
++
++		partitions {
++			compatible = "fixed-partitions";
++			#address-cells = <1>;
++			#size-cells = <1>;
++
++			partition@0 {
++				label = "u-boot";
++				reg = <0x000000 0x040000>;
++				read-only;
++			};
++
++			partition@40000 {
++				label = "u-boot-env";
++				reg = <0x040000 0x010000>;
++			};
++
++			partition@50000 {
++				label = "art";
++				reg = <0x050000 0x010000>;
++				read-only;
++
++				nvmem-layout {
++					compatible = "fixed-layout";
++					#address-cells = <1>;
++					#size-cells = <1>;
++
++					cal_art_1000: calibration@1000 {
++						reg = <0x1000 0x440>;
++					};
++				};
++			};
++
++			partition@60000 {
++				label = "config";
++				reg = <0x060000 0x010000>;
++				read-only;
++
++				nvmem-layout {
++					compatible = "fixed-layout";
++					#address-cells = <1>;
++					#size-cells = <1>;
++
++					macaddr_config_201a: macaddr@201a {
++						reg = <0x201a 0x6>;
++					};
++				};
++			};
++
++			partition@70000 {
++				compatible = "denx,uimage";
++				label = "firmware";
++				reg = <0x070000 0xf90000>;
++			};
++		};
++	};
++};
++
++&mdio0 {
++	status = "okay";
++
++	phy-mask = <0x10>;
++
++	phy4: ethernet-phy@4 {
++		reg = <4>;
++		eee-broken-100tx;
++		eee-broken-1000t;
++	};
++};
++
++&eth0 {
++	status = "okay";
++
++	pll-data = <0xa6000000 0xa0000101 0xa0001313>;
++
++	nvmem-cells = <&macaddr_config_201a>;
++	nvmem-cell-names = "mac-address";
++
++	phy-mode = "rgmii-id";
++	phy-handle = <&phy4>;
++
++	gmac_config: gmac-config {
++		device = <&gmac>;
++
++		rgmii-enabled = <1>;
++
++		rxdv-delay = <3>;
++		rxd-delay = <3>;
++		txen-delay = <3>;
++		txd-delay = <3>;
++	};
++};
++
++&wmac {
++	status = "okay";
++
++	nvmem-cells = <&cal_art_1000>;
++	nvmem-cell-names = "calibration";
++};
+diff --git a/target/linux/ath79/generic/base-files/etc/board.d/02_network b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+index 8474c1c4c2..8f79a3fad8 100644
+--- a/target/linux/ath79/generic/base-files/etc/board.d/02_network
++++ b/target/linux/ath79/generic/base-files/etc/board.d/02_network
+@@ -76,6 +76,7 @@ ath79_setup_interfaces()
+ 	ruckus,zf7351|\
+ 	siemens,ws-ap3610|\
+ 	sophos,ap15|\
++	sophos,ap15c|\
+ 	sophos,ap55|\
+ 	sophos,ap55c|\
+ 	sophos,ap100|\
+diff --git a/target/linux/ath79/image/generic.mk b/target/linux/ath79/image/generic.mk
+index c075f050db..0173f5cb16 100644
+--- a/target/linux/ath79/image/generic.mk
++++ b/target/linux/ath79/image/generic.mk
+@@ -2972,6 +2972,14 @@ define Device/sophos_ap15
+ endef
+ TARGET_DEVICES += sophos_ap15
+ 
++define Device/sophos_ap15c
++  SOC := qca9557
++  DEVICE_VENDOR := Sophos
++  DEVICE_MODEL := AP15C
++  IMAGE_SIZE := 15936k
++endef
++TARGET_DEVICES += sophos_ap15c
++
+ define Device/sophos_ap55
+   SOC := qca9558
+   DEVICE_VENDOR := Sophos
+-- 
+2.34.1
+

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -368,6 +368,11 @@ device('sophos-ap15', 'sophos_ap15', {
 	broken = true, -- no button and no external console port
 })
 
+device('sophos-ap15c', 'sophos_ap15c', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 device('sophos-ap100', 'sophos_ap100', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [ ] Web interface
  - [X] TFTP (serial console)
  - [X] Other: Vendor Software
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`
  
  See: https://github.com/openwrt/openwrt/pull/16868