### PR TITLE
ci: push image for all next branches

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - 'main'
-      - 'next'
+      - 'next*'
       - 'v202[0-9].[0-9].x'
     tags:
       - 'v*'


### PR DESCRIPTION
Currently the docker image is published for the next branch. If we have two next branches (e.g. during a pending OpenWrt release), a branch like "next-24.10" would not be pushing a docker image.

Match the push action to all branches starting with next. This is helpful if a downstream CI builds using the Gluon docker image.