### PR TITLE
[v2021.1.x] batman-adv: update to version 2024.3

### DIFF
--- a/patches/packages/routing/0005-batman-adv-update-to-version-2024.3.patch
+++ b/patches/packages/routing/0005-batman-adv-update-to-version-2024.3.patch
@@ -1,0 +1,5773 @@
+From: Linus Lüssing <linus.luessing@c0d3.blue>
+Date: Tue, 19 Nov 2024 14:30:33 +0100
+Subject: batman-adv: update to version 2024.3
+
+This updates batman-adv to the latest version, as provided in the
+openwrt/routing feed and its master branch. The goal is to prevent the
+deprecated 4/32 devices stuck on OpenWrt 19.07 to disable newer
+batman-adv features.
+
+The main difference to the openwrt/routing upstream version is:
+
+* noflood mark addition, as used in Gluon (patch 2002)
+* always assume absence of multicast routers (patch 9001)
+  -> to avoid disabling multicast for packets with a
+     routeable multicast destination address
+* compat patches to be able to build on OpenWrt 19.07 / Linux 4.14
+  (the batman-adv compat hacks approach is too complicated due to
+   the compat hacks from wireless-backports, therefore these
+   patches apply/revert code inside the net/batman-adv/*.{c,h} directly,
+   as a safer way)
+
+This has been tested via https://github.com/T-X/gluon-batman-adv-next/
+at Freifunk Lübeck for several months now (with the addition of patches
+2001, 2003 and 2004).
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+
+diff --git a/batman-adv/Config.in b/batman-adv/Config.in
+index 8995cdb5c44b0a54cf7097577bcfd203eaf3071a..81163366012acf57be24854496f6217cf78e33d4 100644
+--- a/batman-adv/Config.in
++++ b/batman-adv/Config.in
+@@ -65,17 +65,6 @@ config BATMAN_ADV_MCAST
+ 	  reduce the air overhead while improving the reliability of
+ 	  multicast messages.
+ 
+-config BATMAN_ADV_DEBUGFS
+-	bool "batman-adv debugfs entries"
+-	depends on PACKAGE_kmod-batman-adv
+-	select KERNEL_DEBUG_FS
+-	help
+-	  Enable this to export routing related debug tables via debugfs.
+-	  The information for each soft-interface and used hard-interface can be
+-	  found under batman_adv/
+-
+-	  If unsure, say N.
+-
+ config BATMAN_ADV_DEBUG
+ 	bool "B.A.T.M.A.N. debugging"
+ 	depends on PACKAGE_kmod-batman-adv
+@@ -86,18 +75,6 @@ config BATMAN_ADV_DEBUG
+ 	  buffer. The output is controlled via the batadv netdev specific
+ 	  log_level setting.
+ 
+-config BATMAN_ADV_SYSFS
+-	bool "batman-adv sysfs entries"
+-	depends on PACKAGE_kmod-batman-adv
+-	default y
+-	help
+-	  Say Y here if you want to enable batman-adv device configuration and
+-	  status interface through sysfs attributes. It is replaced by the
+-	  batadv generic netlink family but still used by various userspace
+-	  tools and scripts.
+-
+-	  If unsure, say Y.
+-
+ config BATMAN_ADV_TRACING
+ 	bool "B.A.T.M.A.N. tracing support"
+ 	depends on PACKAGE_kmod-batman-adv
+diff --git a/batman-adv/Makefile b/batman-adv/Makefile
+index 40b3e8bd35682ab10f3041cc3234bc51d11b4428..dcacdf1608c6b81618a595d55ff9841fc7412eb9 100644
+--- a/batman-adv/Makefile
++++ b/batman-adv/Makefile
+@@ -1,45 +1,54 @@
+-#
+-# Copyright (C) 2010 OpenWrt.org
+-#
+-# This is free software, licensed under the GNU General Public License v2.
+-# See /LICENSE for more information.
+-#
++# SPDX-License-Identifier: GPL-2.0-only
+ 
+ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=batman-adv
+-
+-PKG_VERSION:=2019.2
+-PKG_RELEASE:=14
+-PKG_HASH:=70c3f6a6cf88d2b25681a76768a52ed92d9fe992ba8e358368b6a8088757adc8
++PKG_VERSION:=2024.3
++PKG_RELEASE:=1
+ 
+ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+ PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
+-PKG_LICENSE:=GPL-2.0
+-PKG_EXTMOD_SUBDIRS=net/batman-adv
++PKG_HASH:=b96817ed1f4f48917c32550a84faad8c87ecf53aa6f6f46cc26554b999b57ff3
++PKG_EXTMOD_SUBDIRS:=net/batman-adv
++
++PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
++PKG_LICENSE:=GPL-2.0-only MIT
++PKG_LICENSE_FILES:=LICENSES/preferred/GPL-2.0 LICENSES/preferred/MIT
++
++PKG_BUILD_PARALLEL:=1
+ 
+ STAMP_CONFIGURED_DEPENDS := $(STAGING_DIR)/usr/include/mac80211-backport/backport/autoconf.h
+ 
++PKG_CONFIG_DEPENDS += \
++	CONFIG_BATMAN_ADV_BATMAN_V \
++	CONFIG_BATMAN_ADV_BLA \
++	CONFIG_BATMAN_ADV_DAT \
++	CONFIG_BATMAN_ADV_NC \
++	CONFIG_BATMAN_ADV_MCAST \
++	CONFIG_BATMAN_ADV_DEBUG \
++	CONFIG_BATMAN_ADV_TRACING
++
+ include $(INCLUDE_DIR)/kernel.mk
+ include $(INCLUDE_DIR)/package.mk
+ 
+ define KernelPackage/batman-adv
+-  URL:=https://www.open-mesh.org/
+-  MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
+   SUBMENU:=Network Support
+-  DEPENDS:=+BATMAN_ADV_BLA:kmod-lib-crc16 +kmod-lib-crc32c +kmod-cfg80211 +batctl
+   TITLE:=B.A.T.M.A.N. Adv
++  URL:=https://www.open-mesh.org/
++  DEPENDS:=+BATMAN_ADV_BLA:kmod-lib-crc16 +kmod-lib-crc32c +kmod-cfg80211 +batctl
++  DEPENDS+=+(LINUX_5_15&&PACKAGE_gluon-mesh-batman-adv-15):gluon-mesh-batman-adv-brmldproxy
++  DEPENDS+=+(LINUX_6_6&&PACKAGE_gluon-mesh-batman-adv-15):gluon-mesh-batman-adv-brmldproxy
+   FILES:=$(PKG_BUILD_DIR)/net/batman-adv/batman-adv.$(LINUX_KMOD_SUFFIX)
+   AUTOLOAD:=$(call AutoProbe,batman-adv)
+ endef
+ 
+ define KernelPackage/batman-adv/description
+-B.A.T.M.A.N. (better approach to mobile ad-hoc networking) is
+-a routing protocol for multi-hop ad-hoc mesh networks. The
+-networks may be wired or wireless. See
+-https://www.open-mesh.org/ for more information and user space
+-tools. This package builds version $(PKG_VERSION) of the kernel
+-module.
++  B.A.T.M.A.N. (better approach to mobile ad-hoc networking) is
++  a routing protocol for multi-hop ad-hoc mesh networks. The
++  networks may be wired or wireless. See
++  https://www.open-mesh.org/ for more information and user space
++  tools. This package builds version $(PKG_VERSION) of the kernel
++  module.
+ endef
+ 
+ define KernelPackage/batman-adv/config
+@@ -53,41 +62,41 @@ endef
+ PKG_EXTRA_KCONFIG:= \
+ 	CONFIG_BATMAN_ADV=m \
+ 	CONFIG_BATMAN_ADV_DEBUG=$(if $(CONFIG_BATMAN_ADV_DEBUG),y,n) \
+-	CONFIG_BATMAN_ADV_DEBUGFS=$(if $(CONFIG_BATMAN_ADV_DEBUGFS),y,n) \
+ 	CONFIG_BATMAN_ADV_BLA=$(if $(CONFIG_BATMAN_ADV_BLA),y,n) \
+ 	CONFIG_BATMAN_ADV_DAT=$(if $(CONFIG_BATMAN_ADV_DAT),y,n) \
+ 	CONFIG_BATMAN_ADV_MCAST=$(if $(CONFIG_BATMAN_ADV_MCAST),y,n) \
+ 	CONFIG_BATMAN_ADV_NC=$(if $(CONFIG_BATMAN_ADV_NC),y,n) \
+ 	CONFIG_BATMAN_ADV_BATMAN_V=$(if $(CONFIG_BATMAN_ADV_BATMAN_V),y,n) \
+-	CONFIG_BATMAN_ADV_SYSFS=$(if $(CONFIG_BATMAN_ADV_SYSFS),y,n) \
+ 	CONFIG_BATMAN_ADV_TRACING=$(if $(CONFIG_BATMAN_ADV_TRACING),y,n) \
+ 
+ PKG_EXTRA_CFLAGS:= \
+ 	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=m,%,$(filter %=m,$(PKG_EXTRA_KCONFIG)))) \
+ 	$(patsubst CONFIG_%, -DCONFIG_%=1, $(patsubst %=y,%,$(filter %=y,$(PKG_EXTRA_KCONFIG)))) \
+ 
++BACKPORTS_VERSION:= \
++	$(shell cat $(STAGING_DIR)/pkginfo/kmod-mac80211.version)
++
++HAVE_BACKPORTS_LESS_5_10_FLAG:= \
++	$(shell if [ -z "$(BACKPORTS_VERSION)" ] || [ "$$(printf '%s\n' "5.10" "$(BACKPORTS_VERSION)" | sort -V | head -n1)" = "5.10" ]; then echo -n ""; else echo -n "-DHAVE_BACKPORTS_LESS_5_10"; fi)
++
+ NOSTDINC_FLAGS = \
++	$(KERNEL_NOSTDINC_FLAGS) \
++	$(HAVE_BACKPORTS_LESS_5_10_FLAG) \
+ 	-I$(PKG_BUILD_DIR)/net/batman-adv \
+ 	-I$(STAGING_DIR)/usr/include/mac80211-backport \
+ 	-I$(STAGING_DIR)/usr/include/mac80211-backport/uapi \
+ 	-I$(STAGING_DIR)/usr/include/mac80211 \
+ 	-I$(STAGING_DIR)/usr/include/mac80211/uapi \
+ 	-I$(PKG_BUILD_DIR)/include/ \
++	-include backport/autoconf.h \
+ 	-include backport/backport.h \
+ 	-include $(PKG_BUILD_DIR)/compat-hacks.h \
+-	-DBATADV_SOURCE_VERSION=\\\"openwrt-$(PKG_VERSION)-$(PKG_RELEASE)\\\"
+-
+-COMPAT_SOURCES = \
+-	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/core/skbuff.o,) \
+-	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv4/igmp.o,) \
+-	$(if $(CONFIG_BATMAN_ADV_MCAST),../../compat-sources/net/ipv6/mcast_snoop.o,) \
++	-DBATADV_SOURCE_VERSION=\\\"$(PKG_VERSION)-openwrt-$(PKG_RELEASE)\\\"
+ 
+ define Build/Compile
+-	+env "batman-adv-y=$(COMPAT_SOURCES)" \
+ 	$(MAKE) $(PKG_JOBS) -C "$(LINUX_DIR)" \
+-		ARCH="$(LINUX_KARCH)" \
+-		CROSS_COMPILE="$(TARGET_CROSS)" \
+-		SUBDIRS="$(PKG_BUILD_DIR)/net/batman-adv" \
++		$(KERNEL_MAKE_FLAGS) \
++		M="$(PKG_BUILD_DIR)/net/batman-adv" \
+ 		$(PKG_EXTRA_KCONFIG) \
+ 		EXTRA_CFLAGS="$(PKG_EXTRA_CFLAGS)" \
+ 		NOSTDINC_FLAGS="$(NOSTDINC_FLAGS)" \
+diff --git a/batman-adv/files/lib/netifd/proto/batadv.sh b/batman-adv/files/lib/netifd/proto/batadv.sh
+index a7fe63cd8f45ebd2a6d3c2841e805ff8b8fe930e..edc14f4cbd5485ede408e897fada8eae6f8f09d3 100755
+--- a/batman-adv/files/lib/netifd/proto/batadv.sh
++++ b/batman-adv/files/lib/netifd/proto/batadv.sh
+@@ -72,42 +72,42 @@ proto_batadv_setup() {
+ 	set_default routing_algo 'BATMAN_IV'
+ 
+ 	batctl routing_algo "$routing_algo"
+-	batctl -m "$iface" interface create
++	batctl meshif "$iface" interface create
+ 
+-	[ -n "$aggregated_ogms" ] && batctl -m "$iface" aggregation "$aggregated_ogms"
+-	[ -n "$ap_isolation" ] && batctl -m "$iface" ap_isolation "$ap_isolation"
+-	[ -n "$bonding" ] && batctl -m "$iface" bonding "$bonding"
+-	[ -n "$bridge_loop_avoidance" ] &&  batctl -m "$iface" bridge_loop_avoidance "$bridge_loop_avoidance" 2>&-
+-	[ -n "$distributed_arp_table" ] && batctl -m "$iface" distributed_arp_table "$distributed_arp_table" 2>&-
+-	[ -n "$fragmentation" ] && batctl -m "$iface" fragmentation "$fragmentation"
++	[ -n "$aggregated_ogms" ] && batctl meshif "$iface" aggregation "$aggregated_ogms"
++	[ -n "$ap_isolation" ] && batctl meshif "$iface" ap_isolation "$ap_isolation"
++	[ -n "$bonding" ] && batctl meshif "$iface" bonding "$bonding"
++	[ -n "$bridge_loop_avoidance" ] &&  batctl meshif "$iface" bridge_loop_avoidance "$bridge_loop_avoidance" 2>&-
++	[ -n "$distributed_arp_table" ] && batctl meshif "$iface" distributed_arp_table "$distributed_arp_table" 2>&-
++	[ -n "$fragmentation" ] && batctl meshif "$iface" fragmentation "$fragmentation"
+ 
+ 	case "$gw_mode" in
+ 	server)
+ 		if [ -n "$gw_bandwidth" ]; then
+-			batctl -m "$iface" gw_mode "server" "$gw_bandwidth"
++			batctl meshif "$iface" gw_mode "server" "$gw_bandwidth"
+ 		else
+-			batctl -m "$iface" gw_mode "server"
++			batctl meshif "$iface" gw_mode "server"
+ 		fi
+ 		;;
+ 	client)
+ 		if [ -n "$gw_sel_class" ]; then
+-			batctl -m "$iface" gw_mode "client" "$gw_sel_class"
++			batctl meshif "$iface" gw_mode "client" "$gw_sel_class"
+ 		else
+-			batctl -m "$iface" gw_mode "client"
++			batctl meshif "$iface" gw_mode "client"
+ 		fi
+ 		;;
+ 	*)
+-		batctl -m "$iface" gw_mode "off"
++		batctl meshif "$iface" gw_mode "off"
+ 		;;
+ 	esac
+ 
+-	[ -n "$hop_penalty" ] && batctl -m "$iface" hop_penalty "$hop_penalty"
+-	[ -n "$isolation_mark" ] && batctl -m "$iface" isolation_mark "$isolation_mark"
+-	[ -n "$multicast_fanout" ] && batctl -m "$iface" multicast_fanout "$multicast_fanout"
+-	[ -n "$multicast_mode" ] && batctl -m "$iface" multicast_mode "$multicast_mode" 2>&-
+-	[ -n "$network_coding" ] && batctl -m "$iface" network_coding "$network_coding" 2>&-
+-	[ -n "$log_level" ] && batctl -m "$iface" loglevel "$log_level" 2>&-
+-	[ -n "$orig_interval" ] && batctl -m "$iface" orig_interval "$orig_interval"
++	[ -n "$hop_penalty" ] && batctl meshif "$iface" hop_penalty "$hop_penalty"
++	[ -n "$isolation_mark" ] && batctl meshif "$iface" isolation_mark "$isolation_mark"
++	[ -n "$multicast_fanout" ] && batctl meshif "$iface" multicast_fanout "$multicast_fanout"
++	[ -n "$multicast_mode" ] && batctl meshif "$iface" multicast_mode "$multicast_mode" 2>&-
++	[ -n "$network_coding" ] && batctl meshif "$iface" network_coding "$network_coding" 2>&-
++	[ -n "$log_level" ] && batctl meshif "$iface" loglevel "$log_level" 2>&-
++	[ -n "$orig_interval" ] && batctl meshif "$iface" orig_interval "$orig_interval"
+ 
+ 	proto_init_update "$iface" 1
+ 	proto_send_update "$config"
+@@ -117,7 +117,7 @@ proto_batadv_teardown() {
+ 	local config="$1"
+ 	local iface="$config"
+ 
+-	batctl -m "$iface" interface destroy
++	batctl meshif "$iface" interface destroy
+ }
+ 
+ add_protocol batadv
+diff --git a/batman-adv/files/lib/netifd/proto/batadv_hardif.sh b/batman-adv/files/lib/netifd/proto/batadv_hardif.sh
+index 76ccd8199e44f5dc3f485f343f7ee91495631b67..b2f87dd6c24eb67e68da1dc66270d9aa67af8140 100755
+--- a/batman-adv/files/lib/netifd/proto/batadv_hardif.sh
++++ b/batman-adv/files/lib/netifd/proto/batadv_hardif.sh
+@@ -8,6 +8,7 @@
+ 
+ proto_batadv_hardif_init_config() {
+ 	proto_config_add_int 'elp_interval'
++	proto_config_add_int 'hop_penalty'
+ 	proto_config_add_string "master"
+ 	proto_config_add_string 'throughput_override'
+ }
+@@ -17,19 +18,22 @@ proto_batadv_hardif_setup() {
+ 	local iface="$2"
+ 
+ 	local elp_interval
++	local hop_penalty
+ 	local master
+ 	local throughput_override
+ 
+ 	json_get_vars elp_interval
++	json_get_vars hop_penalty
+ 	json_get_vars master
+ 	json_get_vars throughput_override
+ 
+ 	( proto_add_host_dependency "$config" '' "$master" )
+ 
+-	batctl -m "$master" interface -M add "$iface"
++	batctl meshif "$master" interface -M add "$iface"
+ 
+-	[ -n "$elp_interval" ] && batctl -m "$master" hardif "$iface" elp_interval "$elp_interval"
+-	[ -n "$throughput_override" ] && batctl -m "$master" hardif "$iface" throughput_override "$throughput_override"
++	[ -n "$elp_interval" ] && batctl hardif "$iface" elp_interval "$elp_interval"
++	[ -n "$hop_penalty" ] && batctl hardif "$iface" hop_penalty "$hop_penalty"
++	[ -n "$throughput_override" ] && batctl hardif "$iface" throughput_override "$throughput_override"
+ 
+ 	proto_init_update "$iface" 1
+ 	proto_send_update "$config"
+@@ -43,7 +47,7 @@ proto_batadv_hardif_teardown() {
+ 
+ 	json_get_vars master
+ 
+-	batctl -m "$master" interface -M del "$iface" || true
++	batctl meshif "$master" interface -M del "$iface" || true
+ }
+ 
+ add_protocol batadv_hardif
+diff --git a/batman-adv/files/lib/netifd/proto/batadv_vlan.sh b/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
+index b4835f6d703c97da34f95caf94bfef9ea0ff9963..5b0c76fd2efcdeb46765792dcbb43c741665372b 100755
+--- a/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
++++ b/batman-adv/files/lib/netifd/proto/batadv_vlan.sh
+@@ -17,9 +17,13 @@ proto_batadv_vlan_setup() {
+ 
+ 	json_get_vars ap_isolation
+ 
+-	[ -n "$ap_isolation" ] && batctl -m "$iface" ap_isolation "$ap_isolation"
++	[ -n "$ap_isolation" ] && batctl vlan "$iface" ap_isolation "$ap_isolation"
+ 	proto_init_update "$iface" 1
+ 	proto_send_update "$config"
+ }
+ 
++proto_batadv_vlan_teardown() {
++	local cfg="$1"
++}
++
+ add_protocol batadv_vlan
+diff --git a/batman-adv/patches/0001-Revert-batman-adv-Migrate-to-linux-container_of.h.patch b/batman-adv/patches/0001-Revert-batman-adv-Migrate-to-linux-container_of.h.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..5f85db086f6c5737b3ba3e21c2fcb3b62ed560ef
+--- /dev/null
++++ b/batman-adv/patches/0001-Revert-batman-adv-Migrate-to-linux-container_of.h.patch
+@@ -0,0 +1,275 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Fri, 6 May 2022 22:03:29 +0200
++Subject: Revert "batman-adv: Migrate to linux/container_of.h"
++
++The original patch requires Linux 5.16.0 or a mac80211 compat header with this
++name. But the mac80211 package is currently not providing this header and
++OpenWrt main is still using older Linux kernel versions for some targets.
++
++This reverts commit 043ae5634bdfd4c4dd8b95a22890752495080bb5.
++
++--- a/compat-include/linux/container_of.h
+++++ /dev/null
++@@ -1,20 +0,0 @@
++-/* SPDX-License-Identifier: GPL-2.0 */
++-/* Copyright (C) B.A.T.M.A.N. contributors:
++- *
++- * Marek Lindner, Simon Wunderlich
++- *
++- * This file contains macros for maintaining compatibility with older versions
++- * of the Linux kernel.
++- */
++-
++-#ifndef _NET_BATMAN_ADV_COMPAT_LINUX_CONTAINER_OF_H_
++-#define _NET_BATMAN_ADV_COMPAT_LINUX_CONTAINER_OF_H_
++-
++-#include <linux/version.h>
++-#if LINUX_VERSION_IS_GEQ(5, 16, 0)
++-#include_next <linux/container_of.h>
++-#else
++-#include <linux/kernel.h>
++-#endif
++-
++-#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_CONTAINER_OF_H_ */
++--- a/net/batman-adv/bat_iv_ogm.c
+++++ b/net/batman-adv/bat_iv_ogm.c
++@@ -13,13 +13,13 @@
++ #include <linux/bug.h>
++ #include <linux/byteorder/generic.h>
++ #include <linux/cache.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++ #include <linux/if_ether.h>
++ #include <linux/init.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
++--- a/net/batman-adv/bat_v_elp.c
+++++ b/net/batman-adv/bat_v_elp.c
++@@ -10,13 +10,13 @@
++ #include <linux/atomic.h>
++ #include <linux/bitops.h>
++ #include <linux/byteorder/generic.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++ #include <linux/ethtool.h>
++ #include <linux/gfp.h>
++ #include <linux/if_ether.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/minmax.h>
++ #include <linux/netdevice.h>
++--- a/net/batman-adv/bat_v_ogm.c
+++++ b/net/batman-adv/bat_v_ogm.c
++@@ -9,12 +9,12 @@
++ 
++ #include <linux/atomic.h>
++ #include <linux/byteorder/generic.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++ #include <linux/if_ether.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
++--- a/net/batman-adv/bridge_loop_avoidance.c
+++++ b/net/batman-adv/bridge_loop_avoidance.c
++@@ -10,7 +10,6 @@
++ #include <linux/atomic.h>
++ #include <linux/byteorder/generic.h>
++ #include <linux/compiler.h>
++-#include <linux/container_of.h>
++ #include <linux/crc16.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++--- a/net/batman-adv/distributed-arp-table.c
+++++ b/net/batman-adv/distributed-arp-table.c
++@@ -11,7 +11,6 @@
++ #include <linux/atomic.h>
++ #include <linux/bitops.h>
++ #include <linux/byteorder/generic.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++@@ -21,6 +20,7 @@
++ #include <linux/in.h>
++ #include <linux/ip.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/netlink.h>
++--- a/net/batman-adv/gateway_client.c
+++++ b/net/batman-adv/gateway_client.c
++@@ -9,7 +9,6 @@
++ 
++ #include <linux/atomic.h>
++ #include <linux/byteorder/generic.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++--- a/net/batman-adv/hard-interface.c
+++++ b/net/batman-adv/hard-interface.c
++@@ -10,12 +10,12 @@
++ #include <linux/atomic.h>
++ #include <linux/byteorder/generic.h>
++ #include <linux/compiler.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/gfp.h>
++ #include <linux/if.h>
++ #include <linux/if_arp.h>
++ #include <linux/if_ether.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/limits.h>
++ #include <linux/list.h>
++--- a/net/batman-adv/main.c
+++++ b/net/batman-adv/main.c
++@@ -10,7 +10,6 @@
++ #include <linux/atomic.h>
++ #include <linux/build_bug.h>
++ #include <linux/byteorder/generic.h>
++-#include <linux/container_of.h>
++ #include <linux/crc32c.h>
++ #include <linux/device.h>
++ #include <linux/errno.h>
++--- a/net/batman-adv/multicast.c
+++++ b/net/batman-adv/multicast.c
++@@ -11,7 +11,6 @@
++ #include <linux/bitops.h>
++ #include <linux/bug.h>
++ #include <linux/byteorder/generic.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++--- a/net/batman-adv/network-coding.c
+++++ b/net/batman-adv/network-coding.c
++@@ -11,7 +11,6 @@
++ #include <linux/bitops.h>
++ #include <linux/byteorder/generic.h>
++ #include <linux/compiler.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++@@ -20,6 +19,7 @@
++ #include <linux/init.h>
++ #include <linux/jhash.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
++--- a/net/batman-adv/originator.c
+++++ b/net/batman-adv/originator.c
++@@ -8,12 +8,12 @@
++ #include "main.h"
++ 
++ #include <linux/atomic.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++ #include <linux/if_vlan.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
++--- a/net/batman-adv/send.c
+++++ b/net/batman-adv/send.c
++@@ -10,13 +10,13 @@
++ #include <linux/atomic.h>
++ #include <linux/bug.h>
++ #include <linux/byteorder/generic.h>
++-#include <linux/container_of.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++ #include <linux/if.h>
++ #include <linux/if_ether.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/netdevice.h>
++--- a/net/batman-adv/soft-interface.c
+++++ b/net/batman-adv/soft-interface.c
++@@ -11,7 +11,6 @@
++ #include <linux/byteorder/generic.h>
++ #include <linux/cache.h>
++ #include <linux/compiler.h>
++-#include <linux/container_of.h>
++ #include <linux/cpumask.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++@@ -20,6 +19,7 @@
++ #include <linux/if_ether.h>
++ #include <linux/if_vlan.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
++--- a/net/batman-adv/tp_meter.c
+++++ b/net/batman-adv/tp_meter.c
++@@ -12,13 +12,13 @@
++ #include <linux/byteorder/generic.h>
++ #include <linux/cache.h>
++ #include <linux/compiler.h>
++-#include <linux/container_of.h>
++ #include <linux/err.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++ #include <linux/if_ether.h>
++ #include <linux/init.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/kthread.h>
++ #include <linux/limits.h>
++--- a/net/batman-adv/translation-table.c
+++++ b/net/batman-adv/translation-table.c
++@@ -13,7 +13,6 @@
++ #include <linux/byteorder/generic.h>
++ #include <linux/cache.h>
++ #include <linux/compiler.h>
++-#include <linux/container_of.h>
++ #include <linux/crc32c.h>
++ #include <linux/errno.h>
++ #include <linux/etherdevice.h>
++@@ -22,6 +21,7 @@
++ #include <linux/init.h>
++ #include <linux/jhash.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
++--- a/net/batman-adv/tvlv.c
+++++ b/net/batman-adv/tvlv.c
++@@ -7,10 +7,10 @@
++ #include "main.h"
++ 
++ #include <linux/byteorder/generic.h>
++-#include <linux/container_of.h>
++ #include <linux/etherdevice.h>
++ #include <linux/gfp.h>
++ #include <linux/if_ether.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
+diff --git a/batman-adv/patches/0001-Revert-batman-adv-convert-stream-like-files-from-non.patch b/batman-adv/patches/0001-Revert-batman-adv-convert-stream-like-files-from-non.patch
+deleted file mode 100644
+index 74dd54e32dbe6938e829d0031bb57a7a0b7a4acb..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0001-Revert-batman-adv-convert-stream-like-files-from-non.patch
++++ /dev/null
+@@ -1,49 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 23 May 2019 19:26:27 +0200
+-Subject: Revert "batman-adv: convert stream-like files from nonseekable_open -> stream_open"
+-
+-OpenWrt's mac80211 package is not yet ready to support the generic netlink
+-API of Linux 5.2.
+-
+-This reverts commit 337ae19a00d4455cf84afa58abfb432f78c882b9.
+-
+---- a/compat-include/linux/fs.h
+-+++ b/compat-include/linux/fs.h
+-@@ -31,15 +31,4 @@ static inline struct dentry *batadv_file
+- 
+- #endif /* < KERNEL_VERSION(4, 6, 0) */
+- 
+--#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+--
+--static inline int batadv_stream_open(struct inode *inode, struct file *filp)
+--{
+--	return nonseekable_open(inode, filp);
+--}
+--
+--#define stream_open batadv_stream_open
+--
+--#endif /* < KERNEL_VERSION(5, 2, 0) */
+--
+- #endif	/* _NET_BATMAN_ADV_COMPAT_LINUX_FS_H_ */
+---- a/net/batman-adv/icmp_socket.c
+-+++ b/net/batman-adv/icmp_socket.c
+-@@ -65,7 +65,7 @@ static int batadv_socket_open(struct ino
+- 
+- 	batadv_debugfs_deprecated(file, "");
+- 
+--	stream_open(inode, file);
+-+	nonseekable_open(inode, file);
+- 
+- 	socket_client = kmalloc(sizeof(*socket_client), GFP_KERNEL);
+- 	if (!socket_client) {
+---- a/net/batman-adv/log.c
+-+++ b/net/batman-adv/log.c
+-@@ -90,7 +90,7 @@ static int batadv_log_open(struct inode
+- 	batadv_debugfs_deprecated(file,
+- 				  "Use tracepoint batadv:batadv_dbg instead\n");
+- 
+--	stream_open(inode, file);
+-+	nonseekable_open(inode, file);
+- 	file->private_data = inode->i_private;
+- 	return 0;
+- }
+diff --git a/batman-adv/patches/0002-Revert-batman-adv-compat-Drop-support-for-genl_ops-s.patch b/batman-adv/patches/0002-Revert-batman-adv-compat-Drop-support-for-genl_ops-s.patch
+deleted file mode 100644
+index 38615f755aae8b1112d3f7af83ca484158c99e05..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0002-Revert-batman-adv-compat-Drop-support-for-genl_ops-s.patch
++++ /dev/null
+@@ -1,27 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 23 May 2019 19:26:36 +0200
+-Subject: Revert "batman-adv: compat: Drop support for genl_ops->start"
+-
+-OpenWrt's mac80211 package is not yet ready to support the generic netlink
+-API of Linux 5.2.
+-
+-This reverts commit 1d30dbe3917d0d6fdb8ba473dfdd6265ac46670b.
+-
+---- a/compat-include/net/genetlink.h
+-+++ b/compat-include/net/genetlink.h
+-@@ -42,6 +42,7 @@ enum genl_validate_flags {
+- struct batadv_genl_ops {
+- 	int		       (*doit)(struct sk_buff *skb,
+- 				       struct genl_info *info);
+-+	int		       (*start)(struct netlink_callback *cb);
+- 	int		       (*dumpit)(struct sk_buff *skb,
+- 					 struct netlink_callback *cb);
+- 	int		       (*done)(struct netlink_callback *cb);
+-@@ -104,6 +105,7 @@ static inline int batadv_genl_register_f
+- 
+- 	for (i = 0; i < family->family.n_ops; i++) {
+- 		ops[i].doit = family->ops[i].doit;
+-+		ops[i].start = family->ops[i].start;
+- 		ops[i].dumpit = family->ops[i].dumpit;
+- 		ops[i].done = family->ops[i].done;
+- 		ops[i].cmd = family->ops[i].cmd;
+diff --git a/batman-adv/patches/0002-fix-batadv_is_cfg80211_netdev.patch b/batman-adv/patches/0002-fix-batadv_is_cfg80211_netdev.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..ae70c8545069f2f24eadeb0083fbdfd720079af9
+--- /dev/null
++++ b/batman-adv/patches/0002-fix-batadv_is_cfg80211_netdev.patch
+@@ -0,0 +1,19 @@
++From: Alexandru Gagniuc <mr.nuke.me@gmail.com>
++Date: Thu, 6 Apr 2023 18:05:50 -0500
++Subject: fix batadv_is_cfg80211_netdev
++
++Replace CONFIG_CFG80211 with CPTCFG_CFG80211, which is the correct
++macro to use when building under backports.
++
++--- a/net/batman-adv/hard-interface.c
+++++ b/net/batman-adv/hard-interface.c
++@@ -308,8 +308,7 @@ static bool batadv_is_cfg80211_netdev(st
++ {
++ 	if (!net_device)
++ 		return false;
++-
++-#if IS_ENABLED(CONFIG_CFG80211)
+++#if IS_ENABLED(CPTCFG_CFG80211)
++ 	/* cfg80211 drivers have to set ieee80211_ptr */
++ 	if (net_device->ieee80211_ptr)
++ 		return true;
+diff --git a/batman-adv/patches/0003-Revert-batman-adv-Switch-to-linux-sprintf.h.patch b/batman-adv/patches/0003-Revert-batman-adv-Switch-to-linux-sprintf.h.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..e072f56e40fd6fe1d7d3cc441ecd01b64d5b05ed
+--- /dev/null
++++ b/batman-adv/patches/0003-Revert-batman-adv-Switch-to-linux-sprintf.h.patch
+@@ -0,0 +1,97 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Fri, 2 Feb 2024 22:49:00 +0100
++Subject: Revert "batman-adv: Switch to linux/sprintf.h"
++
++The original patch requires Linux 6.6.0 or a mac80211 compat header with this
++name. But the mac80211 package is currently not providing this header and
++OpenWrt main is still using older Linux kernel versions for some targets.
++
++This reverts commit f0fb49c5ab70dfa064f0aa8d1c5d84f65e8cbc86.
++
++--- a/compat-include/linux/sprintf.h
+++++ /dev/null
++@@ -1,20 +0,0 @@
++-/* SPDX-License-Identifier: GPL-2.0 */
++-/* Copyright (C) B.A.T.M.A.N. contributors:
++- *
++- * Marek Lindner, Simon Wunderlich
++- *
++- * This file contains macros for maintaining compatibility with older versions
++- * of the Linux kernel.
++- */
++-
++-#ifndef _NET_BATMAN_ADV_COMPAT_LINUX_SPRINTF_H_
++-#define _NET_BATMAN_ADV_COMPAT_LINUX_SPRINTF_H_
++-
++-#include <linux/version.h>
++-#if LINUX_VERSION_IS_GEQ(6, 6, 0)
++-#include_next <linux/sprintf.h>
++-#else
++-#include <linux/kernel.h>
++-#endif
++-
++-#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_SPRINTF_H_ */
++--- a/net/batman-adv/bridge_loop_avoidance.c
+++++ b/net/batman-adv/bridge_loop_avoidance.c
++@@ -19,6 +19,7 @@
++ #include <linux/if_vlan.h>
++ #include <linux/jhash.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
++@@ -29,7 +30,6 @@
++ #include <linux/skbuff.h>
++ #include <linux/slab.h>
++ #include <linux/spinlock.h>
++-#include <linux/sprintf.h>
++ #include <linux/stddef.h>
++ #include <linux/string.h>
++ #include <linux/workqueue.h>
++--- a/net/batman-adv/gateway_client.c
+++++ b/net/batman-adv/gateway_client.c
++@@ -17,6 +17,7 @@
++ #include <linux/in.h>
++ #include <linux/ip.h>
++ #include <linux/ipv6.h>
+++#include <linux/kernel.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
++@@ -27,7 +28,6 @@
++ #include <linux/skbuff.h>
++ #include <linux/slab.h>
++ #include <linux/spinlock.h>
++-#include <linux/sprintf.h>
++ #include <linux/stddef.h>
++ #include <linux/udp.h>
++ #include <net/sock.h>
++--- a/net/batman-adv/main.c
+++++ b/net/batman-adv/main.c
++@@ -31,7 +31,6 @@
++ #include <linux/skbuff.h>
++ #include <linux/slab.h>
++ #include <linux/spinlock.h>
++-#include <linux/sprintf.h>
++ #include <linux/stddef.h>
++ #include <linux/string.h>
++ #include <linux/workqueue.h>
++--- a/net/batman-adv/multicast.c
+++++ b/net/batman-adv/multicast.c
++@@ -24,6 +24,7 @@
++ #include <linux/ip.h>
++ #include <linux/ipv6.h>
++ #include <linux/jiffies.h>
+++#include <linux/kernel.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
++ #include <linux/netdevice.h>
++@@ -34,7 +35,6 @@
++ #include <linux/skbuff.h>
++ #include <linux/slab.h>
++ #include <linux/spinlock.h>
++-#include <linux/sprintf.h>
++ #include <linux/stddef.h>
++ #include <linux/string.h>
++ #include <linux/types.h>
+diff --git a/batman-adv/patches/0003-Revert-batman-adv-genetlink-optionally-validate-stri.patch b/batman-adv/patches/0003-Revert-batman-adv-genetlink-optionally-validate-stri.patch
+deleted file mode 100644
+index f0e7cd1f46fbfcbbb0a9870c837ca642d2a9dc94..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0003-Revert-batman-adv-genetlink-optionally-validate-stri.patch
++++ /dev/null
+@@ -1,218 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 23 May 2019 19:26:45 +0200
+-Subject: Revert "batman-adv: genetlink: optionally validate strictly/dumps"
+-
+-OpenWrt's mac80211 package is not yet ready to support the generic netlink
+-API of Linux 5.2.
+-
+-This reverts commit 2ee47abaeb35ca62bb909830e10b0e973393b853.
+-
+---- a/compat-include/net/genetlink.h
+-+++ b/compat-include/net/genetlink.h
+-@@ -33,25 +33,6 @@ void batadv_genl_dump_check_consistent(s
+- 
+- #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+- 
+--enum genl_validate_flags {
+--	GENL_DONT_VALIDATE_STRICT		= BIT(0),
+--	GENL_DONT_VALIDATE_DUMP			= BIT(1),
+--	GENL_DONT_VALIDATE_DUMP_STRICT		= BIT(2),
+--};
+--
+--struct batadv_genl_ops {
+--	int		       (*doit)(struct sk_buff *skb,
+--				       struct genl_info *info);
+--	int		       (*start)(struct netlink_callback *cb);
+--	int		       (*dumpit)(struct sk_buff *skb,
+--					 struct netlink_callback *cb);
+--	int		       (*done)(struct netlink_callback *cb);
+--	u8			cmd;
+--	u8			internal_flags;
+--	u8			flags;
+--	u8			validate;
+--};
+--
+- struct batadv_genl_family {
+- 	/* data handled by the actual kernel */
+- 	struct genl_family family;
+-@@ -69,7 +50,7 @@ struct batadv_genl_family {
+- 			 struct genl_info *info);
+-         void (*post_doit)(const struct genl_ops *ops, struct sk_buff *skb,
+- 			  struct genl_info *info);
+--	const struct batadv_genl_ops *ops;
+-+	const struct genl_ops *ops;
+- 	const struct genl_multicast_group *mcgrps;
+- 	unsigned int n_ops;
+- 	unsigned int n_mcgrps;
+-@@ -82,6 +63,8 @@ struct batadv_genl_family {
+- 	struct genl_ops *copy_ops;
+- };
+- 
+-+#define genl_family batadv_genl_family
+-+
+- static inline int batadv_genl_register_family(struct batadv_genl_family *family)
+- {
+- 	struct genl_ops *ops;
+-@@ -99,20 +82,12 @@ static inline int batadv_genl_register_f
+- 	family->family.n_mcgrps = family->n_mcgrps;
+- 	family->family.module = family->module;
+- 
+--	ops = kzalloc(sizeof(*ops) * family->n_ops, GFP_KERNEL);
+-+	ops = kmemdup(family->ops, sizeof(*ops) * family->n_ops, GFP_KERNEL);
+- 	if (!ops)
+- 		return -ENOMEM;
+- 
+--	for (i = 0; i < family->family.n_ops; i++) {
+--		ops[i].doit = family->ops[i].doit;
+--		ops[i].start = family->ops[i].start;
+--		ops[i].dumpit = family->ops[i].dumpit;
+--		ops[i].done = family->ops[i].done;
+--		ops[i].cmd = family->ops[i].cmd;
+--		ops[i].internal_flags = family->ops[i].internal_flags;
+--		ops[i].flags = family->ops[i].flags;
+-+	for (i = 0; i < family->family.n_ops; i++)
+- 		ops[i].policy = family->policy;
+--	}
+- 
+- 	family->family.ops = ops;
+- 	family->copy_ops = ops;
+-@@ -120,17 +95,6 @@ static inline int batadv_genl_register_f
+- 	return genl_register_family(&family->family);
+- }
+- 
+--typedef struct genl_ops batadv_genl_ops_old;
+--
+--#define batadv_pre_doit(__x, __y, __z) \
+--	batadv_pre_doit(const batadv_genl_ops_old *ops, __y, __z)
+--
+--#define batadv_post_doit(__x, __y, __z) \
+--	batadv_post_doit(const batadv_genl_ops_old *ops, __y, __z)
+--
+--#define genl_ops batadv_genl_ops
+--#define genl_family batadv_genl_family
+--
+- #define genl_register_family(family) \
+- 	batadv_genl_register_family((family))
+- 
+---- a/net/batman-adv/netlink.c
+-+++ b/net/batman-adv/netlink.c
+-@@ -1343,34 +1343,29 @@ static void batadv_post_doit(const struc
+- static const struct genl_ops batadv_netlink_ops[] = {
+- 	{
+- 		.cmd = BATADV_CMD_GET_MESH,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		/* can be retrieved by unprivileged users */
+- 		.doit = batadv_netlink_get_mesh,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_TP_METER,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.doit = batadv_netlink_tp_meter_start,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_TP_METER_CANCEL,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.doit = batadv_netlink_tp_meter_cancel,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_ROUTING_ALGOS,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_algo_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_HARDIF,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		/* can be retrieved by unprivileged users */
+- 		.dumpit = batadv_netlink_dump_hardif,
+- 		.doit = batadv_netlink_get_hardif,
+-@@ -1379,68 +1374,57 @@ static const struct genl_ops batadv_netl
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_TRANSTABLE_LOCAL,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_tt_local_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_TRANSTABLE_GLOBAL,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_tt_global_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_ORIGINATORS,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_orig_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_NEIGHBORS,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_hardif_neigh_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_GATEWAYS,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_gw_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_BLA_CLAIM,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_bla_claim_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_BLA_BACKBONE,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_bla_backbone_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_DAT_CACHE,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_dat_cache_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_MCAST_FLAGS,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.dumpit = batadv_mcast_flags_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_SET_MESH,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.doit = batadv_netlink_set_mesh,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_SET_HARDIF,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.doit = batadv_netlink_set_hardif,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH |
+-@@ -1448,7 +1432,6 @@ static const struct genl_ops batadv_netl
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_VLAN,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		/* can be retrieved by unprivileged users */
+- 		.doit = batadv_netlink_get_vlan,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH |
+-@@ -1456,7 +1439,6 @@ static const struct genl_ops batadv_netl
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_SET_VLAN,
+--		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+- 		.flags = GENL_ADMIN_PERM,
+- 		.doit = batadv_netlink_set_vlan,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH |
+diff --git a/batman-adv/patches/0004-Revert-batman-adv-Switch-to-linux-array_size.h.patch b/batman-adv/patches/0004-Revert-batman-adv-Switch-to-linux-array_size.h.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..838cc93e983d502f39dbe9b7f3630faad085cd17
+--- /dev/null
++++ b/batman-adv/patches/0004-Revert-batman-adv-Switch-to-linux-array_size.h.patch
+@@ -0,0 +1,69 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Fri, 2 Feb 2024 22:49:48 +0100
++Subject: Revert "batman-adv: Switch to linux/array_size.h"
++
++The original patch requires Linux 6.7.0 or a mac80211 compat header with this
++name. But the mac80211 package is currently not providing this header and
++OpenWrt main is still using older Linux kernel versions for some targets.
++
++This reverts commit f33d7f724675544a36b24c77f8d4b95d41252ae2.
++
++--- a/compat-include/linux/array_size.h
+++++ /dev/null
++@@ -1,20 +0,0 @@
++-/* SPDX-License-Identifier: GPL-2.0 */
++-/* Copyright (C) B.A.T.M.A.N. contributors:
++- *
++- * Marek Lindner, Simon Wunderlich
++- *
++- * This file contains macros for maintaining compatibility with older versions
++- * of the Linux kernel.
++- */
++-
++-#ifndef _NET_BATMAN_ADV_COMPAT_LINUX_ARRAY_SIZE_H_
++-#define _NET_BATMAN_ADV_COMPAT_LINUX_ARRAY_SIZE_H_
++-
++-#include <linux/version.h>
++-#if LINUX_VERSION_IS_GEQ(6, 7, 0)
++-#include_next <linux/array_size.h>
++-#else
++-#include <linux/kernel.h>
++-#endif
++-
++-#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_ARRAY_SIZE_H_ */
++--- a/net/batman-adv/main.c
+++++ b/net/batman-adv/main.c
++@@ -6,7 +6,6 @@
++ 
++ #include "main.h"
++ 
++-#include <linux/array_size.h>
++ #include <linux/atomic.h>
++ #include <linux/build_bug.h>
++ #include <linux/byteorder/generic.h>
++@@ -19,6 +18,7 @@
++ #include <linux/init.h>
++ #include <linux/ip.h>
++ #include <linux/ipv6.h>
+++#include <linux/kernel.h>
++ #include <linux/kobject.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
++--- a/net/batman-adv/netlink.c
+++++ b/net/batman-adv/netlink.c
++@@ -7,7 +7,6 @@
++ #include "netlink.h"
++ #include "main.h"
++ 
++-#include <linux/array_size.h>
++ #include <linux/atomic.h>
++ #include <linux/bitops.h>
++ #include <linux/bug.h>
++@@ -19,6 +18,7 @@
++ #include <linux/if_ether.h>
++ #include <linux/if_vlan.h>
++ #include <linux/init.h>
+++#include <linux/kernel.h>
++ #include <linux/limits.h>
++ #include <linux/list.h>
++ #include <linux/minmax.h>
+diff --git a/batman-adv/patches/0004-Revert-batman-adv-genetlink-make-policy-common-to-fa.patch b/batman-adv/patches/0004-Revert-batman-adv-genetlink-make-policy-common-to-fa.patch
+deleted file mode 100644
+index f4de313f67272294a1173e59bdbdcd3d28a5ca8f..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0004-Revert-batman-adv-genetlink-make-policy-common-to-fa.patch
++++ /dev/null
+@@ -1,250 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 23 May 2019 19:26:58 +0200
+-Subject: Revert "batman-adv: genetlink: make policy common to family"
+-
+-OpenWrt's mac80211 package is not yet ready to support the generic netlink
+-API of Linux 5.2.
+-
+-This reverts commit acfc9a214d01695d1676313ca80cfd2d9309f633.
+-
+---- a/compat-include/linux/cache.h
+-+++ b/compat-include/linux/cache.h
+-@@ -13,8 +13,12 @@
+- #include <linux/version.h>
+- #include_next <linux/cache.h>
+- 
+--#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+-+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
+- 
+-+/* hack for netlink.c which marked the family ops as ro */
+-+#ifdef __ro_after_init
+-+#undef __ro_after_init
+-+#endif
+- #define __ro_after_init
+- 
+- #endif /* < KERNEL_VERSION(4, 6, 0) */
+---- a/compat-include/net/genetlink.h
+-+++ b/compat-include/net/genetlink.h
+-@@ -30,92 +30,4 @@ void batadv_genl_dump_check_consistent(s
+- 
+- #endif /* < KERNEL_VERSION(4, 15, 0) */
+- 
+--
+--#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+--
+--struct batadv_genl_family {
+--	/* data handled by the actual kernel */
+--	struct genl_family family;
+--
+--	/* data which has to be copied to family by
+--	 * batadv_genl_register_family
+--	 */
+--	unsigned int hdrsize;
+--	char name[GENL_NAMSIZ];
+--	unsigned int version;
+--	unsigned int maxattr;
+--	const struct nla_policy *policy;
+--	bool netnsok;
+--        int  (*pre_doit)(const struct genl_ops *ops, struct sk_buff *skb,
+--			 struct genl_info *info);
+--        void (*post_doit)(const struct genl_ops *ops, struct sk_buff *skb,
+--			  struct genl_info *info);
+--	const struct genl_ops *ops;
+--	const struct genl_multicast_group *mcgrps;
+--	unsigned int n_ops;
+--	unsigned int n_mcgrps;
+--	struct module *module;
+--
+--	/* allocated by batadv_genl_register_family and free'd by
+--	 * batadv_genl_unregister_family. Used to modify the usually read-only
+--	 * ops
+--	 */
+--	struct genl_ops *copy_ops;
+--};
+--
+--#define genl_family batadv_genl_family
+--
+--static inline int batadv_genl_register_family(struct batadv_genl_family *family)
+--{
+--	struct genl_ops *ops;
+--	unsigned int i;
+--
+--	family->family.hdrsize = family->hdrsize;
+--	strncpy(family->family.name, family->name, sizeof(family->family.name));
+--	family->family.version = family->version;
+--	family->family.maxattr = family->maxattr;
+--	family->family.netnsok = family->netnsok;
+--	family->family.pre_doit = family->pre_doit;
+--	family->family.post_doit = family->post_doit;
+--	family->family.mcgrps = family->mcgrps;
+--	family->family.n_ops = family->n_ops;
+--	family->family.n_mcgrps = family->n_mcgrps;
+--	family->family.module = family->module;
+--
+--	ops = kmemdup(family->ops, sizeof(*ops) * family->n_ops, GFP_KERNEL);
+--	if (!ops)
+--		return -ENOMEM;
+--
+--	for (i = 0; i < family->family.n_ops; i++)
+--		ops[i].policy = family->policy;
+--
+--	family->family.ops = ops;
+--	family->copy_ops = ops;
+--
+--	return genl_register_family(&family->family);
+--}
+--
+--#define genl_register_family(family) \
+--	batadv_genl_register_family((family))
+--
+--static inline void
+--batadv_genl_unregister_family(struct batadv_genl_family *family)
+--{
+--
+--	genl_unregister_family(&family->family);
+--	kfree(family->copy_ops);
+--}
+--
+--#define genl_unregister_family(family) \
+--	batadv_genl_unregister_family((family))
+--
+--#define genlmsg_put(_skb, _pid, _seq, _family, _flags, _cmd) \
+--	genlmsg_put(_skb, _pid, _seq, &(_family)->family, _flags, _cmd)
+--
+--#define genlmsg_multicast_netns(_family, _net, _skb, _portid, _group, _flags) \
+--	genlmsg_multicast_netns(&(_family)->family, _net, _skb, _portid, \
+--				_group, _flags)
+--
+--#endif /* < KERNEL_VERSION(5, 2, 0) */
+--
+- #endif /* _NET_BATMAN_ADV_COMPAT_NET_GENETLINK_H_ */
+---- a/net/batman-adv/netlink.c
+-+++ b/net/batman-adv/netlink.c
+-@@ -1344,29 +1344,34 @@ static const struct genl_ops batadv_netl
+- 	{
+- 		.cmd = BATADV_CMD_GET_MESH,
+- 		/* can be retrieved by unprivileged users */
+-+		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_get_mesh,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_TP_METER,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_tp_meter_start,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_TP_METER_CANCEL,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_tp_meter_cancel,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_ROUTING_ALGOS,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_algo_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_HARDIF,
+- 		/* can be retrieved by unprivileged users */
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_netlink_dump_hardif,
+- 		.doit = batadv_netlink_get_hardif,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH |
+-@@ -1375,57 +1380,68 @@ static const struct genl_ops batadv_netl
+- 	{
+- 		.cmd = BATADV_CMD_GET_TRANSTABLE_LOCAL,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_tt_local_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_TRANSTABLE_GLOBAL,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_tt_global_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_ORIGINATORS,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_orig_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_NEIGHBORS,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_hardif_neigh_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_GATEWAYS,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_gw_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_BLA_CLAIM,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_bla_claim_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_BLA_BACKBONE,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_bla_backbone_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_DAT_CACHE,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_dat_cache_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_MCAST_FLAGS,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_mcast_flags_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_SET_MESH,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_set_mesh,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_SET_HARDIF,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_set_hardif,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH |
+- 				  BATADV_FLAG_NEED_HARDIF,
+-@@ -1433,6 +1449,7 @@ static const struct genl_ops batadv_netl
+- 	{
+- 		.cmd = BATADV_CMD_GET_VLAN,
+- 		/* can be retrieved by unprivileged users */
+-+		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_get_vlan,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH |
+- 				  BATADV_FLAG_NEED_VLAN,
+-@@ -1440,6 +1457,7 @@ static const struct genl_ops batadv_netl
+- 	{
+- 		.cmd = BATADV_CMD_SET_VLAN,
+- 		.flags = GENL_ADMIN_PERM,
+-+		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_set_vlan,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH |
+- 				  BATADV_FLAG_NEED_VLAN,
+-@@ -1451,7 +1469,6 @@ struct genl_family batadv_netlink_family
+- 	.name = BATADV_NL_NAME,
+- 	.version = 1,
+- 	.maxattr = BATADV_ATTR_MAX,
+--	.policy = batadv_netlink_policy,
+- 	.netnsok = true,
+- 	.pre_doit = batadv_pre_doit,
+- 	.post_doit = batadv_post_doit,
+diff --git a/batman-adv/patches/0005-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch b/batman-adv/patches/0005-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch
+deleted file mode 100644
+index 6c695572bab3e3afab6e061ff9ac724a29a4726f..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0005-batman-adv-Fix-duplicated-OGMs-on-NETDEV_UP.patch
++++ /dev/null
+@@ -1,71 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sun, 2 Jun 2019 10:57:31 +0200
+-Subject: batman-adv: Fix duplicated OGMs on NETDEV_UP
+-
+-The state of slave interfaces are handled differently depending on whether
+-the interface is up or not. All active interfaces (IFF_UP) will transmit
+-OGMs. But for B.A.T.M.A.N. IV, also non-active interfaces are scheduling
+-(low TTL) OGMs on active interfaces. The code which setups and schedules
+-the OGMs must therefore already be called when the interfaces gets added as
+-slave interface and the transmit function must then check whether it has to
+-send out the OGM or not on the specific slave interface.
+-
+-But the commit 0d8468553c3c ("batman-adv: remove ogm_emit and ogm_schedule
+-API calls") moved the setup code from the enable function to the activate
+-function. The latter is called either when the added slave was already up
+-when batadv_hardif_enable_interface processed the new interface or when a
+-NETDEV_UP event was received for this slave interfac. As result, each
+-NETDEV_UP would schedule a new OGM worker for the interface and thus OGMs
+-would be send a lot more than expected.
+-
+-Fixes: 0d8468553c3c ("batman-adv: remove ogm_emit and ogm_schedule API calls")
+-Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/c92331e0df3c0c5645ee5a897eb018c5da5e4aa5
+-
+---- a/net/batman-adv/bat_iv_ogm.c
+-+++ b/net/batman-adv/bat_iv_ogm.c
+-@@ -2337,7 +2337,7 @@ batadv_iv_ogm_neigh_is_sob(struct batadv
+- 	return ret;
+- }
+- 
+--static void batadv_iv_iface_activate(struct batadv_hard_iface *hard_iface)
+-+static void batadv_iv_iface_enabled(struct batadv_hard_iface *hard_iface)
+- {
+- 	/* begin scheduling originator messages on that interface */
+- 	batadv_iv_ogm_schedule(hard_iface);
+-@@ -2683,8 +2683,8 @@ unlock:
+- static struct batadv_algo_ops batadv_batman_iv __read_mostly = {
+- 	.name = "BATMAN_IV",
+- 	.iface = {
+--		.activate = batadv_iv_iface_activate,
+- 		.enable = batadv_iv_ogm_iface_enable,
+-+		.enabled = batadv_iv_iface_enabled,
+- 		.disable = batadv_iv_ogm_iface_disable,
+- 		.update_mac = batadv_iv_ogm_iface_update_mac,
+- 		.primary_set = batadv_iv_ogm_primary_iface_set,
+---- a/net/batman-adv/hard-interface.c
+-+++ b/net/batman-adv/hard-interface.c
+-@@ -795,6 +795,9 @@ int batadv_hardif_enable_interface(struc
+- 
+- 	batadv_hardif_recalc_extra_skbroom(soft_iface);
+- 
+-+	if (bat_priv->algo_ops->iface.enabled)
+-+		bat_priv->algo_ops->iface.enabled(hard_iface);
+-+
+- out:
+- 	return 0;
+- 
+---- a/net/batman-adv/types.h
+-+++ b/net/batman-adv/types.h
+-@@ -2129,6 +2129,9 @@ struct batadv_algo_iface_ops {
+- 	/** @enable: init routing info when hard-interface is enabled */
+- 	int (*enable)(struct batadv_hard_iface *hard_iface);
+- 
+-+	/** @enabled: notification when hard-interface was enabled (optional) */
+-+	void (*enabled)(struct batadv_hard_iface *hard_iface);
+-+
+- 	/** @disable: de-init routing info when hard-interface is disabled */
+- 	void (*disable)(struct batadv_hard_iface *hard_iface);
+- 
+diff --git a/batman-adv/patches/0006-batman-adv-Fix-netlink-dumping-of-all-mcast_flags-bu.patch b/batman-adv/patches/0006-batman-adv-Fix-netlink-dumping-of-all-mcast_flags-bu.patch
+deleted file mode 100644
+index 78a4bb37a52619678951a33d14b9c3dd337fece2..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0006-batman-adv-Fix-netlink-dumping-of-all-mcast_flags-bu.patch
++++ /dev/null
+@@ -1,27 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sun, 7 Jul 2019 22:19:22 +0200
+-Subject: batman-adv: Fix netlink dumping of all mcast_flags buckets
+-
+-The bucket variable is only updated outside the loop over the mcast_flags
+-buckets. It will only be updated during a dumping run when the dumping has
+-to be interrupted and a new message has to be started.
+-
+-This could result in repeated or missing entries when the multicast flags
+-are dumped to userspace.
+-
+-Fixes: 06c82b7b15b1 ("batman-adv: Add inconsistent multicast netlink dump detection")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/d1de7f7aa316d6f7b3268f61afa88f5d2c1a5db5
+-
+---- a/net/batman-adv/multicast.c
+-+++ b/net/batman-adv/multicast.c
+-@@ -1653,7 +1653,7 @@ __batadv_mcast_flags_dump(struct sk_buff
+- 
+- 	while (bucket_tmp < hash->size) {
+- 		if (batadv_mcast_flags_dump_bucket(msg, portid, cb, hash,
+--						   *bucket, &idx_tmp))
+-+						   bucket_tmp, &idx_tmp))
+- 			break;
+- 
+- 		bucket_tmp++;
+diff --git a/batman-adv/patches/0007-batman-adv-fix-uninit-value-in-batadv_netlink_get_if.patch b/batman-adv/patches/0007-batman-adv-fix-uninit-value-in-batadv_netlink_get_if.patch
+deleted file mode 100644
+index f81cf615c1826fea83cd58de6a7dacc29778bce9..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0007-batman-adv-fix-uninit-value-in-batadv_netlink_get_if.patch
++++ /dev/null
+@@ -1,56 +0,0 @@
+-From: Eric Dumazet <edumazet@google.com>
+-Date: Mon, 12 Aug 2019 04:57:27 -0700
+-Subject: batman-adv: fix uninit-value in batadv_netlink_get_ifindex()
+-
+-batadv_netlink_get_ifindex() needs to make sure user passed
+-a correct u32 attribute.
+-
+-syzbot reported :
+-BUG: KMSAN: uninit-value in batadv_netlink_dump_hardif+0x70d/0x880 net/batman-adv/netlink.c:968
+-CPU: 1 PID: 11705 Comm: syz-executor888 Not tainted 5.1.0+ #1
+-Hardware name: Google Google Compute Engine/Google Compute Engine, BIOS Google 01/01/2011
+-Call Trace:
+- __dump_stack lib/dump_stack.c:77 [inline]
+- dump_stack+0x191/0x1f0 lib/dump_stack.c:113
+- kmsan_report+0x130/0x2a0 mm/kmsan/kmsan.c:622
+- __msan_warning+0x75/0xe0 mm/kmsan/kmsan_instr.c:310
+- batadv_netlink_dump_hardif+0x70d/0x880 net/batman-adv/netlink.c:968
+- genl_lock_dumpit+0xc6/0x130 net/netlink/genetlink.c:482
+- netlink_dump+0xa84/0x1ab0 net/netlink/af_netlink.c:2253
+- __netlink_dump_start+0xa3a/0xb30 net/netlink/af_netlink.c:2361
+- genl_family_rcv_msg net/netlink/genetlink.c:550 [inline]
+- genl_rcv_msg+0xfc1/0x1a40 net/netlink/genetlink.c:627
+- netlink_rcv_skb+0x431/0x620 net/netlink/af_netlink.c:2486
+- genl_rcv+0x63/0x80 net/netlink/genetlink.c:638
+- netlink_unicast_kernel net/netlink/af_netlink.c:1311 [inline]
+- netlink_unicast+0xf3e/0x1020 net/netlink/af_netlink.c:1337
+- netlink_sendmsg+0x127e/0x12f0 net/netlink/af_netlink.c:1926
+- sock_sendmsg_nosec net/socket.c:651 [inline]
+- sock_sendmsg net/socket.c:661 [inline]
+- ___sys_sendmsg+0xcc6/0x1200 net/socket.c:2260
+- __sys_sendmsg net/socket.c:2298 [inline]
+- __do_sys_sendmsg net/socket.c:2307 [inline]
+- __se_sys_sendmsg+0x305/0x460 net/socket.c:2305
+- __x64_sys_sendmsg+0x4a/0x70 net/socket.c:2305
+- do_syscall_64+0xbc/0xf0 arch/x86/entry/common.c:291
+- entry_SYSCALL_64_after_hwframe+0x63/0xe7
+-RIP: 0033:0x440209
+-
+-Fixes: 55d368c3a57e ("batman-adv: netlink: hardif query")
+-Signed-off-by: Eric Dumazet <edumazet@google.com>
+-Reported-by: syzbot <syzkaller@googlegroups.com>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/9b470b8a2b9ef4ce68d6e95febd3a0574be1ac14
+-
+---- a/net/batman-adv/netlink.c
+-+++ b/net/batman-adv/netlink.c
+-@@ -164,7 +164,7 @@ batadv_netlink_get_ifindex(const struct
+- {
+- 	struct nlattr *attr = nlmsg_find_attr(nlh, GENL_HDRLEN, attrtype);
+- 
+--	return attr ? nla_get_u32(attr) : 0;
+-+	return (attr && nla_len(attr) == sizeof(u32)) ? nla_get_u32(attr) : 0;
+- }
+- 
+- /**
+diff --git a/batman-adv/patches/0008-batman-adv-Only-read-OGM-tvlv_len-after-buffer-len-c.patch b/batman-adv/patches/0008-batman-adv-Only-read-OGM-tvlv_len-after-buffer-len-c.patch
+deleted file mode 100644
+index e5b13834e4a296224df367c332eb56810856772e..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0008-batman-adv-Only-read-OGM-tvlv_len-after-buffer-len-c.patch
++++ /dev/null
+@@ -1,72 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Fri, 23 Aug 2019 14:34:27 +0200
+-Subject: batman-adv: Only read OGM tvlv_len after buffer len check
+-
+-Multiple batadv_ogm_packet can be stored in an skbuff. The functions
+-batadv_iv_ogm_send_to_if()/batadv_iv_ogm_receive() use
+-batadv_iv_ogm_aggr_packet() to check if there is another additional
+-batadv_ogm_packet in the skb or not before they continue processing the
+-packet.
+-
+-The length for such an OGM is BATADV_OGM_HLEN +
+-batadv_ogm_packet->tvlv_len. The check must first check that at least
+-BATADV_OGM_HLEN bytes are available before it accesses tvlv_len (which is
+-part of the header. Otherwise it might try read outside of the currently
+-available skbuff to get the content of tvlv_len.
+-
+-Fixes: 0b6aa0d43767 ("batman-adv: tvlv - basic infrastructure")
+-Reported-by: syzbot+355cab184197dbbfa384@syzkaller.appspotmail.com
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Antonio Quartulli <a@unstable.cc>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/07b6051ebcfaa7ea89b4f278eca2ff4070d29e56
+-
+---- a/net/batman-adv/bat_iv_ogm.c
+-+++ b/net/batman-adv/bat_iv_ogm.c
+-@@ -277,17 +277,23 @@ static u8 batadv_hop_penalty(u8 tq, cons
+-  * batadv_iv_ogm_aggr_packet() - checks if there is another OGM attached
+-  * @buff_pos: current position in the skb
+-  * @packet_len: total length of the skb
+-- * @tvlv_len: tvlv length of the previously considered OGM
+-+ * @ogm_packet: potential OGM in buffer
+-  *
+-  * Return: true if there is enough space for another OGM, false otherwise.
+-  */
+--static bool batadv_iv_ogm_aggr_packet(int buff_pos, int packet_len,
+--				      __be16 tvlv_len)
+-+static bool
+-+batadv_iv_ogm_aggr_packet(int buff_pos, int packet_len,
+-+			  const struct batadv_ogm_packet *ogm_packet)
+- {
+- 	int next_buff_pos = 0;
+- 
+--	next_buff_pos += buff_pos + BATADV_OGM_HLEN;
+--	next_buff_pos += ntohs(tvlv_len);
+-+	/* check if there is enough space for the header */
+-+	next_buff_pos += buff_pos + sizeof(*ogm_packet);
+-+	if (next_buff_pos > packet_len)
+-+		return false;
+-+
+-+	/* check if there is enough space for the optional TVLV */
+-+	next_buff_pos += ntohs(ogm_packet->tvlv_len);
+- 
+- 	return (next_buff_pos <= packet_len) &&
+- 	       (next_buff_pos <= BATADV_MAX_AGGREGATION_BYTES);
+-@@ -315,7 +321,7 @@ static void batadv_iv_ogm_send_to_if(str
+- 
+- 	/* adjust all flags and log packets */
+- 	while (batadv_iv_ogm_aggr_packet(buff_pos, forw_packet->packet_len,
+--					 batadv_ogm_packet->tvlv_len)) {
+-+					 batadv_ogm_packet)) {
+- 		/* we might have aggregated direct link packets with an
+- 		 * ordinary base packet
+- 		 */
+-@@ -1704,7 +1710,7 @@ static int batadv_iv_ogm_receive(struct
+- 
+- 	/* unpack the aggregated packets and process them one by one */
+- 	while (batadv_iv_ogm_aggr_packet(ogm_offset, skb_headlen(skb),
+--					 ogm_packet->tvlv_len)) {
+-+					 ogm_packet)) {
+- 		batadv_iv_ogm_process(skb, ogm_offset, if_incoming);
+- 
+- 		ogm_offset += BATADV_OGM_HLEN;
+diff --git a/batman-adv/patches/0009-batman-adv-Only-read-OGM2-tvlv_len-after-buffer-len-.patch b/batman-adv/patches/0009-batman-adv-Only-read-OGM2-tvlv_len-after-buffer-len-.patch
+deleted file mode 100644
+index 292199474b434c65116c0881fde639e324e9cf3d..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0009-batman-adv-Only-read-OGM2-tvlv_len-after-buffer-len-.patch
++++ /dev/null
+@@ -1,60 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Fri, 23 Aug 2019 14:34:28 +0200
+-Subject: batman-adv: Only read OGM2 tvlv_len after buffer len check
+-
+-Multiple batadv_ogm2_packet can be stored in an skbuff. The functions
+-batadv_v_ogm_send_to_if() uses batadv_v_ogm_aggr_packet() to check if there
+-is another additional batadv_ogm2_packet in the skb or not before they
+-continue processing the packet.
+-
+-The length for such an OGM2 is BATADV_OGM2_HLEN +
+-batadv_ogm2_packet->tvlv_len. The check must first check that at least
+-BATADV_OGM2_HLEN bytes are available before it accesses tvlv_len (which is
+-part of the header. Otherwise it might try read outside of the currently
+-available skbuff to get the content of tvlv_len.
+-
+-Fixes: 667996ebeab4 ("batman-adv: OGMv2 - implement originators logic")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/18f77da3761c5550f42a2d131f0fe5cac62e022d
+-
+---- a/net/batman-adv/bat_v_ogm.c
+-+++ b/net/batman-adv/bat_v_ogm.c
+-@@ -631,17 +631,23 @@ batadv_v_ogm_process_per_outif(struct ba
+-  * batadv_v_ogm_aggr_packet() - checks if there is another OGM aggregated
+-  * @buff_pos: current position in the skb
+-  * @packet_len: total length of the skb
+-- * @tvlv_len: tvlv length of the previously considered OGM
+-+ * @ogm2_packet: potential OGM2 in buffer
+-  *
+-  * Return: true if there is enough space for another OGM, false otherwise.
+-  */
+--static bool batadv_v_ogm_aggr_packet(int buff_pos, int packet_len,
+--				     __be16 tvlv_len)
+-+static bool
+-+batadv_v_ogm_aggr_packet(int buff_pos, int packet_len,
+-+			 const struct batadv_ogm2_packet *ogm2_packet)
+- {
+- 	int next_buff_pos = 0;
+- 
+--	next_buff_pos += buff_pos + BATADV_OGM2_HLEN;
+--	next_buff_pos += ntohs(tvlv_len);
+-+	/* check if there is enough space for the header */
+-+	next_buff_pos += buff_pos + sizeof(*ogm2_packet);
+-+	if (next_buff_pos > packet_len)
+-+		return false;
+-+
+-+	/* check if there is enough space for the optional TVLV */
+-+	next_buff_pos += ntohs(ogm2_packet->tvlv_len);
+- 
+- 	return (next_buff_pos <= packet_len) &&
+- 	       (next_buff_pos <= BATADV_MAX_AGGREGATION_BYTES);
+-@@ -818,7 +824,7 @@ int batadv_v_ogm_packet_recv(struct sk_b
+- 	ogm_packet = (struct batadv_ogm2_packet *)skb->data;
+- 
+- 	while (batadv_v_ogm_aggr_packet(ogm_offset, skb_headlen(skb),
+--					ogm_packet->tvlv_len)) {
+-+					ogm_packet)) {
+- 		batadv_v_ogm_process(skb, ogm_offset, if_incoming);
+- 
+- 		ogm_offset += BATADV_OGM2_HLEN;
+diff --git a/batman-adv/patches/0010-batman-adv-Avoid-free-alloc-race-when-handling-OGM2-.patch b/batman-adv/patches/0010-batman-adv-Avoid-free-alloc-race-when-handling-OGM2-.patch
+deleted file mode 100644
+index 420a4e6d9b7630ddfa5b292562b67cff0a991785..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0010-batman-adv-Avoid-free-alloc-race-when-handling-OGM2-.patch
++++ /dev/null
+@@ -1,115 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 3 Oct 2019 17:02:01 +0200
+-Subject: batman-adv: Avoid free/alloc race when handling OGM2 buffer
+-
+-A B.A.T.M.A.N. V virtual interface has an OGM2 packet buffer which is
+-initialized using data from the RTNL lock protected netdevice notifier and
+-other rtnetlink related hooks. It is sent regularly via various slave
+-interfaces of the batadv virtual interface and in this process also
+-modified (realloced) to integrate additional state information via TVLV
+-containers.
+-
+-It must be avoided that the worker item is executed without a common lock
+-with the netdevice notifier/rtnetlink helpers. Otherwise it can either
+-happen that half modified data is sent out or the functions modifying the
+-OGM2 buffer try to access already freed memory regions.
+-
+-Fixes: 632835348e65 ("batman-adv: OGMv2 - add basic infrastructure")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/14ee24576213ff02272b7f8d975c7c61d5448aa2
+-
+---- a/net/batman-adv/bat_v_ogm.c
+-+++ b/net/batman-adv/bat_v_ogm.c
+-@@ -21,6 +21,7 @@
+- #include <linux/random.h>
+- #include <linux/rculist.h>
+- #include <linux/rcupdate.h>
+-+#include <linux/rtnetlink.h>
+- #include <linux/skbuff.h>
+- #include <linux/slab.h>
+- #include <linux/stddef.h>
+-@@ -116,14 +117,12 @@ static void batadv_v_ogm_send_to_if(stru
+- }
+- 
+- /**
+-- * batadv_v_ogm_send() - periodic worker broadcasting the own OGM
+-- * @work: work queue item
+-+ * batadv_v_ogm_send_softif() - periodic worker broadcasting the own OGM
+-+ * @bat_priv: the bat priv with all the soft interface information
+-  */
+--static void batadv_v_ogm_send(struct work_struct *work)
+-+static void batadv_v_ogm_send_softif(struct batadv_priv *bat_priv)
+- {
+- 	struct batadv_hard_iface *hard_iface;
+--	struct batadv_priv_bat_v *bat_v;
+--	struct batadv_priv *bat_priv;
+- 	struct batadv_ogm2_packet *ogm_packet;
+- 	struct sk_buff *skb, *skb_tmp;
+- 	unsigned char *ogm_buff;
+-@@ -131,8 +130,7 @@ static void batadv_v_ogm_send(struct wor
+- 	u16 tvlv_len = 0;
+- 	int ret;
+- 
+--	bat_v = container_of(work, struct batadv_priv_bat_v, ogm_wq.work);
+--	bat_priv = container_of(bat_v, struct batadv_priv, bat_v);
+-+	ASSERT_RTNL();
+- 
+- 	if (atomic_read(&bat_priv->mesh_state) == BATADV_MESH_DEACTIVATING)
+- 		goto out;
+-@@ -224,6 +222,22 @@ out:
+- }
+- 
+- /**
+-+ * batadv_v_ogm_send() - periodic worker broadcasting the own OGM
+-+ * @work: work queue item
+-+ */
+-+static void batadv_v_ogm_send(struct work_struct *work)
+-+{
+-+	struct batadv_priv_bat_v *bat_v;
+-+	struct batadv_priv *bat_priv;
+-+
+-+	rtnl_lock();
+-+	bat_v = container_of(work, struct batadv_priv_bat_v, ogm_wq.work);
+-+	bat_priv = container_of(bat_v, struct batadv_priv, bat_v);
+-+	batadv_v_ogm_send_softif(bat_priv);
+-+	rtnl_unlock();
+-+}
+-+
+-+/**
+-  * batadv_v_ogm_iface_enable() - prepare an interface for B.A.T.M.A.N. V
+-  * @hard_iface: the interface to prepare
+-  *
+-@@ -249,6 +263,8 @@ void batadv_v_ogm_primary_iface_set(stru
+- 	struct batadv_priv *bat_priv = netdev_priv(primary_iface->soft_iface);
+- 	struct batadv_ogm2_packet *ogm_packet;
+- 
+-+	ASSERT_RTNL();
+-+
+- 	if (!bat_priv->bat_v.ogm_buff)
+- 		return;
+- 
+-@@ -857,6 +873,8 @@ int batadv_v_ogm_init(struct batadv_priv
+- 	unsigned char *ogm_buff;
+- 	u32 random_seqno;
+- 
+-+	ASSERT_RTNL();
+-+
+- 	bat_priv->bat_v.ogm_buff_len = BATADV_OGM2_HLEN;
+- 	ogm_buff = kzalloc(bat_priv->bat_v.ogm_buff_len, GFP_ATOMIC);
+- 	if (!ogm_buff)
+---- a/net/batman-adv/types.h
+-+++ b/net/batman-adv/types.h
+-@@ -1477,10 +1477,10 @@ struct batadv_softif_vlan {
+-  * struct batadv_priv_bat_v - B.A.T.M.A.N. V per soft-interface private data
+-  */
+- struct batadv_priv_bat_v {
+--	/** @ogm_buff: buffer holding the OGM packet */
+-+	/** @ogm_buff: buffer holding the OGM packet. rtnl protected */
+- 	unsigned char *ogm_buff;
+- 
+--	/** @ogm_buff_len: length of the OGM packet buffer */
+-+	/** @ogm_buff_len: length of the OGM packet buffer. rtnl protected */
+- 	int ogm_buff_len;
+- 
+- 	/** @ogm_seqno: OGM sequence number - used to identify each OGM */
+diff --git a/batman-adv/patches/0011-batman-adv-initialize-struct-batadv_tvlv_tt_vlan_dat.patch b/batman-adv/patches/0011-batman-adv-initialize-struct-batadv_tvlv_tt_vlan_dat.patch
+deleted file mode 100644
+index a612310fa35ba09c9fbc0d681fa97e0df624134f..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0011-batman-adv-initialize-struct-batadv_tvlv_tt_vlan_dat.patch
++++ /dev/null
+@@ -1,39 +0,0 @@
+-From: Tetsuo Handa <penguin-kernel@I-love.SAKURA.ne.jp>
+-Date: Mon, 5 Apr 2021 19:16:50 +0900
+-Subject: batman-adv: initialize "struct batadv_tvlv_tt_vlan_data"->reserved field
+-
+-KMSAN found uninitialized value at batadv_tt_prepare_tvlv_local_data()
+-[1], for commit ced72933a5e8ab52 ("batman-adv: use CRC32C instead of CRC16
+-in TT code") inserted 'reserved' field into "struct batadv_tvlv_tt_data"
+-and commit 7ea7b4a142758dea ("batman-adv: make the TT CRC logic VLAN
+-specific") moved that field to "struct batadv_tvlv_tt_vlan_data" but left
+-that field uninitialized.
+-
+-[1] https://syzkaller.appspot.com/bug?id=07f3e6dba96f0eb3cabab986adcd8a58b9bdbe9d
+-
+-Reported-by: syzbot <syzbot+50ee810676e6a089487b@syzkaller.appspotmail.com>
+-Tested-by: syzbot <syzbot+50ee810676e6a089487b@syzkaller.appspotmail.com>
+-Signed-off-by: Tetsuo Handa <penguin-kernel@I-love.SAKURA.ne.jp>
+-Fixes: c5e7a06a2961 ("batman-adv: use CRC32C instead of CRC16 in TT code")
+-Fixes: 21a57f6e7a3b ("batman-adv: make the TT CRC logic VLAN specific")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/fe8bf38f47a0c1a0e53c487228e3f5a44c86939f
+-
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -891,6 +891,7 @@ batadv_tt_prepare_tvlv_global_data(struc
+- 	hlist_for_each_entry_rcu(vlan, &orig_node->vlan_list, list) {
+- 		tt_vlan->vid = htons(vlan->vid);
+- 		tt_vlan->crc = htonl(vlan->tt.crc);
+-+		tt_vlan->reserved = 0;
+- 
+- 		tt_vlan++;
+- 	}
+-@@ -974,6 +975,7 @@ batadv_tt_prepare_tvlv_local_data(struct
+- 
+- 		tt_vlan->vid = htons(vlan->vid);
+- 		tt_vlan->crc = htonl(vlan->tt.crc);
+-+		tt_vlan->reserved = 0;
+- 
+- 		tt_vlan++;
+- 	}
+diff --git a/batman-adv/patches/0012-batman-adv-Avoid-free-alloc-race-when-handling-OGM-b.patch b/batman-adv/patches/0012-batman-adv-Avoid-free-alloc-race-when-handling-OGM-b.patch
+deleted file mode 100644
+index ffcefde3bb5d7522c57c107842c845646b7cff3d..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0012-batman-adv-Avoid-free-alloc-race-when-handling-OGM-b.patch
++++ /dev/null
+@@ -1,132 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 3 Oct 2019 17:02:01 +0200
+-Subject: batman-adv: Avoid free/alloc race when handling OGM buffer
+-
+-Each slave interface of an B.A.T.M.A.N. IV virtual interface has an OGM
+-packet buffer which is initialized using data from the RTNL lock protected
+-netdevice notifier and other rtnetlink related hooks. It is sent regularly
+-via various slave interfaces of the batadv virtual interface and in this
+-process also modified (realloced) to integrate additional state information
+-via TVLV containers.
+-
+-It must be avoided that the worker item is executed without a common lock
+-with the netdevice notifier/rtnetlink helpers. Otherwise it can either
+-happen that half modified/freed data is sent out or functions modifying the
+-OGM buffer try to access already freed memory regions.
+-
+-Reported-by: syzbot+0cc629f19ccb8534935b@syzkaller.appspotmail.com
+-Fixes: ea6f8d42a595 ("batman-adv: move /proc interface handling to /sys")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/9b8ceef26c697d0c8319748428944c3339a498dc
+-
+---- a/net/batman-adv/bat_iv_ogm.c
+-+++ b/net/batman-adv/bat_iv_ogm.c
+-@@ -29,6 +29,7 @@
+- #include <linux/random.h>
+- #include <linux/rculist.h>
+- #include <linux/rcupdate.h>
+-+#include <linux/rtnetlink.h>
+- #include <linux/seq_file.h>
+- #include <linux/skbuff.h>
+- #include <linux/slab.h>
+-@@ -193,6 +194,8 @@ static int batadv_iv_ogm_iface_enable(st
+- 	unsigned char *ogm_buff;
+- 	u32 random_seqno;
+- 
+-+	ASSERT_RTNL();
+-+
+- 	/* randomize initial seqno to avoid collision */
+- 	get_random_bytes(&random_seqno, sizeof(random_seqno));
+- 	atomic_set(&hard_iface->bat_iv.ogm_seqno, random_seqno);
+-@@ -217,6 +220,8 @@ static int batadv_iv_ogm_iface_enable(st
+- 
+- static void batadv_iv_ogm_iface_disable(struct batadv_hard_iface *hard_iface)
+- {
+-+	ASSERT_RTNL();
+-+
+- 	kfree(hard_iface->bat_iv.ogm_buff);
+- 	hard_iface->bat_iv.ogm_buff = NULL;
+- }
+-@@ -226,6 +231,8 @@ static void batadv_iv_ogm_iface_update_m
+- 	struct batadv_ogm_packet *batadv_ogm_packet;
+- 	unsigned char *ogm_buff = hard_iface->bat_iv.ogm_buff;
+- 
+-+	ASSERT_RTNL();
+-+
+- 	batadv_ogm_packet = (struct batadv_ogm_packet *)ogm_buff;
+- 	ether_addr_copy(batadv_ogm_packet->orig,
+- 			hard_iface->net_dev->dev_addr);
+-@@ -239,6 +246,8 @@ batadv_iv_ogm_primary_iface_set(struct b
+- 	struct batadv_ogm_packet *batadv_ogm_packet;
+- 	unsigned char *ogm_buff = hard_iface->bat_iv.ogm_buff;
+- 
+-+	ASSERT_RTNL();
+-+
+- 	batadv_ogm_packet = (struct batadv_ogm_packet *)ogm_buff;
+- 	batadv_ogm_packet->ttl = BATADV_TTL;
+- }
+-@@ -753,6 +762,8 @@ static void batadv_iv_ogm_schedule(struc
+- 	u16 tvlv_len = 0;
+- 	unsigned long send_time;
+- 
+-+	ASSERT_RTNL();
+-+
+- 	if (hard_iface->if_status == BATADV_IF_NOT_IN_USE ||
+- 	    hard_iface->if_status == BATADV_IF_TO_BE_REMOVED)
+- 		return;
+-@@ -1643,16 +1654,12 @@ static void batadv_iv_ogm_process(const
+- 	batadv_orig_node_put(orig_node);
+- }
+- 
+--static void batadv_iv_send_outstanding_bat_ogm_packet(struct work_struct *work)
+-+static void
+-+batadv_iv_send_outstanding_forw_packet(struct batadv_forw_packet *forw_packet)
+- {
+--	struct delayed_work *delayed_work;
+--	struct batadv_forw_packet *forw_packet;
+- 	struct batadv_priv *bat_priv;
+- 	bool dropped = false;
+- 
+--	delayed_work = to_delayed_work(work);
+--	forw_packet = container_of(delayed_work, struct batadv_forw_packet,
+--				   delayed_work);
+- 	bat_priv = netdev_priv(forw_packet->if_incoming->soft_iface);
+- 
+- 	if (atomic_read(&bat_priv->mesh_state) == BATADV_MESH_DEACTIVATING) {
+-@@ -1681,6 +1688,20 @@ out:
+- 		batadv_forw_packet_free(forw_packet, dropped);
+- }
+- 
+-+static void batadv_iv_send_outstanding_bat_ogm_packet(struct work_struct *work)
+-+{
+-+	struct delayed_work *delayed_work;
+-+	struct batadv_forw_packet *forw_packet;
+-+
+-+	delayed_work = to_delayed_work(work);
+-+	forw_packet = container_of(delayed_work, struct batadv_forw_packet,
+-+				   delayed_work);
+-+
+-+	rtnl_lock();
+-+	batadv_iv_send_outstanding_forw_packet(forw_packet);
+-+	rtnl_unlock();
+-+}
+-+
+- static int batadv_iv_ogm_receive(struct sk_buff *skb,
+- 				 struct batadv_hard_iface *if_incoming)
+- {
+---- a/net/batman-adv/types.h
+-+++ b/net/batman-adv/types.h
+-@@ -71,10 +71,10 @@ enum batadv_dhcp_recipient {
+-  * struct batadv_hard_iface_bat_iv - per hard-interface B.A.T.M.A.N. IV data
+-  */
+- struct batadv_hard_iface_bat_iv {
+--	/** @ogm_buff: buffer holding the OGM packet */
+-+	/** @ogm_buff: buffer holding the OGM packet. rtnl protected */
+- 	unsigned char *ogm_buff;
+- 
+--	/** @ogm_buff_len: length of the OGM packet buffer */
+-+	/** @ogm_buff_len: length of the OGM packet buffer. rtnl protected */
+- 	int ogm_buff_len;
+- 
+- 	/** @ogm_seqno: OGM sequence number - used to identify each OGM */
+diff --git a/batman-adv/patches/0013-batman-adv-Introduce-own-OGM2-buffer-mutex.patch b/batman-adv/patches/0013-batman-adv-Introduce-own-OGM2-buffer-mutex.patch
+deleted file mode 100644
+index c93850799bdcdbda2835d86abd488101b6a09d0d..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0013-batman-adv-Introduce-own-OGM2-buffer-mutex.patch
++++ /dev/null
+@@ -1,134 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sun, 13 Oct 2019 21:03:06 +0200
+-Subject: batman-adv: Introduce own OGM2 buffer mutex
+-
+-Only a single function is currently automatically locked by the rtnl_lock
+-because (unlike B.A.T.M.A.N. IV) the OGM2 buffer is independent of the hard
+-interfaces on which it will be transmitted. A private mutex can be used
+-instead to avoid unnecessary delays which would have been introduced by the
+-global lock.
+-
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/8069c581f9097f1f9398f2d49047a1dab8093821
+-
+---- a/net/batman-adv/bat_v_ogm.c
+-+++ b/net/batman-adv/bat_v_ogm.c
+-@@ -17,11 +17,12 @@
+- #include <linux/kernel.h>
+- #include <linux/kref.h>
+- #include <linux/list.h>
+-+#include <linux/lockdep.h>
+-+#include <linux/mutex.h>
+- #include <linux/netdevice.h>
+- #include <linux/random.h>
+- #include <linux/rculist.h>
+- #include <linux/rcupdate.h>
+--#include <linux/rtnetlink.h>
+- #include <linux/skbuff.h>
+- #include <linux/slab.h>
+- #include <linux/stddef.h>
+-@@ -130,7 +131,7 @@ static void batadv_v_ogm_send_softif(str
+- 	u16 tvlv_len = 0;
+- 	int ret;
+- 
+--	ASSERT_RTNL();
+-+	lockdep_assert_held(&bat_priv->bat_v.ogm_buff_mutex);
+- 
+- 	if (atomic_read(&bat_priv->mesh_state) == BATADV_MESH_DEACTIVATING)
+- 		goto out;
+-@@ -230,11 +231,12 @@ static void batadv_v_ogm_send(struct wor
+- 	struct batadv_priv_bat_v *bat_v;
+- 	struct batadv_priv *bat_priv;
+- 
+--	rtnl_lock();
+- 	bat_v = container_of(work, struct batadv_priv_bat_v, ogm_wq.work);
+- 	bat_priv = container_of(bat_v, struct batadv_priv, bat_v);
+-+
+-+	mutex_lock(&bat_priv->bat_v.ogm_buff_mutex);
+- 	batadv_v_ogm_send_softif(bat_priv);
+--	rtnl_unlock();
+-+	mutex_unlock(&bat_priv->bat_v.ogm_buff_mutex);
+- }
+- 
+- /**
+-@@ -263,13 +265,15 @@ void batadv_v_ogm_primary_iface_set(stru
+- 	struct batadv_priv *bat_priv = netdev_priv(primary_iface->soft_iface);
+- 	struct batadv_ogm2_packet *ogm_packet;
+- 
+--	ASSERT_RTNL();
+--
+-+	mutex_lock(&bat_priv->bat_v.ogm_buff_mutex);
+- 	if (!bat_priv->bat_v.ogm_buff)
+--		return;
+-+		goto unlock;
+- 
+- 	ogm_packet = (struct batadv_ogm2_packet *)bat_priv->bat_v.ogm_buff;
+- 	ether_addr_copy(ogm_packet->orig, primary_iface->net_dev->dev_addr);
+-+
+-+unlock:
+-+	mutex_unlock(&bat_priv->bat_v.ogm_buff_mutex);
+- }
+- 
+- /**
+-@@ -873,8 +877,6 @@ int batadv_v_ogm_init(struct batadv_priv
+- 	unsigned char *ogm_buff;
+- 	u32 random_seqno;
+- 
+--	ASSERT_RTNL();
+--
+- 	bat_priv->bat_v.ogm_buff_len = BATADV_OGM2_HLEN;
+- 	ogm_buff = kzalloc(bat_priv->bat_v.ogm_buff_len, GFP_ATOMIC);
+- 	if (!ogm_buff)
+-@@ -893,6 +895,8 @@ int batadv_v_ogm_init(struct batadv_priv
+- 	atomic_set(&bat_priv->bat_v.ogm_seqno, random_seqno);
+- 	INIT_DELAYED_WORK(&bat_priv->bat_v.ogm_wq, batadv_v_ogm_send);
+- 
+-+	mutex_init(&bat_priv->bat_v.ogm_buff_mutex);
+-+
+- 	return 0;
+- }
+- 
+-@@ -904,7 +908,11 @@ void batadv_v_ogm_free(struct batadv_pri
+- {
+- 	cancel_delayed_work_sync(&bat_priv->bat_v.ogm_wq);
+- 
+-+	mutex_lock(&bat_priv->bat_v.ogm_buff_mutex);
+-+
+- 	kfree(bat_priv->bat_v.ogm_buff);
+- 	bat_priv->bat_v.ogm_buff = NULL;
+- 	bat_priv->bat_v.ogm_buff_len = 0;
+-+
+-+	mutex_unlock(&bat_priv->bat_v.ogm_buff_mutex);
+- }
+---- a/net/batman-adv/types.h
+-+++ b/net/batman-adv/types.h
+-@@ -16,6 +16,7 @@
+- #include <linux/compiler.h>
+- #include <linux/if_ether.h>
+- #include <linux/kref.h>
+-+#include <linux/mutex.h>
+- #include <linux/netdevice.h>
+- #include <linux/netlink.h>
+- #include <linux/sched.h> /* for linux/wait.h */
+-@@ -1477,15 +1478,18 @@ struct batadv_softif_vlan {
+-  * struct batadv_priv_bat_v - B.A.T.M.A.N. V per soft-interface private data
+-  */
+- struct batadv_priv_bat_v {
+--	/** @ogm_buff: buffer holding the OGM packet. rtnl protected */
+-+	/** @ogm_buff: buffer holding the OGM packet */
+- 	unsigned char *ogm_buff;
+- 
+--	/** @ogm_buff_len: length of the OGM packet buffer. rtnl protected */
+-+	/** @ogm_buff_len: length of the OGM packet buffer */
+- 	int ogm_buff_len;
+- 
+- 	/** @ogm_seqno: OGM sequence number - used to identify each OGM */
+- 	atomic_t ogm_seqno;
+- 
+-+	/** @ogm_buff_mutex: lock protecting ogm_buff and ogm_buff_len */
+-+	struct mutex ogm_buff_mutex;
+-+
+- 	/** @ogm_wq: workqueue used to schedule OGM transmissions */
+- 	struct delayed_work ogm_wq;
+- };
+diff --git a/batman-adv/patches/0014-batman-adv-Avoid-OGM-workqueue-synchronous-cancel-de.patch b/batman-adv/patches/0014-batman-adv-Avoid-OGM-workqueue-synchronous-cancel-de.patch
+deleted file mode 100644
+index 0216ca8de116b7b7e7731636b7ace9d00f709ad7..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0014-batman-adv-Avoid-OGM-workqueue-synchronous-cancel-de.patch
++++ /dev/null
+@@ -1,257 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sun, 13 Oct 2019 21:03:07 +0200
+-Subject: batman-adv: Avoid OGM workqueue synchronous cancel deadlock
+-
+-batadv_forw_packet_list_free can be called when an interface is being
+-disabled. Under this circumstance, the rntl_lock will be held and while it
+-calls cancel_delayed_work_sync.
+-
+-cancel_delayed_work_sync will stop the execution of the current context
+-when the work item is currently processed. It can now happen that the
+-cancel_delayed_work_sync was called when rtnl_lock was already called in
+-batadv_iv_send_outstanding_bat_ogm_packet or when it was in the process of
+-calling it. In this case, batadv_iv_send_outstanding_bat_ogm_packet waits
+-for the lock and cancel_delayed_work_sync (which holds the rtnl_lock) is
+-waiting for batadv_iv_send_outstanding_bat_ogm_packet to finish.
+-
+-This can only be avoided by not using (conflicting) blocking locks while
+-cancel_delayed_work_sync is called. It also has the benefit that the
+-ogm scheduling functionality can avoid unnecessary delays which can be
+-introduced by a global lock.
+-
+-Fixes: 9b8ceef26c69 ("batman-adv: Avoid free/alloc race when handling OGM buffer")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/d3be478f1aa27b47f61c4a62e18eb063d47c9168
+-
+---- a/net/batman-adv/bat_iv_ogm.c
+-+++ b/net/batman-adv/bat_iv_ogm.c
+-@@ -22,6 +22,8 @@
+- #include <linux/kernel.h>
+- #include <linux/kref.h>
+- #include <linux/list.h>
+-+#include <linux/lockdep.h>
+-+#include <linux/mutex.h>
+- #include <linux/netdevice.h>
+- #include <linux/netlink.h>
+- #include <linux/pkt_sched.h>
+-@@ -29,7 +31,6 @@
+- #include <linux/random.h>
+- #include <linux/rculist.h>
+- #include <linux/rcupdate.h>
+--#include <linux/rtnetlink.h>
+- #include <linux/seq_file.h>
+- #include <linux/skbuff.h>
+- #include <linux/slab.h>
+-@@ -194,7 +195,7 @@ static int batadv_iv_ogm_iface_enable(st
+- 	unsigned char *ogm_buff;
+- 	u32 random_seqno;
+- 
+--	ASSERT_RTNL();
+-+	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
+- 
+- 	/* randomize initial seqno to avoid collision */
+- 	get_random_bytes(&random_seqno, sizeof(random_seqno));
+-@@ -202,8 +203,10 @@ static int batadv_iv_ogm_iface_enable(st
+- 
+- 	hard_iface->bat_iv.ogm_buff_len = BATADV_OGM_HLEN;
+- 	ogm_buff = kmalloc(hard_iface->bat_iv.ogm_buff_len, GFP_ATOMIC);
+--	if (!ogm_buff)
+-+	if (!ogm_buff) {
+-+		mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+- 		return -ENOMEM;
+-+	}
+- 
+- 	hard_iface->bat_iv.ogm_buff = ogm_buff;
+- 
+-@@ -215,41 +218,59 @@ static int batadv_iv_ogm_iface_enable(st
+- 	batadv_ogm_packet->reserved = 0;
+- 	batadv_ogm_packet->tq = BATADV_TQ_MAX_VALUE;
+- 
+-+	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+-+
+- 	return 0;
+- }
+- 
+- static void batadv_iv_ogm_iface_disable(struct batadv_hard_iface *hard_iface)
+- {
+--	ASSERT_RTNL();
+-+	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
+- 
+- 	kfree(hard_iface->bat_iv.ogm_buff);
+- 	hard_iface->bat_iv.ogm_buff = NULL;
+-+
+-+	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+- }
+- 
+- static void batadv_iv_ogm_iface_update_mac(struct batadv_hard_iface *hard_iface)
+- {
+- 	struct batadv_ogm_packet *batadv_ogm_packet;
+--	unsigned char *ogm_buff = hard_iface->bat_iv.ogm_buff;
+-+	void *ogm_buff;
+- 
+--	ASSERT_RTNL();
+-+	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
+- 
+--	batadv_ogm_packet = (struct batadv_ogm_packet *)ogm_buff;
+-+	ogm_buff = hard_iface->bat_iv.ogm_buff;
+-+	if (!ogm_buff)
+-+		goto unlock;
+-+
+-+	batadv_ogm_packet = ogm_buff;
+- 	ether_addr_copy(batadv_ogm_packet->orig,
+- 			hard_iface->net_dev->dev_addr);
+- 	ether_addr_copy(batadv_ogm_packet->prev_sender,
+- 			hard_iface->net_dev->dev_addr);
+-+
+-+unlock:
+-+	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+- }
+- 
+- static void
+- batadv_iv_ogm_primary_iface_set(struct batadv_hard_iface *hard_iface)
+- {
+- 	struct batadv_ogm_packet *batadv_ogm_packet;
+--	unsigned char *ogm_buff = hard_iface->bat_iv.ogm_buff;
+-+	void *ogm_buff;
+- 
+--	ASSERT_RTNL();
+-+	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
+- 
+--	batadv_ogm_packet = (struct batadv_ogm_packet *)ogm_buff;
+-+	ogm_buff = hard_iface->bat_iv.ogm_buff;
+-+	if (!ogm_buff)
+-+		goto unlock;
+-+
+-+	batadv_ogm_packet = ogm_buff;
+- 	batadv_ogm_packet->ttl = BATADV_TTL;
+-+
+-+unlock:
+-+	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+- }
+- 
+- /* when do we schedule our own ogm to be sent */
+-@@ -751,7 +772,11 @@ batadv_iv_ogm_slide_own_bcast_window(str
+- 	}
+- }
+- 
+--static void batadv_iv_ogm_schedule(struct batadv_hard_iface *hard_iface)
+-+/**
+-+ * batadv_iv_ogm_schedule_buff() - schedule submission of hardif ogm buffer
+-+ * @hard_iface: interface whose ogm buffer should be transmitted
+-+ */
+-+static void batadv_iv_ogm_schedule_buff(struct batadv_hard_iface *hard_iface)
+- {
+- 	struct batadv_priv *bat_priv = netdev_priv(hard_iface->soft_iface);
+- 	unsigned char **ogm_buff = &hard_iface->bat_iv.ogm_buff;
+-@@ -762,11 +787,7 @@ static void batadv_iv_ogm_schedule(struc
+- 	u16 tvlv_len = 0;
+- 	unsigned long send_time;
+- 
+--	ASSERT_RTNL();
+--
+--	if (hard_iface->if_status == BATADV_IF_NOT_IN_USE ||
+--	    hard_iface->if_status == BATADV_IF_TO_BE_REMOVED)
+--		return;
+-+	lockdep_assert_held(&hard_iface->bat_iv.ogm_buff_mutex);
+- 
+- 	/* the interface gets activated here to avoid race conditions between
+- 	 * the moment of activating the interface in
+-@@ -834,6 +855,17 @@ out:
+- 		batadv_hardif_put(primary_if);
+- }
+- 
+-+static void batadv_iv_ogm_schedule(struct batadv_hard_iface *hard_iface)
+-+{
+-+	if (hard_iface->if_status == BATADV_IF_NOT_IN_USE ||
+-+	    hard_iface->if_status == BATADV_IF_TO_BE_REMOVED)
+-+		return;
+-+
+-+	mutex_lock(&hard_iface->bat_iv.ogm_buff_mutex);
+-+	batadv_iv_ogm_schedule_buff(hard_iface);
+-+	mutex_unlock(&hard_iface->bat_iv.ogm_buff_mutex);
+-+}
+-+
+- /**
+-  * batadv_iv_orig_ifinfo_sum() - Get bcast_own sum for originator over iterface
+-  * @orig_node: originator which reproadcasted the OGMs directly
+-@@ -1654,12 +1686,16 @@ static void batadv_iv_ogm_process(const
+- 	batadv_orig_node_put(orig_node);
+- }
+- 
+--static void
+--batadv_iv_send_outstanding_forw_packet(struct batadv_forw_packet *forw_packet)
+-+static void batadv_iv_send_outstanding_bat_ogm_packet(struct work_struct *work)
+- {
+-+	struct delayed_work *delayed_work;
+-+	struct batadv_forw_packet *forw_packet;
+- 	struct batadv_priv *bat_priv;
+- 	bool dropped = false;
+- 
+-+	delayed_work = to_delayed_work(work);
+-+	forw_packet = container_of(delayed_work, struct batadv_forw_packet,
+-+				   delayed_work);
+- 	bat_priv = netdev_priv(forw_packet->if_incoming->soft_iface);
+- 
+- 	if (atomic_read(&bat_priv->mesh_state) == BATADV_MESH_DEACTIVATING) {
+-@@ -1688,20 +1724,6 @@ out:
+- 		batadv_forw_packet_free(forw_packet, dropped);
+- }
+- 
+--static void batadv_iv_send_outstanding_bat_ogm_packet(struct work_struct *work)
+--{
+--	struct delayed_work *delayed_work;
+--	struct batadv_forw_packet *forw_packet;
+--
+--	delayed_work = to_delayed_work(work);
+--	forw_packet = container_of(delayed_work, struct batadv_forw_packet,
+--				   delayed_work);
+--
+--	rtnl_lock();
+--	batadv_iv_send_outstanding_forw_packet(forw_packet);
+--	rtnl_unlock();
+--}
+--
+- static int batadv_iv_ogm_receive(struct sk_buff *skb,
+- 				 struct batadv_hard_iface *if_incoming)
+- {
+---- a/net/batman-adv/hard-interface.c
+-+++ b/net/batman-adv/hard-interface.c
+-@@ -17,6 +17,7 @@
+- #include <linux/kernel.h>
+- #include <linux/kref.h>
+- #include <linux/list.h>
+-+#include <linux/mutex.h>
+- #include <linux/netdevice.h>
+- #include <linux/printk.h>
+- #include <linux/rculist.h>
+-@@ -930,6 +931,7 @@ batadv_hardif_add_interface(struct net_d
+- 	INIT_LIST_HEAD(&hard_iface->list);
+- 	INIT_HLIST_HEAD(&hard_iface->neigh_list);
+- 
+-+	mutex_init(&hard_iface->bat_iv.ogm_buff_mutex);
+- 	spin_lock_init(&hard_iface->neigh_list_lock);
+- 	kref_init(&hard_iface->refcount);
+- 
+---- a/net/batman-adv/types.h
+-+++ b/net/batman-adv/types.h
+-@@ -72,14 +72,17 @@ enum batadv_dhcp_recipient {
+-  * struct batadv_hard_iface_bat_iv - per hard-interface B.A.T.M.A.N. IV data
+-  */
+- struct batadv_hard_iface_bat_iv {
+--	/** @ogm_buff: buffer holding the OGM packet. rtnl protected */
+-+	/** @ogm_buff: buffer holding the OGM packet */
+- 	unsigned char *ogm_buff;
+- 
+--	/** @ogm_buff_len: length of the OGM packet buffer. rtnl protected */
+-+	/** @ogm_buff_len: length of the OGM packet buffer */
+- 	int ogm_buff_len;
+- 
+- 	/** @ogm_seqno: OGM sequence number - used to identify each OGM */
+- 	atomic_t ogm_seqno;
+-+
+-+	/** @ogm_buff_mutex: lock protecting ogm_buff and ogm_buff_len */
+-+	struct mutex ogm_buff_mutex;
+- };
+- 
+- /**
+diff --git a/batman-adv/patches/0015-batman-adv-Fix-DAT-candidate-selection-on-little-end.patch b/batman-adv/patches/0015-batman-adv-Fix-DAT-candidate-selection-on-little-end.patch
+deleted file mode 100644
+index 23a7ae45805b4abab8f857a039dfe5c4d8f8b707..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0015-batman-adv-Fix-DAT-candidate-selection-on-little-end.patch
++++ /dev/null
+@@ -1,41 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 28 Nov 2019 12:43:49 +0100
+-Subject: batman-adv: Fix DAT candidate selection on little endian systems
+-
+-The distributed arp table is using a DHT to store and retrieve MAC address
+-information for an IP address. This is done using unicast messages to
+-selected peers. The potential peers are looked up using the IP address and
+-the VID.
+-
+-While the IP address is always stored in big endian byte order, it is not
+-the case of the VID. It can (depending on the host system) either be big
+-endian or little endian. The host must therefore always convert it to big
+-endian to ensure that all devices calculate the same peers for the same
+-lookup data.
+-
+-Fixes: 3e26722bc9f2 ("batman-adv: make the Distributed ARP Table vlan aware")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Antonio Quartulli <a@unstable.cc>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/728aea06f38e0e4d70f4f7d43698187f7f7055c5
+-
+---- a/net/batman-adv/distributed-arp-table.c
+-+++ b/net/batman-adv/distributed-arp-table.c
+-@@ -285,6 +285,7 @@ static u32 batadv_hash_dat(const void *d
+- 	u32 hash = 0;
+- 	const struct batadv_dat_entry *dat = data;
+- 	const unsigned char *key;
+-+	__be16 vid;
+- 	u32 i;
+- 
+- 	key = (const unsigned char *)&dat->ip;
+-@@ -294,7 +295,8 @@ static u32 batadv_hash_dat(const void *d
+- 		hash ^= (hash >> 6);
+- 	}
+- 
+--	key = (const unsigned char *)&dat->vid;
+-+	vid = htons(dat->vid);
+-+	key = (__force const unsigned char *)&vid;
+- 	for (i = 0; i < sizeof(dat->vid); i++) {
+- 		hash += key[i];
+- 		hash += (hash << 10);
+diff --git a/batman-adv/patches/0016-batman-adv-Don-t-schedule-OGM-for-disabled-interface.patch b/batman-adv/patches/0016-batman-adv-Don-t-schedule-OGM-for-disabled-interface.patch
+deleted file mode 100644
+index 99a2e023a100beaadfc0feabca3c230b60d9ebf6..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0016-batman-adv-Don-t-schedule-OGM-for-disabled-interface.patch
++++ /dev/null
+@@ -1,35 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sun, 16 Feb 2020 13:02:06 +0100
+-Subject: batman-adv: Don't schedule OGM for disabled interface
+-
+-A transmission scheduling for an interface which is currently dropped by
+-batadv_iv_ogm_iface_disable could still be in progress. The B.A.T.M.A.N. V
+-is simply cancelling the workqueue item in an synchronous way but this is
+-not possible with B.A.T.M.A.N. IV because the OGM submissions are
+-intertwined.
+-
+-Instead it has to stop submitting the OGM when it detect that the buffer
+-pointer is set to NULL.
+-
+-Reported-by: syzbot+a98f2016f40b9cd3818a@syzkaller.appspotmail.com
+-Reported-by: syzbot+ac36b6a33c28a491e929@syzkaller.appspotmail.com
+-Fixes: c6c8fea29769 ("net: Add batman-adv meshing protocol")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Cc: Hillf Danton <hdanton@sina.com>
+-Signed-off-by: Simon Wunderlich <sw@simonwunderlich.de>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/a089c55ca004b396d340baae58abe9a79f32cc0f
+-
+---- a/net/batman-adv/bat_iv_ogm.c
+-+++ b/net/batman-adv/bat_iv_ogm.c
+-@@ -789,6 +789,10 @@ static void batadv_iv_ogm_schedule_buff(
+- 
+- 	lockdep_assert_held(&hard_iface->bat_iv.ogm_buff_mutex);
+- 
+-+	/* interface already disabled by batadv_iv_ogm_iface_disable */
+-+	if (!*ogm_buff)
+-+		return;
+-+
+- 	/* the interface gets activated here to avoid race conditions between
+- 	 * the moment of activating the interface in
+- 	 * hardif_activate_interface() where the originator mac is set and
+diff --git a/batman-adv/patches/0017-batman-adv-fix-batadv_nc_random_weight_tq.patch b/batman-adv/patches/0017-batman-adv-fix-batadv_nc_random_weight_tq.patch
+deleted file mode 100644
+index 1694f57bb0ad447639d7bb443a0d7d3972c777c2..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0017-batman-adv-fix-batadv_nc_random_weight_tq.patch
++++ /dev/null
+@@ -1,57 +0,0 @@
+-From: George Spelvin <lkml@sdf.org>
+-Date: Sun, 8 Mar 2020 09:44:59 -0400
+-Subject: batman-adv: fix batadv_nc_random_weight_tq
+-
+-and change to pseudorandom numbers, as this is a traffic dithering
+-operation that doesn't need crypto-grade.
+-
+-The previous code operated in 4 steps:
+-
+-1. Generate a random byte 0 <= rand_tq <= 255
+-2. Multiply it by BATADV_TQ_MAX_VALUE - tq
+-3. Divide by 255 (= BATADV_TQ_MAX_VALUE)
+-4. Return BATADV_TQ_MAX_VALUE - rand_tq
+-
+-This would apperar to scale (BATADV_TQ_MAX_VALUE - tq) by a random
+-value between 0/255 and 255/255.
+-
+-But!  The intermediate value between steps 3 and 4 is stored in a u8
+-variable.  So it's truncated, and most of the time, is less than 255, after
+-which the division produces 0.  Specifically, if tq is odd, the product is
+-always even, and can never be 255.  If tq is even, there's exactly one
+-random byte value that will produce a product byte of 255.
+-
+-Thus, the return value is 255 (511/512 of the time) or 254 (1/512
+-of the time).
+-
+-If we assume that the truncation is a bug, and the code is meant to scale
+-the input, a simpler way of looking at it is that it's returning a random
+-value between tq and BATADV_TQ_MAX_VALUE, inclusive.
+-
+-Well, we have an optimized function for doing just that.
+-
+-Fixes: c3289f3650d3 ("batman-adv: network coding - code and transmit packets if possible")
+-Signed-off-by: George Spelvin <lkml@sdf.org>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/db48c60b0edb995450ee846157364bd09bb23762
+-
+---- a/net/batman-adv/network-coding.c
+-+++ b/net/batman-adv/network-coding.c
+-@@ -1009,15 +1009,8 @@ static struct batadv_nc_path *batadv_nc_
+-  */
+- static u8 batadv_nc_random_weight_tq(u8 tq)
+- {
+--	u8 rand_val, rand_tq;
+--
+--	get_random_bytes(&rand_val, sizeof(rand_val));
+--
+- 	/* randomize the estimated packet loss (max TQ - estimated TQ) */
+--	rand_tq = rand_val * (BATADV_TQ_MAX_VALUE - tq);
+--
+--	/* normalize the randomized packet loss */
+--	rand_tq /= BATADV_TQ_MAX_VALUE;
+-+	u8 rand_tq = prandom_u32_max(BATADV_TQ_MAX_VALUE + 1 - tq);
+- 
+- 	/* convert to (randomized) estimated tq again */
+- 	return BATADV_TQ_MAX_VALUE - rand_tq;
+diff --git a/batman-adv/patches/0018-batman-adv-Fix-refcnt-leak-in-batadv_show_throughput.patch b/batman-adv/patches/0018-batman-adv-Fix-refcnt-leak-in-batadv_show_throughput.patch
+deleted file mode 100644
+index 725e4cf3481ed5a3b5e15ca2c1b3b01e1b1e49d3..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0018-batman-adv-Fix-refcnt-leak-in-batadv_show_throughput.patch
++++ /dev/null
+@@ -1,36 +0,0 @@
+-From: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+-Date: Wed, 15 Apr 2020 16:31:50 +0800
+-Subject: batman-adv: Fix refcnt leak in batadv_show_throughput_override
+-
+-batadv_show_throughput_override() invokes batadv_hardif_get_by_netdev(),
+-which gets a batadv_hard_iface object from net_dev with increased refcnt
+-and its reference is assigned to a local pointer 'hard_iface'.
+-
+-When batadv_show_throughput_override() returns, "hard_iface" becomes
+-invalid, so the refcount should be decreased to keep refcount balanced.
+-
+-The issue happens in the normal path of
+-batadv_show_throughput_override(), which forgets to decrease the refcnt
+-increased by batadv_hardif_get_by_netdev() before the function returns,
+-causing a refcnt leak.
+-
+-Fix this issue by calling batadv_hardif_put() before the
+-batadv_show_throughput_override() returns in the normal path.
+-
+-Fixes: c513176e4b7a ("batman-adv: add throughput override attribute to hard_ifaces")
+-Signed-off-by: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+-Signed-off-by: Xin Tan <tanxin.ctf@gmail.com>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/f301bfed59b146a63471d0f147b767d7cafede6f
+-
+---- a/net/batman-adv/sysfs.c
+-+++ b/net/batman-adv/sysfs.c
+-@@ -1189,6 +1189,7 @@ static ssize_t batadv_show_throughput_ov
+- 
+- 	tp_override = atomic_read(&hard_iface->bat_v.throughput_override);
+- 
+-+	batadv_hardif_put(hard_iface);
+- 	return sprintf(buff, "%u.%u MBit\n", tp_override / 10,
+- 		       tp_override % 10);
+- }
+diff --git a/batman-adv/patches/0019-batman-adv-Fix-refcnt-leak-in-batadv_store_throughpu.patch b/batman-adv/patches/0019-batman-adv-Fix-refcnt-leak-in-batadv_store_throughpu.patch
+deleted file mode 100644
+index 69ed25075bb0207eff06331b339b2705345b6ec1..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0019-batman-adv-Fix-refcnt-leak-in-batadv_store_throughpu.patch
++++ /dev/null
+@@ -1,37 +0,0 @@
+-From: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+-Date: Wed, 15 Apr 2020 16:35:21 +0800
+-Subject: batman-adv: Fix refcnt leak in batadv_store_throughput_override
+-
+-batadv_show_throughput_override() invokes batadv_hardif_get_by_netdev(),
+-which gets a batadv_hard_iface object from net_dev with increased refcnt
+-and its reference is assigned to a local pointer 'hard_iface'.
+-
+-When batadv_store_throughput_override() returns, "hard_iface" becomes
+-invalid, so the refcount should be decreased to keep refcount balanced.
+-
+-The issue happens in one error path of
+-batadv_store_throughput_override(). When batadv_parse_throughput()
+-returns NULL, the refcnt increased by batadv_hardif_get_by_netdev() is
+-not decreased, causing a refcnt leak.
+-
+-Fix this issue by jumping to "out" label when batadv_parse_throughput()
+-returns NULL.
+-
+-Fixes: c513176e4b7a ("batman-adv: add throughput override attribute to hard_ifaces")
+-Signed-off-by: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+-Signed-off-by: Xin Tan <tanxin.ctf@gmail.com>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/b69cd8bdbfd6fa7e61878c2fa9e6637406f40dd9
+-
+---- a/net/batman-adv/sysfs.c
+-+++ b/net/batman-adv/sysfs.c
+-@@ -1149,7 +1149,7 @@ static ssize_t batadv_store_throughput_o
+- 	ret = batadv_parse_throughput(net_dev, buff, "throughput_override",
+- 				      &tp_override);
+- 	if (!ret)
+--		return count;
+-+		goto out;
+- 
+- 	old_tp_override = atomic_read(&hard_iface->bat_v.throughput_override);
+- 	if (old_tp_override == tp_override)
+diff --git a/batman-adv/patches/0020-batman-adv-Fix-refcnt-leak-in-batadv_v_ogm_process.patch b/batman-adv/patches/0020-batman-adv-Fix-refcnt-leak-in-batadv_v_ogm_process.patch
+deleted file mode 100644
+index 5c59f2f25ae3dab8a920ac71e65b69c6bfea5f83..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0020-batman-adv-Fix-refcnt-leak-in-batadv_v_ogm_process.patch
++++ /dev/null
+@@ -1,37 +0,0 @@
+-From: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+-Date: Mon, 20 Apr 2020 13:37:20 +0800
+-Subject: batman-adv: Fix refcnt leak in batadv_v_ogm_process
+-
+-batadv_v_ogm_process() invokes batadv_hardif_neigh_get(), which returns
+-a reference of the neighbor object to "hardif_neigh" with increased
+-refcount.
+-
+-When batadv_v_ogm_process() returns, "hardif_neigh" becomes invalid, so
+-the refcount should be decreased to keep refcount balanced.
+-
+-The reference counting issue happens in one exception handling paths of
+-batadv_v_ogm_process(). When batadv_v_ogm_orig_get() fails to get the
+-orig node and returns NULL, the refcnt increased by
+-batadv_hardif_neigh_get() is not decreased, causing a refcnt leak.
+-
+-Fix this issue by jumping to "out" label when batadv_v_ogm_orig_get()
+-fails to get the orig node.
+-
+-Fixes: 667996ebeab4 ("batman-adv: OGMv2 - implement originators logic")
+-Signed-off-by: Xiyu Yang <xiyuyang19@fudan.edu.cn>
+-Signed-off-by: Xin Tan <tanxin.ctf@gmail.com>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/4515f5e6a4ccbe1c563b05f2d487eb9eef3c9740
+-
+---- a/net/batman-adv/bat_v_ogm.c
+-+++ b/net/batman-adv/bat_v_ogm.c
+-@@ -723,7 +723,7 @@ static void batadv_v_ogm_process(const s
+- 
+- 	orig_node = batadv_v_ogm_orig_get(bat_priv, ogm_packet->orig);
+- 	if (!orig_node)
+--		return;
+-+		goto out;
+- 
+- 	neigh_node = batadv_neigh_node_get_or_create(orig_node, if_incoming,
+- 						     ethhdr->h_source);
+diff --git a/batman-adv/patches/0021-batman-adv-Revert-disable-ethtool-link-speed-detecti.patch b/batman-adv/patches/0021-batman-adv-Revert-disable-ethtool-link-speed-detecti.patch
+deleted file mode 100644
+index adc6ba96fb1f1b730ca674275abf1b5fe3c1747b..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0021-batman-adv-Revert-disable-ethtool-link-speed-detecti.patch
++++ /dev/null
+@@ -1,72 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Mon, 25 Nov 2019 10:46:50 +0100
+-Subject: batman-adv: Revert "disable ethtool link speed detection when auto negotiation off"
+-
+-The commit d60b8fc69ef2 ("batman-adv: disable ethtool link speed detection
+-when auto negotiation off") disabled the usage of ethtool's link_ksetting
+-when auto negotation was enabled due to invalid values when used with
+-tun/tap virtual net_devices. According to the patch, automatic measurements
+-should be used for these kind of interfaces.
+-
+-But there are major flaws with this argumentation:
+-
+-* automatic measurements are not implemented
+-* auto negotiation has nothing to do with the validity of the retrieved
+-  values
+-
+-The first point has to be fixed by a longer patch series. The "validity"
+-part of the second point must be addressed in the same patch series by
+-dropping the usage of ethtool's link_ksetting (thus always doing automatic
+-measurements over ethernet).
+-
+-Drop the patch again to have more default values for various net_device
+-types/configurations. The user can still overwrite them using the
+-batadv_hardif's BATADV_ATTR_THROUGHPUT_OVERRIDE.
+-
+-Reported-by: Matthias Schiffer <mschiffer@universe-factory.net>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/6e860b3d5e4147bafcda32bf9b3e769926f232c5
+-
+---- a/compat-include/linux/ethtool.h
+-+++ b/compat-include/linux/ethtool.h
+-@@ -21,7 +21,6 @@ struct batadv_ethtool_link_ksettings {
+- 	struct {
+- 		__u32	speed;
+- 		__u8	duplex;
+--		__u8	autoneg;
+- 	} base;
+- };
+- 
+-@@ -42,7 +41,6 @@ batadv_ethtool_get_link_ksettings(struct
+- 		return ret;
+- 
+- 	link_ksettings->base.duplex = cmd.duplex;
+--	link_ksettings->base.autoneg = cmd.autoneg;
+- 	link_ksettings->base.speed = ethtool_cmd_speed(&cmd);
+- 
+- 	return 0;
+---- a/net/batman-adv/bat_v_elp.c
+-+++ b/net/batman-adv/bat_v_elp.c
+-@@ -120,20 +120,7 @@ static u32 batadv_v_elp_get_throughput(s
+- 	rtnl_lock();
+- 	ret = __ethtool_get_link_ksettings(hard_iface->net_dev, &link_settings);
+- 	rtnl_unlock();
+--
+--	/* Virtual interface drivers such as tun / tap interfaces, VLAN, etc
+--	 * tend to initialize the interface throughput with some value for the
+--	 * sake of having a throughput number to export via ethtool. This
+--	 * exported throughput leaves batman-adv to conclude the interface
+--	 * throughput is genuine (reflecting reality), thus no measurements
+--	 * are necessary.
+--	 *
+--	 * Based on the observation that those interface types also tend to set
+--	 * the link auto-negotiation to 'off', batman-adv shall check this
+--	 * setting to differentiate between genuine link throughput information
+--	 * and placeholders installed by virtual interfaces.
+--	 */
+--	if (ret == 0 && link_settings.base.autoneg == AUTONEG_ENABLE) {
+-+	if (ret == 0) {
+- 		/* link characteristics might change over time */
+- 		if (link_settings.base.duplex == DUPLEX_FULL)
+- 			hard_iface->bat_v.flags |= BATADV_FULL_DUPLEX;
+diff --git a/batman-adv/patches/0022-batman-adv-Avoid-uninitialized-chaddr-when-handling-.patch b/batman-adv/patches/0022-batman-adv-Avoid-uninitialized-chaddr-when-handling-.patch
+deleted file mode 100644
+index 9d14c6dc32883376cceb14730aa2016e9483b71b..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0022-batman-adv-Avoid-uninitialized-chaddr-when-handling-.patch
++++ /dev/null
+@@ -1,40 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Wed, 22 Jul 2020 20:49:23 +0200
+-Subject: batman-adv: Avoid uninitialized chaddr when handling DHCP
+-
+-The gateway client code can try to optimize the delivery of DHCP packets to
+-avoid broadcasting them through the whole mesh. But also transmissions to
+-the client can be optimized by looking up the destination via the chaddr of
+-the DHCP packet.
+-
+-But the chaddr is currently only done when chaddr is fully inside the
+-non-paged area of the skbuff. Otherwise it will not be initialized and the
+-unoptimized path should have been taken.
+-
+-But the implementation didn't handle this correctly. It didn't retrieve the
+-correct chaddr but still tried to perform the TT lookup with this
+-uninitialized memory.
+-
+-Reported-by: syzbot+ab16e463b903f5a37036@syzkaller.appspotmail.com
+-Fixes: 2d5b555644b2 ("batman-adv: send every DHCP packet as bat-unicast")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Acked-by: Antonio Quartulli <a@unstable.cc>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/fcdf008ffd749246632d1f9423163af5dc3f8c7f
+-
+---- a/net/batman-adv/gateway_client.c
+-+++ b/net/batman-adv/gateway_client.c
+-@@ -703,8 +703,10 @@ batadv_gw_dhcp_recipient_get(struct sk_b
+- 
+- 	chaddr_offset = *header_len + BATADV_DHCP_CHADDR_OFFSET;
+- 	/* store the client address if the message is going to a client */
+--	if (ret == BATADV_DHCP_TO_CLIENT &&
+--	    pskb_may_pull(skb, chaddr_offset + ETH_ALEN)) {
+-+	if (ret == BATADV_DHCP_TO_CLIENT) {
+-+		if (!pskb_may_pull(skb, chaddr_offset + ETH_ALEN))
+-+			return BATADV_DHCP_NO;
+-+
+- 		/* check if the DHCP packet carries an Ethernet DHCP */
+- 		p = skb->data + *header_len + BATADV_DHCP_HTYPE_OFFSET;
+- 		if (*p != BATADV_DHCP_HTYPE_ETHERNET)
+diff --git a/batman-adv/patches/0023-batman-adv-Fix-own-OGM-check-in-aggregated-OGMs.patch b/batman-adv/patches/0023-batman-adv-Fix-own-OGM-check-in-aggregated-OGMs.patch
+deleted file mode 100644
+index 6bda3965242c6e9ad72256264b13f3a4e725da02..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0023-batman-adv-Fix-own-OGM-check-in-aggregated-OGMs.patch
++++ /dev/null
+@@ -1,57 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Fri, 31 Jul 2020 00:22:55 +0200
+-Subject: batman-adv: Fix own OGM check in aggregated OGMs
+-
+-The own OGM check is currently misplaced and can lead to the following
+-issues:
+-
+-For one thing we might receive an aggregated OGM from a neighbor node
+-which has our own OGM in the first place. We would then not only skip
+-our own OGM but erroneously also any other, following OGM in the
+-aggregate.
+-
+-For another, we might receive an OGM aggregate which has our own OGM in
+-a place other then the first one. Then we would wrongly not skip this
+-OGM, leading to populating the orginator and gateway table with ourself.
+-
+-The latter seems to not only be a cosmetic issue, but there were reports
+-that this causes issues with various subsystems of batman-adv, too. For
+-instance there were reports about issues with DAT and either disabling
+-DAT or aggregation seemed to solve it.
+-
+-Fixing these issues by applying the own OGM check not on the first OGM
+-in an aggregate but for each OGM in an aggregate instead.
+-
+-Fixes: 667996ebeab ("batman-adv: OGMv2 - implement originators logic")
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/d41cc7cb62c184b2fb8ab97fda45815918200001
+-
+---- a/net/batman-adv/bat_v_ogm.c
+-+++ b/net/batman-adv/bat_v_ogm.c
+-@@ -704,6 +704,12 @@ static void batadv_v_ogm_process(const s
+- 		   ntohl(ogm_packet->seqno), ogm_throughput, ogm_packet->ttl,
+- 		   ogm_packet->version, ntohs(ogm_packet->tvlv_len));
+- 
+-+	if (batadv_is_my_mac(bat_priv, ogm_packet->orig)) {
+-+		batadv_dbg(BATADV_DBG_BATMAN, bat_priv,
+-+			   "Drop packet: originator packet from ourself\n");
+-+		return;
+-+	}
+-+
+- 	/* If the throughput metric is 0, immediately drop the packet. No need
+- 	 * to create orig_node / neigh_node for an unusable route.
+- 	 */
+-@@ -831,11 +837,6 @@ int batadv_v_ogm_packet_recv(struct sk_b
+- 	if (batadv_is_my_mac(bat_priv, ethhdr->h_source))
+- 		goto free_skb;
+- 
+--	ogm_packet = (struct batadv_ogm2_packet *)skb->data;
+--
+--	if (batadv_is_my_mac(bat_priv, ogm_packet->orig))
+--		goto free_skb;
+--
+- 	batadv_inc_counter(bat_priv, BATADV_CNT_MGMT_RX);
+- 	batadv_add_counter(bat_priv, BATADV_CNT_MGMT_RX_BYTES,
+- 			   skb->len + ETH_HLEN);
+diff --git a/batman-adv/patches/0024-batman-adv-bla-use-netif_rx_ni-when-not-in-interrupt.patch b/batman-adv/patches/0024-batman-adv-bla-use-netif_rx_ni-when-not-in-interrupt.patch
+deleted file mode 100644
+index 4d5634f557c5a599dee55d40bb1f636937232979..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0024-batman-adv-bla-use-netif_rx_ni-when-not-in-interrupt.patch
++++ /dev/null
+@@ -1,29 +0,0 @@
+-From: Jussi Kivilinna <jussi.kivilinna@haltian.com>
+-Date: Tue, 18 Aug 2020 17:46:10 +0300
+-Subject: batman-adv: bla: use netif_rx_ni when not in interrupt context
+-
+-batadv_bla_send_claim() gets called from worker thread context through
+-batadv_bla_periodic_work(), thus netif_rx_ni needs to be used in that
+-case. This fixes "NOHZ: local_softirq_pending 08" log messages seen
+-when batman-adv is enabled.
+-
+-Fixes: a9ce0dc43e2c ("batman-adv: add basic bridge loop avoidance code")
+-Signed-off-by: Jussi Kivilinna <jussi.kivilinna@haltian.com>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/3747f81a1380b65740fc52fc71c7a3af4c6e49de
+-
+---- a/net/batman-adv/bridge_loop_avoidance.c
+-+++ b/net/batman-adv/bridge_loop_avoidance.c
+-@@ -437,7 +437,10 @@ static void batadv_bla_send_claim(struct
+- 	batadv_add_counter(bat_priv, BATADV_CNT_RX_BYTES,
+- 			   skb->len + ETH_HLEN);
+- 
+--	netif_rx(skb);
+-+	if (in_interrupt())
+-+		netif_rx(skb);
+-+	else
+-+		netif_rx_ni(skb);
+- out:
+- 	if (primary_if)
+- 		batadv_hardif_put(primary_if);
+diff --git a/batman-adv/patches/0025-batman-adv-bla-fix-type-misuse-for-backbone_gw-hash-.patch b/batman-adv/patches/0025-batman-adv-bla-fix-type-misuse-for-backbone_gw-hash-.patch
+deleted file mode 100644
+index 4799d6aae5c728880331f94519b5336777d597c7..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0025-batman-adv-bla-fix-type-misuse-for-backbone_gw-hash-.patch
++++ /dev/null
+@@ -1,39 +0,0 @@
+-From: Linus Lüssing <ll@simonwunderlich.de>
+-Date: Thu, 27 Aug 2020 17:34:48 +0200
+-Subject: batman-adv: bla: fix type misuse for backbone_gw hash indexing
+-
+-It seems that due to a copy & paste error the void pointer
+-in batadv_choose_backbone_gw() is cast to the wrong type.
+-
+-Fixing this by using "struct batadv_bla_backbone_gw" instead of "struct
+-batadv_bla_claim" which better matches the caller's side.
+-
+-For now it seems that we were lucky because the two structs both have
+-their orig/vid and addr/vid in the beginning. However I stumbled over
+-this issue when I was trying to add some debug variables in front of
+-"orig" in batadv_backbone_gw, which caused hash lookups to fail.
+-
+-Fixes: 7e15c9305ce0 ("batman-adv: don't rely on positions in struct for hashing")
+-Signed-off-by: Linus Lüssing <ll@simonwunderlich.de>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/398a706cd46c1fc085aef56ae8ed11f76e182bd1
+-
+---- a/net/batman-adv/bridge_loop_avoidance.c
+-+++ b/net/batman-adv/bridge_loop_avoidance.c
+-@@ -83,11 +83,12 @@ static inline u32 batadv_choose_claim(co
+-  */
+- static inline u32 batadv_choose_backbone_gw(const void *data, u32 size)
+- {
+--	const struct batadv_bla_claim *claim = (struct batadv_bla_claim *)data;
+-+	const struct batadv_bla_backbone_gw *gw;
+- 	u32 hash = 0;
+- 
+--	hash = jhash(&claim->addr, sizeof(claim->addr), hash);
+--	hash = jhash(&claim->vid, sizeof(claim->vid), hash);
+-+	gw = (struct batadv_bla_backbone_gw *)data;
+-+	hash = jhash(&gw->orig, sizeof(gw->orig), hash);
+-+	hash = jhash(&gw->vid, sizeof(gw->vid), hash);
+- 
+- 	return hash % size;
+- }
+diff --git a/batman-adv/patches/0026-batman-adv-mcast-TT-fix-wrongly-dropped-or-rerouted-.patch b/batman-adv/patches/0026-batman-adv-mcast-TT-fix-wrongly-dropped-or-rerouted-.patch
+deleted file mode 100644
+index 2a9b1ae8ea16cf51734a6d4fafb52d8c009d8846..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0026-batman-adv-mcast-TT-fix-wrongly-dropped-or-rerouted-.patch
++++ /dev/null
+@@ -1,43 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Fri, 4 Sep 2020 20:28:00 +0200
+-Subject: batman-adv: mcast/TT: fix wrongly dropped or rerouted packets
+-
+-The unicast packet rerouting code makes several assumptions. For
+-instance it assumes that there is always exactly one destination in the
+-TT. This breaks for multicast frames in a unicast packets in several ways:
+-
+-For one thing if there is actually no TT entry and the destination node
+-was selected due to the multicast tvlv flags it announced. Then an
+-intermediate node will wrongly drop the packet.
+-
+-For another thing if there is a TT entry but the TTVN of this entry is
+-newer than the originally addressed destination node: Then the
+-intermediate node will wrongly redirect the packet, leading to
+-duplicated multicast packets at a multicast listener and missing
+-packets at other multicast listeners or multicast routers.
+-
+-Fixing this by not applying the unicast packet rerouting to batman-adv
+-unicast packets with a multicast payload. We are not able to detect a
+-roaming multicast listener at the moment and will just continue to send
+-the multicast frame to both the new and old destination for a while in
+-case of such a roaming multicast listener.
+-
+-Fixes: cea194d90b11 ("batman-adv: improved client announcement mechanism")
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/22e740c5e6c9342e0f5028beb3d14b84a018d113
+-
+---- a/net/batman-adv/routing.c
+-+++ b/net/batman-adv/routing.c
+-@@ -826,6 +826,10 @@ static bool batadv_check_unicast_ttvn(st
+- 	vid = batadv_get_vid(skb, hdr_len);
+- 	ethhdr = (struct ethhdr *)(skb->data + hdr_len);
+- 
+-+	/* do not reroute multicast frames in a unicast header */
+-+	if (is_multicast_ether_addr(ethhdr->h_dest))
+-+		return true;
+-+
+- 	/* check if the destination client was served by this node and it is now
+- 	 * roaming. In this case, it means that the node has got a ROAM_ADV
+- 	 * message and that it knows the new destination in the mesh to re-route
+diff --git a/batman-adv/patches/0027-batman-adv-Add-missing-include-for-in_interrupt.patch b/batman-adv/patches/0027-batman-adv-Add-missing-include-for-in_interrupt.patch
+deleted file mode 100644
+index a9eead302070e4d038850db2aba305e662691be3..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0027-batman-adv-Add-missing-include-for-in_interrupt.patch
++++ /dev/null
+@@ -1,24 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Mon, 14 Sep 2020 13:58:16 +0200
+-Subject: batman-adv: Add missing include for in_interrupt()
+-
+-The fix for receiving (internally generated) bla packets outside the
+-interrupt context introduced the usage of in_interrupt(). But this
+-functionality is only defined in linux/preempt.h which was not included
+-with the same patch.
+-
+-Fixes: 3747f81a1380 ("batman-adv: bla: use netif_rx_ni when not in interrupt context")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/6ea99cd9c82b2d1bc4a313fe9006bcf5d956380e
+-
+---- a/net/batman-adv/bridge_loop_avoidance.c
+-+++ b/net/batman-adv/bridge_loop_avoidance.c
+-@@ -25,6 +25,7 @@
+- #include <linux/lockdep.h>
+- #include <linux/netdevice.h>
+- #include <linux/netlink.h>
+-+#include <linux/preempt.h>
+- #include <linux/rculist.h>
+- #include <linux/rcupdate.h>
+- #include <linux/seq_file.h>
+diff --git a/batman-adv/patches/0028-batman-adv-mcast-fix-duplicate-mcast-packets-in-BLA-.patch b/batman-adv/patches/0028-batman-adv-mcast-fix-duplicate-mcast-packets-in-BLA-.patch
+deleted file mode 100644
+index bebcd0251c5a9bab664a82710eb4fab78cf6ac24..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0028-batman-adv-mcast-fix-duplicate-mcast-packets-in-BLA-.patch
++++ /dev/null
+@@ -1,164 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Tue, 15 Sep 2020 09:54:08 +0200
+-Subject: batman-adv: mcast: fix duplicate mcast packets in BLA backbone from LAN
+-
+-Scenario:
+-* Multicast frame send from a BLA backbone (multiple nodes with
+-  their bat0 bridged together, with BLA enabled)
+-
+-Issue:
+-* BLA backbone nodes receive the frame multiple times on bat0
+-
+-For multicast frames received via batman-adv broadcast packets the
+-originator of the broadcast packet is checked before decapsulating and
+-forwarding the frame to bat0 (batadv_bla_is_backbone_gw()->
+-batadv_recv_bcast_packet()). If it came from a node which shares the
+-same BLA backbone with us then it is not forwarded to bat0 to avoid a
+-loop.
+-
+-When sending a multicast frame in a non-4-address batman-adv unicast
+-packet we are currently missing this check - and cannot do so because
+-the batman-adv unicast packet has no originator address field.
+-
+-However, we can simply fix this on the sender side by only sending the
+-multicast frame via unicasts to interested nodes which do not share the
+-same BLA backbone with us. This also nicely avoids some unnecessary
+-transmissions on mesh side.
+-
+-Note that no infinite loop was observed, probably because of dropping
+-via batadv_interface_tx()->batadv_bla_tx(). However the duplicates still
+-utterly confuse switches/bridges, ICMPv6 duplicate address detection and
+-neighbor discovery and therefore leads to long delays before being able
+-to establish TCP connections, for instance. And it also leads to the Linux
+-bridge printing messages like:
+-"br-lan: received packet on eth1 with own address as source address ..."
+-
+-Fixes: 405cc1e5a81e ("batman-adv: Modified forwarding behaviour for multicast packets")
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Acked-by: Simon Wunderlich <sw@simonwunderlich.de>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: backport, https://git.open-mesh.org/batman-adv.git/commit/3c39a2455a5be02ecceeaf1a15976bddd611392e
+-
+---- a/net/batman-adv/multicast.c
+-+++ b/net/batman-adv/multicast.c
+-@@ -50,6 +50,7 @@
+- #include <uapi/linux/batadv_packet.h>
+- #include <uapi/linux/batman_adv.h>
+- 
+-+#include "bridge_loop_avoidance.h"
+- #include "hard-interface.h"
+- #include "hash.h"
+- #include "log.h"
+-@@ -1020,6 +1021,35 @@ batadv_mcast_forw_mode(struct batadv_pri
+- }
+- 
+- /**
+-+ * batadv_mcast_forw_send_orig() - send a multicast packet to an originator
+-+ * @bat_priv: the bat priv with all the soft interface information
+-+ * @skb: the multicast packet to send
+-+ * @vid: the vlan identifier
+-+ * @orig_node: the originator to send the packet to
+-+ *
+-+ * Return: NET_XMIT_DROP in case of error or NET_XMIT_SUCCESS otherwise.
+-+ */
+-+int batadv_mcast_forw_send_orig(struct batadv_priv *bat_priv,
+-+				struct sk_buff *skb,
+-+				unsigned short vid,
+-+				struct batadv_orig_node *orig_node)
+-+{
+-+	/* Avoid sending multicast-in-unicast packets to other BLA
+-+	 * gateways - they already got the frame from the LAN side
+-+	 * we share with them.
+-+	 * TODO: Refactor to take BLA into account earlier, to avoid
+-+	 * reducing the mcast_fanout count.
+-+	 */
+-+	if (batadv_bla_is_backbone_gw_orig(bat_priv, orig_node->orig, vid)) {
+-+		dev_kfree_skb(skb);
+-+		return NET_XMIT_SUCCESS;
+-+	}
+-+
+-+	return batadv_send_skb_unicast(bat_priv, skb, BATADV_UNICAST, 0,
+-+				       orig_node, vid);
+-+}
+-+
+-+/**
+-  * batadv_mcast_forw_tt() - forwards a packet to multicast listeners
+-  * @bat_priv: the bat priv with all the soft interface information
+-  * @skb: the multicast packet to transmit
+-@@ -1056,8 +1086,8 @@ batadv_mcast_forw_tt(struct batadv_priv
+- 			break;
+- 		}
+- 
+--		batadv_send_skb_unicast(bat_priv, newskb, BATADV_UNICAST, 0,
+--					orig_entry->orig_node, vid);
+-+		batadv_mcast_forw_send_orig(bat_priv, newskb, vid,
+-+					    orig_entry->orig_node);
+- 	}
+- 	rcu_read_unlock();
+- 
+-@@ -1098,8 +1128,7 @@ batadv_mcast_forw_want_all_ipv4(struct b
+- 			break;
+- 		}
+- 
+--		batadv_send_skb_unicast(bat_priv, newskb, BATADV_UNICAST, 0,
+--					orig_node, vid);
+-+		batadv_mcast_forw_send_orig(bat_priv, newskb, vid, orig_node);
+- 	}
+- 	rcu_read_unlock();
+- 	return ret;
+-@@ -1136,8 +1165,7 @@ batadv_mcast_forw_want_all_ipv6(struct b
+- 			break;
+- 		}
+- 
+--		batadv_send_skb_unicast(bat_priv, newskb, BATADV_UNICAST, 0,
+--					orig_node, vid);
+-+		batadv_mcast_forw_send_orig(bat_priv, newskb, vid, orig_node);
+- 	}
+- 	rcu_read_unlock();
+- 	return ret;
+---- a/net/batman-adv/multicast.h
+-+++ b/net/batman-adv/multicast.h
+-@@ -46,6 +46,11 @@ enum batadv_forw_mode
+- batadv_mcast_forw_mode(struct batadv_priv *bat_priv, struct sk_buff *skb,
+- 		       struct batadv_orig_node **mcast_single_orig);
+- 
+-+int batadv_mcast_forw_send_orig(struct batadv_priv *bat_priv,
+-+				struct sk_buff *skb,
+-+				unsigned short vid,
+-+				struct batadv_orig_node *orig_node);
+-+
+- int batadv_mcast_forw_send(struct batadv_priv *bat_priv, struct sk_buff *skb,
+- 			   unsigned short vid);
+- 
+-@@ -72,6 +77,16 @@ batadv_mcast_forw_mode(struct batadv_pri
+- }
+- 
+- static inline int
+-+batadv_mcast_forw_send_orig(struct batadv_priv *bat_priv,
+-+			    struct sk_buff *skb,
+-+			    unsigned short vid,
+-+			    struct batadv_orig_node *orig_node)
+-+{
+-+	kfree_skb(skb);
+-+	return NET_XMIT_DROP;
+-+}
+-+
+-+static inline int
+- batadv_mcast_forw_send(struct batadv_priv *bat_priv, struct sk_buff *skb,
+- 		       unsigned short vid)
+- {
+---- a/net/batman-adv/soft-interface.c
+-+++ b/net/batman-adv/soft-interface.c
+-@@ -363,9 +363,8 @@ send:
+- 				goto dropped;
+- 			ret = batadv_send_skb_via_gw(bat_priv, skb, vid);
+- 		} else if (mcast_single_orig) {
+--			ret = batadv_send_skb_unicast(bat_priv, skb,
+--						      BATADV_UNICAST, 0,
+--						      mcast_single_orig, vid);
+-+			ret = batadv_mcast_forw_send_orig(bat_priv, skb, vid,
+-+							  mcast_single_orig);
+- 		} else if (forw_mode == BATADV_FORW_SOME) {
+- 			ret = batadv_mcast_forw_send(bat_priv, skb, vid);
+- 		} else {
+diff --git a/batman-adv/patches/0029-batman-adv-mcast-fix-duplicate-mcast-packets-in-BLA-.patch b/batman-adv/patches/0029-batman-adv-mcast-fix-duplicate-mcast-packets-in-BLA-.patch
+deleted file mode 100644
+index 23d2a1ea67e0df9f871f8d1a57d6b2e01ec8bfa4..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0029-batman-adv-mcast-fix-duplicate-mcast-packets-in-BLA-.patch
++++ /dev/null
+@@ -1,150 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Tue, 15 Sep 2020 09:54:09 +0200
+-Subject: batman-adv: mcast: fix duplicate mcast packets in BLA backbone from mesh
+-
+-Scenario:
+-* Multicast frame send from mesh to a BLA backbone (multiple nodes
+-  with their bat0 bridged together, with BLA enabled)
+-
+-Issue:
+-* BLA backbone nodes receive the frame multiple times on bat0,
+-  once from mesh->bat0 and once from each backbone_gw from LAN
+-
+-For unicast, a node will send only to the best backbone gateway
+-according to the TQ. However for multicast we currently cannot determine
+-if multiple destination nodes share the same backbone if they don't share
+-the same backbone with us. So we need to keep sending the unicasts to
+-all backbone gateways and let the backbone gateways decide which one
+-will forward the frame. We can use the CLAIM mechanism to make this
+-decision.
+-
+-One catch: The batman-adv gateway feature for DHCP packets potentially
+-sends multicast packets in the same batman-adv unicast header as the
+-multicast optimizations code. And we are not allowed to drop those even
+-if we did not claim the source address of the sender, as for such
+-packets there is only this one multicast-in-unicast packet.
+-
+-How can we distinguish the two cases?
+-
+-The gateway feature uses a batman-adv unicast 4 address header. While
+-the multicast-to-unicasts feature uses a simple, 3 address batman-adv
+-unicast header. So let's use this to distinguish.
+-
+-Fixes: e32470167379 ("batman-adv: check incoming packet type for bla")
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Acked-by: Simon Wunderlich <sw@simonwunderlich.de>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/d7665cf8a824c41c61c6e2110ab63d37eb7a8ef7
+-
+---- a/net/batman-adv/bridge_loop_avoidance.c
+-+++ b/net/batman-adv/bridge_loop_avoidance.c
+-@@ -1814,7 +1814,7 @@ batadv_bla_loopdetect_check(struct batad
+-  * @bat_priv: the bat priv with all the soft interface information
+-  * @skb: the frame to be checked
+-  * @vid: the VLAN ID of the frame
+-- * @is_bcast: the packet came in a broadcast packet type.
+-+ * @packet_type: the batman packet type this frame came in
+-  *
+-  * batadv_bla_rx avoidance checks if:
+-  *  * we have to race for a claim
+-@@ -1826,7 +1826,7 @@ batadv_bla_loopdetect_check(struct batad
+-  * further process the skb.
+-  */
+- bool batadv_bla_rx(struct batadv_priv *bat_priv, struct sk_buff *skb,
+--		   unsigned short vid, bool is_bcast)
+-+		   unsigned short vid, int packet_type)
+- {
+- 	struct batadv_bla_backbone_gw *backbone_gw;
+- 	struct ethhdr *ethhdr;
+-@@ -1848,9 +1848,24 @@ bool batadv_bla_rx(struct batadv_priv *b
+- 		goto handled;
+- 
+- 	if (unlikely(atomic_read(&bat_priv->bla.num_requests)))
+--		/* don't allow broadcasts while requests are in flight */
+--		if (is_multicast_ether_addr(ethhdr->h_dest) && is_bcast)
+--			goto handled;
+-+		/* don't allow multicast packets while requests are in flight */
+-+		if (is_multicast_ether_addr(ethhdr->h_dest))
+-+			/* Both broadcast flooding or multicast-via-unicasts
+-+			 * delivery might send to multiple backbone gateways
+-+			 * sharing the same LAN and therefore need to coordinate
+-+			 * which backbone gateway forwards into the LAN,
+-+			 * by claiming the payload source address.
+-+			 *
+-+			 * Broadcast flooding and multicast-via-unicasts
+-+			 * delivery use the following two batman packet types.
+-+			 * Note: explicitly exclude BATADV_UNICAST_4ADDR,
+-+			 * as the DHCP gateway feature will send explicitly
+-+			 * to only one BLA gateway, so the claiming process
+-+			 * should be avoided there.
+-+			 */
+-+			if (packet_type == BATADV_BCAST ||
+-+			    packet_type == BATADV_UNICAST)
+-+				goto handled;
+- 
+- 	ether_addr_copy(search_claim.addr, ethhdr->h_source);
+- 	search_claim.vid = vid;
+-@@ -1885,13 +1900,14 @@ bool batadv_bla_rx(struct batadv_priv *b
+- 		goto allow;
+- 	}
+- 
+--	/* if it is a broadcast ... */
+--	if (is_multicast_ether_addr(ethhdr->h_dest) && is_bcast) {
+-+	/* if it is a multicast ... */
+-+	if (is_multicast_ether_addr(ethhdr->h_dest) &&
+-+	    (packet_type == BATADV_BCAST || packet_type == BATADV_UNICAST)) {
+- 		/* ... drop it. the responsible gateway is in charge.
+- 		 *
+--		 * We need to check is_bcast because with the gateway
+-+		 * We need to check packet type because with the gateway
+- 		 * feature, broadcasts (like DHCP requests) may be sent
+--		 * using a unicast packet type.
+-+		 * using a unicast 4 address packet type. See comment above.
+- 		 */
+- 		goto handled;
+- 	} else {
+---- a/net/batman-adv/bridge_loop_avoidance.h
+-+++ b/net/batman-adv/bridge_loop_avoidance.h
+-@@ -36,7 +36,7 @@ static inline bool batadv_bla_is_loopdet
+- 
+- #ifdef CONFIG_BATMAN_ADV_BLA
+- bool batadv_bla_rx(struct batadv_priv *bat_priv, struct sk_buff *skb,
+--		   unsigned short vid, bool is_bcast);
+-+		   unsigned short vid, int packet_type);
+- bool batadv_bla_tx(struct batadv_priv *bat_priv, struct sk_buff *skb,
+- 		   unsigned short vid);
+- bool batadv_bla_is_backbone_gw(struct sk_buff *skb,
+-@@ -67,7 +67,7 @@ bool batadv_bla_check_claim(struct batad
+- 
+- static inline bool batadv_bla_rx(struct batadv_priv *bat_priv,
+- 				 struct sk_buff *skb, unsigned short vid,
+--				 bool is_bcast)
+-+				 int packet_type)
+- {
+- 	return false;
+- }
+---- a/net/batman-adv/soft-interface.c
+-+++ b/net/batman-adv/soft-interface.c
+-@@ -423,10 +423,10 @@ void batadv_interface_rx(struct net_devi
+- 	struct vlan_ethhdr *vhdr;
+- 	struct ethhdr *ethhdr;
+- 	unsigned short vid;
+--	bool is_bcast;
+-+	int packet_type;
+- 
+- 	batadv_bcast_packet = (struct batadv_bcast_packet *)skb->data;
+--	is_bcast = (batadv_bcast_packet->packet_type == BATADV_BCAST);
+-+	packet_type = batadv_bcast_packet->packet_type;
+- 
+- 	skb_pull_rcsum(skb, hdr_size);
+- 	skb_reset_mac_header(skb);
+-@@ -469,7 +469,7 @@ void batadv_interface_rx(struct net_devi
+- 	/* Let the bridge loop avoidance check the packet. If will
+- 	 * not handle it, we can safely push it up.
+- 	 */
+--	if (batadv_bla_rx(bat_priv, skb, vid, is_bcast))
+-+	if (batadv_bla_rx(bat_priv, skb, vid, packet_type))
+- 		goto out;
+- 
+- 	if (orig_node)
+diff --git a/batman-adv/patches/0030-batman-adv-mcast-fix-duplicate-mcast-packets-from-BL.patch b/batman-adv/patches/0030-batman-adv-mcast-fix-duplicate-mcast-packets-from-BL.patch
+deleted file mode 100644
+index 1ab3677ed9d3c6c92d00e158c5a8e16c01df5222..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0030-batman-adv-mcast-fix-duplicate-mcast-packets-from-BL.patch
++++ /dev/null
+@@ -1,189 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Tue, 15 Sep 2020 09:54:10 +0200
+-Subject: batman-adv: mcast: fix duplicate mcast packets from BLA backbone to mesh
+-
+-Scenario:
+-* Multicast frame send from BLA backbone gateways (multiple nodes
+-  with their bat0 bridged together, with BLA enabled) sharing the same
+-  LAN to nodes in the mesh
+-
+-Issue:
+-* Nodes receive the frame multiple times on bat0 from the mesh,
+-  once from each foreign BLA backbone gateway which shares the same LAN
+-  with another
+-
+-For multicast frames via batman-adv broadcast packets coming from the
+-same BLA backbone but from different backbone gateways duplicates are
+-currently detected via a CRC history of previously received packets.
+-
+-However this CRC so far was not performed for multicast frames received
+-via batman-adv unicast packets. Fixing this by appyling the same check
+-for such packets, too.
+-
+-Room for improvements in the future: Ideally we would introduce the
+-possibility to not only claim a client, but a complete originator, too.
+-This would allow us to only send a multicast-in-unicast packet from a BLA
+-backbone gateway claiming the node and by that avoid potential redundant
+-transmissions in the first place.
+-
+-Fixes: e5cf86d30a9b ("batman-adv: add broadcast duplicate check")
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/c5cb6a670cc3070d9d5c5562f95fa75faac767ba
+-
+---- a/net/batman-adv/bridge_loop_avoidance.c
+-+++ b/net/batman-adv/bridge_loop_avoidance.c
+-@@ -1581,13 +1581,16 @@ int batadv_bla_init(struct batadv_priv *
+- }
+- 
+- /**
+-- * batadv_bla_check_bcast_duplist() - Check if a frame is in the broadcast dup.
+-+ * batadv_bla_check_duplist() - Check if a frame is in the broadcast dup.
+-  * @bat_priv: the bat priv with all the soft interface information
+-- * @skb: contains the bcast_packet to be checked
+-- *
+-- * check if it is on our broadcast list. Another gateway might
+-- * have sent the same packet because it is connected to the same backbone,
+-- * so we have to remove this duplicate.
+-+ * @skb: contains the multicast packet to be checked
+-+ * @payload_ptr: pointer to position inside the head buffer of the skb
+-+ *  marking the start of the data to be CRC'ed
+-+ * @orig: originator mac address, NULL if unknown
+-+ *
+-+ * Check if it is on our broadcast list. Another gateway might have sent the
+-+ * same packet because it is connected to the same backbone, so we have to
+-+ * remove this duplicate.
+-  *
+-  * This is performed by checking the CRC, which will tell us
+-  * with a good chance that it is the same packet. If it is furthermore
+-@@ -1596,19 +1599,17 @@ int batadv_bla_init(struct batadv_priv *
+-  *
+-  * Return: true if a packet is in the duplicate list, false otherwise.
+-  */
+--bool batadv_bla_check_bcast_duplist(struct batadv_priv *bat_priv,
+--				    struct sk_buff *skb)
+-+static bool batadv_bla_check_duplist(struct batadv_priv *bat_priv,
+-+				     struct sk_buff *skb, u8 *payload_ptr,
+-+				     const u8 *orig)
+- {
+--	int i, curr;
+--	__be32 crc;
+--	struct batadv_bcast_packet *bcast_packet;
+- 	struct batadv_bcast_duplist_entry *entry;
+- 	bool ret = false;
+--
+--	bcast_packet = (struct batadv_bcast_packet *)skb->data;
+-+	int i, curr;
+-+	__be32 crc;
+- 
+- 	/* calculate the crc ... */
+--	crc = batadv_skb_crc32(skb, (u8 *)(bcast_packet + 1));
+-+	crc = batadv_skb_crc32(skb, payload_ptr);
+- 
+- 	spin_lock_bh(&bat_priv->bla.bcast_duplist_lock);
+- 
+-@@ -1627,8 +1628,21 @@ bool batadv_bla_check_bcast_duplist(stru
+- 		if (entry->crc != crc)
+- 			continue;
+- 
+--		if (batadv_compare_eth(entry->orig, bcast_packet->orig))
+--			continue;
+-+		/* are the originators both known and not anonymous? */
+-+		if (orig && !is_zero_ether_addr(orig) &&
+-+		    !is_zero_ether_addr(entry->orig)) {
+-+			/* If known, check if the new frame came from
+-+			 * the same originator:
+-+			 * We are safe to take identical frames from the
+-+			 * same orig, if known, as multiplications in
+-+			 * the mesh are detected via the (orig, seqno) pair.
+-+			 * So we can be a bit more liberal here and allow
+-+			 * identical frames from the same orig which the source
+-+			 * host might have sent multiple times on purpose.
+-+			 */
+-+			if (batadv_compare_eth(entry->orig, orig))
+-+				continue;
+-+		}
+- 
+- 		/* this entry seems to match: same crc, not too old,
+- 		 * and from another gw. therefore return true to forbid it.
+-@@ -1644,7 +1658,14 @@ bool batadv_bla_check_bcast_duplist(stru
+- 	entry = &bat_priv->bla.bcast_duplist[curr];
+- 	entry->crc = crc;
+- 	entry->entrytime = jiffies;
+--	ether_addr_copy(entry->orig, bcast_packet->orig);
+-+
+-+	/* known originator */
+-+	if (orig)
+-+		ether_addr_copy(entry->orig, orig);
+-+	/* anonymous originator */
+-+	else
+-+		eth_zero_addr(entry->orig);
+-+
+- 	bat_priv->bla.bcast_duplist_curr = curr;
+- 
+- out:
+-@@ -1654,6 +1675,48 @@ out:
+- }
+- 
+- /**
+-+ * batadv_bla_check_ucast_duplist() - Check if a frame is in the broadcast dup.
+-+ * @bat_priv: the bat priv with all the soft interface information
+-+ * @skb: contains the multicast packet to be checked, decapsulated from a
+-+ *  unicast_packet
+-+ *
+-+ * Check if it is on our broadcast list. Another gateway might have sent the
+-+ * same packet because it is connected to the same backbone, so we have to
+-+ * remove this duplicate.
+-+ *
+-+ * Return: true if a packet is in the duplicate list, false otherwise.
+-+ */
+-+static bool batadv_bla_check_ucast_duplist(struct batadv_priv *bat_priv,
+-+					   struct sk_buff *skb)
+-+{
+-+	return batadv_bla_check_duplist(bat_priv, skb, (u8 *)skb->data, NULL);
+-+}
+-+
+-+/**
+-+ * batadv_bla_check_bcast_duplist() - Check if a frame is in the broadcast dup.
+-+ * @bat_priv: the bat priv with all the soft interface information
+-+ * @skb: contains the bcast_packet to be checked
+-+ *
+-+ * Check if it is on our broadcast list. Another gateway might have sent the
+-+ * same packet because it is connected to the same backbone, so we have to
+-+ * remove this duplicate.
+-+ *
+-+ * Return: true if a packet is in the duplicate list, false otherwise.
+-+ */
+-+bool batadv_bla_check_bcast_duplist(struct batadv_priv *bat_priv,
+-+				    struct sk_buff *skb)
+-+{
+-+	struct batadv_bcast_packet *bcast_packet;
+-+	u8 *payload_ptr;
+-+
+-+	bcast_packet = (struct batadv_bcast_packet *)skb->data;
+-+	payload_ptr = (u8 *)(bcast_packet + 1);
+-+
+-+	return batadv_bla_check_duplist(bat_priv, skb, payload_ptr,
+-+					bcast_packet->orig);
+-+}
+-+
+-+/**
+-  * batadv_bla_is_backbone_gw_orig() - Check if the originator is a gateway for
+-  *  the VLAN identified by vid.
+-  * @bat_priv: the bat priv with all the soft interface information
+-@@ -1867,6 +1930,14 @@ bool batadv_bla_rx(struct batadv_priv *b
+- 			    packet_type == BATADV_UNICAST)
+- 				goto handled;
+- 
+-+	/* potential duplicates from foreign BLA backbone gateways via
+-+	 * multicast-in-unicast packets
+-+	 */
+-+	if (is_multicast_ether_addr(ethhdr->h_dest) &&
+-+	    packet_type == BATADV_UNICAST &&
+-+	    batadv_bla_check_ucast_duplist(bat_priv, skb))
+-+		goto handled;
+-+
+- 	ether_addr_copy(search_claim.addr, ethhdr->h_source);
+- 	search_claim.vid = vid;
+- 	claim = batadv_claim_hash_find(bat_priv, &search_claim);
+diff --git a/batman-adv/patches/0031-batman-adv-set-.owner-to-THIS_MODULE.patch b/batman-adv/patches/0031-batman-adv-set-.owner-to-THIS_MODULE.patch
+deleted file mode 100644
+index 73e0a6a9f3e5635c1161b1ad8bb677bf446b43a3..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0031-batman-adv-set-.owner-to-THIS_MODULE.patch
++++ /dev/null
+@@ -1,23 +0,0 @@
+-From: Taehee Yoo <ap420073@gmail.com>
+-Date: Sun, 15 Nov 2020 10:30:04 +0000
+-Subject: batman-adv: set .owner to THIS_MODULE
+-
+-If THIS_MODULE is not set, the module would be removed while debugfs is
+-being used.
+-It eventually makes kernel panic.
+-
+-Fixes: 24571be14371 ("batman-adv: add routing debug log accessible via debugfs")
+-Signed-off-by: Taehee Yoo <ap420073@gmail.com>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/6e2937539a2c9f8a8536515258bc1f08bed19a06
+-
+---- a/net/batman-adv/log.c
+-+++ b/net/batman-adv/log.c
+-@@ -180,6 +180,7 @@ static const struct file_operations bata
+- 	.read           = batadv_log_read,
+- 	.poll           = batadv_log_poll,
+- 	.llseek         = no_llseek,
+-+	.owner          = THIS_MODULE,
+- };
+- 
+- /**
+diff --git a/batman-adv/patches/0032-batman-adv-Consider-fragmentation-for-needed_headroo.patch b/batman-adv/patches/0032-batman-adv-Consider-fragmentation-for-needed_headroo.patch
+deleted file mode 100644
+index 1bd442fc13abd2b52180d4825d7120e2ead1a4be..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0032-batman-adv-Consider-fragmentation-for-needed_headroo.patch
++++ /dev/null
+@@ -1,28 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 26 Nov 2020 18:15:06 +0100
+-Subject: batman-adv: Consider fragmentation for needed_headroom
+-
+-If a batman-adv packets has to be fragmented, then the original batman-adv
+-packet header is not stripped away. Instead, only a new header is added in
+-front of the packet after it was split.
+-
+-This size must be considered to avoid cost intensive reallocations during
+-the transmission through the various device layers.
+-
+-Fixes: e2b4301f4e2d ("batman-adv: Add lower layer needed_(head|tail)room to own ones")
+-Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/92064deda9b063ca2d5a53b307c6127a9453357c
+-
+---- a/net/batman-adv/hard-interface.c
+-+++ b/net/batman-adv/hard-interface.c
+-@@ -553,6 +553,9 @@ static void batadv_hardif_recalc_extra_s
+- 	needed_headroom = lower_headroom + (lower_header_len - ETH_HLEN);
+- 	needed_headroom += batadv_max_header_len();
+- 
+-+	/* fragmentation headers don't strip the unicast/... header */
+-+	needed_headroom += sizeof(struct batadv_frag_packet);
+-+
+- 	soft_iface->needed_headroom = needed_headroom;
+- 	soft_iface->needed_tailroom = lower_tailroom;
+- }
+diff --git a/batman-adv/patches/0033-batman-adv-Reserve-needed_-room-for-fragments.patch b/batman-adv/patches/0033-batman-adv-Reserve-needed_-room-for-fragments.patch
+deleted file mode 100644
+index 12137820e85873afc3128d8e9ec2fce75a9d751b..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0033-batman-adv-Reserve-needed_-room-for-fragments.patch
++++ /dev/null
+@@ -1,79 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Wed, 25 Nov 2020 13:16:43 +0100
+-Subject: batman-adv: Reserve needed_*room for fragments
+-
+-The batadv net_device is trying to propagate the needed_headroom and
+-needed_tailroom from the lower devices. This is needed to avoid cost
+-intensive reallocations using pskb_expand_head during the transmission.
+-
+-But the fragmentation code split the skb's without adding extra room at the
+-end/beginning of the various fragments. This reduced the performance of
+-transmissions over complex scenarios (batadv on vxlan on wireguard) because
+-the lower devices had to perform the reallocations at least once.
+-
+-Fixes: db56e4ecf5c2 ("batman-adv: Fragment and send skbs larger than mtu")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/0966d5424bb87e863037301488519ccdd69e4d26
+-
+---- a/net/batman-adv/fragmentation.c
+-+++ b/net/batman-adv/fragmentation.c
+-@@ -391,6 +391,7 @@ out:
+- 
+- /**
+-  * batadv_frag_create() - create a fragment from skb
+-+ * @net_dev: outgoing device for fragment
+-  * @skb: skb to create fragment from
+-  * @frag_head: header to use in new fragment
+-  * @fragment_size: size of new fragment
+-@@ -401,22 +402,25 @@ out:
+-  *
+-  * Return: the new fragment, NULL on error.
+-  */
+--static struct sk_buff *batadv_frag_create(struct sk_buff *skb,
+-+static struct sk_buff *batadv_frag_create(struct net_device *net_dev,
+-+					  struct sk_buff *skb,
+- 					  struct batadv_frag_packet *frag_head,
+- 					  unsigned int fragment_size)
+- {
+-+	unsigned int ll_reserved = LL_RESERVED_SPACE(net_dev);
+-+	unsigned int tailroom = net_dev->needed_tailroom;
+- 	struct sk_buff *skb_fragment;
+- 	unsigned int header_size = sizeof(*frag_head);
+- 	unsigned int mtu = fragment_size + header_size;
+- 
+--	skb_fragment = netdev_alloc_skb(NULL, mtu + ETH_HLEN);
+-+	skb_fragment = dev_alloc_skb(ll_reserved + mtu + tailroom);
+- 	if (!skb_fragment)
+- 		goto err;
+- 
+- 	skb_fragment->priority = skb->priority;
+- 
+- 	/* Eat the last mtu-bytes of the skb */
+--	skb_reserve(skb_fragment, header_size + ETH_HLEN);
+-+	skb_reserve(skb_fragment, ll_reserved + header_size);
+- 	skb_split(skb, skb_fragment, skb->len - fragment_size);
+- 
+- 	/* Add the header */
+-@@ -439,11 +443,12 @@ int batadv_frag_send_packet(struct sk_bu
+- 			    struct batadv_orig_node *orig_node,
+- 			    struct batadv_neigh_node *neigh_node)
+- {
+-+	struct net_device *net_dev = neigh_node->if_incoming->net_dev;
+- 	struct batadv_priv *bat_priv;
+- 	struct batadv_hard_iface *primary_if = NULL;
+- 	struct batadv_frag_packet frag_header;
+- 	struct sk_buff *skb_fragment;
+--	unsigned int mtu = neigh_node->if_incoming->net_dev->mtu;
+-+	unsigned int mtu = net_dev->mtu;
+- 	unsigned int header_size = sizeof(frag_header);
+- 	unsigned int max_fragment_size, num_fragments;
+- 	int ret;
+-@@ -503,7 +508,7 @@ int batadv_frag_send_packet(struct sk_bu
+- 			goto put_primary_if;
+- 		}
+- 
+--		skb_fragment = batadv_frag_create(skb, &frag_header,
+-+		skb_fragment = batadv_frag_create(net_dev, skb, &frag_header,
+- 						  max_fragment_size);
+- 		if (!skb_fragment) {
+- 			ret = -ENOMEM;
+diff --git a/batman-adv/patches/0034-batman-adv-Don-t-always-reallocate-the-fragmentation.patch b/batman-adv/patches/0034-batman-adv-Don-t-always-reallocate-the-fragmentation.patch
+deleted file mode 100644
+index 19dde1247817f937a07eaaea6dcd4c28fdc93d50..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0034-batman-adv-Don-t-always-reallocate-the-fragmentation.patch
++++ /dev/null
+@@ -1,39 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Thu, 26 Nov 2020 18:24:49 +0100
+-Subject: batman-adv: Don't always reallocate the fragmentation skb head
+-
+-When a packet is fragmented by batman-adv, the original batman-adv header
+-is not modified. Only a new fragmentation is inserted between the original
+-one and the ethernet header. The code must therefore make sure that it has
+-a writable region of this size in the skbuff head.
+-
+-But it is not useful to always reallocate the skbuff by this size even when
+-there would be more than enough headroom still in the skb. The reallocation
+-is just to costly during in this codepath.
+-
+-Fixes: db56e4ecf5c2 ("batman-adv: Fragment and send skbs larger than mtu")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/3e3ff987876d3be70d928561acbefe5a48ab1654
+-
+---- a/net/batman-adv/fragmentation.c
+-+++ b/net/batman-adv/fragmentation.c
+-@@ -527,13 +527,14 @@ int batadv_frag_send_packet(struct sk_bu
+- 		frag_header.no++;
+- 	}
+- 
+--	/* Make room for the fragment header. */
+--	if (batadv_skb_head_push(skb, header_size) < 0 ||
+--	    pskb_expand_head(skb, header_size + ETH_HLEN, 0, GFP_ATOMIC) < 0) {
+--		ret = -ENOMEM;
+-+	/* make sure that there is at least enough head for the fragmentation
+-+	 * and ethernet headers
+-+	 */
+-+	ret = skb_cow_head(skb, ETH_HLEN + header_size);
+-+	if (ret < 0)
+- 		goto put_primary_if;
+--	}
+- 
+-+	skb_push(skb, header_size);
+- 	memcpy(skb->data, &frag_header, header_size);
+- 
+- 	/* Send the last fragment */
+diff --git a/batman-adv/patches/0034-batman-adv-Introduce-no-noflood-mark.patch b/batman-adv/patches/0034-batman-adv-Introduce-no-noflood-mark.patch
+deleted file mode 100644
+index 2ccb6da270acf41e56f9a37801e23301e592b112..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0034-batman-adv-Introduce-no-noflood-mark.patch
++++ /dev/null
+@@ -1,167 +0,0 @@
+-From 25b21382238c783298c0d8defc8c739126c1b54d Mon Sep 17 00:00:00 2001
+-From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+-Date: Sat, 31 Mar 2018 03:36:19 +0200
+-Subject: [PATCH] batman-adv: Introduce no noflood mark
+-MIME-Version: 1.0
+-Content-Type: text/plain; charset=UTF-8
+-Content-Transfer-Encoding: 8bit
+-
+-This mark prevents a multicast packet being flooded through the whole
+-mesh. The advantage of marking certain multicast packets via e.g.
+-ebtables instead of dropping is then the following:
+-
+-This allows an administrator to let specific multicast packets pass as
+-long as they are forwarded to a limited number of nodes only and are
+-therefore creating no burdon to unrelated nodes.
+-
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-
+----
+-
+-https://www.open-mesh.org/projects/batman-adv/wiki/Noflood-broadcast-prevention
+-
+-Changelog v2:
+-
+-* rebased to master
+-* sysfs -> netlink
+----
+- include/uapi/linux/batman_adv.h | 12 ++++++++++++
+- net/batman-adv/netlink.c        | 22 ++++++++++++++++++++++
+- net/batman-adv/soft-interface.c | 20 ++++++++++++++++++++
+- net/batman-adv/types.h          | 12 ++++++++++++
+- 4 files changed, 66 insertions(+)
+-
+-diff --git a/include/uapi/linux/batman_adv.h b/include/uapi/linux/batman_adv.h
+-index 67f46367..6fabb7aa 100644
+---- a/include/uapi/linux/batman_adv.h
+-+++ b/include/uapi/linux/batman_adv.h
+-@@ -480,6 +480,18 @@ enum batadv_nl_attrs {
+- 	 */
+- 	BATADV_ATTR_MULTICAST_FANOUT,
+- 
+-+	/**
+-+	 * @BATADV_ATTR_NOFLOOD_MARK: the noflood mark which allows to tag
+-+	 *  frames which should never be broadcast flooded through the mesh.
+-+	 */
+-+	BATADV_ATTR_NOFLOOD_MARK,
+-+
+-+	/**
+-+	 * @BATADV_ATTR_NOFLOOD_MASK: the noflood (bit)mask which allows to tag
+-+	 *  frames which should never be broadcast flooded through the mesh.
+-+	 */
+-+	BATADV_ATTR_NOFLOOD_MASK,
+-+
+- 	/* add attributes above here, update the policy in netlink.c */
+- 
+- 	/**
+-diff --git a/net/batman-adv/netlink.c b/net/batman-adv/netlink.c
+-index e1978bc5..3d2c147a 100644
+---- a/net/batman-adv/netlink.c
+-+++ b/net/batman-adv/netlink.c
+-@@ -134,6 +134,8 @@ static const struct nla_policy batadv_netlink_policy[NUM_BATADV_ATTR] = {
+- 	[BATADV_ATTR_AP_ISOLATION_ENABLED]	= { .type = NLA_U8 },
+- 	[BATADV_ATTR_ISOLATION_MARK]		= { .type = NLA_U32 },
+- 	[BATADV_ATTR_ISOLATION_MASK]		= { .type = NLA_U32 },
+-+	[BATADV_ATTR_NOFLOOD_MARK]		= { .type = NLA_U32 },
+-+	[BATADV_ATTR_NOFLOOD_MASK]		= { .type = NLA_U32 },
+- 	[BATADV_ATTR_BONDING_ENABLED]		= { .type = NLA_U8 },
+- 	[BATADV_ATTR_BRIDGE_LOOP_AVOIDANCE_ENABLED]	= { .type = NLA_U8 },
+- 	[BATADV_ATTR_DISTRIBUTED_ARP_TABLE_ENABLED]	= { .type = NLA_U8 },
+-@@ -286,6 +288,14 @@ static int batadv_netlink_mesh_fill(struct sk_buff *msg,
+- 			bat_priv->isolation_mark_mask))
+- 		goto nla_put_failure;
+- 
+-+	if (nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MARK,
+-+			bat_priv->noflood_mark))
+-+		goto nla_put_failure;
+-+
+-+	if (nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MASK,
+-+			bat_priv->noflood_mark_mask))
+-+		goto nla_put_failure;
+-+
+- 	if (nla_put_u8(msg, BATADV_ATTR_BONDING_ENABLED,
+- 		       !!atomic_read(&bat_priv->bonding)))
+- 		goto nla_put_failure;
+-@@ -466,6 +476,18 @@ static int batadv_netlink_set_mesh(struct sk_buff *skb, struct genl_info *info)
+- 		bat_priv->isolation_mark_mask = nla_get_u32(attr);
+- 	}
+- 
+-+	if (info->attrs[BATADV_ATTR_NOFLOOD_MARK]) {
+-+		attr = info->attrs[BATADV_ATTR_NOFLOOD_MARK];
+-+
+-+		bat_priv->noflood_mark = nla_get_u32(attr);
+-+	}
+-+
+-+	if (info->attrs[BATADV_ATTR_NOFLOOD_MASK]) {
+-+		attr = info->attrs[BATADV_ATTR_NOFLOOD_MASK];
+-+
+-+		bat_priv->noflood_mark_mask = nla_get_u32(attr);
+-+	}
+-+
+- 	if (info->attrs[BATADV_ATTR_BONDING_ENABLED]) {
+- 		attr = info->attrs[BATADV_ATTR_BONDING_ENABLED];
+- 
+-diff --git a/net/batman-adv/soft-interface.c b/net/batman-adv/soft-interface.c
+-index c99facdb..4e71b9f3 100644
+---- a/net/batman-adv/soft-interface.c
+-+++ b/net/batman-adv/soft-interface.c
+-@@ -176,6 +176,23 @@ static void batadv_interface_set_rx_mode(struct net_device *dev)
+- {
+- }
+- 
+-+/**
+-+ * batadv_send_skb_has_noflood_mark() - check if packet has a noflood mark
+-+ * @bat_priv: the bat priv with all the soft interface information
+-+ * @skb: the packet to check
+-+ *
+-+ * Return: True if the skb's mark matches a configured noflood mark and
+-+ * noflood mark mask. False otherwise.
+-+ */
+-+static bool
+-+batadv_skb_has_noflood_mark(struct batadv_priv *bat_priv, struct sk_buff *skb)
+-+{
+-+	u32 match_mark = skb->mark & bat_priv->noflood_mark_mask;
+-+
+-+	return bat_priv->noflood_mark_mask &&
+-+	       match_mark == bat_priv->noflood_mark;
+-+}
+-+
+- static netdev_tx_t batadv_interface_tx(struct sk_buff *skb,
+- 				       struct net_device *soft_iface)
+- {
+-@@ -326,6 +343,9 @@ static netdev_tx_t batadv_interface_tx(struct sk_buff *skb,
+- 		if (batadv_dat_snoop_outgoing_arp_request(bat_priv, skb))
+- 			brd_delay = msecs_to_jiffies(ARP_REQ_DELAY);
+- 
+-+		if (batadv_skb_has_noflood_mark(bat_priv, skb))
+-+			goto dropped;
+-+
+- 		if (batadv_skb_head_push(skb, sizeof(*bcast_packet)) < 0)
+- 			goto dropped;
+- 
+-diff --git a/net/batman-adv/types.h b/net/batman-adv/types.h
+-index c0ded822..09c877fa 100644
+---- a/net/batman-adv/types.h
+-+++ b/net/batman-adv/types.h
+-@@ -1599,6 +1599,18 @@ struct batadv_priv {
+- 	 */
+- 	u32 isolation_mark_mask;
+- 
+-+	/**
+-+	 * @noflood_mark: the skb->mark value used to allow directed targeting
+-+	 *  only
+-+	 */
+-+	u32 noflood_mark;
+-+
+-+	/**
+-+	 * @noflood_mark_mask: bitmask identifying the bits in skb->mark to be
+-+	 *  used for the noflood mark
+-+	 */
+-+	u32 noflood_mark_mask;
+-+
+- 	/** @bcast_seqno: last sent broadcast packet sequence number */
+- 	atomic_t bcast_seqno;
+- 
+--- 
+-2.31.0
+-
+diff --git a/batman-adv/patches/0035-batman-adv-Avoid-WARN_ON-timing-related-checks.patch b/batman-adv/patches/0035-batman-adv-Avoid-WARN_ON-timing-related-checks.patch
+deleted file mode 100644
+index 0fcb9ec3fc0d96393e970ce69d1bbc2b9f3ba84c..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0035-batman-adv-Avoid-WARN_ON-timing-related-checks.patch
++++ /dev/null
+@@ -1,31 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Tue, 18 May 2021 21:00:27 +0200
+-Subject: batman-adv: Avoid WARN_ON timing related checks
+-
+-The soft/batadv interface for a queued OGM can be changed during the time
+-the OGM was queued for transmission and when the OGM is actually
+-transmitted by the worker.
+-
+-But WARN_ON must be used to denote kernel bugs and not to print simple
+-warnings. A warning can simply be printed using pr_warn.
+-
+-Reported-by: Tetsuo Handa <penguin-kernel@i-love.sakura.ne.jp>
+-Reported-by: syzbot+c0b807de416427ff3dd1@syzkaller.appspotmail.com
+-Fixes: 29b9256e6631 ("batman-adv: consider outgoing interface in OGM sending")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/5061f9c502d7101912089d8f4a7866e0a926a49a
+-
+---- a/net/batman-adv/bat_iv_ogm.c
+-+++ b/net/batman-adv/bat_iv_ogm.c
+-@@ -409,8 +409,10 @@ static void batadv_iv_ogm_emit(struct ba
+- 	if (WARN_ON(!forw_packet->if_outgoing))
+- 		return;
+- 
+--	if (WARN_ON(forw_packet->if_outgoing->soft_iface != soft_iface))
+-+	if (forw_packet->if_outgoing->soft_iface != soft_iface) {
+-+		pr_warn("%s: soft interface switch for queued OGM\n", __func__);
+- 		return;
+-+	}
+- 
+- 	if (forw_packet->if_incoming->if_status != BATADV_IF_ACTIVE)
+- 		return;
+diff --git a/batman-adv/patches/0036-batman-adv-fix-error-handling.patch b/batman-adv/patches/0036-batman-adv-fix-error-handling.patch
+deleted file mode 100644
+index 0daaae4c869f77f7f11c022f6145639377bc99e2..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0036-batman-adv-fix-error-handling.patch
++++ /dev/null
+@@ -1,162 +0,0 @@
+-From: Pavel Skripkin <paskripkin@gmail.com>
+-Date: Sun, 24 Oct 2021 16:13:56 +0300
+-Subject: batman-adv: fix error handling
+-
+-Syzbot reported ODEBUG warning in batadv_nc_mesh_free(). The problem was
+-in wrong error handling in batadv_mesh_init().
+-
+-Before this patch batadv_mesh_init() was calling batadv_mesh_free() in case
+-of any batadv_*_init() calls failure. This approach may work well, when
+-there is some kind of indicator, which can tell which parts of batadv are
+-initialized; but there isn't any.
+-
+-All written above lead to cleaning up uninitialized fields. Even if we hide
+-ODEBUG warning by initializing bat_priv->nc.work, syzbot was able to hit
+-GPF in batadv_nc_purge_paths(), because hash pointer in still NULL. [1]
+-
+-To fix these bugs we can unwind batadv_*_init() calls one by one.
+-It is good approach for 2 reasons: 1) It fixes bugs on error handling
+-path 2) It improves the performance, since we won't call unneeded
+-batadv_*_free() functions.
+-
+-So, this patch makes all batadv_*_init() clean up all allocated memory
+-before returning with an error to no call correspoing batadv_*_free()
+-and open-codes batadv_mesh_free() with proper order to avoid touching
+-uninitialized fields.
+-
+-Link: https://lore.kernel.org/netdev/000000000000c87fbd05cef6bcb0@google.com/ [1]
+-Reported-and-tested-by: syzbot+28b0702ada0bf7381f58@syzkaller.appspotmail.com
+-Fixes: 21e838760727 ("[batman-adv] fix various race conditions during startup & shutdown")
+-Signed-off-by: Pavel Skripkin <paskripkin@gmail.com>
+-Signed-off-by: David S. Miller <davem@davemloft.net>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: upstream, https://git.open-mesh.org/batman-adv.git/commit/0631e0825c8129cd3896926da62a09ac00bf13a0
+-
+---- a/net/batman-adv/bridge_loop_avoidance.c
+-+++ b/net/batman-adv/bridge_loop_avoidance.c
+-@@ -1561,10 +1561,14 @@ int batadv_bla_init(struct batadv_priv *
+- 		return 0;
+- 
+- 	bat_priv->bla.claim_hash = batadv_hash_new(128);
+--	bat_priv->bla.backbone_hash = batadv_hash_new(32);
+-+	if (!bat_priv->bla.claim_hash)
+-+		return -ENOMEM;
+- 
+--	if (!bat_priv->bla.claim_hash || !bat_priv->bla.backbone_hash)
+-+	bat_priv->bla.backbone_hash = batadv_hash_new(32);
+-+	if (!bat_priv->bla.backbone_hash) {
+-+		batadv_hash_destroy(bat_priv->bla.claim_hash);
+- 		return -ENOMEM;
+-+	}
+- 
+- 	batadv_hash_set_lock_class(bat_priv->bla.claim_hash,
+- 				   &batadv_claim_hash_lock_class_key);
+---- a/net/batman-adv/main.c
+-+++ b/net/batman-adv/main.c
+-@@ -197,29 +197,41 @@ int batadv_mesh_init(struct net_device *
+- 
+- 	bat_priv->gw.generation = 0;
+- 
+--	ret = batadv_v_mesh_init(bat_priv);
+--	if (ret < 0)
+--		goto err;
+--
+- 	ret = batadv_originator_init(bat_priv);
+--	if (ret < 0)
+--		goto err;
+-+	if (ret < 0) {
+-+		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
+-+		goto err_orig;
+-+	}
+- 
+- 	ret = batadv_tt_init(bat_priv);
+--	if (ret < 0)
+--		goto err;
+-+	if (ret < 0) {
+-+		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
+-+		goto err_tt;
+-+	}
+-+
+-+	ret = batadv_v_mesh_init(bat_priv);
+-+	if (ret < 0) {
+-+		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
+-+		goto err_v;
+-+	}
+- 
+- 	ret = batadv_bla_init(bat_priv);
+--	if (ret < 0)
+--		goto err;
+-+	if (ret < 0) {
+-+		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
+-+		goto err_bla;
+-+	}
+- 
+- 	ret = batadv_dat_init(bat_priv);
+--	if (ret < 0)
+--		goto err;
+-+	if (ret < 0) {
+-+		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
+-+		goto err_dat;
+-+	}
+- 
+- 	ret = batadv_nc_mesh_init(bat_priv);
+--	if (ret < 0)
+--		goto err;
+-+	if (ret < 0) {
+-+		atomic_set(&bat_priv->mesh_state, BATADV_MESH_DEACTIVATING);
+-+		goto err_nc;
+-+	}
+- 
+- 	batadv_gw_init(bat_priv);
+- 	batadv_mcast_init(bat_priv);
+-@@ -229,8 +241,20 @@ int batadv_mesh_init(struct net_device *
+- 
+- 	return 0;
+- 
+--err:
+--	batadv_mesh_free(soft_iface);
+-+err_nc:
+-+	batadv_dat_free(bat_priv);
+-+err_dat:
+-+	batadv_bla_free(bat_priv);
+-+err_bla:
+-+	batadv_v_mesh_free(bat_priv);
+-+err_v:
+-+	batadv_tt_free(bat_priv);
+-+err_tt:
+-+	batadv_originator_free(bat_priv);
+-+err_orig:
+-+	batadv_purge_outstanding_packets(bat_priv, NULL);
+-+	atomic_set(&bat_priv->mesh_state, BATADV_MESH_INACTIVE);
+-+
+- 	return ret;
+- }
+- 
+---- a/net/batman-adv/network-coding.c
+-+++ b/net/batman-adv/network-coding.c
+-@@ -155,8 +155,10 @@ int batadv_nc_mesh_init(struct batadv_pr
+- 				   &batadv_nc_coding_hash_lock_class_key);
+- 
+- 	bat_priv->nc.decoding_hash = batadv_hash_new(128);
+--	if (!bat_priv->nc.decoding_hash)
+-+	if (!bat_priv->nc.decoding_hash) {
+-+		batadv_hash_destroy(bat_priv->nc.coding_hash);
+- 		goto err;
+-+	}
+- 
+- 	batadv_hash_set_lock_class(bat_priv->nc.decoding_hash,
+- 				   &batadv_nc_decoding_hash_lock_class_key);
+---- a/net/batman-adv/translation-table.c
+-+++ b/net/batman-adv/translation-table.c
+-@@ -4405,8 +4405,10 @@ int batadv_tt_init(struct batadv_priv *b
+- 		return ret;
+- 
+- 	ret = batadv_tt_global_init(bat_priv);
+--	if (ret < 0)
+-+	if (ret < 0) {
+-+		batadv_tt_local_table_free(bat_priv);
+- 		return ret;
+-+	}
+- 
+- 	batadv_tvlv_handler_register(bat_priv, batadv_tt_tvlv_ogm_handler_v1,
+- 				     batadv_tt_tvlv_unicast_handler_v1,
+diff --git a/batman-adv/patches/0037-batman-adv-allow-netlink-usage-in-unprivileged-conta.patch b/batman-adv/patches/0037-batman-adv-allow-netlink-usage-in-unprivileged-conta.patch
+deleted file mode 100644
+index e235c2723108872023c225b0af99647a0db9f4f3..0000000000000000000000000000000000000000
+--- a/batman-adv/patches/0037-batman-adv-allow-netlink-usage-in-unprivileged-conta.patch
++++ /dev/null
+@@ -1,182 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Mon, 1 Nov 2021 21:46:17 +0100
+-Subject: batman-adv: allow netlink usage in unprivileged containers
+-
+-Currently, creating a batman-adv interface in an unprivileged LXD
+-container and attaching secondary interfaces to it with "ip" or "batctl"
+-works fine. However all batctl debug and configuration commands
+-fail:
+-
+-  root@container:~# batctl originators
+-  Error received: Operation not permitted
+-  root@container:~# batctl orig_interval
+-  1000
+-  root@container:~# batctl orig_interval 2000
+-  root@container:~# batctl orig_interval
+-  1000
+-
+-To fix this change the generic netlink permissions from GENL_ADMIN_PERM
+-to GENL_UNS_ADMIN_PERM. This way a batman-adv interface is fully
+-maintainable as root from within a user namespace, from an unprivileged
+-container.
+-
+-All except one batman-adv netlink setting are per interface and do not
+-leak information or change settings from the host system and are
+-therefore save to retrieve or modify as root from within an unprivileged
+-container.
+-
+-"batctl routing_algo" / BATADV_CMD_GET_ROUTING_ALGOS is the only
+-exception: It provides the batman-adv kernel module wide default routing
+-algorithm. However it is read-only from netlink and an unprivileged
+-container is still not allowed to modify
+-/sys/module/batman_adv/parameters/routing_algo. Instead it is advised to
+-use the newly introduced "batctl if create routing_algo RA_NAME" /
+-IFLA_BATADV_ALGO_NAME to set the routing algorithm on interface
+-creation, which already works fine in an unprivileged container.
+-
+-Cc: Tycho Andersen <tycho@tycho.pizza>
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: backport, https://git.open-mesh.org/batman-adv.git/commit/055fa41b73ca8dae1c1ed41777e32a8f02e80c82
+-
+---- /dev/null
+-+++ b/compat-include/uapi/linux/genetlink.h
+-@@ -0,0 +1,22 @@
+-+/* SPDX-License-Identifier: GPL-2.0 */
+-+/* Copyright (C) B.A.T.M.A.N. contributors:
+-+ *
+-+ * Marek Lindner, Simon Wunderlich
+-+ *
+-+ * This file contains macros for maintaining compatibility with older versions
+-+ * of the Linux kernel.
+-+ */
+-+
+-+#ifndef _NET_BATMAN_ADV_COMPAT_UAPI_LINUX_GENETLINK_H_
+-+#define _NET_BATMAN_ADV_COMPAT_UAPI_LINUX_GENETLINK_H_
+-+
+-+#include <linux/version.h>
+-+#include_next <uapi/linux/genetlink.h>
+-+
+-+#if LINUX_VERSION_IS_LESS(4, 6, 0)
+-+
+-+#define GENL_UNS_ADMIN_PERM GENL_ADMIN_PERM
+-+
+-+#endif /* LINUX_VERSION_IS_LESS(4, 6, 0) */
+-+
+-+#endif /* _NET_BATMAN_ADV_COMPAT_UAPI_LINUX_GENETLINK_H_ */
+---- a/net/batman-adv/netlink.c
+-+++ b/net/batman-adv/netlink.c
+-@@ -1350,21 +1350,21 @@ static const struct genl_ops batadv_netl
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_TP_METER,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_tp_meter_start,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_TP_METER_CANCEL,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_tp_meter_cancel,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_ROUTING_ALGOS,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_algo_dump,
+- 	},
+-@@ -1379,68 +1379,68 @@ static const struct genl_ops batadv_netl
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_TRANSTABLE_LOCAL,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_tt_local_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_TRANSTABLE_GLOBAL,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_tt_global_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_ORIGINATORS,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_orig_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_NEIGHBORS,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_hardif_neigh_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_GATEWAYS,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_gw_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_BLA_CLAIM,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_bla_claim_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_BLA_BACKBONE,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_bla_backbone_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_DAT_CACHE,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_dat_cache_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_GET_MCAST_FLAGS,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.dumpit = batadv_mcast_flags_dump,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_SET_MESH,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_set_mesh,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH,
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_SET_HARDIF,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_set_hardif,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH |
+-@@ -1456,7 +1456,7 @@ static const struct genl_ops batadv_netl
+- 	},
+- 	{
+- 		.cmd = BATADV_CMD_SET_VLAN,
+--		.flags = GENL_ADMIN_PERM,
+-+		.flags = GENL_UNS_ADMIN_PERM,
+- 		.policy = batadv_netlink_policy,
+- 		.doit = batadv_netlink_set_vlan,
+- 		.internal_flags = BATADV_FLAG_NEED_MESH |
+diff --git a/batman-adv/patches/0501-batman-adv-Fix-build-of-multicast-code-against-Linux.patch b/batman-adv/patches/0501-batman-adv-Fix-build-of-multicast-code-against-Linux.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..d1f55405bdb167c8ea03e87aafb06ce1ce3fa568
+--- /dev/null
++++ b/batman-adv/patches/0501-batman-adv-Fix-build-of-multicast-code-against-Linux.patch
+@@ -0,0 +1,34 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Fri, 14 May 2021 19:34:35 +0200
++Subject: batman-adv: Fix build of multicast code against Linux < 5.13
++
++Fixes: 007b4c4b031f ("batman-adv: convert ifmcaddr6 to RCU")
++Signed-off-by: Sven Eckelmann <sven@narfation.org>
++
++--- a/net/batman-adv/multicast.c
+++++ b/net/batman-adv/multicast.c
++@@ -461,9 +461,14 @@ batadv_mcast_mla_softif_get_ipv6(struct
++ 		return 0;
++ 	}
++ 
+++#if LINUX_VERSION_IS_LESS(5, 13, 0)
+++	read_lock_bh(&in6_dev->lock);
+++	for (pmc6 = in6_dev->mc_list; pmc6; pmc6 = pmc6->next) {
+++#else
++ 	for (pmc6 = rcu_dereference(in6_dev->mc_list);
++ 	     pmc6;
++ 	     pmc6 = rcu_dereference(pmc6->next)) {
+++#endif
++ 		if (IPV6_ADDR_MC_SCOPE(&pmc6->mca_addr) <
++ 		    IPV6_ADDR_SCOPE_LINKLOCAL)
++ 			continue;
++@@ -492,6 +497,9 @@ batadv_mcast_mla_softif_get_ipv6(struct
++ 		hlist_add_head(&new->list, mcast_list);
++ 		ret++;
++ 	}
+++#if LINUX_VERSION_IS_LESS(5, 13, 0)
+++	read_unlock_bh(&in6_dev->lock);
+++#endif
++ 	rcu_read_unlock();
++ 
++ 	return ret;
+diff --git a/batman-adv/patches/0502-Revert-batman-adv-use-Linux-s-stdarg.h.patch b/batman-adv/patches/0502-Revert-batman-adv-use-Linux-s-stdarg.h.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..ce2df718ce3f9ec9ea9c629eacdef4b82070b26a
+--- /dev/null
++++ b/batman-adv/patches/0502-Revert-batman-adv-use-Linux-s-stdarg.h.patch
+@@ -0,0 +1,19 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Tue, 14 Sep 2021 21:07:34 +0200
++Subject: Revert "batman-adv: use Linux's stdarg.h"
++
++This header is only available since Linux 5.15
++
++This reverts commit 36d059797a14f0e373fdc3c79df7b467435925ad.
++
++--- a/net/batman-adv/log.c
+++++ b/net/batman-adv/log.c
++@@ -7,7 +7,7 @@
++ #include "log.h"
++ #include "main.h"
++ 
++-#include <linux/stdarg.h>
+++#include <stdarg.h>
++ 
++ #include "trace.h"
++ 
+diff --git a/batman-adv/patches/0503-Revert-batman-adv-genetlink-move-to-smaller-ops-wherever-possible.patch b/batman-adv/patches/0503-Revert-batman-adv-genetlink-move-to-smaller-ops-wherever-possible.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..f11dc9acabd630c705122f3994c3f25ea345446a
+--- /dev/null
++++ b/batman-adv/patches/0503-Revert-batman-adv-genetlink-move-to-smaller-ops-wherever-possible.patch
+@@ -0,0 +1,41 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Sat, 24 Oct 2020 22:51:23 +0200
++Subject: Revert "batman-adv: genetlink: move to smaller ops wherever possible"
++
++To be able to build batman-adv v2023.3 on OpenWrt 19.07 /
++backports-4.19.237-1 we need to partially revert the according
++commit in batman-adv, depending on the backports version used, as
++backports-4.19 does not provide this function either.
++
++This reverts commit 725b4ef5be840cfcd0ca33b9393c14dee40c10f7.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/net/batman-adv/netlink.c
+++++ b/net/batman-adv/netlink.c
++@@ -1357,7 +1357,11 @@ static void batadv_post_doit(const struc
++ 	}
++ }
++ 
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++static const struct genl_ops batadv_netlink_ops[] = {
+++#else // UGLY_HACK_NEW
++ static const struct genl_small_ops batadv_netlink_ops[] = {
+++#endif // UGLY_HACK_STOP
++ 	{
++ 		.cmd = BATADV_CMD_GET_MESH,
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++@@ -1491,8 +1495,13 @@ struct genl_family batadv_netlink_family
++ 	.pre_doit = batadv_pre_doit,
++ 	.post_doit = batadv_post_doit,
++ 	.module = THIS_MODULE,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++	.ops = batadv_netlink_ops,
+++	.n_ops = ARRAY_SIZE(batadv_netlink_ops),
+++#else // UGLY_HACK_NEW
++ 	.small_ops = batadv_netlink_ops,
++ 	.n_small_ops = ARRAY_SIZE(batadv_netlink_ops),
+++#endif // UGLY_HACK_STOP
++ #if LINUX_VERSION_IS_GEQ(6, 1, 0) // UGLY_HACK_NEW
++ 	.resv_start_op = BATADV_CMD_SET_VLAN + 1,
++ #endif // UGLY_HACK_STOP
+diff --git a/batman-adv/patches/0504-Revert-batman-adv-Add-new-include-for-min-max-helpers.patch b/batman-adv/patches/0504-Revert-batman-adv-Add-new-include-for-min-max-helpers.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..85bdff183569153647c30e418753090522eb5497
+--- /dev/null
++++ b/batman-adv/patches/0504-Revert-batman-adv-Add-new-include-for-min-max-helpers.patch
+@@ -0,0 +1,136 @@
++From: Sven Eckelmann <sven@narfation.org>
++Date: Thu, 28 Jan 2021 21:06:51 +0100
++Subject: Revert "batman-adv: Add new include for min/max helpers"
++
++The OpenWrt kernel sources and backports sources are currently missing this
++header.
++
++This reverts commit 1810de05310d5c5e9140f870ac21052f38bc06b8.
++
++Signed-off-by: Sven Eckelmann <sven@narfation.org>
++[linus.luessing@c0d3.blue: add checks for backports >= 5.10, to be usable
++ on such newer backports, too]
++
++--- a/compat-include/linux/minmax.h
+++++ /dev/null
++@@ -1,20 +0,0 @@
++-/* SPDX-License-Identifier: GPL-2.0 */
++-/* Copyright (C) B.A.T.M.A.N. contributors:
++- *
++- * Marek Lindner, Simon Wunderlich
++- *
++- * This file contains macros for maintaining compatibility with older versions
++- * of the Linux kernel.
++- */
++-
++-#ifndef _NET_BATMAN_ADV_COMPAT_LINUX_MINMAX_H_
++-#define _NET_BATMAN_ADV_COMPAT_LINUX_MINMAX_H_
++-
++-#include <linux/version.h>
++-#if LINUX_VERSION_IS_GEQ(5, 10, 0)
++-#include_next <linux/minmax.h>
++-#else
++-#include <linux/kernel.h>
++-#endif
++-
++-#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_MINMAX_H_ */
++--- a/net/batman-adv/bat_v.c
+++++ b/net/batman-adv/bat_v.c
++@@ -16,7 +16,11 @@
++ #include <linux/kref.h>
++ #include <linux/limits.h>
++ #include <linux/list.h>
+++#if !defined(HAVE_BACKPORTS_LESS_5_10) && LINUX_VERSION_IS_GEQ(5, 10, 0)
++ #include <linux/minmax.h>
+++#else /* defined(HAVE_BACKPORTS_LESS_5_10) || LINUX_VERSION_IS_LESS(5, 10, 0) */
+++#include <linux/kernel.h>
+++#endif
++ #include <linux/netdevice.h>
++ #include <linux/netlink.h>
++ #include <linux/rculist.h>
++--- a/net/batman-adv/bat_v_elp.c
+++++ b/net/batman-adv/bat_v_elp.c
++@@ -18,7 +18,9 @@
++ #include <linux/jiffies.h>
++ #include <linux/kernel.h>
++ #include <linux/kref.h>
+++#if !defined(HAVE_BACKPORTS_LESS_5_10) && LINUX_VERSION_IS_GEQ(5, 10, 0)
++ #include <linux/minmax.h>
+++#endif
++ #include <linux/netdevice.h>
++ #include <linux/nl80211.h>
++ #include <linux/random.h>
++--- a/net/batman-adv/bat_v_ogm.c
+++++ b/net/batman-adv/bat_v_ogm.c
++@@ -18,7 +18,9 @@
++ #include <linux/kref.h>
++ #include <linux/list.h>
++ #include <linux/lockdep.h>
+++#if !defined(HAVE_BACKPORTS_LESS_5_10) && LINUX_VERSION_IS_GEQ(5, 10, 0)
++ #include <linux/minmax.h>
+++#endif
++ #include <linux/mutex.h>
++ #include <linux/netdevice.h>
++ #include <linux/random.h>
++--- a/net/batman-adv/fragmentation.c
+++++ b/net/batman-adv/fragmentation.c
++@@ -15,7 +15,11 @@
++ #include <linux/if_ether.h>
++ #include <linux/jiffies.h>
++ #include <linux/lockdep.h>
+++#if !defined(HAVE_BACKPORTS_LESS_5_10) && LINUX_VERSION_IS_GEQ(5, 10, 0)
++ #include <linux/minmax.h>
+++#else /* defined(HAVE_BACKPORTS_LESS_5_10) || LINUX_VERSION_IS_LESS(5, 10, 0) */
+++#include <linux/kernel.h>
+++#endif
++ #include <linux/netdevice.h>
++ #include <linux/skbuff.h>
++ #include <linux/slab.h>
++--- a/net/batman-adv/hard-interface.c
+++++ b/net/batman-adv/hard-interface.c
++@@ -19,7 +19,9 @@
++ #include <linux/kref.h>
++ #include <linux/limits.h>
++ #include <linux/list.h>
+++#if !defined(HAVE_BACKPORTS_LESS_5_10) && LINUX_VERSION_IS_GEQ(5, 10, 0)
++ #include <linux/minmax.h>
+++#endif
++ #include <linux/mutex.h>
++ #include <linux/netdevice.h>
++ #include <linux/printk.h>
++--- a/net/batman-adv/main.c
+++++ b/net/batman-adv/main.c
++@@ -22,7 +22,9 @@
++ #include <linux/kobject.h>
++ #include <linux/kref.h>
++ #include <linux/list.h>
+++#if !defined(HAVE_BACKPORTS_LESS_5_10) && LINUX_VERSION_IS_GEQ(5, 10, 0)
++ #include <linux/minmax.h>
+++#endif
++ #include <linux/module.h>
++ #include <linux/netdevice.h>
++ #include <linux/printk.h>
++--- a/net/batman-adv/netlink.c
+++++ b/net/batman-adv/netlink.c
++@@ -21,7 +21,9 @@
++ #include <linux/kernel.h>
++ #include <linux/limits.h>
++ #include <linux/list.h>
+++#if !defined(HAVE_BACKPORTS_LESS_5_10) && LINUX_VERSION_IS_GEQ(5, 10, 0)
++ #include <linux/minmax.h>
+++#endif
++ #include <linux/netdevice.h>
++ #include <linux/netlink.h>
++ #include <linux/printk.h>
++--- a/net/batman-adv/tp_meter.c
+++++ b/net/batman-adv/tp_meter.c
++@@ -23,7 +23,9 @@
++ #include <linux/kthread.h>
++ #include <linux/limits.h>
++ #include <linux/list.h>
+++#if !defined(HAVE_BACKPORTS_LESS_5_10) && LINUX_VERSION_IS_GEQ(5, 10, 0)
++ #include <linux/minmax.h>
+++#endif
++ #include <linux/netdevice.h>
++ #include <linux/param.h>
++ #include <linux/printk.h>
+diff --git a/batman-adv/patches/0505-Revert-batman-adv-use-rcu_replace_pointer-where-appropriate.patch b/batman-adv/patches/0505-Revert-batman-adv-use-rcu_replace_pointer-where-appropriate.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..486b17fa5a91a9505127befc6443a91c29b2ef47
+--- /dev/null
++++ b/batman-adv/patches/0505-Revert-batman-adv-use-rcu_replace_pointer-where-appropriate.patch
+@@ -0,0 +1,102 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Mon, 27 Nov 2023 07:27:24 +0100
++Subject: Revert "batman-adv: use rcu_replace_pointer() where appropriate"
++
++rcu_replace_pointer() was introduced in Linux 5.10 and initially
++used/introduced in batman-adv v2020.2.
++
++To be able to build batman-adv v2023.3 on OpenWrt 19.07 /
++backports-4.19.237-1 we need to partially revert the according
++commit in batman-adv, depending on the backports version used, as
++backports-4.19 does not provide this function either.
++
++This reverts commit e2f194d7f45e59c2b00dfe0da822e47ea82f0a3e.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/compat-include/linux/rcupdate.h
+++++ /dev/null
++@@ -1,28 +0,0 @@
++-/* SPDX-License-Identifier: GPL-2.0 */
++-/* Copyright (C) B.A.T.M.A.N. contributors:
++- *
++- * Antonio Quartulli
++- *
++- * This file contains macros for maintaining compatibility with older versions
++- * of the Linux kernel.
++- */
++-
++-#ifndef _NET_BATMAN_ADV_COMPAT_LINUX_RCUPDATE_H_
++-#define _NET_BATMAN_ADV_COMPAT_LINUX_RCUPDATE_H_
++-
++-#include <linux/version.h>
++-#include_next <linux/rcupdate.h>
++-
++-#if LINUX_VERSION_IS_LESS(5, 5, 0)
++-
++-#undef rcu_replace_pointer
++-#define rcu_replace_pointer(rcu_ptr, ptr, c)				\
++-({									\
++-	typeof(ptr) __tmp = rcu_dereference_protected((rcu_ptr), (c));	\
++-	rcu_assign_pointer((rcu_ptr), (ptr));				\
++-	__tmp;								\
++-})
++-
++-#endif /* LINUX_VERSION_IS_LESS(5, 5, 0) */
++-
++-#endif /* _NET_BATMAN_ADV_COMPAT_LINUX_RCUPDATE_H_ */
++--- a/net/batman-adv/gateway_client.c
+++++ b/net/batman-adv/gateway_client.c
++@@ -134,8 +134,13 @@ static void batadv_gw_select(struct bata
++ 	if (new_gw_node)
++ 		kref_get(&new_gw_node->refcount);
++ 
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++	curr_gw_node = rcu_dereference_protected(bat_priv->gw.curr_gw, 1);
+++	rcu_assign_pointer(bat_priv->gw.curr_gw, new_gw_node);
+++#else // UGLY_HACK_NEW
++ 	curr_gw_node = rcu_replace_pointer(bat_priv->gw.curr_gw, new_gw_node,
++ 					   true);
+++#endif // UGLY_HACK_STOP
++ 
++ 	batadv_gw_node_put(curr_gw_node);
++ 
++--- a/net/batman-adv/hard-interface.c
+++++ b/net/batman-adv/hard-interface.c
++@@ -485,8 +485,13 @@ static void batadv_primary_if_select(str
++ 	if (new_hard_iface)
++ 		kref_get(&new_hard_iface->refcount);
++ 
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++	curr_hard_iface = rcu_dereference_protected(bat_priv->primary_if, 1);
+++	rcu_assign_pointer(bat_priv->primary_if, new_hard_iface);
+++#else // UGLY_HACK_NEW
++ 	curr_hard_iface = rcu_replace_pointer(bat_priv->primary_if,
++ 					      new_hard_iface, 1);
+++#endif // UGLY_HACK_STOP
++ 
++ 	if (!new_hard_iface)
++ 		goto out;
++--- a/net/batman-adv/routing.c
+++++ b/net/batman-adv/routing.c
++@@ -70,13 +70,20 @@ static void _batadv_update_route(struct
++ 	 * the code needs to ensure the curr_router variable contains a pointer
++ 	 * to the replaced best neighbor.
++ 	 */
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++	curr_router = rcu_dereference_protected(orig_ifinfo->router, true);
+++#endif // UGLY_HACK_STOP
++ 
++ 	/* increase refcount of new best neighbor */
++ 	if (neigh_node)
++ 		kref_get(&neigh_node->refcount);
++ 
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++	rcu_assign_pointer(orig_ifinfo->router, neigh_node);
+++#else // UGLY_HACK_NEW
++ 	curr_router = rcu_replace_pointer(orig_ifinfo->router, neigh_node,
++ 					  true);
+++#endif // UGLY_HACK_STOP
++ 	spin_unlock_bh(&orig_node->neigh_list_lock);
++ 	batadv_orig_ifinfo_put(orig_ifinfo);
++ 
+diff --git a/batman-adv/patches/0506-Revert-batman-adv-Add-extack-to-upper-device-linking.patch b/batman-adv/patches/0506-Revert-batman-adv-Add-extack-to-upper-device-linking.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..a6eb441785f91820eb66cf6d5f2c6060c969bf27
+--- /dev/null
++++ b/batman-adv/patches/0506-Revert-batman-adv-Add-extack-to-upper-device-linking.patch
+@@ -0,0 +1,32 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Mon, 27 Nov 2023 08:07:01 +0100
++Subject: Revert "batman-adv: Add extack to upper device linking"
++
++The extack argument to netdev_master_upper_dev_link() was introduced in
++Linux 4.15 and initially used/introduced in batman-adv v2017.4.
++
++To be able to build batman-adv v2023.3 on OpenWrt 19.07 /
++backports-4.19.237-1 we need to partially revert the according
++commit in batman-adv, depending on the backports version used, as
++backports-4.19 does not provide this function either.
++
++This reverts commit 93418db608c2d131ef2956aa6c436c8182183184.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/net/batman-adv/hard-interface.c
+++++ b/net/batman-adv/hard-interface.c
++@@ -737,8 +737,13 @@ int batadv_hardif_enable_interface(struc
++ 	hard_iface->soft_iface = soft_iface;
++ 	bat_priv = netdev_priv(hard_iface->soft_iface);
++ 
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++	ret = netdev_master_upper_dev_link(hard_iface->net_dev,
+++					   soft_iface, NULL, NULL);
+++#else // UGLY_HACK_NEW
++ 	ret = netdev_master_upper_dev_link(hard_iface->net_dev,
++ 					   soft_iface, NULL, NULL, NULL);
+++#endif // UGLY_HACK_STOP
++ 	if (ret)
++ 		goto err_dev;
++ 
+diff --git a/batman-adv/patches/0507-Revert-batman-adv-genetlink-optionally-validate-strictly-dumps.patch b/batman-adv/patches/0507-Revert-batman-adv-genetlink-optionally-validate-strictly-dumps.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..b5ff118c20c24af5c675c1941ba0128308488078
+--- /dev/null
++++ b/batman-adv/patches/0507-Revert-batman-adv-genetlink-optionally-validate-strictly-dumps.patch
+@@ -0,0 +1,174 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Thu, 30 Nov 2023 04:26:56 +0100
++Subject: Revert "batman-adv: genetlink: optionally validate strictly/dumps"
++
++The .validate attribute was introduced in Linux 5.2 and initially
++used/introduced in batman-adv v2019.2.
++
++To be able to build batman-adv v2023.3 on OpenWrt 19.07 /
++backports-4.19.237-1 we need to partially revert the according
++commit in batman-adv, depending on the backports version used, as
++backports-4.19 does not provide this function either.
++
++This reverts commit 2ee47abaeb35ca62bb909830e10b0e973393b853.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/net/batman-adv/netlink.c
+++++ b/net/batman-adv/netlink.c
++@@ -1366,34 +1366,44 @@ static const struct genl_small_ops batad
++ #endif // UGLY_HACK_STOP
++ 	{
++ 		.cmd = BATADV_CMD_GET_MESH,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		/* can be retrieved by unprivileged users */
++ 		.doit = batadv_netlink_get_mesh,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_TP_METER,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.doit = batadv_netlink_tp_meter_start,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_TP_METER_CANCEL,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.doit = batadv_netlink_tp_meter_cancel,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_ROUTING_ALGOS,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_algo_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_HARDIF,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		/* can be retrieved by unprivileged users */
++ 		.dumpit = batadv_netlink_dump_hardif,
++ 		.doit = batadv_netlink_get_hardif,
++@@ -1402,68 +1412,90 @@ static const struct genl_small_ops batad
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_TRANSTABLE_LOCAL,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_tt_local_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_TRANSTABLE_GLOBAL,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_tt_global_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_ORIGINATORS,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_orig_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_NEIGHBORS,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_hardif_neigh_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_GATEWAYS,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_gw_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_BLA_CLAIM,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_bla_claim_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_BLA_BACKBONE,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_bla_backbone_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_DAT_CACHE,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_dat_cache_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_MCAST_FLAGS,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.dumpit = batadv_mcast_flags_dump,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_SET_MESH,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.doit = batadv_netlink_set_mesh,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_SET_HARDIF,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.doit = batadv_netlink_set_hardif,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++@@ -1471,7 +1503,9 @@ static const struct genl_small_ops batad
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_GET_VLAN,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		/* can be retrieved by unprivileged users */
++ 		.doit = batadv_netlink_get_vlan,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++@@ -1479,7 +1513,9 @@ static const struct genl_small_ops batad
++ 	},
++ 	{
++ 		.cmd = BATADV_CMD_SET_VLAN,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
+++#endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
++ 		.doit = batadv_netlink_set_vlan,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
+diff --git a/batman-adv/patches/0508-Revert-batman-adv-genetlink-make-policy-common-to-family.patch b/batman-adv/patches/0508-Revert-batman-adv-genetlink-make-policy-common-to-family.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..4f325e8dd24d3906059545b3ca105fe121c0ae53
+--- /dev/null
++++ b/batman-adv/patches/0508-Revert-batman-adv-genetlink-make-policy-common-to-family.patch
+@@ -0,0 +1,208 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Thu, 30 Nov 2023 04:41:40 +0100
++Subject: Revert "batman-adv: genetlink: make policy common to family"
++
++The .policy attribute was moved in Linux 5.2 and initially
++used/introduced in batman-adv v2019.2.
++
++To be able to build batman-adv v2023.3 on OpenWrt 19.07 /
++backports-4.19.237-1 we need to partially revert the according
++commit in batman-adv, depending on the backports version used, as
++backports-4.19 does not provide this function either.
++
++This reverts commit acfc9a214d01695d1676313ca80cfd2d9309f633.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/net/batman-adv/netlink.c
+++++ b/net/batman-adv/netlink.c
++@@ -1370,6 +1370,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		/* can be retrieved by unprivileged users */
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.doit = batadv_netlink_get_mesh,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++@@ -1379,6 +1382,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.doit = batadv_netlink_tp_meter_start,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++@@ -1388,6 +1394,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.doit = batadv_netlink_tp_meter_cancel,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++@@ -1397,6 +1406,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_algo_dump,
++ 	},
++ 	{
++@@ -1405,6 +1417,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		/* can be retrieved by unprivileged users */
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_netlink_dump_hardif,
++ 		.doit = batadv_netlink_get_hardif,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++@@ -1416,6 +1431,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_tt_local_dump,
++ 	},
++ 	{
++@@ -1424,6 +1442,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_tt_global_dump,
++ 	},
++ 	{
++@@ -1432,6 +1453,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_orig_dump,
++ 	},
++ 	{
++@@ -1440,6 +1464,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_hardif_neigh_dump,
++ 	},
++ 	{
++@@ -1448,6 +1475,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_gw_dump,
++ 	},
++ 	{
++@@ -1456,6 +1486,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_bla_claim_dump,
++ 	},
++ 	{
++@@ -1464,6 +1497,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_bla_backbone_dump,
++ 	},
++ 	{
++@@ -1472,6 +1508,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_dat_cache_dump,
++ 	},
++ 	{
++@@ -1480,6 +1519,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.dumpit = batadv_mcast_flags_dump,
++ 	},
++ 	{
++@@ -1488,6 +1530,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.doit = batadv_netlink_set_mesh,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH,
++ 	},
++@@ -1497,6 +1542,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.doit = batadv_netlink_set_hardif,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++ 				  BATADV_FLAG_NEED_HARDIF,
++@@ -1508,6 +1556,9 @@ static const struct genl_small_ops batad
++ #endif // UGLY_HACK_STOP
++ 		/* can be retrieved by unprivileged users */
++ 		.doit = batadv_netlink_get_vlan,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++ 				  BATADV_FLAG_NEED_VLAN,
++ 	},
++@@ -1517,6 +1568,9 @@ static const struct genl_small_ops batad
++ 		.validate = GENL_DONT_VALIDATE_STRICT | GENL_DONT_VALIDATE_DUMP,
++ #endif // UGLY_HACK_STOP
++ 		.flags = GENL_UNS_ADMIN_PERM,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 		.doit = batadv_netlink_set_vlan,
++ 		.internal_flags = BATADV_FLAG_NEED_MESH |
++ 				  BATADV_FLAG_NEED_VLAN,
++@@ -1528,7 +1582,9 @@ struct genl_family batadv_netlink_family
++ 	.name = BATADV_NL_NAME,
++ 	.version = 1,
++ 	.maxattr = BATADV_ATTR_MAX,
+++#ifndef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
++ 	.policy = batadv_netlink_policy,
+++#endif // UGLY_HACK_STOP
++ 	.netnsok = true,
++ 	.pre_doit = batadv_pre_doit,
++ 	.post_doit = batadv_post_doit,
+diff --git a/batman-adv/patches/0509-Revert-batman-adv-use-eth_hw_addr_set-instead-of-ether_addr_copy.patch b/batman-adv/patches/0509-Revert-batman-adv-use-eth_hw_addr_set-instead-of-ether_addr_copy.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..b91e22b3313993d279f1771e4265b4a4898345c5
+--- /dev/null
++++ b/batman-adv/patches/0509-Revert-batman-adv-use-eth_hw_addr_set-instead-of-ether_addr_copy.patch
+@@ -0,0 +1,29 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Thu, 30 Nov 2023 05:28:22 +0100
++Subject: Revert "batman-adv: use eth_hw_addr_set() instead of ether_addr_copy()"
++
++Introduced in Linux v5.16 / batman-adv v2021.4.
++
++To be able to build batman-adv v2023.3 on OpenWrt 19.07 /
++backports-4.19.237-1 we need to partially revert the according
++commit in batman-adv, depending on the backports version used, as
++backports-4.19 does not provide this function either.
++
++This reverts commit a4dbfc15a07ea34d610aa391de1d847bd5b9312d.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/net/batman-adv/soft-interface.c
+++++ b/net/batman-adv/soft-interface.c
++@@ -133,7 +133,11 @@ static int batadv_interface_set_mac_addr
++ 		return -EADDRNOTAVAIL;
++ 
++ 	ether_addr_copy(old_addr, dev->dev_addr);
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++	ether_addr_copy(dev->dev_addr, addr->sa_data);
+++#else // UGLY_HACK_NEW
++ 	eth_hw_addr_set(dev, addr->sa_data);
+++#endif // UGLY_HACK_STOP
++ 
++ 	/* only modify transtable if it has been initialized before */
++ 	if (atomic_read(&bat_priv->mesh_state) != BATADV_MESH_ACTIVE)
+diff --git a/batman-adv/patches/0510-Revert-batman-adv-Use-fallthrough-pseudo-keyword.patch b/batman-adv/patches/0510-Revert-batman-adv-Use-fallthrough-pseudo-keyword.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..294296cdf66038f31372b84fa343bfc9bcde4ae2
+--- /dev/null
++++ b/batman-adv/patches/0510-Revert-batman-adv-Use-fallthrough-pseudo-keyword.patch
+@@ -0,0 +1,53 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Thu, 30 Nov 2023 05:53:34 +0100
++Subject: Revert "batman-adv: Use 'fallthrough' pseudo keyword"
++
++Introduced in Linux v5.5 / batman-adv v2019.5.
++
++To be able to build batman-adv v2023.3 on OpenWrt 19.07 /
++backports-4.19.237-1 we need to partially revert the according
++commit in batman-adv, depending on the backports version used, as
++backports-4.19 does not provide this function either.
++
++This reverts commit 7bb9b06ac44dfd0189cf58d6564bfc890cc10e9c.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/net/batman-adv/soft-interface.c
+++++ b/net/batman-adv/soft-interface.c
++@@ -234,7 +234,11 @@ static netdev_tx_t batadv_interface_tx(s
++ 			break;
++ 		}
++ 
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		/* fall through */
+++#else // UGLY_HACK_NEW
++ 		fallthrough;
+++#endif // UGLY_HACK_STOP
++ 	case ETH_P_BATMAN:
++ 		goto dropped;
++ 	}
++@@ -315,7 +319,11 @@ send:
++ 				do_bcast = false;
++ 				break;
++ 			case BATADV_FORW_NONE:
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++				/* fall through */
+++#else // UGLY_HACK_NEW
++ 				fallthrough;
+++#endif // UGLY_HACK_STOP
++ 			default:
++ 				goto dropped;
++ 			}
++@@ -455,7 +463,11 @@ void batadv_interface_rx(struct net_devi
++ 		if (vhdr->h_vlan_encapsulated_proto != htons(ETH_P_BATMAN))
++ 			break;
++ 
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++		/* fall through */
+++#else // UGLY_HACK_NEW
++ 		fallthrough;
+++#endif // UGLY_HACK_STOP
++ 	case ETH_P_BATMAN:
++ 		goto dropped;
++ 	}
+diff --git a/batman-adv/patches/0511-Revert-batman-adv-netfilter-drop-bridge-nf-reset-from-nf_reset.patch b/batman-adv/patches/0511-Revert-batman-adv-netfilter-drop-bridge-nf-reset-from-nf_reset.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..8fd6374179215dd10be6176973918cedd0b66cc8
+--- /dev/null
++++ b/batman-adv/patches/0511-Revert-batman-adv-netfilter-drop-bridge-nf-reset-from-nf_reset.patch
+@@ -0,0 +1,29 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Thu, 30 Nov 2023 06:06:25 +0100
++Subject: Revert "batman-adv: netfilter: drop bridge nf reset from nf_reset"
++
++Introduced in Linux v5.4 / batman-adv v2019.4.
++
++To be able to build batman-adv v2023.3 on OpenWrt 19.07 /
++backports-4.19.237-1 we need to partially revert the according
++commit in batman-adv, depending on the backports version used, as
++backports-4.19 does not provide this function either.
++
++This reverts commit ab636a2bec851b103c638ec4cde059be0432528a.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/net/batman-adv/soft-interface.c
+++++ b/net/batman-adv/soft-interface.c
++@@ -444,7 +444,11 @@ void batadv_interface_rx(struct net_devi
++ 	/* clean the netfilter state now that the batman-adv header has been
++ 	 * removed
++ 	 */
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++	nf_reset(skb);
+++#else // UGLY_HACK_NEW
++ 	nf_reset_ct(skb);
+++#endif // UGLY_HACK_STOP
++ 
++ 	if (unlikely(!pskb_may_pull(skb, ETH_HLEN)))
++ 		goto dropped;
+diff --git a/batman-adv/patches/0512-Revert-batman-adv-Add-extack-to-ndo_add_slave.patch b/batman-adv/patches/0512-Revert-batman-adv-Add-extack-to-ndo_add_slave.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..a53aaad45f74992c35db5beae1558a7ef76692ff
+--- /dev/null
++++ b/batman-adv/patches/0512-Revert-batman-adv-Add-extack-to-ndo_add_slave.patch
+@@ -0,0 +1,29 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Thu, 30 Nov 2023 06:17:37 +0100
++Subject: Revert "batman-adv: Add extack to ndo_add_slave"
++
++To be able to build batman-adv v2023.3 on OpenWrt 19.07 /
++backports-4.19.237-1 we need to partially revert the according
++commit in batman-adv, depending on the backports version used, as
++backports-4.19 does not provide this function either.
++
++This reverts commit 621c17e76450528c6803c326837917d96388d992.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/net/batman-adv/soft-interface.c
+++++ b/net/batman-adv/soft-interface.c
++@@ -851,8 +851,13 @@ free_bat_counters:
++  * Return: 0 if successful or error otherwise.
++  */
++ static int batadv_softif_slave_add(struct net_device *dev,
+++#ifdef HAVE_BACKPORTS_LESS_5_10 // UGLY_HACK_START
+++				   struct net_device *slave_dev)
+++#else // UGLY_HACK_NEW
++ 				   struct net_device *slave_dev,
++ 				   struct netlink_ext_ack *extack)
+++#endif // UGLY_HACK_STOP
+++
++ {
++ 	struct batadv_hard_iface *hard_iface;
++ 	int ret = -EINVAL;
+diff --git a/batman-adv/patches/2002-batman-adv-Introduce-no-noflood-mark.patch b/batman-adv/patches/2002-batman-adv-Introduce-no-noflood-mark.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..b671b95aea9b8f089ad079a706c07509e0696b91
+--- /dev/null
++++ b/batman-adv/patches/2002-batman-adv-Introduce-no-noflood-mark.patch
+@@ -0,0 +1,137 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Sat, 31 Mar 2018 03:36:19 +0200
++Subject: batman-adv: Introduce no noflood mark
++
++This mark prevents a multicast packet being flooded through the whole
++mesh. The advantage of marking certain multicast packets via e.g.
++ebtables instead of dropping is then the following:
++
++This allows an administrator to let specific multicast packets pass as
++long as they are forwarded to a limited number of nodes only and are
++therefore creating no burdon to unrelated nodes.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/include/uapi/linux/batman_adv.h
+++++ b/include/uapi/linux/batman_adv.h
++@@ -481,6 +481,18 @@ enum batadv_nl_attrs {
++ 	 */
++ 	BATADV_ATTR_MULTICAST_FANOUT,
++ 
+++	/**
+++	 * @BATADV_ATTR_NOFLOOD_MARK: the noflood mark which allows to tag
+++	 *  frames which should never be broadcast flooded through the mesh.
+++	 */
+++	BATADV_ATTR_NOFLOOD_MARK,
+++
+++	/**
+++	 * @BATADV_ATTR_NOFLOOD_MASK: the noflood (bit)mask which allows to tag
+++	 *  frames which should never be broadcast flooded through the mesh.
+++	 */
+++	BATADV_ATTR_NOFLOOD_MASK,
+++
++ 	/* add attributes above here, update the policy in netlink.c */
++ 
++ 	/**
++--- a/net/batman-adv/netlink.c
+++++ b/net/batman-adv/netlink.c
++@@ -135,6 +135,8 @@ static const struct nla_policy batadv_ne
++ 	[BATADV_ATTR_AP_ISOLATION_ENABLED]	= { .type = NLA_U8 },
++ 	[BATADV_ATTR_ISOLATION_MARK]		= { .type = NLA_U32 },
++ 	[BATADV_ATTR_ISOLATION_MASK]		= { .type = NLA_U32 },
+++	[BATADV_ATTR_NOFLOOD_MARK]		= { .type = NLA_U32 },
+++	[BATADV_ATTR_NOFLOOD_MASK]		= { .type = NLA_U32 },
++ 	[BATADV_ATTR_BONDING_ENABLED]		= { .type = NLA_U8 },
++ 	[BATADV_ATTR_BRIDGE_LOOP_AVOIDANCE_ENABLED]	= { .type = NLA_U8 },
++ 	[BATADV_ATTR_DISTRIBUTED_ARP_TABLE_ENABLED]	= { .type = NLA_U8 },
++@@ -287,6 +289,14 @@ static int batadv_netlink_mesh_fill(stru
++ 			bat_priv->isolation_mark_mask))
++ 		goto nla_put_failure;
++ 
+++	if (nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MARK,
+++			bat_priv->noflood_mark))
+++		goto nla_put_failure;
+++
+++	if (nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MASK,
+++			bat_priv->noflood_mark_mask))
+++		goto nla_put_failure;
+++
++ 	if (nla_put_u8(msg, BATADV_ATTR_BONDING_ENABLED,
++ 		       !!atomic_read(&bat_priv->bonding)))
++ 		goto nla_put_failure;
++@@ -465,6 +475,18 @@ static int batadv_netlink_set_mesh(struc
++ 		bat_priv->isolation_mark_mask = nla_get_u32(attr);
++ 	}
++ 
+++	if (info->attrs[BATADV_ATTR_NOFLOOD_MARK]) {
+++		attr = info->attrs[BATADV_ATTR_NOFLOOD_MARK];
+++
+++		bat_priv->noflood_mark = nla_get_u32(attr);
+++	}
+++
+++	if (info->attrs[BATADV_ATTR_NOFLOOD_MASK]) {
+++		attr = info->attrs[BATADV_ATTR_NOFLOOD_MASK];
+++
+++		bat_priv->noflood_mark_mask = nla_get_u32(attr);
+++	}
+++
++ 	if (info->attrs[BATADV_ATTR_BONDING_ENABLED]) {
++ 		attr = info->attrs[BATADV_ATTR_BONDING_ENABLED];
++ 
++--- a/net/batman-adv/soft-interface.c
+++++ b/net/batman-adv/soft-interface.c
++@@ -181,6 +181,23 @@ static void batadv_interface_set_rx_mode
++ {
++ }
++ 
+++/**
+++ * batadv_send_skb_has_noflood_mark() - check if packet has a noflood mark
+++ * @bat_priv: the bat priv with all the soft interface information
+++ * @skb: the packet to check
+++ *
+++ * Return: True if the skb's mark matches a configured noflood mark and
+++ * noflood mark mask. False otherwise.
+++ */
+++static bool
+++batadv_skb_has_noflood_mark(struct batadv_priv *bat_priv, struct sk_buff *skb)
+++{
+++	u32 match_mark = skb->mark & bat_priv->noflood_mark_mask;
+++
+++	return bat_priv->noflood_mark_mask &&
+++	       match_mark == bat_priv->noflood_mark;
+++}
+++
++ static netdev_tx_t batadv_interface_tx(struct sk_buff *skb,
++ 				       struct net_device *soft_iface)
++ {
++@@ -345,6 +362,9 @@ send:
++ 		if (batadv_dat_snoop_outgoing_arp_request(bat_priv, skb))
++ 			brd_delay = msecs_to_jiffies(ARP_REQ_DELAY);
++ 
+++		if (batadv_skb_has_noflood_mark(bat_priv, skb))
+++			goto dropped;
+++
++ 		if (batadv_skb_head_push(skb, sizeof(*bcast_packet)) < 0)
++ 			goto dropped;
++ 
++--- a/net/batman-adv/types.h
+++++ b/net/batman-adv/types.h
++@@ -1711,6 +1711,18 @@ struct batadv_priv {
++ 	 */
++ 	u32 isolation_mark_mask;
++ 
+++	/**
+++	 * @noflood_mark: the skb->mark value used to allow directed targeting
+++	 *  only
+++	 */
+++	u32 noflood_mark;
+++
+++	/**
+++	 * @noflood_mark_mask: bitmask identifying the bits in skb->mark to be
+++	 *  used for the noflood mark
+++	 */
+++	u32 noflood_mark_mask;
+++
++ 	/** @bcast_seqno: last sent broadcast packet sequence number */
++ 	atomic_t bcast_seqno;
++ 
+diff --git a/batman-adv/patches/9001-batman-adv-GLUON-assume-absence-of-mcast-routers-on-OpenWrt-23.05.patch b/batman-adv/patches/9001-batman-adv-GLUON-assume-absence-of-mcast-routers-on-OpenWrt-23.05.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..da1fff08f599885030e559cb618239c4f47f4503
+--- /dev/null
++++ b/batman-adv/patches/9001-batman-adv-GLUON-assume-absence-of-mcast-routers-on-OpenWrt-23.05.patch
+@@ -0,0 +1,72 @@
++From: Linus Lüssing <linus.luessing@c0d3.blue>
++Date: Mon, 20 Nov 2023 13:47:30 +0100
++Subject: batman-adv: GLUON: assume absence of mcast routers on OpenWrt < 23.05
++
++In Gluon networks we currently have the issue that a lot of devices are
++still running OpenWrt < 23.05. And likely many small RAM/flash devices
++will be stuck on Gluon v2021.1.2 / OpenWrt 19.07 for a while longer.
++
++These devices would block the availability of the batman-adv multicast
++opitimizations feature for routable IPv6 multicast addresses. Therefore,
++instead of defaulting to "multicast-router-present" this changes the
++behaviour to assume "no-multicast-router-present" on this "old" devices
++/ kernels.
++
++The only downside of this is: If there were a multicast router behind
++one of these "old" devices / kernels then this would potentially lead to
++multicast packet loss to it. However, with the current
++"multicast-router-present" default we would likely get over the 16 nodes
++limit enforced in Gluon (noflood-mark) and would have such packets
++filtered anyway. Therefore there is no real downside for this change in
++Gluon.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++
++--- a/compat-include/linux/if_bridge.h
+++++ b/compat-include/linux/if_bridge.h
++@@ -55,43 +55,13 @@ inline void __batadv_br_ip_list_check(vo
++ 
++ #if LINUX_VERSION_IS_LESS(5, 14, 0)
++ 
++-#include <net/addrconf.h>
+++#include <linux/netdevice.h>
++ 
++-#if IS_ENABLED(CONFIG_IPV6)
++ static inline bool
++ br_multicast_has_router_adjacent(struct net_device *dev, int proto)
++ {
++-	struct list_head bridge_mcast_list = LIST_HEAD_INIT(bridge_mcast_list);
++-	struct br_ip_list *br_ip_entry, *tmp;
++-	int ret;
++-
++-	if (proto != ETH_P_IPV6)
++-		return true;
++-
++-	ret = br_multicast_list_adjacent(dev, &bridge_mcast_list);
++-	if (ret < 0)
++-		return true;
++-
++-	ret = false;
++-
++-	list_for_each_entry_safe(br_ip_entry, tmp, &bridge_mcast_list, list) {
++-		if (br_ip_entry->addr.proto == htons(ETH_P_IPV6) &&
++-		    ipv6_addr_is_ll_all_routers(&br_ip_entry->addr.dst.ip6))
++-			ret = true;
++-
++-		list_del(&br_ip_entry->list);
++-		kfree(br_ip_entry);
++-	}
++-
++-	return ret;
++-}
++-#else
++-static inline bool
++-br_multicast_has_router_adjacent(struct net_device *dev, int proto)
++-{
++-	return true;
+++	return false;
++ }
++-#endif
++ 
++ #endif /* LINUX_VERSION_IS_LESS(5, 14, 0) */
++ 
+diff --git a/batman-adv/src/compat-hacks.h b/batman-adv/src/compat-hacks.h
+index 1cbcfcf070c7dd943574612c0d13f886c88ecc25..ed5a027ef00ff83745ea356e408e3a312c8561b5 100644
+--- a/batman-adv/src/compat-hacks.h
++++ b/batman-adv/src/compat-hacks.h
+@@ -5,175 +5,135 @@
+ #include <linux/version.h>	/* LINUX_VERSION_CODE */
+ #include <linux/types.h>
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
++#if LINUX_VERSION_IS_LESS(4, 16, 0)
+ 
+-#define dev_get_iflink(_net_dev) ((_net_dev)->iflink)
+-
+-#endif /* < KERNEL_VERSION(4, 1, 0) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 5, 0)
+-
+-#include <linux/netdevice.h>
+-
+-#define netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info, extack) ({\
+-	BUILD_BUG_ON(upper_priv != NULL); \
+-	BUILD_BUG_ON(upper_info != NULL); \
+-	BUILD_BUG_ON(extack != NULL); \
+-	netdev_master_upper_dev_link(dev, upper_dev); \
+-})
+-
+-#elif LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
+-
+-#include <linux/netdevice.h>
+-
+-#define netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info, extack) ({\
+-	BUILD_BUG_ON(extack != NULL); \
+-	netdev_master_upper_dev_link(dev, upper_dev, upper_priv, upper_info); \
+-})
+-
+-#endif /* < KERNEL_VERSION(4, 5, 0) */
+-
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 0, 0)
+-
+-/* wild hack for batadv_getlink_net only */
+-#define get_link_net get_xstats_size || 1 ? fallback_net : (struct net*)netdev->rtnl_link_ops->get_xstats_size
+-
+-#endif /* < KERNEL_VERSION(4, 0, 0) */
+-
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0)
+-
+-struct sk_buff *skb_checksum_trimmed(struct sk_buff *skb,
+-				     unsigned int transport_len,
+-				     __sum16(*skb_chkf)(struct sk_buff *skb));
+-
+-int ip_mc_check_igmp(struct sk_buff *skb);
+-int ipv6_mc_check_mld(struct sk_buff *skb);
+-
+-#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 1, 0)
++/**
++ * sizeof_field() - Report the size of a struct field in bytes
++ *
++ * @TYPE: The structure containing the field of interest
++ * @MEMBER: The field to return the size of
++ */
++#define sizeof_field(TYPE, MEMBER) sizeof((((TYPE *)0)->MEMBER))
+ 
+-#undef ip_mc_check_igmp
+-#undef ipv6_mc_check_mld
++#endif /* LINUX_VERSION_IS_LESS(4, 16, 0) */
+ 
+-#include_next <linux/igmp.h>
+-#include_next <net/addrconf.h>
++#if LINUX_VERSION_IS_LESS(5, 10, 0)
+ 
+-#endif /* < KERNEL_VERSION(4, 2, 0) */
++#include <linux/if_bridge.h>
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 3, 0)
++struct batadv_br_ip {
++	union {
++		__be32  ip4;
++#if IS_ENABLED(CONFIG_IPV6)
++		struct in6_addr ip6;
++#endif
++	} dst;
++	__be16          proto;
++	__u16           vid;
++};
+ 
+-#define IFF_NO_QUEUE	0; dev->tx_queue_len = 0
++struct batadv_br_ip_list {
++	struct list_head list;
++	struct batadv_br_ip addr;
++};
+ 
+-static inline bool hlist_fake(struct hlist_node *h)
++#if 0
++/* "static" dropped to force compiler to evaluate it as part of multicast.c
++ * might need to be added again and then called in some kind of dummy
++ * compat.c in case this header is included in multiple files.
++ */
++inline void __batadv_br_ip_list_check(void)
+ {
+-	return h->pprev == &h->next;
++	BUILD_BUG_ON(sizeof(struct batadv_br_ip_list) != sizeof(struct br_ip_list));
++	BUILD_BUG_ON(offsetof(struct batadv_br_ip_list, list) != offsetof(struct br_ip_list, list));
++	BUILD_BUG_ON(offsetof(struct batadv_br_ip_list, addr) != offsetof(struct br_ip_list, addr));
++
++	BUILD_BUG_ON(sizeof(struct batadv_br_ip) != sizeof(struct br_ip));
++	BUILD_BUG_ON(offsetof(struct batadv_br_ip, dst.ip4) != offsetof(struct br_ip, u.ip4));
++	BUILD_BUG_ON(offsetof(struct batadv_br_ip, dst.ip6) != offsetof(struct br_ip, u.ip6));
++	BUILD_BUG_ON(offsetof(struct batadv_br_ip, proto) != offsetof(struct br_ip, proto));
++	BUILD_BUG_ON(offsetof(struct batadv_br_ip, vid) != offsetof(struct br_ip, vid));
+ }
++#endif
+ 
+-#endif /* < KERNEL_VERSION(4, 3, 0) */
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 6, 0)
+-
+-#include <linux/ethtool.h>
++#define br_ip batadv_br_ip
++#define br_ip_list batadv_br_ip_list
+ 
+-#define ethtool_link_ksettings batadv_ethtool_link_ksettings
++#endif /* LINUX_VERSION_IS_LESS(5, 10, 0) */
+ 
+-struct batadv_ethtool_link_ksettings {
+-	struct {
+-		__u32	speed;
+-		__u8	duplex;
+-		__u8    autoneg;
+-	} base;
+-};
++#if LINUX_VERSION_IS_LESS(5, 14, 0)
+ 
+-#define __ethtool_get_link_ksettings(__dev, __link_settings) \
+-	batadv_ethtool_get_link_ksettings(__dev, __link_settings)
++#include <linux/netdevice.h>
+ 
+-static inline int
+-batadv_ethtool_get_link_ksettings(struct net_device *dev,
+-				  struct ethtool_link_ksettings *link_ksettings)
++static inline bool
++br_multicast_has_router_adjacent(struct net_device *dev, int proto)
+ {
+-	struct ethtool_cmd cmd;
+-	int ret;
++	return false;
++}
+ 
+-	memset(&cmd, 0, sizeof(cmd));
+-	ret = __ethtool_get_settings(dev, &cmd);
++#endif /* LINUX_VERSION_IS_LESS(5, 14, 0) */
+ 
+-	if (ret != 0)
+-		return ret;
++#if LINUX_VERSION_IS_LESS(5, 15, 0)
+ 
+-	link_ksettings->base.duplex = cmd.duplex;
+-	link_ksettings->base.speed = ethtool_cmd_speed(&cmd);
+-	link_ksettings->base.autoneg = cmd.autoneg;
++static inline void batadv_dev_put(struct net_device *dev)
++{
++	if (!dev)
++		return;
+ 
+-	return 0;
++	dev_put(dev);
+ }
++#define dev_put batadv_dev_put
+ 
+-#endif /* < KERNEL_VERSION(4, 6, 0) */
+-
+-
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 10, 0)
++static inline void batadv_dev_hold(struct net_device *dev)
++{
++	if (!dev)
++		return;
+ 
+-#include_next <linux/cache.h>
++	dev_hold(dev);
++}
++#define dev_hold batadv_dev_hold
+ 
+-/* hack for netlink.c which marked the family ops as ro */
+-#ifdef __ro_after_init
+-#undef __ro_after_init
+-#endif
+-#define __ro_after_init
++#endif /* LINUX_VERSION_IS_LESS(5, 15, 0) */
+ 
+-#endif /* < KERNEL_VERSION(4, 10, 0) */
++#if LINUX_VERSION_IS_LESS(6, 0, 0)
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 9)
++#define __vstring(item, fmt, ap) __dynamic_array(char, item, 256)
++#define __assign_vstr(dst, fmt, va) \
++	WARN_ON_ONCE(vsnprintf(__get_dynamic_array(dst), 256, fmt, *va) >= 256)
+ 
+-#include <linux/netdevice.h>
++#endif /* LINUX_VERSION_IS_LESS(6, 0, 0) */
+ 
+-/* work around missing attribute needs_free_netdev and priv_destructor in
+- * net_device
+- */
+-#define ether_setup(dev) \
+-	void batadv_softif_free2(struct net_device *dev) \
+-	{ \
+-		batadv_softif_free(dev); \
+-		free_netdev(dev); \
+-	} \
+-	void (*t1)(struct net_device *dev) __attribute__((unused)); \
+-	bool t2 __attribute__((unused)); \
+-	ether_setup(dev)
+-#define needs_free_netdev destructor = batadv_softif_free2; t2
+-#define priv_destructor destructor = batadv_softif_free2; t1
++#if LINUX_VERSION_IS_LESS(6, 2, 0)
+ 
+-#endif /* < KERNEL_VERSION(4, 11, 9) */
++#include <linux/random.h>
+ 
++#define genl_split_ops genl_ops
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 15, 0)
++static inline u32 batadv_get_random_u32_below(u32 ep_ro)
++{
++	return prandom_u32_max(ep_ro);
++}
+ 
+-#define batadv_softif_slave_add(__dev, __slave_dev, __extack) \
+-	batadv_softif_slave_add(__dev, __slave_dev)
++#define get_random_u32_below batadv_get_random_u32_below
+ 
+-#endif /* < KERNEL_VERSION(4, 15, 0) */
++#endif /* LINUX_VERSION_IS_LESS(6, 2, 0) */
+ 
++#if LINUX_VERSION_IS_LESS(6, 4, 0) && \
++    !(LINUX_VERSION_IS_GEQ(5, 10, 205) && LINUX_VERSION_IS_LESS(5, 11, 0)) && \
++    !(LINUX_VERSION_IS_GEQ(5, 15, 144) && LINUX_VERSION_IS_LESS(5, 16, 0)) && \
++    !(LINUX_VERSION_IS_GEQ(6, 1, 69) && LINUX_VERSION_IS_LESS(6, 2, 0))
+ 
+-#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
++#include <linux/if_vlan.h>
+ 
+-static inline int batadv_access_ok(int type, const void __user *p,
+-				   unsigned long size)
++/* Prefer this version in TX path, instead of
++ * skb_reset_mac_header() + vlan_eth_hdr()
++ */
++static inline struct vlan_ethhdr *skb_vlan_eth_hdr(const struct sk_buff *skb)
+ {
+-	return access_ok(type, p, size);
++	return (struct vlan_ethhdr *)skb->data;
+ }
+ 
+-#ifdef access_ok
+-#undef access_ok
+-#endif
+-
+-#define access_ok_get(_1, _2, _3 , access_ok_name, ...) access_ok_name
+-#define access_ok(...) \
+-	access_ok_get(__VA_ARGS__, access_ok3, access_ok2)(__VA_ARGS__)
+-
+-#define access_ok2(addr, size)	batadv_access_ok(VERIFY_WRITE, (addr), (size))
+-#define access_ok3(type, addr, size)	batadv_access_ok((type), (addr), (size))
+-
+-#endif /* < KERNEL_VERSION(5, 0, 0) */
++#endif /* LINUX_VERSION_IS_LESS(6, 4, 0) */
+ 
+ /* <DECLARE_EWMA> */
+ 

--- a/patches/packages/routing/0006-batctl-update-to-version-2024.3.patch
+++ b/patches/packages/routing/0006-batctl-update-to-version-2024.3.patch
@@ -1,0 +1,2305 @@
+From: Linus Lüssing <linus.luessing@c0d3.blue>
+Date: Tue, 19 Nov 2024 14:58:54 +0100
+Subject: batctl: update to version 2024.3
+
+Similarly, also update batctl to the version provided in the
+latest openwrt/routing feed's master branch.
+Plus the noflood mark patch used by Gluon.
+
+Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+
+diff --git a/batctl/Makefile b/batctl/Makefile
+index 129015f77ee49950f32b3af160cff35fbc92c703..daee9dc41aa8ded1dd0223842bb2a3eeda8576f9 100644
+--- a/batctl/Makefile
++++ b/batctl/Makefile
+@@ -1,53 +1,50 @@
+-#
+-# Copyright (C) 2014 OpenWrt.org
+-#
+-# This is free software, licensed under the GNU General Public License v2.
+-# See /LICENSE for more information.
+-#
++# SPDX-License-Identifier: GPL-2.0-only
+ 
+ include $(TOPDIR)/rules.mk
+ 
+ PKG_NAME:=batctl
+-
+-PKG_VERSION:=2019.2
+-PKG_RELEASE:=8
+-PKG_HASH:=fb656208ff7d4cd8b1b422f60c9e6d8747302a347cbf6c199d7afa9b80f80ea3
++PKG_VERSION:=2024.3
++PKG_RELEASE:=1
+ 
+ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
+ PKG_SOURCE_URL:=https://downloads.open-mesh.org/batman/releases/batman-adv-$(PKG_VERSION)
+-PKG_LICENSE:=GPL-2.0
+-
++PKG_HASH:=665e655eda381415218a4d5f5fd77ff33c4fa9b5edbb7e88e839096961e3600b
+ PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
+ 
++PKG_MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
++PKG_LICENSE:=GPL-2.0-only ISC MIT
++PKG_LICENSE_FILES:=LICENSES/preferred/GPL-2.0 LICENSES/preferred/MIT LICENSES/deprecated/ISC
++
++PKG_BUILD_PARALLEL:=1
++PKG_BUILD_FLAGS:=gc-sections lto
++
+ include $(INCLUDE_DIR)/package.mk
+ 
+ define Package/batctl/Default
+-  URL:=https://www.open-mesh.org/
+   SECTION:=net
+   CATEGORY:=Network
++  URL:=https://www.open-mesh.org/
+   DEPENDS:=+libnl-tiny +libc +librt
+   PROVIDES:=batctl
+-  MAINTAINER:=Simon Wunderlich <sw@simonwunderlich.de>
+ endef
+ 
+ define Package/batctl/description
+-batctl is a more intuitive managment utility for B.A.T.M.A.N.-Advanced.
+-It is an easier method for configuring batman-adv and provides some
+-additional tools for debugging as well. This package builds
+-version $(PKG_VERSION) of the user space utility.
++  batctl is a more intuitive managment utility for B.A.T.M.A.N.-Advanced.
++  It is an easier method for configuring batman-adv and provides some
++  additional tools for debugging as well. This package builds
++  version $(PKG_VERSION) of the user space utility.
+ endef
+ 
+ define Package/batctl-tiny
+ $(call Package/batctl/Default)
+   TITLE:=B.A.T.M.A.N. Advanced user space configuration tool (Minimal)
+   VARIANT:=tiny
+-  PROVIDES:=batctl
+   ALTERNATIVES:=100:/usr/sbin/batctl:/usr/libexec/batctl-tiny
+ endef
+ 
+ define Package/batctl-tiny/description
+ $(Package/batctl/description)
+-Only configuration relevant subcommands are enabled.
++  Only configuration relevant subcommands are enabled.
+ endef
+ 
+ define Package/batctl-default
+@@ -59,7 +56,7 @@ endef
+ 
+ define Package/batctl-default/description
+ $(Package/batctl/description)
+-Standard subcommands for configuration and online debugging are enabled.
++  Standard subcommands for configuration and online debugging are enabled.
+ endef
+ 
+ define Package/batctl-full
+@@ -71,36 +68,15 @@ endef
+ 
+ define Package/batctl-full/description
+ $(Package/batctl/description)
+-Subcommands for configuration, online and offline debugging are enabled.
++  Subcommands for configuration, online and offline debugging are enabled.
+ endef
+ 
+-# The linker can identify unused sections of a binary when each symbol is stored
+-# in a separate section. This mostly removes unused linker sections and reduces
+-# the size by ~3% on mipsel.
+-
+-TARGET_CFLAGS  += -ffunction-sections -fdata-sections
+-TARGET_LDFLAGS += -Wl,--gc-sections
+-
+-# Link-time optimization allows to move parts of the optimization from the single
+-# source file to the global source view. This is done by emitting the GIMPLE
+-# representation in each object file and analyzing it again during the link step.
+-
+-TARGET_CFLAGS  += -flto
+-TARGET_LDFLAGS += -fuse-linker-plugin
+-
+-MAKE_BATCTL_ENV += \
+-        CPPFLAGS="$(TARGET_CPPFLAGS)" \
+-        CFLAGS="$(TARGET_CFLAGS)" \
+-        LDFLAGS="$(TARGET_LDFLAGS)" \
++MAKE_VARS += \
+         LIBNL_NAME="libnl-tiny" \
+         LIBNL_GENL_NAME="libnl-tiny"
+ 
+-MAKE_BATCTL_ARGS += \
+-        REVISION="$(PKG_BATCTL_SHORTREV)" \
+-        CC="$(TARGET_CC)" \
+-        DESTDIR="$(PKG_INSTALL_DIR)" \
+-        batctl install \
+-        REVISION="openwrt-$(PKG_VERSION)-$(PKG_RELEASE)"
++MAKE_FLAGS += \
++        REVISION="$(PKG_VERSION)-openwrt-$(PKG_RELEASE)"
+ 
+ config-n := \
+ 	aggregation \
+@@ -108,28 +84,37 @@ config-n := \
+ 	backbonetable \
+ 	bisect_iv \
+ 	bonding \
++	bla_backbone_json \
++	bla_claim_json \
+ 	bridge_loop_avoidance \
+ 	claimtable \
+ 	dat_cache \
++	dat_cache_json \
+ 	distributed_arp_table \
+ 	elp_interval \
+ 	event \
+ 	fragmentation \
+ 	gateways \
++	gateways_json \
+ 	gw_mode \
++	hardif_json \
++	hardifs_json \
+ 	hop_penalty \
+ 	interface \
+ 	isolation_mark \
+ 	loglevel \
+ 	mcast_flags \
++	mcast_flags_json \
++	mesh_json \
+ 	multicast_fanout \
+ 	multicast_forceflood \
+ 	multicast_mode \
+-	nc_nodes \
+ 	neighbors \
++	neighbors_json \
+ 	network_coding \
+ 	orig_interval \
+ 	originators \
++	originators_json \
+ 	ping \
+ 	routing_algo \
+ 	statistics \
+@@ -140,6 +125,9 @@ config-n := \
+ 	transglobal \
+ 	translate \
+ 	translocal \
++	transtable_global_json \
++	transtable_local_json \
++	vlan_json \
+ 
+ config-settings := \
+ 	aggregation \
+@@ -168,13 +156,27 @@ config-tables := \
+ 	dat_cache \
+ 	gateways \
+ 	mcast_flags \
+-	nc_nodes \
+ 	neighbors \
+ 	originators \
+ 	statistics \
+ 	transglobal \
+ 	translocal \
+ 
++config-json := \
++	bla_backbone_json \
++	bla_claim_json \
++	dat_cache_json \
++	gateways_json \
++	hardif_json \
++	hardifs_json \
++	mcast_flags_json \
++	mesh_json \
++	neighbors_json \
++	originators_json \
++	transtable_global_json \
++	transtable_local_json \
++	vlan_json \
++
+ config-tools := \
+ 	event \
+ 	ping \
+@@ -198,6 +200,7 @@ ifeq ($(BUILD_VARIANT),default)
+ config-y := \
+ 	$(config-settings) \
+ 	$(config-tables) \
++	$(config-json) \
+ 	$(config-tools) \
+ 
+ endif
+@@ -207,6 +210,7 @@ ifeq ($(BUILD_VARIANT),full)
+ config-y := \
+ 	$(config-settings) \
+ 	$(config-tables) \
++	$(config-json) \
+ 	$(config-tools) \
+ 	$(config-extratools) \
+ 
+@@ -222,10 +226,7 @@ $(call ConfigVars,n)$(call ConfigVars,y)
+ endef
+ $(eval $(call shexport,batctl_config))
+ 
+-define Build/Compile
+-	$(MAKE_BATCTL_ENV) $(MAKE) -C "$(PKG_BUILD_DIR)" $(MAKE_BATCTL_ARGS) \
+-		$$$$$(call shvar,batctl_config)
+-endef
++MAKE_FLAGS += $$$$$(call shvar,batctl_config)
+ 
+ define Package/batctl-tiny/install
+ 	$(INSTALL_DIR) $(1)/usr/libexec
+diff --git a/batctl/patches/0001-batctl-Make-vlan-setting-explicit.patch b/batctl/patches/0001-batctl-Make-vlan-setting-explicit.patch
+deleted file mode 100644
+index 77fe2fdabb309dc771523ae99d3f2a62ba0c3fd9..0000000000000000000000000000000000000000
+--- a/batctl/patches/0001-batctl-Make-vlan-setting-explicit.patch
++++ /dev/null
+@@ -1,592 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Tue, 9 Jul 2019 19:26:46 +0200
+-Subject: batctl: Make vlan setting explicit
+-
+-The requirement to have a VLAN master device on top of the batadv mesh
+-interface is artificially limiting the capabilities of batctl. Not all
+-master devices in linux which register a VLAN are from type "vlan" and are
+-only registering a single VLAN.
+-
+-For example VLAN aware bridges can create multiple VLANs. These require
+-that the VLAN is identified using the VID and not the vlan device.
+-
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/4704c5e05af7a4f6a397d80ff80f2f2c56fe8f2c
+-
+-diff --git a/ap_isolation.c b/ap_isolation.c
+-index 71dcd00eac845d488c4969b17e1339f181c6c913..36fd4d607d03768251150951ebe450740501d446 100644
+---- a/ap_isolation.c
+-+++ b/ap_isolation.c
+-@@ -28,7 +28,7 @@ static int get_attrs_ap_isolation(struct nl_msg *msg, void *arg)
+- {
+- 	struct state *state = arg;
+- 
+--	if (state->vid >= 0)
+-+	if (state->selector == SP_VLAN)
+- 		nla_put_u16(msg, BATADV_ATTR_VLANID, state->vid);
+- 
+- 	return 0;
+-@@ -38,7 +38,7 @@ static int get_ap_isolation(struct state *state)
+- {
+- 	enum batadv_nl_commands nl_cmd = BATADV_CMD_SET_MESH;
+- 
+--	if (state->vid >= 0)
+-+	if (state->selector == SP_VLAN)
+- 		nl_cmd = BATADV_CMD_GET_VLAN;
+- 
+- 	return sys_simple_nlquery(state, nl_cmd, get_attrs_ap_isolation,
+-@@ -53,7 +53,7 @@ static int set_attrs_ap_isolation(struct nl_msg *msg, void *arg)
+- 
+- 	nla_put_u8(msg, BATADV_ATTR_AP_ISOLATION_ENABLED, data->val);
+- 
+--	if (state->vid >= 0)
+-+	if (state->selector == SP_VLAN)
+- 		nla_put_u16(msg, BATADV_ATTR_VLANID, state->vid);
+- 
+- 	return 0;
+-@@ -63,7 +63,7 @@ static int set_ap_isolation(struct state *state)
+- {
+- 	enum batadv_nl_commands nl_cmd = BATADV_CMD_SET_MESH;
+- 
+--	if (state->vid >= 0)
+-+	if (state->selector == SP_VLAN)
+- 		nl_cmd = BATADV_CMD_SET_VLAN;
+- 
+- 	return sys_simple_nlquery(state, nl_cmd, set_attrs_ap_isolation, NULL);
+-@@ -81,3 +81,8 @@ COMMAND_NAMED(SUBCOMMAND, ap_isolation, "ap", handle_sys_setting,
+- 	      COMMAND_FLAG_MESH_IFACE | COMMAND_FLAG_NETLINK,
+- 	      &batctl_settings_ap_isolation,
+- 	      "[0|1]             \tdisplay or modify ap_isolation setting");
+-+
+-+COMMAND_NAMED(SUBCOMMAND_VID, ap_isolation, "ap", handle_sys_setting,
+-+	      COMMAND_FLAG_MESH_IFACE | COMMAND_FLAG_NETLINK,
+-+	      &batctl_settings_ap_isolation,
+-+	      "[0|1]             \tdisplay or modify ap_isolation setting for vlan device or id");
+-diff --git a/functions.c b/functions.c
+-index aad6327a8f0fe6e512157e427d88dd0649acd052..61ea4879ebffbdadf8ef5bb12bb737c1ed7ff76f 100644
+---- a/functions.c
+-+++ b/functions.c
+-@@ -919,32 +919,44 @@ static int query_rtnl_link_single(int mesh_ifindex,
+- 	return 0;
+- }
+- 
+--int translate_mesh_iface(struct state *state)
+-+int translate_vlan_iface(struct state *state, const char *vlandev)
+- {
+- 	struct rtnl_link_iface_data link_data;
+- 	unsigned int arg_ifindex;
+- 
+--	arg_ifindex = if_nametoindex(state->arg_iface);
+-+	arg_ifindex = if_nametoindex(vlandev);
+- 	if (arg_ifindex == 0)
+--		goto fallback_meshif;
+-+		return -ENODEV;
+- 
+- 	query_rtnl_link_single(arg_ifindex, &link_data);
+- 	if (!link_data.vid_found)
+--		goto fallback_meshif;
+-+		return -ENODEV;
+- 
+- 	if (!link_data.link_found)
+--		goto fallback_meshif;
+-+		return -EINVAL;
+- 
+- 	if (!link_data.kind_found)
+--		goto fallback_meshif;
+-+		return -EINVAL;
+- 
+- 	if (strcmp(link_data.kind, "vlan") != 0)
+--		goto fallback_meshif;
+-+		return -EINVAL;
+- 
+- 	if (!if_indextoname(link_data.link, state->mesh_iface))
+--		goto fallback_meshif;
+-+		return -ENODEV;
+- 
+- 	state->vid = link_data.vid;
+-+	state->selector = SP_VLAN;
+-+
+-+	return 0;
+-+}
+-+
+-+int translate_mesh_iface_vlan(struct state *state, const char *vlandev)
+-+{
+-+	int ret;
+-+
+-+	ret = translate_vlan_iface(state, vlandev);
+-+	if (ret < 0)
+-+		goto fallback_meshif;
+- 
+- 	return 0;
+- 
+-@@ -952,9 +964,36 @@ int translate_mesh_iface(struct state *state)
+- 	/* if there is no vid then the argument must be the
+- 	 * mesh interface
+- 	 */
+--	snprintf(state->mesh_iface, sizeof(state->mesh_iface), "%s",
+--		 state->arg_iface);
+--	state->vid = -1;
+-+	snprintf(state->mesh_iface, sizeof(state->mesh_iface), "%s", vlandev);
+-+	state->selector = SP_NONE_OR_MESHIF;
+-+
+-+	return 0;
+-+}
+-+
+-+int translate_vid(struct state *state, const char *vidstr)
+-+{
+-+	unsigned long vid;
+-+	char *endptr;
+-+
+-+	if (vidstr[0] == '\0') {
+-+		fprintf(stderr, "Error - unparsable vid\n");
+-+		return -EINVAL;
+-+	}
+-+
+-+	vid = strtoul(vidstr, &endptr, 0);
+-+	if (!endptr || *endptr != '\0') {
+-+		fprintf(stderr, "Error - unparsable vid\n");
+-+		return -EINVAL;
+-+	}
+-+
+-+	if (vid > 4095) {
+-+		fprintf(stderr, "Error - too large vid (max 4095)\n");
+-+		return -ERANGE;
+-+	}
+-+
+-+	/* get mesh interface and overwrite vid afterwards */
+-+	state->vid = vid;
+-+	state->selector = SP_VLAN;
+- 
+- 	return 0;
+- }
+-diff --git a/functions.h b/functions.h
+-index d4a556879664eb5b4b11e6c638c22728db7a83a4..7474c40bbcdcb8fac8865def2e82514aede62b69 100644
+---- a/functions.h
+-+++ b/functions.h
+-@@ -50,7 +50,9 @@ struct ether_addr *translate_mac(const char *mesh_iface,
+- struct ether_addr *resolve_mac(const char *asc);
+- int query_rtnl_link(int ifindex, nl_recvmsg_msg_cb_t func, void *arg);
+- int netlink_simple_request(struct nl_msg *msg);
+--int translate_mesh_iface(struct state *state);
+-+int translate_mesh_iface_vlan(struct state *state, const char *vlandev);
+-+int translate_vlan_iface(struct state *state, const char *vlandev);
+-+int translate_vid(struct state *state, const char *vidstr);
+- int get_algoname(const char *mesh_iface, char *algoname, size_t algoname_len);
+- int check_mesh_iface(struct state *state);
+- int check_mesh_iface_ownership(struct state *state, char *hard_iface);
+-diff --git a/main.c b/main.c
+-index 278683c6080e3ff4a9f3225931d0c5eb44f89595..309087799b839848029bd5cbec60cbe1213f9190 100644
+---- a/main.c
+-+++ b/main.c
+-@@ -28,48 +28,75 @@ extern const struct command *__stop___command[];
+- 
+- static void print_usage(void)
+- {
+--	enum command_type type[] = {
+--		SUBCOMMAND,
+--		DEBUGTABLE,
+-+	struct {
+-+		const char *label;
+-+		uint32_t types;
+-+	} type[] = {
+-+		{
+-+			.label = "commands:\n",
+-+			.types = BIT(SUBCOMMAND) |
+-+				 BIT(SUBCOMMAND_VID),
+-+		},
+-+		{
+-+			.label = "debug tables:                                   \tdisplay the corresponding debug table\n",
+-+			.types = BIT(DEBUGTABLE),
+-+		},
+-+	};
+-+	const char *default_prefixes[] = {
+-+		"",
+-+		NULL,
+-+	};
+-+	const char *vlan_prefixes[] = {
+-+		"vlan <vdev> ",
+-+		"vid <vid> ",
+-+		NULL,
+- 	};
+- 	const struct command **p;
+--	char buf[32];
+-+	const char **prefixes;
+-+	const char **prefix;
+-+	char buf[64];
+- 	size_t i;
+- 
+- 	fprintf(stderr, "Usage: batctl [options] command|debug table [parameters]\n");
+- 	fprintf(stderr, "options:\n");
+--	fprintf(stderr, " \t-m mesh interface or VLAN created on top of a mesh interface (default 'bat0')\n");
+-+	fprintf(stderr, " \t-m mesh interface (default 'bat0')\n");
+- 	fprintf(stderr, " \t-h print this help (or 'batctl <command|debug table> -h' for the parameter help)\n");
+- 	fprintf(stderr, " \t-v print version\n");
+- 
+- 	for (i = 0; i < sizeof(type) / sizeof(*type); i++) {
+- 		fprintf(stderr, "\n");
+- 
+--		switch (type[i]) {
+--		case SUBCOMMAND:
+--			fprintf(stderr, "commands:\n");
+--			break;
+--		case DEBUGTABLE:
+--			fprintf(stderr, "debug tables:                                   \tdisplay the corresponding debug table\n");
+--			break;
+--		}
+-+		fprintf(stderr, "%s", type[i].label);
+- 
+- 		for (p = __start___command; p < __stop___command; p++) {
+- 			const struct command *cmd = *p;
+- 
+--			if (cmd->type != type[i])
+-+			if (!(BIT(cmd->type) & type[i].types))
+- 				continue;
+- 
+- 			if (!cmd->usage)
+- 				continue;
+- 
+--			if (strcmp(cmd->name, cmd->abbr) == 0)
+--				snprintf(buf, sizeof(buf), "%s", cmd->name);
+--			else
+--				snprintf(buf, sizeof(buf), "%s|%s", cmd->name,
+--					 cmd->abbr);
+-+			switch (cmd->type) {
+-+			case SUBCOMMAND_VID:
+-+				prefixes = vlan_prefixes;
+-+				break;
+-+			default:
+-+				prefixes = default_prefixes;
+-+				break;
+-+			}
+- 
+--			fprintf(stderr, " \t%-27s%s\n", buf, cmd->usage);
+-+			for (prefix = &prefixes[0]; *prefix; prefix++) {
+-+				if (strcmp(cmd->name, cmd->abbr) == 0)
+-+					snprintf(buf, sizeof(buf), "%s%s",
+-+						 *prefix, cmd->name);
+-+				else
+-+					snprintf(buf, sizeof(buf), "%s%s|%s",
+-+						 *prefix, cmd->name, cmd->abbr);
+-+
+-+				fprintf(stderr, " \t%-35s%s\n", buf,
+-+					cmd->usage);
+-+			}
+- 		}
+- 	}
+- }
+-@@ -93,13 +120,17 @@ static void version(void)
+- 	exit(EXIT_SUCCESS);
+- }
+- 
+--static const struct command *find_command(const char *name)
+-+static const struct command *find_command_by_types(uint32_t types,
+-+						   const char *name)
+- {
+- 	const struct command **p;
+- 
+- 	for (p = __start___command; p < __stop___command; p++) {
+- 		const struct command *cmd = *p;
+- 
+-+		if (!(BIT(cmd->type) & types))
+-+			continue;
+-+
+- 		if (strcmp(cmd->name, name) == 0)
+- 			return cmd;
+- 
+-@@ -110,13 +141,123 @@ static const struct command *find_command(const char *name)
+- 	return NULL;
+- }
+- 
+-+static const struct command *find_command(struct state *state, const char *name)
+-+{
+-+	uint32_t types;
+-+
+-+	switch (state->selector) {
+-+	case SP_NONE_OR_MESHIF:
+-+		types = BIT(SUBCOMMAND) |
+-+			BIT(DEBUGTABLE);
+-+		break;
+-+	case SP_VLAN:
+-+		types = BIT(SUBCOMMAND_VID);
+-+		break;
+-+	default:
+-+		return NULL;
+-+	}
+-+
+-+	return find_command_by_types(types, name);
+-+}
+-+
+-+static int detect_selector_prefix(int argc, char *argv[],
+-+				  enum selector_prefix *selector)
+-+{
+-+	/* not enough remaining arguments to detect anything */
+-+	if (argc < 2)
+-+		return -EINVAL;
+-+
+-+	/* only detect selector prefix which identifies meshif */
+-+	if (strcmp(argv[0], "vlan") == 0) {
+-+		*selector = SP_VLAN;
+-+		return 2;
+-+	}
+-+
+-+	return 0;
+-+}
+-+
+-+static int parse_meshif_args(struct state *state, int argc, char *argv[])
+-+{
+-+	enum selector_prefix selector;
+-+	int parsed_args;
+-+	char *dev_arg;
+-+	int ret;
+-+
+-+	parsed_args = detect_selector_prefix(argc, argv, &selector);
+-+	if (parsed_args < 1)
+-+		goto fallback_meshif_vlan;
+-+
+-+	dev_arg = argv[parsed_args - 1];
+-+
+-+	switch (selector) {
+-+	case SP_VLAN:
+-+		ret = translate_vlan_iface(state, dev_arg);
+-+		if (ret < 0) {
+-+			fprintf(stderr, "Error - invalid vlan device %s: %s\n",
+-+				dev_arg, strerror(-ret));
+-+			return ret;
+-+		}
+-+
+-+		return parsed_args;
+-+	case SP_NONE_OR_MESHIF:
+-+		/* not allowed - see detect_selector_prefix */
+-+		break;
+-+	}
+-+
+-+fallback_meshif_vlan:
+-+	/* parse vlan as part of -m parameter or mesh_dfl_iface */
+-+	translate_mesh_iface_vlan(state, state->arg_iface);
+-+	return 0;
+-+}
+-+
+-+static int parse_dev_args(struct state *state, int argc, char *argv[])
+-+{
+-+	int dev_arguments;
+-+	int ret;
+-+
+-+	/* try to parse selector prefix which can be used to identify meshif */
+-+	dev_arguments = parse_meshif_args(state, argc, argv);
+-+	if (dev_arguments < 0)
+-+		return dev_arguments;
+-+
+-+	/* try to parse secondary prefix selectors which cannot be used to
+-+	 * identify the meshif
+-+	 */
+-+	argv += dev_arguments;
+-+	argc -= dev_arguments;
+-+
+-+	switch (state->selector) {
+-+	case SP_NONE_OR_MESHIF:
+-+		/* continue below */
+-+		break;
+-+	default:
+-+		return dev_arguments;
+-+	}
+-+
+-+	/* enough room for additional selectors? */
+-+	if (argc < 2)
+-+		return dev_arguments;
+-+
+-+	if (strcmp(argv[0], "vid") == 0) {
+-+		ret = translate_vid(state, argv[1]);
+-+		if (ret < 0)
+-+			return ret;
+-+
+-+		return dev_arguments + 2;
+-+	}
+-+
+-+	return dev_arguments;
+-+}
+-+
+- int main(int argc, char **argv)
+- {
+- 	const struct command *cmd;
+- 	struct state state = {
+- 		.arg_iface = mesh_dfl_iface,
+-+		.selector = SP_NONE_OR_MESHIF,
+- 		.cmd = NULL,
+- 	};
+-+	int dev_arguments;
+- 	int opt;
+- 	int ret;
+- 
+-@@ -152,7 +293,20 @@ int main(int argc, char **argv)
+- 	argc -= optind;
+- 	optind = 0;
+- 
+--	cmd = find_command(argv[0]);
+-+	/* parse arguments to identify vlan, ... */
+-+	dev_arguments = parse_dev_args(&state, argc, argv);
+-+	if (dev_arguments < 0)
+-+		goto err;
+-+
+-+	argv += dev_arguments;
+-+	argc -= dev_arguments;
+-+
+-+	if (argc == 0) {
+-+		fprintf(stderr, "Error - no command specified\n");
+-+		goto err;
+-+	}
+-+
+-+	cmd = find_command(&state, argv[0]);
+- 	if (!cmd) {
+- 		fprintf(stderr,
+- 			"Error - no valid command or debug table specified: %s\n",
+-@@ -162,8 +316,6 @@ int main(int argc, char **argv)
+- 
+- 	state.cmd = cmd;
+- 
+--	translate_mesh_iface(&state);
+--
+- 	if (cmd->flags & COMMAND_FLAG_MESH_IFACE &&
+- 	    check_mesh_iface(&state) < 0) {
+- 		fprintf(stderr,
+-diff --git a/main.h b/main.h
+-index 1a4701513c49ad8974b9c9189619f5dde622acd4..efc277c5465942d7b4dba284d29f653273b42dce 100644
+---- a/main.h
+-+++ b/main.h
+-@@ -56,13 +56,20 @@ enum command_flags {
+- 	COMMAND_FLAG_INVERSE = BIT(2),
+- };
+- 
+-+enum selector_prefix {
+-+	SP_NONE_OR_MESHIF,
+-+	SP_VLAN,
+-+};
+-+
+- enum command_type {
+- 	SUBCOMMAND,
+-+	SUBCOMMAND_VID,
+- 	DEBUGTABLE,
+- };
+- 
+- struct state {
+- 	char *arg_iface;
+-+	enum selector_prefix selector;
+- 	char mesh_iface[IF_NAMESIZE];
+- 	unsigned int mesh_ifindex;
+- 	int vid;
+-@@ -84,7 +91,7 @@ struct command {
+- };
+- 
+- #define COMMAND_NAMED(_type, _name, _abbr, _handler, _flags, _arg, _usage) \
+--	static const struct command command_ ## _name = { \
+-+	static const struct command command_ ## _name ## _ ## _type = { \
+- 		.type = (_type), \
+- 		.name = (#_name), \
+- 		.abbr = _abbr, \
+-@@ -93,8 +100,8 @@ struct command {
+- 		.arg = (_arg), \
+- 		.usage = (_usage), \
+- 	}; \
+--	static const struct command *__command_ ## _name \
+--	__attribute__((__used__)) __attribute__ ((__section__ ("__command"))) = &command_ ## _name
+-+	static const struct command *__command_ ## _name ## _ ## _type \
+-+	__attribute__((__used__)) __attribute__ ((__section__ ("__command"))) = &command_ ## _name ## _ ## _type
+- 
+- #define COMMAND(_type, _handler, _abbr, _flags, _arg, _usage) \
+- 	COMMAND_NAMED(_type, _handler, _abbr, _handler, _flags, _arg, _usage)
+-diff --git a/man/batctl.8 b/man/batctl.8
+-index 0b430313075b5a7a4c796eba0867954e10061002..a5656cf9059bd82c1b85928c22e30d01c56e475f 100644
+---- a/man/batctl.8
+-+++ b/man/batctl.8
+-@@ -46,7 +46,7 @@ performances, is also included.
+- .SH OPTIONS
+- .TP
+- .I \fBoptions:
+--\-m     specify mesh interface or VLAN created on top of a mesh interface (default 'bat0')
+-+\-m     specify mesh interface (default 'bat0')
+- .br
+- \-h     print general batctl help
+- .br
+-@@ -70,7 +70,11 @@ originator interval. The interval is in units of milliseconds.
+- .br
+- .IP "\fBap_isolation\fP|\fBap\fP [\fB0\fP|\fB1\fP]"
+- If no parameter is given the current ap isolation setting is displayed. Otherwise the parameter is used to enable or
+--disable ap isolation. This command can be used in conjunction with "\-m" option to target per VLAN configurations.
+-+disable ap isolation.
+-+.br
+-+.IP "<\fBvlan <vdev>\fP|\fBvid <vid>\fP> \fBap_isolation\fP|\fBap\fP [\fB0\fP|\fB1\fP]"
+-+If no parameter is given the current ap isolation setting for the specified VLAN is displayed. Otherwise the parameter is used to enable or
+-+disable ap isolation for the specified VLAN.
+- .br
+- .IP "\fBbridge_loop_avoidance\fP|\fBbl\fP [\fB0\fP|\fB1\fP]"
+- If no parameter is given the current bridge loop avoidance setting is displayed. Otherwise the parameter is used to enable
+-diff --git a/sys.c b/sys.c
+-index 39123db87d391b8898b7454eba7708515bfb3c78..61a314d88010ef34507ec9dd6a77b53f318f63a8 100644
+---- a/sys.c
+-+++ b/sys.c
+-@@ -141,9 +141,35 @@ int sys_simple_print_boolean(struct nl_msg *msg, void *arg,
+- 
+- static void settings_usage(struct state *state)
+- {
+--	fprintf(stderr, "Usage: batctl [options] %s|%s [parameters] %s\n",
+--		state->cmd->name, state->cmd->abbr,
+--		state->cmd->usage ? state->cmd->usage : "");
+-+	const char *default_prefixes[] = {
+-+		"",
+-+		NULL,
+-+	};
+-+	const char *vlan_prefixes[] = {
+-+		"vlan <vdev> ",
+-+		"vid <vid> ",
+-+		NULL,
+-+	};
+-+	const char *linestart = "Usage:";
+-+	const char **prefixes;
+-+	const char **prefix;
+-+
+-+	switch (state->cmd->type) {
+-+	case SUBCOMMAND_VID:
+-+		prefixes = vlan_prefixes;
+-+		break;
+-+	default:
+-+		prefixes = default_prefixes;
+-+		break;
+-+	}
+-+
+-+	for (prefix = &prefixes[0]; *prefix; prefix++) {
+-+		fprintf(stderr, "%s batctl [options] %s%s|%s [parameters] %s\n",
+-+			linestart, *prefix, state->cmd->name, state->cmd->abbr,
+-+			state->cmd->usage ? state->cmd->usage : "");
+-+
+-+		linestart = "      ";
+-+	}
+- 
+- 	fprintf(stderr, "parameters:\n");
+- 	fprintf(stderr, " \t -h print this help\n");
+-@@ -233,15 +259,19 @@ int handle_sys_setting(struct state *state, int argc, char **argv)
+- 		return EXIT_FAILURE;
+- 	}
+- 
+--	/* if the specified interface is a VLAN then change the path to point
+--	 * to the proper "vlan%{vid}" subfolder in the sysfs tree.
+--	 */
+--	if (state->vid >= 0)
+--		snprintf(path_buff, PATH_BUFF_LEN, SYS_VLAN_PATH,
+--			 state->mesh_iface, state->vid);
+--	else
+-+	switch (state->selector) {
+-+	case SP_NONE_OR_MESHIF:
+- 		snprintf(path_buff, PATH_BUFF_LEN, SYS_BATIF_PATH_FMT,
+- 			 state->mesh_iface);
+-+		break;
+-+	case SP_VLAN:
+-+		/* if the specified interface is a VLAN then change the path to
+-+		 * point to the proper "vlan%{vid}" subfolder in the sysfs tree.
+-+		 */
+-+		snprintf(path_buff, PATH_BUFF_LEN, SYS_VLAN_PATH,
+-+			 state->mesh_iface, state->vid);
+-+		break;
+-+	}
+- 
+- 	if (argc == 1) {
+- 		res = sys_read_setting(state, path_buff, settings->sysfs_name);
+diff --git a/batctl/patches/0002-batctl-Integrate-hardif-setting-framework.patch b/batctl/patches/0002-batctl-Integrate-hardif-setting-framework.patch
+deleted file mode 100644
+index 21f6e94f199b23336271d608ac1080ce5a2c884c..0000000000000000000000000000000000000000
+--- a/batctl/patches/0002-batctl-Integrate-hardif-setting-framework.patch
++++ /dev/null
+@@ -1,222 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Tue, 9 Jul 2019 19:26:47 +0200
+-Subject: batctl: Integrate hardif setting framework
+-
+-batctl currently supports settings which are either mesh interface or vlan
+-specific. But B.A.T.M.A.N. V introduced two additional settings which are
+-hard (slave) interface specific.
+-
+-To support these, an additional command prefix called hardif is implemented
+-for some sysfs commands:
+-
+-  $ batctl hardif eth0 ...
+-
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/6ed4dfc5459fd3b9ed221308075db592e538c92f
+-
+-diff --git a/functions.c b/functions.c
+-index 61ea4879ebffbdadf8ef5bb12bb737c1ed7ff76f..4ffa86ca7830dea3ed2599656831b56f6fec9e33 100644
+---- a/functions.c
+-+++ b/functions.c
+-@@ -998,6 +998,28 @@ int translate_vid(struct state *state, const char *vidstr)
+- 	return 0;
+- }
+- 
+-+int translate_hard_iface(struct state *state, const char *hardif)
+-+{
+-+	struct rtnl_link_iface_data link_data;
+-+	unsigned int arg_ifindex;
+-+
+-+	arg_ifindex = if_nametoindex(hardif);
+-+	if (arg_ifindex == 0)
+-+		return -ENODEV;
+-+
+-+	query_rtnl_link_single(arg_ifindex, &link_data);
+-+	if (!link_data.master_found)
+-+		return -ENOLINK;
+-+
+-+	if (!if_indextoname(link_data.master, state->mesh_iface))
+-+		return -ENOLINK;
+-+
+-+	state->hif = arg_ifindex;
+-+	state->selector = SP_HARDIF;
+-+
+-+	return 0;
+-+}
+-+
+- static int check_mesh_iface_netlink(struct state *state)
+- {
+- 	struct rtnl_link_iface_data link_data;
+-diff --git a/functions.h b/functions.h
+-index 7474c40bbcdcb8fac8865def2e82514aede62b69..0a08870cee651ee676e67d3e55677c53f59e41c4 100644
+---- a/functions.h
+-+++ b/functions.h
+-@@ -53,6 +53,7 @@ int netlink_simple_request(struct nl_msg *msg);
+- int translate_mesh_iface_vlan(struct state *state, const char *vlandev);
+- int translate_vlan_iface(struct state *state, const char *vlandev);
+- int translate_vid(struct state *state, const char *vidstr);
+-+int translate_hard_iface(struct state *state, const char *hardif);
+- int get_algoname(const char *mesh_iface, char *algoname, size_t algoname_len);
+- int check_mesh_iface(struct state *state);
+- int check_mesh_iface_ownership(struct state *state, char *hard_iface);
+-diff --git a/main.c b/main.c
+-index 309087799b839848029bd5cbec60cbe1213f9190..3b3a16f4c1caffdd2be897e6bf2a00564e5580f8 100644
+---- a/main.c
+-+++ b/main.c
+-@@ -35,7 +35,8 @@ static void print_usage(void)
+- 		{
+- 			.label = "commands:\n",
+- 			.types = BIT(SUBCOMMAND) |
+--				 BIT(SUBCOMMAND_VID),
+-+				 BIT(SUBCOMMAND_VID) |
+-+				 BIT(SUBCOMMAND_HIF),
+- 		},
+- 		{
+- 			.label = "debug tables:                                   \tdisplay the corresponding debug table\n",
+-@@ -51,6 +52,10 @@ static void print_usage(void)
+- 		"vid <vid> ",
+- 		NULL,
+- 	};
+-+	const char *hardif_prefixes[] = {
+-+		"hardif <netdev> ",
+-+		NULL,
+-+	};
+- 	const struct command **p;
+- 	const char **prefixes;
+- 	const char **prefix;
+-@@ -81,6 +86,9 @@ static void print_usage(void)
+- 			case SUBCOMMAND_VID:
+- 				prefixes = vlan_prefixes;
+- 				break;
+-+			case SUBCOMMAND_HIF:
+-+				prefixes = hardif_prefixes;
+-+				break;
+- 			default:
+- 				prefixes = default_prefixes;
+- 				break;
+-@@ -153,6 +161,9 @@ static const struct command *find_command(struct state *state, const char *name)
+- 	case SP_VLAN:
+- 		types = BIT(SUBCOMMAND_VID);
+- 		break;
+-+	case SP_HARDIF:
+-+		types = BIT(SUBCOMMAND_HIF);
+-+		break;
+- 	default:
+- 		return NULL;
+- 	}
+-@@ -171,6 +182,9 @@ static int detect_selector_prefix(int argc, char *argv[],
+- 	if (strcmp(argv[0], "vlan") == 0) {
+- 		*selector = SP_VLAN;
+- 		return 2;
+-+	} else if (strcmp(argv[0], "hardif") == 0) {
+-+		*selector = SP_HARDIF;
+-+		return 2;
+- 	}
+- 
+- 	return 0;
+-@@ -197,7 +211,17 @@ static int parse_meshif_args(struct state *state, int argc, char *argv[])
+- 				dev_arg, strerror(-ret));
+- 			return ret;
+- 		}
+-+		return parsed_args;
+-+	case SP_HARDIF:
+-+		ret = translate_hard_iface(state, dev_arg);
+-+		if (ret < 0) {
+-+			fprintf(stderr, "Error - invalid hardif %s: %s\n",
+-+				dev_arg, strerror(-ret));
+-+			return ret;
+-+		}
+- 
+-+		snprintf(state->hard_iface, sizeof(state->hard_iface), "%s",
+-+			 dev_arg);
+- 		return parsed_args;
+- 	case SP_NONE_OR_MESHIF:
+- 		/* not allowed - see detect_selector_prefix */
+-diff --git a/main.h b/main.h
+-index efc277c5465942d7b4dba284d29f653273b42dce..a97b26fe7b969e01cbdb848e58824e36e3d236ab 100644
+---- a/main.h
+-+++ b/main.h
+-@@ -59,11 +59,13 @@ enum command_flags {
+- enum selector_prefix {
+- 	SP_NONE_OR_MESHIF,
+- 	SP_VLAN,
+-+	SP_HARDIF,
+- };
+- 
+- enum command_type {
+- 	SUBCOMMAND,
+- 	SUBCOMMAND_VID,
+-+	SUBCOMMAND_HIF,
+- 	DEBUGTABLE,
+- };
+- 
+-@@ -72,7 +74,11 @@ struct state {
+- 	enum selector_prefix selector;
+- 	char mesh_iface[IF_NAMESIZE];
+- 	unsigned int mesh_ifindex;
+--	int vid;
+-+	char hard_iface[IF_NAMESIZE];
+-+	union {
+-+		unsigned int hif;
+-+		int vid;
+-+	};
+- 	const struct command *cmd;
+- 
+- 	struct nl_sock *sock;
+-diff --git a/sys.c b/sys.c
+-index 61a314d88010ef34507ec9dd6a77b53f318f63a8..b9555ee484f89c1022c0b4e74e18154d18b7af6b 100644
+---- a/sys.c
+-+++ b/sys.c
+-@@ -150,6 +150,10 @@ static void settings_usage(struct state *state)
+- 		"vid <vid> ",
+- 		NULL,
+- 	};
+-+	const char *hardif_prefixes[] = {
+-+		"hardif <netdev> ",
+-+		NULL,
+-+	};
+- 	const char *linestart = "Usage:";
+- 	const char **prefixes;
+- 	const char **prefix;
+-@@ -158,6 +162,9 @@ static void settings_usage(struct state *state)
+- 	case SUBCOMMAND_VID:
+- 		prefixes = vlan_prefixes;
+- 		break;
+-+	case SUBCOMMAND_HIF:
+-+		prefixes = hardif_prefixes;
+-+		break;
+- 	default:
+- 		prefixes = default_prefixes;
+- 		break;
+-@@ -271,6 +278,14 @@ int handle_sys_setting(struct state *state, int argc, char **argv)
+- 		snprintf(path_buff, PATH_BUFF_LEN, SYS_VLAN_PATH,
+- 			 state->mesh_iface, state->vid);
+- 		break;
+-+	case SP_HARDIF:
+-+		/* if a hard interface was specified then change the path to
+-+		 * point to the proper ${hardif}/batman-adv path in the sysfs
+-+		 * tree.
+-+		 */
+-+		snprintf(path_buff, PATH_BUFF_LEN, SYS_HARDIF_PATH,
+-+			 state->hard_iface);
+-+		break;
+- 	}
+- 
+- 	if (argc == 1) {
+-diff --git a/sys.h b/sys.h
+-index d4f2fcf542bc66b2b1c6ec55a9ac16e10fdc5cac..b6f0f9043a9af8e3c4d4f8bf7e4af4cab0aa5df9 100644
+---- a/sys.h
+-+++ b/sys.h
+-@@ -21,8 +21,9 @@
+- #define SYS_BATIF_PATH_FMT	"/sys/class/net/%s/mesh/"
+- #define SYS_IFACE_PATH		"/sys/class/net"
+- #define SYS_IFACE_DIR		SYS_IFACE_PATH"/%s/"
+--#define SYS_MESH_IFACE_FMT	SYS_IFACE_PATH"/%s/batman_adv/mesh_iface"
+--#define SYS_IFACE_STATUS_FMT	SYS_IFACE_PATH"/%s/batman_adv/iface_status"
+-+#define SYS_HARDIF_PATH		SYS_IFACE_DIR "batman_adv/"
+-+#define SYS_MESH_IFACE_FMT	SYS_HARDIF_PATH "mesh_iface"
+-+#define SYS_IFACE_STATUS_FMT	SYS_HARDIF_PATH "iface_status"
+- #define SYS_VLAN_PATH		SYS_IFACE_PATH"/%s/mesh/vlan%d/"
+- #define SYS_ROUTING_ALGO_FMT	SYS_IFACE_PATH"/%s/mesh/routing_algo"
+- #define VLAN_ID_MAX_LEN		4
+diff --git a/batctl/patches/0003-batctl-Add-elp_interval-setting-command.patch b/batctl/patches/0003-batctl-Add-elp_interval-setting-command.patch
+deleted file mode 100644
+index 4bb6fc664a15000a75d9e3d0d62d5f0b07b8ac59..0000000000000000000000000000000000000000
+--- a/batctl/patches/0003-batctl-Add-elp_interval-setting-command.patch
++++ /dev/null
+@@ -1,183 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Tue, 9 Jul 2019 19:26:48 +0200
+-Subject: batctl: Add elp_interval setting command
+-
+-B.A.T.M.A.N. V introduced a hard interface specific setting called
+-elp_interval. It defines the interval in milliseconds in which batman-adv
+-emits probing packets for neighbor sensing (ELP).
+-
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/df5c452a446951c5f2fde265d08f3c2809ac2334
+-
+-diff --git a/Makefile b/Makefile
+-index b7bd545e92963c62128efe60c0dc401bdd9fa023..f071da20f866bff6c162d697d2e43fa9d68ee08d 100755
+---- a/Makefile
+-+++ b/Makefile
+-@@ -45,6 +45,7 @@ $(eval $(call add_command,bridge_loop_avoidance,y))
+- $(eval $(call add_command,claimtable,y))
+- $(eval $(call add_command,dat_cache,y))
+- $(eval $(call add_command,distributed_arp_table,y))
+-+$(eval $(call add_command,elp_interval,y))
+- $(eval $(call add_command,event,y))
+- $(eval $(call add_command,fragmentation,y))
+- $(eval $(call add_command,gateways,y))
+-diff --git a/README.rst b/README.rst
+-index bc54412bc77dae1889d4f05298c34efc1966776b..92983aa6030e2a890283bca448b9203cd4d56b51 100644
+---- a/README.rst
+-+++ b/README.rst
+-@@ -386,6 +386,22 @@ Example::
+-   1000
+- 
+- 
+-+batctl elp interval
+-+===================
+-+
+-+display or modify the elp interval in ms for hard interface
+-+
+-+Usage::
+-+
+-+  batctl hardif $hardif elp_interval|et [interval]
+-+
+-+Example::
+-+
+-+  $ batctl hardif eth0 elp_interval 200
+-+  $ batctl hardif eth0 elp_interval
+-+  200
+-+
+-+
+- batctl loglevel
+- ===============
+- 
+-diff --git a/elp_interval.c b/elp_interval.c
+-new file mode 100644
+-index 0000000000000000000000000000000000000000..0a5e98923a622f52e523696b1ec1bfb856eeca9f
+---- /dev/null
+-+++ b/elp_interval.c
+-@@ -0,0 +1,111 @@
+-+// SPDX-License-Identifier: GPL-2.0
+-+/* Copyright (C) 2009-2019  B.A.T.M.A.N. contributors:
+-+ *
+-+ * Marek Lindner <mareklindner@neomailbox.ch>
+-+ *
+-+ * License-Filename: LICENSES/preferred/GPL-2.0
+-+ */
+-+
+-+#include <errno.h>
+-+#include <stddef.h>
+-+#include <stdint.h>
+-+#include <string.h>
+-+
+-+#include "main.h"
+-+#include "sys.h"
+-+
+-+static struct elp_interval_data {
+-+	uint32_t elp_interval;
+-+} elp_interval;
+-+
+-+static int parse_elp_interval(struct state *state, int argc, char *argv[])
+-+{
+-+	struct settings_data *settings = state->cmd->arg;
+-+	struct elp_interval_data *data = settings->data;
+-+	char *endptr;
+-+
+-+	if (argc != 2) {
+-+		fprintf(stderr, "Error - incorrect number of arguments (expected 1)\n");
+-+		return -EINVAL;
+-+	}
+-+
+-+	data->elp_interval = strtoul(argv[1], &endptr, 0);
+-+	if (!endptr || *endptr != '\0') {
+-+		fprintf(stderr, "Error - the supplied argument is invalid: %s\n", argv[1]);
+-+		return -EINVAL;
+-+	}
+-+
+-+	return 0;
+-+}
+-+
+-+static int print_elp_interval(struct nl_msg *msg, void *arg)
+-+{
+-+	struct nlattr *attrs[BATADV_ATTR_MAX + 1];
+-+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+-+	struct genlmsghdr *ghdr;
+-+	int *result = arg;
+-+
+-+	if (!genlmsg_valid_hdr(nlh, 0))
+-+		return NL_OK;
+-+
+-+	ghdr = nlmsg_data(nlh);
+-+
+-+	if (nla_parse(attrs, BATADV_ATTR_MAX, genlmsg_attrdata(ghdr, 0),
+-+		      genlmsg_len(ghdr), batadv_netlink_policy)) {
+-+		return NL_OK;
+-+	}
+-+
+-+	if (!attrs[BATADV_ATTR_ELP_INTERVAL])
+-+		return NL_OK;
+-+
+-+	printf("%u\n", nla_get_u32(attrs[BATADV_ATTR_ELP_INTERVAL]));
+-+
+-+	*result = 0;
+-+	return NL_STOP;
+-+}
+-+
+-+static int get_attrs_elp_interval(struct nl_msg *msg, void *arg)
+-+{
+-+	struct state *state = arg;
+-+
+-+	nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX, state->hif);
+-+
+-+	return 0;
+-+}
+-+
+-+static int get_elp_interval(struct state *state)
+-+{
+-+	return sys_simple_nlquery(state, BATADV_CMD_GET_HARDIF,
+-+				  get_attrs_elp_interval, print_elp_interval);
+-+}
+-+
+-+static int set_attrs_elp_interval(struct nl_msg *msg, void *arg)
+-+{
+-+	struct state *state = arg;
+-+	struct settings_data *settings = state->cmd->arg;
+-+	struct elp_interval_data *data = settings->data;
+-+
+-+	nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX, state->hif);
+-+	nla_put_u32(msg, BATADV_ATTR_ELP_INTERVAL, data->elp_interval);
+-+
+-+	return 0;
+-+}
+-+
+-+static int set_elp_interval(struct state *state)
+-+{
+-+	return sys_simple_nlquery(state, BATADV_CMD_SET_HARDIF,
+-+				  set_attrs_elp_interval, NULL);
+-+}
+-+
+-+static struct settings_data batctl_settings_elp_interval = {
+-+	.sysfs_name = "elp_interval",
+-+	.data = &elp_interval,
+-+	.parse = parse_elp_interval,
+-+	.netlink_get = get_elp_interval,
+-+	.netlink_set = set_elp_interval,
+-+};
+-+
+-+COMMAND_NAMED(SUBCOMMAND_HIF, elp_interval, "et", handle_sys_setting,
+-+	      COMMAND_FLAG_MESH_IFACE | COMMAND_FLAG_NETLINK,
+-+	      &batctl_settings_elp_interval,
+-+	      "[interval]        \tdisplay or modify elp_interval setting");
+-diff --git a/man/batctl.8 b/man/batctl.8
+-index a5656cf9059bd82c1b85928c22e30d01c56e475f..eef7cd8f1246b83f03627cf307471abcade87cfc 100644
+---- a/man/batctl.8
+-+++ b/man/batctl.8
+-@@ -97,6 +97,10 @@ the bonding mode.
+- batctl will monitor for events from the netlink kernel interface of batman-adv. The local timestamp of the event will be printed
+- when parameter \fB\-t\fP is specified. Parameter \fB\-r\fP will do the same but with relative timestamps.
+- .br
+-+.IP "\fBhardif <hardif>\fP \fBelp_interval\fP|\fBet\fP [\fBinterval\fP]"
+-+If no parameter is given the current ELP interval setting of the hard interface is displayed otherwise the parameter is used to set the
+-+ELP interval. The interval is in units of milliseconds.
+-+.br
+- .IP "\fBfragmentation\fP|\fBf\fP [\fB0\fP|\fB1\fP]"
+- If no parameter is given the current fragmentation mode setting is displayed. Otherwise the parameter is used to enable or
+- disable fragmentation.
+diff --git a/batctl/patches/0004-batctl-Add-throughput_override-setting-command.patch b/batctl/patches/0004-batctl-Add-throughput_override-setting-command.patch
+deleted file mode 100644
+index 28dbb5381ec2ca30132f6cd4acc2b053b52a2eb5..0000000000000000000000000000000000000000
+--- a/batctl/patches/0004-batctl-Add-throughput_override-setting-command.patch
++++ /dev/null
+@@ -1,189 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Tue, 9 Jul 2019 19:26:49 +0200
+-Subject: batctl: Add throughput_override setting command
+-
+-B.A.T.M.A.N. V introduced a hard interface specific setting called
+-throughput. It defines the throughput value to be used by B.A.T.M.A.N. V
+-when estimating the link throughput using this interface. If the value is
+-set to 0 then batman-adv will try to estimate the throughput by itself.
+-
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/e5e6560df82813a9aad4a6c958be4d8ea012e909
+-
+-diff --git a/Makefile b/Makefile
+-index f071da20f866bff6c162d697d2e43fa9d68ee08d..e3747a2a28eb34323e34a1e22f5507dd1d7cd0f6 100755
+---- a/Makefile
+-+++ b/Makefile
+-@@ -67,6 +67,7 @@ $(eval $(call add_command,ping,y))
+- $(eval $(call add_command,routing_algo,y))
+- $(eval $(call add_command,statistics,y))
+- $(eval $(call add_command,tcpdump,y))
+-+$(eval $(call add_command,throughput_override,y))
+- $(eval $(call add_command,throughputmeter,y))
+- $(eval $(call add_command,traceroute,y))
+- $(eval $(call add_command,transglobal,y))
+-diff --git a/README.rst b/README.rst
+-index 92983aa6030e2a890283bca448b9203cd4d56b51..128f539852fa085d023fb6d26ae436e76b617bb6 100644
+---- a/README.rst
+-+++ b/README.rst
+-@@ -402,6 +402,23 @@ Example::
+-   200
+- 
+- 
+-+batctl throughput override
+-+==========================
+-+
+-+display or modify the throughput override in kbit/s for hard interface
+-+
+-+Usage::
+-+
+-+  batctl hardif $hardif throughput_override|to [kbit]
+-+
+-+Example::
+-+
+-+  $ batctl hardif eth0 throughput_override 15000
+-+  $ batctl hardif eth0 throughput_override 15mbit
+-+  $ batctl hardif eth0 throughput_override
+-+  15.0 MBit
+-+
+-+
+- batctl loglevel
+- ===============
+- 
+-diff --git a/man/batctl.8 b/man/batctl.8
+-index eef7cd8f1246b83f03627cf307471abcade87cfc..d42b6825dd3172009369e370e45ed6e7a9bf9d0d 100644
+---- a/man/batctl.8
+-+++ b/man/batctl.8
+-@@ -207,6 +207,12 @@ supported routing algorithms are displayed.
+- Otherwise the parameter is used to select the routing algorithm for the following
+- batX interface to be created.
+- .br
+-+.IP "\fBhardif <hardif>\fP \fBthroughput_override|to\fP [\fBbandwidth\fP]\fP"
+-+If no parameter is given the current througput override is displayed otherwise
+-+the parameter is used to set the throughput override for the specified hard
+-+interface.
+-+Just enter any number (optionally followed by "kbit" or "mbit").
+-+.br
+- .IP "\fBisolation_mark\fP|\fBmark\fP"
+- If no parameter is given the current isolation mark value is displayed.
+- Otherwise the parameter is used to set or unset the isolation mark used by the
+-diff --git a/throughput_override.c b/throughput_override.c
+-new file mode 100644
+-index 0000000000000000000000000000000000000000..28a6588b9417cca213ebde3545a3eb425592ad89
+---- /dev/null
+-+++ b/throughput_override.c
+-@@ -0,0 +1,113 @@
+-+// SPDX-License-Identifier: GPL-2.0
+-+/* Copyright (C) 2009-2019  B.A.T.M.A.N. contributors:
+-+ *
+-+ * Marek Lindner <mareklindner@neomailbox.ch>
+-+ *
+-+ * License-Filename: LICENSES/preferred/GPL-2.0
+-+ */
+-+
+-+#include <errno.h>
+-+#include <stddef.h>
+-+#include <stdint.h>
+-+#include <string.h>
+-+
+-+#include "functions.h"
+-+#include "main.h"
+-+#include "sys.h"
+-+
+-+static struct throughput_override_data {
+-+	uint32_t throughput_override;
+-+} throughput_override;
+-+
+-+static int parse_throughput_override(struct state *state, int argc, char *argv[])
+-+{
+-+	struct settings_data *settings = state->cmd->arg;
+-+	struct throughput_override_data *data = settings->data;
+-+	bool ret;
+-+
+-+	if (argc != 2) {
+-+		fprintf(stderr, "Error - incorrect number of arguments (expected 1)\n");
+-+		return -EINVAL;
+-+	}
+-+
+-+	ret = parse_throughput(argv[1], "throughput override",
+-+				&data->throughput_override);
+-+	if (!ret)
+-+		return -EINVAL;
+-+
+-+	return 0;
+-+}
+-+
+-+static int print_throughput_override(struct nl_msg *msg, void *arg)
+-+{
+-+	struct nlattr *attrs[BATADV_ATTR_MAX + 1];
+-+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+-+	struct genlmsghdr *ghdr;
+-+	int *result = arg;
+-+	uint32_t mbit;
+-+
+-+	if (!genlmsg_valid_hdr(nlh, 0))
+-+		return NL_OK;
+-+
+-+	ghdr = nlmsg_data(nlh);
+-+
+-+	if (nla_parse(attrs, BATADV_ATTR_MAX, genlmsg_attrdata(ghdr, 0),
+-+		      genlmsg_len(ghdr), batadv_netlink_policy)) {
+-+		return NL_OK;
+-+	}
+-+
+-+	if (!attrs[BATADV_ATTR_THROUGHPUT_OVERRIDE])
+-+		return NL_OK;
+-+
+-+	mbit = nla_get_u32(attrs[BATADV_ATTR_THROUGHPUT_OVERRIDE]);
+-+	printf("%u.%u MBit\n", mbit / 10, mbit % 10);
+-+
+-+	*result = 0;
+-+	return NL_STOP;
+-+}
+-+
+-+static int get_attrs_elp_isolation(struct nl_msg *msg, void *arg)
+-+{
+-+	struct state *state = arg;
+-+
+-+	nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX, state->hif);
+-+
+-+	return 0;
+-+}
+-+
+-+static int get_throughput_override(struct state *state)
+-+{
+-+	return sys_simple_nlquery(state, BATADV_CMD_GET_HARDIF,
+-+				  get_attrs_elp_isolation, print_throughput_override);
+-+}
+-+
+-+static int set_attrs_throughput_override(struct nl_msg *msg, void *arg)
+-+{
+-+	struct state *state = arg;
+-+	struct settings_data *settings = state->cmd->arg;
+-+	struct throughput_override_data *data = settings->data;
+-+
+-+	nla_put_u32(msg, BATADV_ATTR_HARD_IFINDEX, state->hif);
+-+	nla_put_u32(msg, BATADV_ATTR_THROUGHPUT_OVERRIDE, data->throughput_override);
+-+
+-+	return 0;
+-+}
+-+
+-+static int set_throughput_override(struct state *state)
+-+{
+-+	return sys_simple_nlquery(state, BATADV_CMD_SET_HARDIF,
+-+				  set_attrs_throughput_override, NULL);
+-+}
+-+
+-+static struct settings_data batctl_settings_throughput_override = {
+-+	.sysfs_name = "throughput_override",
+-+	.data = &throughput_override,
+-+	.parse = parse_throughput_override,
+-+	.netlink_get = get_throughput_override,
+-+	.netlink_set = set_throughput_override,
+-+};
+-+
+-+COMMAND_NAMED(SUBCOMMAND_HIF, throughput_override, "to", handle_sys_setting,
+-+	      COMMAND_FLAG_MESH_IFACE | COMMAND_FLAG_NETLINK,
+-+	      &batctl_settings_throughput_override,
+-+	      "[mbit]        \tdisplay or modify throughput_override setting");
+diff --git a/batctl/patches/0005-batctl-Prefer-netlink-hardif-status-retrieval-over-s.patch b/batctl/patches/0005-batctl-Prefer-netlink-hardif-status-retrieval-over-s.patch
+deleted file mode 100644
+index 87262449b0771d445d41fe3562a23261d9793b26..0000000000000000000000000000000000000000
+--- a/batctl/patches/0005-batctl-Prefer-netlink-hardif-status-retrieval-over-s.patch
++++ /dev/null
+@@ -1,90 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Wed, 19 Jun 2019 09:37:50 +0200
+-Subject: batctl: Prefer netlink hardif status retrieval over sysfs
+-
+-The sysfs code in batman-adv was changed to print a deprecated warning when
+-sysfs files are accessed. The `batctl if` call would therefore cause
+-warnings like this in the kernel log:
+-
+-  batman_adv: [Deprecated]: batctl (pid 18540) Use of sysfs file "iface_status".
+-  Use batadv genl family instead
+-
+-It is now appropriate to try the generic netlink BATADV_CMD_GET_HARDIF
+-request first to get the status of the interface before falling back to
+-sysfs.
+-
+-Reported-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/ce5f0efb35bff8a80992df63876bcac1d4a94867
+-
+-diff --git a/interface.c b/interface.c
+-index 5ff25a7b790d68aa69155f0cc7661080145ac86e..0a694c9f41f71a3dd72ae87b79b28434f7e8918f 100644
+---- a/interface.c
+-+++ b/interface.c
+-@@ -67,18 +67,18 @@ static int get_iface_status_netlink_parse(struct nl_msg *msg, void *arg)
+- static char *get_iface_status_netlink(unsigned int meshif, unsigned int hardif,
+- 				      char *iface_status)
+- {
+-+	char *ret_status = NULL;
+- 	struct nl_sock *sock;
+- 	struct nl_msg *msg;
+- 	int batadv_family;
+- 	struct nl_cb *cb;
+- 	int ret;
+- 
+--	strncpy(iface_status, "<error reading status>\n", IFACE_STATUS_LEN);
+--	iface_status[IFACE_STATUS_LEN - 1] = '\0';
+-+	iface_status[0] = '\0';
+- 
+- 	sock = nl_socket_alloc();
+- 	if (!sock)
+--		return iface_status;
+-+		return NULL;
+- 
+- 	ret = genl_connect(sock);
+- 	if (ret < 0)
+-@@ -111,6 +111,9 @@ static char *get_iface_status_netlink(unsigned int meshif, unsigned int hardif,
+- 
+- 	nl_recvmsgs(sock, cb);
+- 
+-+	if (strlen(iface_status) > 0)
+-+		ret_status = iface_status;
+-+
+- err_free_msg:
+- 	nlmsg_free(msg);
+- err_free_cb:
+-@@ -118,7 +121,7 @@ static char *get_iface_status_netlink(unsigned int meshif, unsigned int hardif,
+- err_free_sock:
+- 	nl_socket_free(sock);
+- 
+--	return iface_status;
+-+	return ret_status;
+- }
+- 
+- static struct nla_policy link_policy[IFLA_MAX + 1] = {
+-@@ -161,13 +164,17 @@ static int print_interfaces_rtnl_parse(struct nl_msg *msg, void *arg)
+- 	if (master != print_arg->ifindex)
+- 		goto err;
+- 
+--	snprintf(path_buff, sizeof(path_buff), SYS_IFACE_STATUS_FMT, ifname);
+--	ret = read_file("", path_buff, USE_READ_BUFF | SILENCE_ERRORS, 0, 0, 0);
+--	if (ret != EXIT_SUCCESS)
+--		status = get_iface_status_netlink(master, ifm->ifi_index,
+--						  iface_status);
+--	else
+--		status = line_ptr;
+-+	status = get_iface_status_netlink(master, ifm->ifi_index, iface_status);
+-+	if (!status) {
+-+		snprintf(path_buff, sizeof(path_buff), SYS_IFACE_STATUS_FMT,
+-+			 ifname);
+-+		ret = read_file("", path_buff, USE_READ_BUFF | SILENCE_ERRORS,
+-+				0, 0, 0);
+-+		if (ret != EXIT_SUCCESS)
+-+			status = "<error reading status>\n";
+-+		else
+-+			status = line_ptr;
+-+	}
+- 
+- 	printf("%s: %s", ifname, status);
+- 
+diff --git a/batctl/patches/0006-batctl-Return-EXIT_FAILURE-when-throughputmeter-fail.patch b/batctl/patches/0006-batctl-Return-EXIT_FAILURE-when-throughputmeter-fail.patch
+deleted file mode 100644
+index fc7131dd9fb39634be7138b3250d9482322998a8..0000000000000000000000000000000000000000
+--- a/batctl/patches/0006-batctl-Return-EXIT_FAILURE-when-throughputmeter-fail.patch
++++ /dev/null
+@@ -1,37 +0,0 @@
+-From: Leonardo Mörlein <me@irrelefant.net>
+-Date: Wed, 8 Apr 2020 23:49:03 +0200
+-Subject: batctl: Return EXIT_FAILURE when throughputmeter failed
+-
+-The command returned a success even an error was shown during the
+-execution.
+-
+-  $ (sudo batctl tp 77:77:77:77:77:77 && echo true) || echo false
+-  Destination unreachable
+-  true
+-
+-Instead it should indicate a failure when the kernel replied with a
+-non-success return_value:
+-
+-  $ (sudo ./batctl tp 77:77:77:77:77:77 && echo true) || echo false
+-  Destination unreachable
+-  false
+-
+-Fixes: f109b3473f86 ("batctl: introduce throughput meter support")
+-Signed-off-by: Leonardo Mörlein <me@irrelefant.net>
+-[sven@narfation.org: adjusted commit message]
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/df8bf5164b6904f61ae0b0db090fb5bb41b4f06d
+-
+-diff --git a/throughputmeter.c b/throughputmeter.c
+-index f9d98cfcac86d7a9398e2adddd143924b38e50b0..f19d4891981c99b7b9f3fae39c8d59f549243d0a 100644
+---- a/throughputmeter.c
+-+++ b/throughputmeter.c
+-@@ -465,6 +465,7 @@ static int throughputmeter(struct state *state, int argc, char **argv)
+- 		goto out;
+- 	}
+- 
+-+	ret = EXIT_FAILURE;
+- 	switch (result.return_value) {
+- 	case BATADV_TP_REASON_DST_UNREACHABLE:
+- 		fprintf(stderr, "Destination unreachable\n");
+diff --git a/batctl/patches/0007-batctl-fix-endianness-when-reading-radiotap-header.patch b/batctl/patches/0007-batctl-fix-endianness-when-reading-radiotap-header.patch
+deleted file mode 100644
+index bec1b9ed8e717356973048127ec70d57d29da791..0000000000000000000000000000000000000000
+--- a/batctl/patches/0007-batctl-fix-endianness-when-reading-radiotap-header.patch
++++ /dev/null
+@@ -1,38 +0,0 @@
+-From: Marek Lindner <mareklindner@neomailbox.ch>
+-Date: Wed, 29 Apr 2020 12:09:44 +0200
+-Subject: batctl: fix endianness when reading radiotap header
+-
+-All radiotap header fields are specified in little endian byte-order.
+-Header length conversion is necessary on some platforms.
+-
+-Fixes: c6fcdb6dc9a9 ("batctl: add radiotap wifi packet decapsulation support")
+-Signed-off-by: Marek Lindner <mareklindner@neomailbox.ch>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/440ae55a6ef96eb73ee628f9237915cf9fb26dee
+-
+-diff --git a/tcpdump.c b/tcpdump.c
+-index 8106a6457ac1b000f2f802e4b0a751d783540b69..72c1869eb50d25c1f6b1e1fcae42199b9337cb4e 100644
+---- a/tcpdump.c
+-+++ b/tcpdump.c
+-@@ -15,6 +15,7 @@
+- #include <time.h>
+- #include <sys/time.h>
+- #include <arpa/inet.h>
+-+#include <endian.h>
+- #include <net/if.h>
+- #include <net/if_arp.h>
+- #include <netinet/in.h>
+-@@ -1034,10 +1035,10 @@ static int monitor_header_length(unsigned char *packet_buff, ssize_t buff_len, i
+- 			return -1;
+- 
+- 		radiotap_hdr = (struct radiotap_header*)packet_buff;
+--		if (buff_len <= radiotap_hdr->it_len)
+-+		if (buff_len <= le16toh(radiotap_hdr->it_len))
+- 			return -1;
+- 		else
+--			return radiotap_hdr->it_len;
+-+			return le16toh(radiotap_hdr->it_len);
+- 	}
+- 
+- 	return -1;
+diff --git a/batctl/patches/0008-batctl-Only-remove-batadv-interface-on-hardif-reduct.patch b/batctl/patches/0008-batctl-Only-remove-batadv-interface-on-hardif-reduct.patch
+deleted file mode 100644
+index 08a87daa3d1abbe61378fba6bb2449f3827e631d..0000000000000000000000000000000000000000
+--- a/batctl/patches/0008-batctl-Only-remove-batadv-interface-on-hardif-reduct.patch
++++ /dev/null
+@@ -1,49 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sat, 13 Jun 2020 17:59:34 +0200
+-Subject: batctl: Only remove batadv interface on hardif reduction
+-
+-A deletion of a hardif from a batadv meshif will also get a success reply
+-from the kernel when the hardif was never part of the batadv meshif. If the
+-batadv meshif had no attached hardifs before the removal was started, then
+-users are then not expecting that the batadv meshif is removed at all.
+-
+-Since the delete operation is not an atomic compare-and-swap operation,
+-just check first the number of attached interfaces and only start the
+-removal of the batadv meshif when the number attached hardifs was reduced.
+-
+-Fixes: 25022e0b154d ("batctl: Use rtnl to add/remove interfaces")
+-Reported-by: Matthias Schiffer <mschiffer@universe-factory.net>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/6d49a82cf58ee5ebd6235b6ddaca46febd42f876
+-
+-diff --git a/interface.c b/interface.c
+-index 0a694c9f41f71a3dd72ae87b79b28434f7e8918f..138a6cd45744081a04f986fe4be67901b3305b74 100644
+---- a/interface.c
+-+++ b/interface.c
+-@@ -386,6 +386,7 @@ static int interface(struct state *state, int argc, char **argv)
+- 	int ret;
+- 	unsigned int ifindex;
+- 	unsigned int ifmaster;
+-+	unsigned int pre_cnt;
+- 	const char *long_op;
+- 	unsigned int cnt;
+- 	int rest_argc;
+-@@ -502,6 +503,8 @@ static int interface(struct state *state, int argc, char **argv)
+- 		goto err;
+- 	}
+- 
+-+	pre_cnt = count_interfaces(state->mesh_iface);
+-+
+- 	for (i = 1; i < rest_argc; i++) {
+- 		ifindex = if_nametoindex(rest_argv[i]);
+- 
+-@@ -531,7 +534,7 @@ static int interface(struct state *state, int argc, char **argv)
+- 	/* check if there is no interface left and then destroy mesh_iface */
+- 	if (!manual_mode && rest_argv[0][0] == 'd') {
+- 		cnt = count_interfaces(state->mesh_iface);
+--		if (cnt == 0)
+-+		if (cnt == 0 && pre_cnt > 0)
+- 			destroy_interface(state->mesh_iface);
+- 	}
+- 
+diff --git a/batctl/patches/0009-batctl-tcpdump-Fix-endianness-in-ICMPv6-Echo-Request.patch b/batctl/patches/0009-batctl-tcpdump-Fix-endianness-in-ICMPv6-Echo-Request.patch
+deleted file mode 100644
+index 145c9b12625dfaf875b3998be6c44e0b4b34d771..0000000000000000000000000000000000000000
+--- a/batctl/patches/0009-batctl-tcpdump-Fix-endianness-in-ICMPv6-Echo-Request.patch
++++ /dev/null
+@@ -1,39 +0,0 @@
+-From: Linus Lüssing <linus.luessing@c0d3.blue>
+-Date: Sun, 13 Sep 2020 23:30:19 +0200
+-Subject: batctl: tcpdump: Fix endianness in ICMPv6 Echo Request/Reply parsing
+-
+-The ICMPv6 Echo Request/Reply sequence number and id as well as the
+-IPv6 header length are two byte long fields and therefore might need a
+-conversion on a little endian system. Otherwise the output will be
+-broken on such a machine.
+-
+-Fixes: 35b37756f4a3 ("add IPv6 support to tcpdump parser")
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/e42f73d0d2a04edfbed1b9d0ad9fd57af9e90faf
+-
+-diff --git a/tcpdump.c b/tcpdump.c
+-index 72c1869eb50d25c1f6b1e1fcae42199b9337cb4e..f3b1b8bd536e83e583bc535d01630843b80a558d 100644
+---- a/tcpdump.c
+-+++ b/tcpdump.c
+-@@ -537,13 +537,15 @@ static void dump_ipv6(unsigned char *packet_buff, ssize_t buff_len,
+- 			break;
+- 		case ICMP6_ECHO_REQUEST:
+- 			printf(" echo request, id: %d, seq: %d, length: %hu\n",
+--			       icmphdr->icmp6_id, icmphdr->icmp6_seq,
+--			       iphdr->ip6_plen);
+-+			       ntohs(icmphdr->icmp6_id),
+-+			       ntohs(icmphdr->icmp6_seq),
+-+			       ntohs(iphdr->ip6_plen));
+- 			break;
+- 		case ICMP6_ECHO_REPLY:
+- 			printf(" echo reply, id: %d, seq: %d, length: %hu\n",
+--			       icmphdr->icmp6_id, icmphdr->icmp6_seq,
+--			       iphdr->ip6_plen);
+-+			       ntohs(icmphdr->icmp6_id),
+-+			       ntohs(icmphdr->icmp6_seq),
+-+			       ntohs(iphdr->ip6_plen));
+- 			break;
+- 		case ICMP6_TIME_EXCEEDED:
+- 			printf(" time exceeded in-transit, length %zu\n",
+diff --git a/batctl/patches/0010-batctl-Don-t-stop-when-create_interface-detected-exi.patch b/batctl/patches/0010-batctl-Don-t-stop-when-create_interface-detected-exi.patch
+deleted file mode 100644
+index b77d3cd63a4379ba467cc762f782909753beed57..0000000000000000000000000000000000000000
+--- a/batctl/patches/0010-batctl-Don-t-stop-when-create_interface-detected-exi.patch
++++ /dev/null
+@@ -1,31 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Fri, 15 Jan 2021 23:38:31 +0100
+-Subject: batctl: Don't stop when create_interface detected existing interface
+-
+-"batctl meshif bat0 interface add ..." should never be called in parallel.
+-But when something still does this, it could be that the code first detects
+-the missing meshif and then tries to create it - which fails when another
+-process requested the creation of the same interface slightly before batctl
+-did it.
+-
+-But this should not prevent batctl to add the lower interface to the
+-meshif. It is not really important that the batctl process was the one
+-which created it - only that it exists is important.
+-
+-Fixes: 25022e0b154d ("batctl: Use rtnl to add/remove interfaces")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/5d465bfd9a19c4bda20fb4e36c6e4b22c56ceb17
+-
+-diff --git a/interface.c b/interface.c
+-index 138a6cd45744081a04f986fe4be67901b3305b74..2c6a78ad17cb716fbb7f6a1c78e0076494397b01 100644
+---- a/interface.c
+-+++ b/interface.c
+-@@ -479,7 +479,7 @@ static int interface(struct state *state, int argc, char **argv)
+- 	ifmaster = if_nametoindex(state->mesh_iface);
+- 	if (!manual_mode && !ifmaster && rest_argv[0][0] == 'a') {
+- 		ret = create_interface(state->mesh_iface);
+--		if (ret < 0) {
+-+		if (ret < 0 && ret != -EEXIST) {
+- 			fprintf(stderr,
+- 				"Error - failed to create batman-adv interface: %s\n",
+- 				strerror(-ret));
+diff --git a/batctl/patches/0011-batctl-Fix-retrieval-of-meshif-ap_isolation.patch b/batctl/patches/0011-batctl-Fix-retrieval-of-meshif-ap_isolation.patch
+deleted file mode 100644
+index 8b77612bf25b8194b6a215c4177586b68bc6ab1d..0000000000000000000000000000000000000000
+--- a/batctl/patches/0011-batctl-Fix-retrieval-of-meshif-ap_isolation.patch
++++ /dev/null
+@@ -1,26 +0,0 @@
+-From: Sven Eckelmann <sven@narfation.org>
+-Date: Sat, 31 Oct 2020 18:00:26 +0100
+-Subject: batctl: Fix retrieval of meshif ap_isolation
+-
+-The batadv command to retrieve the attributes is called
+-BATADV_CMD_GET_MESH. The used BATADV_CMD_SET_MESH will only return the
+-current settings via the "config" multicast group which is not evaluated by
+-the ap_isolation command.
+-
+-Fixes: c56a63a5f12a ("batctl: Support generic netlink for ap_isolation command")
+-Signed-off-by: Sven Eckelmann <sven@narfation.org>
+-Origin: upstream, https://git.open-mesh.org/batctl.git/commit/107cee536a0f8024208923f49a2a548b40bfc432
+-
+-diff --git a/ap_isolation.c b/ap_isolation.c
+-index 36fd4d607d03768251150951ebe450740501d446..4854bcd1d6514a02786388dc014966f326818122 100644
+---- a/ap_isolation.c
+-+++ b/ap_isolation.c
+-@@ -36,7 +36,7 @@ static int get_attrs_ap_isolation(struct nl_msg *msg, void *arg)
+- 
+- static int get_ap_isolation(struct state *state)
+- {
+--	enum batadv_nl_commands nl_cmd = BATADV_CMD_SET_MESH;
+-+	enum batadv_nl_commands nl_cmd = BATADV_CMD_GET_MESH;
+- 
+- 	if (state->selector == SP_VLAN)
+- 		nl_cmd = BATADV_CMD_GET_VLAN;
+diff --git a/batctl/patches/0012-batctl-Add-noflood_mark-command.patch b/batctl/patches/0012-batctl-Add-noflood_mark-command.patch
+deleted file mode 100644
+index 296f3c51b79333a8e96c340d151ba00b8f457120..0000000000000000000000000000000000000000
+--- a/batctl/patches/0012-batctl-Add-noflood_mark-command.patch
++++ /dev/null
+@@ -1,273 +0,0 @@
+-From c14abebbeb4af76600cd6eb508e5e4e38a436b2f Mon Sep 17 00:00:00 2001
+-From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
+-Date: Fri, 26 Apr 2019 19:27:38 +0200
+-Subject: [PATCH] batctl: Add noflood_mark command
+-MIME-Version: 1.0
+-Content-Type: text/plain; charset=UTF-8
+-Content-Transfer-Encoding: 8bit
+-
+-Adds support for the new 'noflood_mark' setting in batman-adv.
+-
+-Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
+----
+-Changelog v3:
+-* changed command from a noflood tri-state option
+-  to a value/mask one similar to the isolation mark
+-* noflood.c -> noflood_mark.c
+-
+-Changelog v2:
+-* added noflood.c
+----
+- Makefile       |   1 +
+- README.rst     |  15 ++++++
+- batman_adv.h   |  12 +++++
+- man/batctl.8   |  23 ++++++++
+- noflood_mark.c | 141 +++++++++++++++++++++++++++++++++++++++++++++++++
+- 5 files changed, 192 insertions(+)
+- create mode 100644 noflood_mark.c
+-
+-diff --git a/Makefile b/Makefile
+-index e3747a2..686de7e 100755
+---- a/Makefile
+-+++ b/Makefile
+-@@ -61,6 +61,7 @@ $(eval $(call add_command,multicast_mode,y))
+- $(eval $(call add_command,nc_nodes,y))
+- $(eval $(call add_command,neighbors,y))
+- $(eval $(call add_command,network_coding,y))
+-+$(eval $(call add_command,noflood_mark,y))
+- $(eval $(call add_command,orig_interval,y))
+- $(eval $(call add_command,originators,y))
+- $(eval $(call add_command,ping,y))
+-diff --git a/README.rst b/README.rst
+-index 128f539..bc937d2 100644
+---- a/README.rst
+-+++ b/README.rst
+-@@ -582,6 +582,21 @@ Usage::
+- * Example 4: ``batctl mark 0x0f``
+- 
+- 
+-+batctl noflood_mark
+-+=======================
+-+
+-+display or modify noflood_mark setting
+-+
+-+Usage::
+-+
+-+  batctl noflood_mark|nf $value[/0x$mask]
+-+
+-+* Example 1: ``batctl nf 0x00000001/0xffffffff``
+-+* Example 2: ``batctl nf 0x00040000/0xffff0000``
+-+* Example 3: ``batctl nf 16``
+-+* Example 4: ``batctl nf 0x0f``
+-+
+-+
+- batctl translocal
+- =================
+- 
+-diff --git a/batman_adv.h b/batman_adv.h
+-index 67f4636..6fabb7a 100644
+---- a/batman_adv.h
+-+++ b/batman_adv.h
+-@@ -480,6 +480,18 @@ enum batadv_nl_attrs {
+- 	 */
+- 	BATADV_ATTR_MULTICAST_FANOUT,
+- 
+-+	/**
+-+	 * @BATADV_ATTR_NOFLOOD_MARK: the noflood mark which allows to tag
+-+	 *  frames which should never be broadcast flooded through the mesh.
+-+	 */
+-+	BATADV_ATTR_NOFLOOD_MARK,
+-+
+-+	/**
+-+	 * @BATADV_ATTR_NOFLOOD_MASK: the noflood (bit)mask which allows to tag
+-+	 *  frames which should never be broadcast flooded through the mesh.
+-+	 */
+-+	BATADV_ATTR_NOFLOOD_MASK,
+-+
+- 	/* add attributes above here, update the policy in netlink.c */
+- 
+- 	/**
+-diff --git a/man/batctl.8 b/man/batctl.8
+-index d42b682..5489c2e 100644
+---- a/man/batctl.8
+-+++ b/man/batctl.8
+-@@ -124,6 +124,29 @@ If no parameter is given the current multicast fanout setting is displayed. Othe
+- the multicast fanout. The multicast fanout defines the maximum number of packet copies that may be generated for a
+- multicast-to-unicast conversion. Once this limit is exceeded distribution will fall back to broadcast.
+- .br
+-+.IP "\fBnoflood_mark\fP|\fBnf\fP"
+-+If no parameter is given the current noflood mark value is displayed.
+-+Otherwise the parameter is used to set or unset the noflood mark. The
+-+noflood mark allows to prevent broadcast flooding of a frame which
+-+was previously tagged via netfilter for instance. batman-adv will
+-+then only forward a frame into the mesh if destined to a limited
+-+number of destination nodes and drop the frame otherwise.
+-+.br
+-+The input is supposed to be of the form $value/$mask, where $value can be any
+-+32bit long integer (expressed in decimal or hex base) and $mask is a generic
+-+bitmask (expressed in hex base) that selects the bits to take into consideration
+-+from $value. It is also possible to enter the input using only $value and in
+-+this case the full bitmask is used by default.
+-+
+-+.br
+-+.br
+-+Example 1: 0x00000001/0xffffffff
+-+.br
+-+Example 2: 0x00040000/0xffff0000
+-+.br
+-+Example 3: 16 or 0x0F
+-+.br
+-+.br
+- .IP "\fBloglevel\fP|\fBll\fP [\fBlevel\fP[ \fBlevel\fP[ \fBlevel\fP]] \fB...\fP]"
+- If no parameter is given the current log level settings are displayed otherwise the parameter(s) is/are used to set the log
+- level. Level 'none' disables all verbose logging. Level 'batman' enables messages related to routing / flooding / broadcasting.
+-diff --git a/noflood_mark.c b/noflood_mark.c
+-new file mode 100644
+-index 0000000..e89205c
+---- /dev/null
+-+++ b/noflood_mark.c
+-@@ -0,0 +1,141 @@
+-+// SPDX-License-Identifier: GPL-2.0
+-+/* Copyright (C) 2009-2019  B.A.T.M.A.N. contributors:
+-+ *
+-+ * Antonio Quartulli <a@unstable.cc>
+-+ * Linus Lüssing <linus.luessing@c0d3.blue>
+-+ *
+-+ * License-Filename: LICENSES/preferred/GPL-2.0
+-+ */
+-+
+-+#include <errno.h>
+-+#include <stddef.h>
+-+#include <stdint.h>
+-+#include <string.h>
+-+
+-+#include "main.h"
+-+#include "sys.h"
+-+
+-+static struct noflood_mark_data {
+-+	uint32_t noflood_mark;
+-+	uint32_t noflood_mask;
+-+} noflood_mark;
+-+
+-+static int parse_noflood_mark(struct state *state, int argc, char *argv[])
+-+{
+-+	struct settings_data *settings = state->cmd->arg;
+-+	struct noflood_mark_data *data = settings->data;
+-+	char *mask_ptr;
+-+	char buff[256];
+-+	uint32_t mark;
+-+	uint32_t mask;
+-+	char *endptr;
+-+
+-+	if (argc != 2) {
+-+		fprintf(stderr, "Error - incorrect number of arguments (expected 1)\n");
+-+		return -EINVAL;
+-+	}
+-+
+-+	strncpy(buff, argv[1], sizeof(buff));
+-+	buff[sizeof(buff) - 1] = '\0';
+-+
+-+	/* parse the mask if it has been specified, otherwise assume the mask is
+-+	 * the biggest possible
+-+	 */
+-+	mask = 0xFFFFFFFF;
+-+	mask_ptr = strchr(buff, '/');
+-+	if (mask_ptr) {
+-+		*mask_ptr = '\0';
+-+		mask_ptr++;
+-+
+-+		/* the mask must be entered in hex base as it is going to be a
+-+		 * bitmask and not a prefix length
+-+		 */
+-+		mask = strtoul(mask_ptr, &endptr, 16);
+-+		if (!endptr || *endptr != '\0')
+-+			goto inval_format;
+-+	}
+-+
+-+	/* the mark can be entered in any base */
+-+	mark = strtoul(buff, &endptr, 0);
+-+	if (!endptr || *endptr != '\0')
+-+		goto inval_format;
+-+
+-+	data->noflood_mask = mask;
+-+	/* erase bits not covered by the mask */
+-+	data->noflood_mark = mark & mask;
+-+
+-+	return 0;
+-+
+-+inval_format:
+-+	fprintf(stderr, "Error - incorrect number of arguments (expected 1)\n");
+-+	fprintf(stderr, "The following formats for mark(/mask) are allowed:\n");
+-+	fprintf(stderr, " * 0x12345678\n");
+-+	fprintf(stderr, " * 0x12345678/0xabcdef09\n");
+-+	return -EINVAL;
+-+}
+-+
+-+static int print_noflood_mark(struct nl_msg *msg, void *arg)
+-+{
+-+	struct nlattr *attrs[BATADV_ATTR_MAX + 1];
+-+	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+-+	struct genlmsghdr *ghdr;
+-+	int *result = arg;
+-+
+-+	if (!genlmsg_valid_hdr(nlh, 0))
+-+		return NL_OK;
+-+
+-+	ghdr = nlmsg_data(nlh);
+-+
+-+	if (nla_parse(attrs, BATADV_ATTR_MAX, genlmsg_attrdata(ghdr, 0),
+-+		      genlmsg_len(ghdr), batadv_netlink_policy)) {
+-+		return NL_OK;
+-+	}
+-+
+-+	if (!attrs[BATADV_ATTR_NOFLOOD_MARK] ||
+-+	    !attrs[BATADV_ATTR_NOFLOOD_MASK])
+-+		return NL_OK;
+-+
+-+	printf("0x%08x/0x%08x\n",
+-+	       nla_get_u32(attrs[BATADV_ATTR_NOFLOOD_MARK]),
+-+	       nla_get_u32(attrs[BATADV_ATTR_NOFLOOD_MASK]));
+-+
+-+	*result = 0;
+-+	return NL_STOP;
+-+}
+-+
+-+static int get_noflood_mark(struct state *state)
+-+{
+-+	return sys_simple_nlquery(state, BATADV_CMD_GET_MESH,
+-+				  NULL, print_noflood_mark);
+-+}
+-+
+-+static int set_attrs_noflood_mark(struct nl_msg *msg, void *arg)
+-+{
+-+	struct state *state = arg;
+-+	struct settings_data *settings = state->cmd->arg;
+-+	struct noflood_mark_data *data = settings->data;
+-+
+-+	nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MARK, data->noflood_mark);
+-+	nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MASK, data->noflood_mask);
+-+
+-+	return 0;
+-+}
+-+
+-+static int set_noflood_mark(struct state *state)
+-+{
+-+	return sys_simple_nlquery(state, BATADV_CMD_SET_MESH,
+-+				  set_attrs_noflood_mark, NULL);
+-+}
+-+
+-+static struct settings_data batctl_settings_noflood_mark = {
+-+	.sysfs_name = NULL,
+-+	.data = &noflood_mark,
+-+	.parse = parse_noflood_mark,
+-+	.netlink_get = get_noflood_mark,
+-+	.netlink_set = set_noflood_mark,
+-+};
+-+
+-+COMMAND_NAMED(SUBCOMMAND, noflood_mark, "nf", handle_sys_setting,
+-+	      COMMAND_FLAG_MESH_IFACE | COMMAND_FLAG_NETLINK,
+-+	      &batctl_settings_noflood_mark,
+-+	      "[mark]            \tdisplay or modify noflood_mark setting");
+--- 
+-2.31.0
+-
+diff --git a/batctl/patches/2002-batctl-Add-noflood_mark-command.patch b/batctl/patches/2002-batctl-Add-noflood_mark-command.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..d4498603785a21a71951a6195cd96661be44d685
+--- /dev/null
++++ b/batctl/patches/2002-batctl-Add-noflood_mark-command.patch
+@@ -0,0 +1,217 @@
++From 12884631753aa24d9e36c5d65950320ecab61384 Mon Sep 17 00:00:00 2001
++From: =?UTF-8?q?Linus=20L=C3=BCssing?= <linus.luessing@c0d3.blue>
++Date: Fri, 26 Apr 2019 19:27:38 +0200
++Subject: [PATCH] batctl: Add noflood_mark command
++MIME-Version: 1.0
++Content-Type: text/plain; charset=UTF-8
++Content-Transfer-Encoding: 8bit
++
++Adds support for the new 'noflood_mark' setting in batman-adv.
++
++Signed-off-by: Linus Lüssing <linus.luessing@c0d3.blue>
++---
++ Makefile       |   1 +
++ README.rst     |  15 ++++++
++ batman_adv.h   |  12 +++++
++ noflood_mark.c | 140 +++++++++++++++++++++++++++++++++++++++++++++++++
++ 4 files changed, 168 insertions(+)
++ create mode 100644 noflood_mark.c
++
++--- a/Makefile
+++++ b/Makefile
++@@ -69,6 +69,7 @@ $(eval $(call add_command,multicast_mode
++ $(eval $(call add_command,neighbors,y))
++ $(eval $(call add_command,neighbors_json,y))
++ $(eval $(call add_command,network_coding,y))
+++$(eval $(call add_command,noflood_mark,y))
++ $(eval $(call add_command,orig_interval,y))
++ $(eval $(call add_command,originators,y))
++ $(eval $(call add_command,originators_json,y))
++--- a/README.rst
+++++ b/README.rst
++@@ -430,6 +430,21 @@ Example::
++ 
++ 
++ 
+++batctl noflood_mark
+++=======================
+++
+++display or modify noflood_mark setting
+++
+++Usage::
+++
+++  batctl noflood_mark|nf $value[/0x$mask]
+++
+++* Example 1: ``batctl nf 0x00000001/0xffffffff``
+++* Example 2: ``batctl nf 0x00040000/0xffff0000``
+++* Example 3: ``batctl nf 16``
+++* Example 4: ``batctl nf 0x0f``
+++
+++
++ batctl translocal
++ -----------------
++ 
++--- a/batman_adv.h
+++++ b/batman_adv.h
++@@ -481,6 +481,18 @@ enum batadv_nl_attrs {
++ 	 */
++ 	BATADV_ATTR_MULTICAST_FANOUT,
++ 
+++	/**
+++	 * @BATADV_ATTR_NOFLOOD_MARK: the noflood mark which allows to tag
+++	 *  frames which should never be broadcast flooded through the mesh.
+++	 */
+++	BATADV_ATTR_NOFLOOD_MARK,
+++
+++	/**
+++	 * @BATADV_ATTR_NOFLOOD_MASK: the noflood (bit)mask which allows to tag
+++	 *  frames which should never be broadcast flooded through the mesh.
+++	 */
+++	BATADV_ATTR_NOFLOOD_MASK,
+++
++ 	/* add attributes above here, update the policy in netlink.c */
++ 
++ 	/**
++--- /dev/null
+++++ b/noflood_mark.c
++@@ -0,0 +1,140 @@
+++// SPDX-License-Identifier: GPL-2.0
+++/* Copyright (C) 2009-2019  B.A.T.M.A.N. contributors:
+++ *
+++ * Antonio Quartulli <a@unstable.cc>
+++ * Linus Lüssing <linus.luessing@c0d3.blue>
+++ *
+++ * License-Filename: LICENSES/preferred/GPL-2.0
+++ */
+++
+++#include <errno.h>
+++#include <stddef.h>
+++#include <stdint.h>
+++#include <string.h>
+++
+++#include "main.h"
+++#include "sys.h"
+++
+++static struct noflood_mark_data {
+++	uint32_t noflood_mark;
+++	uint32_t noflood_mask;
+++} noflood_mark;
+++
+++static int parse_noflood_mark(struct state *state, int argc, char *argv[])
+++{
+++	struct settings_data *settings = state->cmd->arg;
+++	struct noflood_mark_data *data = settings->data;
+++	char *mask_ptr;
+++	char buff[256];
+++	uint32_t mark;
+++	uint32_t mask;
+++	char *endptr;
+++
+++	if (argc != 2) {
+++		fprintf(stderr, "Error - incorrect number of arguments (expected 1)\n");
+++		return -EINVAL;
+++	}
+++
+++	strncpy(buff, argv[1], sizeof(buff));
+++	buff[sizeof(buff) - 1] = '\0';
+++
+++	/* parse the mask if it has been specified, otherwise assume the mask is
+++	 * the biggest possible
+++	 */
+++	mask = 0xFFFFFFFF;
+++	mask_ptr = strchr(buff, '/');
+++	if (mask_ptr) {
+++		*mask_ptr = '\0';
+++		mask_ptr++;
+++
+++		/* the mask must be entered in hex base as it is going to be a
+++		 * bitmask and not a prefix length
+++		 */
+++		mask = strtoul(mask_ptr, &endptr, 16);
+++		if (!endptr || *endptr != '\0')
+++			goto inval_format;
+++	}
+++
+++	/* the mark can be entered in any base */
+++	mark = strtoul(buff, &endptr, 0);
+++	if (!endptr || *endptr != '\0')
+++		goto inval_format;
+++
+++	data->noflood_mask = mask;
+++	/* erase bits not covered by the mask */
+++	data->noflood_mark = mark & mask;
+++
+++	return 0;
+++
+++inval_format:
+++	fprintf(stderr, "Error - incorrect number of arguments (expected 1)\n");
+++	fprintf(stderr, "The following formats for mark(/mask) are allowed:\n");
+++	fprintf(stderr, " * 0x12345678\n");
+++	fprintf(stderr, " * 0x12345678/0xabcdef09\n");
+++	return -EINVAL;
+++}
+++
+++static int print_noflood_mark(struct nl_msg *msg, void *arg)
+++{
+++	struct nlattr *attrs[BATADV_ATTR_MAX + 1];
+++	struct nlmsghdr *nlh = nlmsg_hdr(msg);
+++	struct genlmsghdr *ghdr;
+++	int *result = arg;
+++
+++	if (!genlmsg_valid_hdr(nlh, 0))
+++		return NL_OK;
+++
+++	ghdr = nlmsg_data(nlh);
+++
+++	if (nla_parse(attrs, BATADV_ATTR_MAX, genlmsg_attrdata(ghdr, 0),
+++		      genlmsg_len(ghdr), batadv_netlink_policy)) {
+++		return NL_OK;
+++	}
+++
+++	if (!attrs[BATADV_ATTR_NOFLOOD_MARK] ||
+++	    !attrs[BATADV_ATTR_NOFLOOD_MASK])
+++		return NL_OK;
+++
+++	printf("0x%08x/0x%08x\n",
+++	       nla_get_u32(attrs[BATADV_ATTR_NOFLOOD_MARK]),
+++	       nla_get_u32(attrs[BATADV_ATTR_NOFLOOD_MASK]));
+++
+++	*result = 0;
+++	return NL_STOP;
+++}
+++
+++static int get_noflood_mark(struct state *state)
+++{
+++	return sys_simple_nlquery(state, BATADV_CMD_GET_MESH,
+++				  NULL, print_noflood_mark);
+++}
+++
+++static int set_attrs_noflood_mark(struct nl_msg *msg, void *arg)
+++{
+++	struct state *state = arg;
+++	struct settings_data *settings = state->cmd->arg;
+++	struct noflood_mark_data *data = settings->data;
+++
+++	nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MARK, data->noflood_mark);
+++	nla_put_u32(msg, BATADV_ATTR_NOFLOOD_MASK, data->noflood_mask);
+++
+++	return 0;
+++}
+++
+++static int set_noflood_mark(struct state *state)
+++{
+++	return sys_simple_nlquery(state, BATADV_CMD_SET_MESH,
+++				  set_attrs_noflood_mark, NULL);
+++}
+++
+++static struct settings_data batctl_settings_noflood_mark = {
+++	.data = &noflood_mark,
+++	.parse = parse_noflood_mark,
+++	.netlink_get = get_noflood_mark,
+++	.netlink_set = set_noflood_mark,
+++};
+++
+++COMMAND_NAMED(SUBCOMMAND, noflood_mark, "nf", handle_sys_setting,
+++	      COMMAND_FLAG_MESH_IFACE | COMMAND_FLAG_NETLINK,
+++	      &batctl_settings_noflood_mark,
+++	      "[mark]            \tdisplay or modify noflood_mark setting");


### PR DESCRIPTION
This updates batman-adv to the latest version, as provided in the openwrt/routing feed and its master branch. The goal is to prevent the deprecated 4/32 devices stuck on OpenWrt 19.07 to disable newer batman-adv features.

The main difference to the openwrt/routing upstream version is:

* noflood mark addition, as used in Gluon (patch 2002)
* always assume absence of multicast routers (patch 9001) -> to avoid disabling multicast for packets with a routeable multicast destination address
* compat patches to be able to build on OpenWrt 19.07 / Linux 4.14 (the batman-adv compat hacks approach is too complicated due to the compat hacks from wireless-backports, therefore these patches apply/revert code inside the net/batman-adv/*.{c,h} directly, as a safer way)

This has been tested via https://github.com/T-X/gluon-batman-adv-next/ at Freifunk Lübeck for several months now (with the addition of patches 2001, 2003 and 2004).