### PR TITLE
ath79: Add support for Sophos AP15C

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -114,6 +114,7 @@ ath79-generic
 
 * Sophos
 
+  - AP15C
   - AP100
   - AP100c
   - AP55

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -368,6 +368,11 @@ device('sophos-ap15', 'sophos_ap15', {
 	broken = true, -- no button and no external console port
 })
 
+device('sophos-ap15c', 'sophos_ap15c', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 device('sophos-ap100', 'sophos_ap100', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [ ] Web interface
  - [X] TFTP (serial console)
  - [X] Other: Vendor Software
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`
  
  See: https://github.com/openwrt/openwrt/pull/16868
  
  Copy of https://github.com/freifunk-gluon/gluon/pull/3368