### PR TITLE
Dockerfile: drop dependency on python3-distutils

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -10,7 +10,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     python3 \
     python3-dev \
-    python3-distutils \
     python3-pyelftools \
     python3-setuptools \
     build-essential \

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -29,7 +29,6 @@ freshly installed Debian Bullseye system the following packages are required:
 
 * `git` (to get Gluon and other dependencies)
 * `python3`
-* `python3-distutils`
 * `build-essential`
 * `ecdsautils` (to sign firmware, see `contrib/sign.sh`)
 * `gawk`


### PR DESCRIPTION
distutils is not required anymore by OpenWRT 24.10.

Distutils was deprecated and removed in Python 3.12, see https://peps.python.org/pep-0632/

This effectively reverts 2d4ab0f0c8dd909c622bbc49352aea729a0e021b
