### PR TITLE
ipq40xx-generic: add extreme-networks-ws-ap3915i

### DIFF
--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -154,3 +154,9 @@ device('zyxel-nbg6617', 'zyxel_nbg6617')
 device('8devices-jalapeno', '8dev_jalapeno', {
 	factory_ext = '.ubi',
 })
+
+-- Extreme Networks
+
+device('extreme-networks-ws-ap3915i', 'extreme-networks_ws-ap3915i', {
+	factory = false,
+})


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [x] TFTP
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [ ] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [ ] Added Device to `docs/user/supported_devices.rst`

Primary MAC Adress is: ca:b2:ef:60:c6:63
Eth0 MAC is: dc:b8:08:72:a2:ad
Label MAC is: dc:b8:08:72:a2:ad

Keeps forgetting config after any sysupgrade