### PR TITLE
mediatek-filogic: Add support for D-Link AQUILA PRO AI M30 A1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -40,6 +40,7 @@ ath79-generic
 
 * D-Link
 
+  - AQUILA PRO AI M30 A1
   - DAP-1330 A1 [#lan_as_wan]_
   - DAP-1365 A1 [#lan_as_wan]_
   - DAP-2660 A1 [#lan_as_wan]_

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -9,6 +9,16 @@ device('asus-tuf-ax6000', 'asus_tuf-ax6000', {
 })
 
 
+-- D-Link
+
+device('d-link-aquila-pro-ai-m30-a1', 'dlink_aquila-pro-ai-m30-a1', {
+	factory = false,
+	extra_images = {
+		{'-squashfs-recovery', '-recovery', '.bin'}
+	},
+})
+
+
 -- Cudy
 
 device('cudy-wr3000-v1', 'cudy_wr3000-v1', {


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface (Recovery web interface)
  - [ ] TFTP
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio - no radio LEDs
    - [ ] Should show activity - no radio LEDs
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) - no switch prot LEDs
    - [ ] Should show link state and activity - no switch prot LEDs
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua` - n/a
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua` - n/a
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/ - n/aupgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`