### PR TITLE
mac80211: silence warning for missing rate information

### DIFF
--- a/patches/openwrt/0006-mac80211-silence-warning-for-missing-rate-information.patch
+++ b/patches/openwrt/0006-mac80211-silence-warning-for-missing-rate-information.patch
@@ -1,0 +1,30 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 18 Jan 2024 00:52:09 +0100
+Subject: mac80211: silence warning for missing rate information
+
+Silence warnings for missing rate information.
+
+These warnings do not provide value. Instead, they might rotate more
+crucial information out of the kernel message ringbuffer.
+
+Link: https://github.com/freifunk-gluon/gluon/issues/3160
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/package/kernel/mac80211/patches/subsys/999-silence-missing-rate.patch b/package/kernel/mac80211/patches/subsys/999-silence-missing-rate.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..a34455f78960ded59b60d3d9600823b39fc7b7a2
+--- /dev/null
++++ b/package/kernel/mac80211/patches/subsys/999-silence-missing-rate.patch
+@@ -0,0 +1,11 @@
++--- a/net/mac80211/mesh_hwmp.c
+++++ b/net/mac80211/mesh_hwmp.c
++@@ -350,7 +350,7 @@ u32 airtime_link_metric_get(struct ieee8
++ 			return MAX_METRIC;
++ 
++ 		rate = ewma_mesh_tx_rate_avg_read(&sta->mesh->tx_rate_avg);
++-		if (WARN_ON(!rate))
+++		if (!rate)
++ 			return MAX_METRIC;
++ 
++ 		err = (fail_avg << ARITH_SHIFT) / 100;


### PR DESCRIPTION
Silence warnings for missing rate information.

These warnings do not provide value. Instead, they might rotate more crucial information out of the kernel message ringbuffer.

Closes #3390

Cherrypicked from #3163
Link #3160
Link https://github.com/openwrt/openwrt/issues/12003

Direct link to kernel change: https://github.com/torvalds/linux/blob/v6.6/net/mac80211/mesh_hwmp.c