### PR TITLE
ipq40xx-generic: add working VDSL config for FB7530

### DIFF
--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -60,12 +60,9 @@ device('avm-fritz-box-7530', 'avm_fritzbox-7530', {
 		'-ath10k-firmware-qca4019-ct',
 
 		-- VDSL modem
-		'-kmod-ltq-vdsl-vr11',
-		'-kmod-ltq-vdsl-vr11-mei',
-		'-ltq-vdsl-vr11-app',
-		'-ltq-dsl-base',
-		'-kmod-atm',
-		'-linux-atm',
+		'ppp',
+		'kmod-ppp',
+		'ppp-mod-pppoe',
 	},
 })
 


### PR DESCRIPTION
this does not do anything as long as the DSL port is unplugged. If the port is plugged and an interface of type pppoe exists, the vrx518 dsl firmware and the pppd daemon is started

<details> 
<summary>Log</summary>

```
Thu Dec 26 20:33:00 2024 daemon.notice hostapd: Reload config for bss 'client1' on phy 'phy1'
Thu Dec 26 20:33:00 2024 daemon.notice hostapd: client1: AP-STA-DISCONNECTED 06:a9:6f:93:ec:b5
Thu Dec 26 20:33:00 2024 daemon.info wgpeerselector: Removing peer sn215 from wg_mesh.
Thu Dec 26 20:33:00 2024 daemon.notice netifd: Network device 'client1' link is down
Thu Dec 26 20:33:00 2024 kern.info kernel: [ 1052.412284] br-client: port 7(client1) entered disabled state
Thu Dec 26 20:33:00 2024 daemon.notice netifd: Network device 'client1' link is up
Thu Dec 26 20:33:00 2024 kern.info kernel: [ 1052.441979] br-client: port 7(client1) entered blocking state
Thu Dec 26 20:33:00 2024 kern.info kernel: [ 1052.442046] br-client: port 7(client1) entered forwarding state
Thu Dec 26 20:33:00 2024 daemon.notice hostapd: Reloaded settings for phy phy1
Thu Dec 26 20:33:00 2024 daemon.notice hostapd: Reload config for bss 'client0' on phy 'phy0'
Thu Dec 26 20:33:00 2024 daemon.notice hostapd: Reloaded settings for phy phy0
Thu Dec 26 20:33:05 2024 daemon.warn wgpeerselector: DNS resolution of ntp server a.ntp.ffac.rocks failed: error code -3
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.259586] plat_tc_request: dsl id: 0, mode: 1, tc_mode: 3, tc_idx: -1
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.260771] vrx518_tc:ptm_tc_hw_fw_init: id(Line)		= 0
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.262321] vrx518_tc:ptm_set_mac_address: ptm mac address update!
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.265025] vrx518_tc:ptm_tc_hw_fw_init: irq		= 64
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.265033] vrx518_tc:ptm_tc_hw_fw_init: membase		= 0xd3300000
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.270583] vrx518_tc:ptm_open: ptm open
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.276404] vrx518_tc:ptm_tc_hw_fw_init: phy_membase	= 0x40800000
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.276429] vrx518_tc:ptm_tc_hw_fw_init: peer_num		= 0
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.276437] vrx518_tc:ptm_tc_hw_fw_init: tc_mode		= PTM Single Line
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.323644] vrx518_tc:is_ptm_sl: is_ptm_sl: SINGLE
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.323742] vrx518_tc:is_ptm_sl: is_ptm_sl: SINGLE
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.328092] vrx518_tc:is_ptm_sl: is_ptm_sl: SINGLE
Thu Dec 26 20:33:07 2024 kern.warn kernel: [ 1059.332231] ppe_aca_cfg_cnt: priv->ep_id[0] bond[0]
Thu Dec 26 20:33:07 2024 kern.warn kernel: [ 1059.336931] ppe_aca_cfg_cnt: 0 0 0 0
Thu Dec 26 20:33:07 2024 kern.warn kernel: [ 1059.341756] ppe_aca_cfg_cnt: cfg->txin.soc_cnt_phyaddr[0]
Thu Dec 26 20:33:07 2024 kern.warn kernel: [ 1059.345522] ppe_aca_cfg_cnt: cfg->txout.soc_cnt_phyaddr[0]
Thu Dec 26 20:33:07 2024 kern.warn kernel: [ 1059.350844] ppe_aca_cfg_cnt: cfg->rxout.soc_cnt_phyaddr[0]
Thu Dec 26 20:33:07 2024 kern.warn kernel: [ 1059.356198] ppe_aca_cfg_cnt: cfg->rxin.soc_cnt_phyaddr[0]
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.361698] Loading PTM FW ver: 3.5.75
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.388913] vrx518_tc:ptm_tc_hw_fw_init: PTM TC init successfully
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.388958] id: 0, txin(0x82e35000: 128, 0x0), txout(0x82e34000: 128, 0x0), rxin(0x0: 0, 0x0), rxout(0x82c00000: 1024, 0x0)
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.394034] vrx518_tc:ptm_aca_init: txin: bswp: 0, hdsz:4, pd: dbase(0x2801c0), dnum(32), sz_indw(2), soc_dbase:0x82e35000, soc_dnum:0x80, soc cnt addr: 0x40b21480
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.404990] vrx518_tc:ptm_aca_init: txout: bswp: 0, hdsz:1, pd: dbase(0x230000), dnum(64), sz_indw(2), soc_dbase:0x82e34000, soc_dnum:0x80, soc cnt addr: 0x40b21484
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.419551] vrx518_tc:ptm_aca_init: rxout: bswp: 0, hdsz:4, pd: dbase(0x230200), dnum(255), sz_indw(2), soc_dbase:0x82c00000, soc_dnum:0x400, soc cnt addr: 0x40b21488
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.434481] vrx518_tc:ptm_aca_init: rxin: bswp: 0, hdsz:4, pd: dbase(0x2855c0), dnum(255), sz_indw(2), soc_dbase:0x0, soc_dnum:0x0, soc cnt addr: 0x40b2148c
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.449146] vrx518_tc:ptm_aca_init: txout: (stat:0x40b6b7d0, pd: 0x40b6b7d4, cnt: 0x40b6b7cc)
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.463304] vrx518_tc:ptm_aca_init: rxout: (stat:0x40b6b7e8, pd: 0x40b6b7ec, cnt: 0x40b6b7e4)
Thu Dec 26 20:33:07 2024 kern.info kernel: [ 1059.471711] vrx518_tc:ptm_aca_init: rxin: (stat:0x40b6b7dc, pd: 0x40b6b7e0, cnt: 0x40b6b7d8)
Thu Dec 26 20:33:07 2024 daemon.notice netifd: Interface 'wan' is enabled
Thu Dec 26 20:33:08 2024 kern.info kernel: [ 1059.583118] vrx518 0000:01:00.0: ACA fw build 0 branch 4 major 0x20 minor 0x0016
Thu Dec 26 20:33:08 2024 kern.info kernel: [ 1059.583187] vrx518 0000:01:00.0: ACA fw for vrx518 supported SoC type xrx500
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589719] vrx518 0000:01:00.0: Header size 0x0000019c fw size 0x00000904
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589739] vrx518 0000:01:00.0: section number 14
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589753] vrx518 0000:01:00.0: Section HIF ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589767] vrx518 0000:01:00.0: Section GenRisc ie_len 2
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589779] vrx518 0000:01:00.0: Section MAC_HT ie_len 3
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589791] vrx518 0000:01:00.0: Section TXIN ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589803] vrx518 0000:01:00.0: Sec TXIN desc base 0x00100128, des_num: 32
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589818] vrx518 0000:01:00.0: Section TXIN_PDRING ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589830] vrx518 0000:01:00.0: Sec TXIN_PDRING desc base 0x00100528, des_num: 64
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589845] vrx518 0000:01:00.0: Section TXOUT ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589857] vrx518 0000:01:00.0: Sec TXOUT desc base 0x00100728, des_num: 32
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589871] vrx518 0000:01:00.0: Section TXOUT_PDRING ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589884] vrx518 0000:01:00.0: Sec TXOUT_PDRING desc base 0x00100b28, des_num: 32
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589899] vrx518 0000:01:00.0: Section RXIN ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589912] vrx518 0000:01:00.0: Sec RXIN desc base 0x00100c28, des_num: 32
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589926] vrx518 0000:01:00.0: Section RXIN_PDRING ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589938] vrx518 0000:01:00.0: Sec RXIN_PDRING desc base 0x00101028, des_num: 32
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589952] vrx518 0000:01:00.0: Section RXOUT ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589964] vrx518 0000:01:00.0: Sec RXOUT desc base 0x00101128, des_num: 32
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589977] vrx518 0000:01:00.0: Section RXOUT_PDRING ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.589989] vrx518 0000:01:00.0: Sec RXOUT_PDRING desc base 0x00101528, des_num: 256
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590003] vrx518 0000:01:00.0: Section DMA ie_len 10
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590016] vrx518 0000:01:00.0: dma channel 0 desc base 0x00100000
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590028] vrx518 0000:01:00.0: dma channel 1 desc base 0x00100008
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590041] vrx518 0000:01:00.0: dma channel 2 desc base 0x00100010
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590053] vrx518 0000:01:00.0: dma channel 3 desc base 0x00100018
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590065] vrx518 0000:01:00.0: dma channel 4 desc base 0x00100030
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590078] vrx518 0000:01:00.0: dma channel 5 desc base 0x00100038
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590090] vrx518 0000:01:00.0: dma channel 6 desc base 0x00100020
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590102] vrx518 0000:01:00.0: dma channel 7 desc base 0x00100028
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590115] vrx518 0000:01:00.0: dma channel 8 desc base 0x00100040
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590127] vrx518 0000:01:00.0: dma channel 9 desc base 0x00100048
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590140] vrx518 0000:01:00.0: Section FW_INIT ie_len 1
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590151] vrx518 0000:01:00.0: init st size: 32, addr: 0x100060
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590164] vrx518 0000:01:00.0: Section ACA FW ie_len 5
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590177] vrx518 0000:01:00.0: aca txin fw offset 0x0 size 20 loc 0x50800 fw base 3cfe8e9d
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590197] vrx518 0000:01:00.0: aca txout fw offset 0x14 size 4 loc 0x50900 fw base 1e4cfb31
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590215] vrx518 0000:01:00.0: aca rxin fw offset 0x18 size 4 loc 0x50a00 fw base 11f7f7c7
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590233] vrx518 0000:01:00.0: aca rxout fw offset 0x1c size 24 loc 0x50b00 fw base cd0cf618
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590250] vrx518 0000:01:00.0: aca Genrisc fw offset 0x34 size 2256 loc 0x58000 fw base 4614a4c8
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590375] vrx518 0000:01:00.0: aca dma init done
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.590389] vrx518 0000:01:00.0: aca basic config done
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.591294] vrx518 0000:01:00.0: aca_hif_param_init
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.591305] vrx518 0000:01:00.0: aca txin init done
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.591315] vrx518 0000:01:00.0: aca txout init done
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.591327] vrx518 0000:01:00.0: aca rxout init done
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.591337] vrx518 0000:01:00.0: aca rxin init done
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.591347] vrx518 0000:01:00.0: init_addr: 100060
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.591359] vrx518 0000:01:00.0: aca_hif_param_init_done
Thu Dec 26 20:33:08 2024 kern.debug kernel: [ 1059.591372] vrx518 0000:01:00.0: aca mdm init done
Thu Dec 26 20:33:08 2024 kern.info kernel: [ 1059.591382] vrx518 0000:01:00.0: aca init done
Thu Dec 26 20:33:08 2024 kern.info kernel: [ 1059.596646] vrx518_tc:is_ptm_sl: is_ptm_sl: SINGLE
Thu Dec 26 20:33:08 2024 kern.err kernel: [ 1059.601094] Sent TC multicast message Fail!
Thu Dec 26 20:33:08 2024 kern.info kernel: [ 1059.605757] vrx518_tc:ptm_tc_load: PTM TC is successfully loaded
Thu Dec 26 20:33:08 2024 kern.info kernel: [ 1059.769278] vrx518_tc:is_ptm_sl: is_ptm_sl: SINGLE
Thu Dec 26 20:33:08 2024 kern.info kernel: [ 1059.769334] vrx518_tc:ptm_erb_addr_get: idx: 0, data addr: 0x40a30000,  desc_addr: 0x40b60000
Thu Dec 26 20:33:10 2024 daemon.warn wgpeerselector: DNS resolution of ntp server ntp-b.aachen.freifunk.net failed: error code -3
Thu Dec 26 20:33:15 2024 daemon.warn wgpeerselector: DNS resolution of ntp server 2.openwrt.pool.ntp.org failed: error code -3
Thu Dec 26 20:33:15 2024 daemon.warn wgpeerselector: no (valid) dns result for ntp servers. skipping time sync.
Thu Dec 26 20:33:15 2024 daemon.info wgpeerselector: Adding peer sn220 to wg_mesh.
Thu Dec 26 20:33:20 2024 daemon.info wgpeerselector: Removing peer sn220 from wg_mesh.
Thu Dec 26 20:33:25 2024 daemon.warn wgpeerselector: DNS resolution of ntp server a.ntp.ffac.rocks failed: error code -3
Thu Dec 26 20:33:30 2024 daemon.warn wgpeerselector: DNS resolution of ntp server ntp-b.aachen.freifunk.net failed: error code -3
Thu Dec 26 20:33:35 2024 daemon.warn wgpeerselector: DNS resolution of ntp server 2.openwrt.pool.ntp.org failed: error code -3
Thu Dec 26 20:33:35 2024 daemon.warn wgpeerselector: no (valid) dns result for ntp servers. skipping time sync.
Thu Dec 26 20:33:35 2024 daemon.info wgpeerselector: Adding peer sn114 to wg_mesh.
Thu Dec 26 20:33:40 2024 daemon.info wgpeerselector: Removing peer sn114 from wg_mesh.
Thu Dec 26 20:33:45 2024 daemon.warn wgpeerselector: DNS resolution of ntp server a.ntp.ffac.rocks failed: error code -3
Thu Dec 26 20:33:50 2024 kern.info kernel: [ 1101.582468] vrx518_tc:ptm_showtime_enter: Line[0]: show time enter!!
Thu Dec 26 20:33:50 2024 kern.info kernel: [ 1101.582579] vrx518_tc:is_ptm_sl: is_ptm_sl: SINGLE
Thu Dec 26 20:33:50 2024 daemon.notice netifd: Network device 'dsl0' link is up
Thu Dec 26 20:33:50 2024 daemon.notice netifd: VLAN 'dsl0.7' link is up
Thu Dec 26 20:33:50 2024 daemon.notice netifd: Interface 'wan' has link connectivity
Thu Dec 26 20:33:50 2024 daemon.notice netifd: Interface 'wan' is setting up now
Thu Dec 26 20:33:50 2024 daemon.info pppd[12651]: Plugin pppoe.so loaded.
Thu Dec 26 20:33:50 2024 daemon.info pppd[12651]: PPPoE plugin from pppd 2.5.1
Thu Dec 26 20:33:50 2024 daemon.notice pppd[12651]: pppd 2.5.1 started by root, uid 0
Thu Dec 26 20:33:50 2024 daemon.warn wgpeerselector: DNS resolution of ntp server ntp-b.aachen.freifunk.net failed: error code -3
Thu Dec 26 20:33:55 2024 daemon.info pppd[12651]: PPP session is 1
Thu Dec 26 20:33:55 2024 daemon.warn pppd[12651]: Connected to 20:E0:9C:03:F4:01 via interface dsl0.7
Thu Dec 26 20:33:55 2024 daemon.info pppd[12651]: Using interface pppoe-wan
Thu Dec 26 20:33:55 2024 daemon.notice pppd[12651]: Connect: pppoe-wan <--> dsl0.7
Thu Dec 26 20:33:55 2024 daemon.warn wgpeerselector: DNS resolution of ntp server 2.openwrt.pool.ntp.org failed: error code -3
Thu Dec 26 20:33:55 2024 daemon.warn wgpeerselector: no (valid) dns result for ntp servers. skipping time sync.
Thu Dec 26 20:33:55 2024 daemon.info wgpeerselector: Adding peer sn216 to wg_mesh.
Thu Dec 26 20:33:58 2024 daemon.info pppd[12651]: CHAP authentication succeeded: CHAP authentication success
Thu Dec 26 20:33:58 2024 daemon.notice pppd[12651]: CHAP authentication succeeded
Thu Dec 26 20:33:58 2024 daemon.notice pppd[12651]: peer from calling number 20:E0:9C:03:F4:01 authorized
Thu Dec 26 20:33:58 2024 daemon.notice pppd[12651]: local  LL address fe80::25cb:2b99:1981:8828
Thu Dec 26 20:33:58 2024 daemon.notice pppd[12651]: remote LL address fe80::22e0:9cff:fe03:f401
Thu Dec 26 20:33:58 2024 daemon.notice pppd[12651]: local  IP address 188.126.x.x
Thu Dec 26 20:33:58 2024 daemon.notice pppd[12651]: remote IP address 78.153.x.x
Thu Dec 26 20:33:58 2024 daemon.notice pppd[12651]: primary   DNS address 212.16.x.x
Thu Dec 26 20:33:58 2024 daemon.notice pppd[12651]: secondary DNS address 212.16.x.x
Thu Dec 26 20:33:58 2024 daemon.notice netifd: Network device 'pppoe-wan' link is up
Thu Dec 26 20:33:58 2024 daemon.notice netifd: Interface 'wan' is now up
Thu Dec 26 20:33:58 2024 daemon.info dnsmasq[1]: reading /tmp/resolv.conf.d/resolv.conf.auto
Thu Dec 26 20:33:58 2024 daemon.info dnsmasq[1]: using nameserver 212.16.x.x#53
Thu Dec 26 20:33:58 2024 daemon.info dnsmasq[1]: using nameserver 212.16.x.x#53
Thu Dec 26 20:33:58 2024 daemon.info dnsmasq[1]: using only locally-known addresses for lan
Thu Dec 26 20:33:58 2024 daemon.notice netifd: Network alias 'pppoe-wan' link is up
Thu Dec 26 20:33:58 2024 daemon.notice netifd: Interface 'wan_6' is enabled
Thu Dec 26 20:33:58 2024 daemon.notice netifd: Interface 'wan_6' has link connectivity
Thu Dec 26 20:33:58 2024 daemon.notice netifd: Interface 'wan_6' is setting up now
Thu Dec 26 20:33:59 2024 user.notice firewall: Reloading firewall due to ifup of wan (pppoe-wan)
Thu Dec 26 20:34:00 2024 user.notice firewall: Reloading firewall due to ifupdate of wan (pppoe-wan)
Thu Dec 26 20:34:00 2024 daemon.notice hostapd: Reload config for bss 'client1' on phy 'phy1'
Thu Dec 26 20:34:00 2024 daemon.notice netifd: Network device 'client1' link is down
Thu Dec 26 20:34:00 2024 kern.info kernel: [ 1112.521505] br-client: port 7(client1) entered disabled state
Thu Dec 26 20:34:00 2024 daemon.info wgpeerselector: Removing peer sn216 from wg_mesh.
Thu Dec 26 20:34:00 2024 daemon.notice netifd: Network device 'client1' link is up
Thu Dec 26 20:34:00 2024 kern.info kernel: [ 1112.558986] br-client: port 7(client1) entered blocking state
Thu Dec 26 20:34:00 2024 kern.info kernel: [ 1112.559091] br-client: port 7(client1) entered forwarding state
Thu Dec 26 20:34:00 2024 daemon.notice hostapd: Reloaded settings for phy phy1
Thu Dec 26 20:34:01 2024 daemon.notice hostapd: Reload config for bss 'client0' on phy 'phy0'
Thu Dec 26 20:34:01 2024 daemon.notice hostapd: Reloaded settings for phy phy0
Thu Dec 26 20:34:01 2024 user.notice general-workaround: detected a reason to act upon.
Thu Dec 26 20:34:01 2024 daemon.err micrond[2403]: general-workaround: detected a reason to act upon.
Thu Dec 26 20:34:01 2024 user.notice general-workaround: network restart possible on next script run.
Thu Dec 26 20:34:01 2024 daemon.err micrond[2403]: general-workaround: network restart possible on next script run.
Thu Dec 26 20:34:01 2024 daemon.notice netifd: wg_mesh_peerselector (10638): ntpd: duplicate peer 5.145.135.149 (5.145.135.149)
Thu Dec 26 20:34:01 2024 daemon.notice netifd: wg_mesh_peerselector (10638): ntpd: duplicate peer 2a00:fe0:43::149 (2a00:fe0:43::149)
Thu Dec 26 20:34:01 2024 daemon.notice netifd: wg_mesh_peerselector (10638): ntpd: send failed: Network unreachable
Thu Dec 26 20:34:01 2024 daemon.notice netifd: wg_mesh_peerselector (10638): ntpd: send failed: Network unreachable
Thu Dec 26 20:34:01 2024 daemon.notice netifd: wg_mesh_peerselector (10638): ntpd: send failed: Network unreachable
Thu Dec 26 20:34:01 2024 daemon.notice netifd: wg_mesh_peerselector (10638): ntpd: send failed: Network unreachable
Thu Dec 26 20:34:01 2024 daemon.notice netifd: wg_mesh_peerselector (10638): ntpd: send failed: Network unreachable
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: exiting on receipt of SIGTERM
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: started, version 2.90 cachesize 150
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: compile time options: IPv6 GNU-getopt no-DBus UBus no-i18n no-IDN DHCP no-DHCPv6 no-Lua TFTP no-conntrack no-ipset no-nftset no-auth cryptohash DNSSEC loop-detect inotify dumpfile
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: UBus support enabled: connected to system bus
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: using only locally-known addresses for lan
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: reading /tmp/resolv.conf.d/resolv.conf.auto
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: using nameserver 212.16.x.x#53
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: using nameserver 212.16.x.x#53
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: using only locally-known addresses for lan
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: read /etc/hosts - 12 names
Thu Dec 26 20:34:01 2024 daemon.info dnsmasq[1]: read /tmp/hosts/dhcp.cfg01411c - 0 names
Thu Dec 26 20:34:02 2024 daemon.info wgpeerselector: Time synchonization was successful.
Thu Dec 26 20:34:02 2024 daemon.info wgpeerselector: Adding peer sn214 to wg_mesh.
Thu Dec 26 20:34:03 2024 daemon.warn netifd: You have delegated IPv6-prefixes but haven't assigned them to any interface. Did you forget to set option ip6assign on your lan-interfaces?
Thu Dec 26 20:34:03 2024 daemon.notice netifd: Interface 'wan_6' is now up
Thu Dec 26 20:34:03 2024 daemon.info dnsmasq[1]: reading /tmp/resolv.conf.d/resolv.conf.auto
Thu Dec 26 20:34:03 2024 daemon.info dnsmasq[1]: using nameserver 212.16.x.x#53
Thu Dec 26 20:34:03 2024 daemon.info dnsmasq[1]: using nameserver 212.16.x.x#53
Thu Dec 26 20:34:03 2024 daemon.info dnsmasq[1]: using only locally-known addresses for lan
Thu Dec 26 20:34:03 2024 user.notice firewall: Reloading firewall due to ifup of wan_6 (pppoe-wan)
Thu Dec 26 20:34:07 2024 daemon.info wgpeerselector: Removing peer sn214 from wg_mesh.
Thu Dec 26 20:34:07 2024 daemon.info wgpeerselector: Adding peer sn219 to wg_mesh.
Thu Dec 26 20:34:12 2024 daemon.info wgpeerselector: Removing peer sn219 from wg_mesh.
Thu Dec 26 20:34:12 2024 daemon.info wgpeerselector: Adding peer sn211 to wg_mesh.
Thu Dec 26 20:34:17 2024 daemon.info wgpeerselector: Removing peer sn211 from wg_mesh.
Thu Dec 26 20:34:17 2024 daemon.info wgpeerselector: Adding peer sn119 to wg_mesh.
Thu Dec 26 20:34:22 2024 daemon.info wgpeerselector: Removing peer sn119 from wg_mesh.
Thu Dec 26 20:34:22 2024 daemon.info wgpeerselector: Adding peer sn113 to wg_mesh.
Thu Dec 26 20:34:27 2024 daemon.info wgpeerselector: Removing peer sn113 from wg_mesh.
Thu Dec 26 20:34:27 2024 daemon.info wgpeerselector: Adding peer sn212 to wg_mesh.
Thu Dec 26 20:34:32 2024 daemon.info wgpeerselector: Removing peer sn212 from wg_mesh.
Thu Dec 26 20:34:32 2024 daemon.info wgpeerselector: Adding peer sn217 to wg_mesh.
Thu Dec 26 20:34:37 2024 daemon.info wgpeerselector: Removing peer sn217 from wg_mesh.
Thu Dec 26 20:34:37 2024 daemon.info wgpeerselector: Adding peer sn213 to wg_mesh.
Thu Dec 26 20:34:42 2024 daemon.info wgpeerselector: Removing peer sn213 from wg_mesh.
Thu Dec 26 20:34:42 2024 daemon.info wgpeerselector: Adding peer sn111 to wg_mesh.
Thu Dec 26 20:34:47 2024 daemon.info wgpeerselector: Removing peer sn111 from wg_mesh.
Thu Dec 26 20:34:47 2024 daemon.info wgpeerselector: Adding peer sn218 to wg_mesh.
Thu Dec 26 20:34:52 2024 daemon.info wgpeerselector: Removing peer sn218 from wg_mesh.
Thu Dec 26 20:34:52 2024 daemon.info wgpeerselector: Adding peer sn117 to wg_mesh.
Thu Dec 26 20:34:57 2024 daemon.info wgpeerselector: Removing peer sn117 from wg_mesh.
Thu Dec 26 20:34:57 2024 daemon.info wgpeerselector: Adding peer sn115 to wg_mesh.
Thu Dec 26 20:35:02 2024 daemon.info wgpeerselector: Removing peer sn115 from wg_mesh.
Thu Dec 26 20:35:02 2024 daemon.info wgpeerselector: Adding peer sn112 to wg_mesh.
Thu Dec 26 20:35:07 2024 daemon.info wgpeerselector: Removing peer sn112 from wg_mesh.
Thu Dec 26 20:35:07 2024 daemon.info wgpeerselector: Adding peer sn118 to wg_mesh.
Thu Dec 26 20:35:12 2024 daemon.info wgpeerselector: Removing peer sn118 from wg_mesh.
Thu Dec 26 20:35:17 2024 daemon.info wgpeerselector: Adding peer sn214 to wg_mesh.
Thu Dec 26 20:35:23 2024 daemon.info wgpeerselector: Removing peer sn214 from wg_mesh.
Thu Dec 26 20:35:23 2024 daemon.info wgpeerselector: Adding peer sn116 to wg_mesh.
Thu Dec 26 20:35:28 2024 daemon.info wgpeerselector: Removing peer sn116 from wg_mesh.
Thu Dec 26 20:35:28 2024 daemon.info wgpeerselector: Adding peer sn218 to wg_mesh.
Thu Dec 26 20:35:33 2024 daemon.info wgpeerselector: Removing peer sn218 from wg_mesh.
Thu Dec 26 20:35:33 2024 daemon.info wgpeerselector: Adding peer sn213 to wg_mesh.
Thu Dec 26 20:35:38 2024 daemon.info wgpeerselector: Removing peer sn213 from wg_mesh.
Thu Dec 26 20:35:38 2024 daemon.info wgpeerselector: Adding peer sn113 to wg_mesh.
Thu Dec 26 20:35:43 2024 daemon.info wgpeerselector: Removing peer sn113 from wg_mesh.
Thu Dec 26 20:35:43 2024 daemon.info wgpeerselector: Adding peer sn112 to wg_mesh.
Thu Dec 26 20:35:48 2024 daemon.info wgpeerselector: Removing peer sn112 from wg_mesh.
Thu Dec 26 20:35:48 2024 daemon.info wgpeerselector: Adding peer sn220 to wg_mesh.
Thu Dec 26 20:35:53 2024 daemon.info wgpeerselector: Connection established with sn220.
Thu Dec 26 20:36:00 2024 daemon.notice hostapd: Reload config for bss 'client1' on phy 'phy1'
Thu Dec 26 20:36:00 2024 daemon.notice netifd: Network device 'client1' link is down
Thu Dec 26 20:36:00 2024 kern.info kernel: [ 1232.288741] br-client: port 7(client1) entered disabled state
Thu Dec 26 20:36:00 2024 daemon.notice netifd: Network device 'client1' link is up
Thu Dec 26 20:36:00 2024 kern.info kernel: [ 1232.300021] br-client: port 7(client1) entered blocking state
Thu Dec 26 20:36:00 2024 kern.info kernel: [ 1232.300088] br-client: port 7(client1) entered forwarding state
Thu Dec 26 20:36:00 2024 daemon.notice hostapd: Reloaded settings for phy phy1
Thu Dec 26 20:36:00 2024 daemon.notice hostapd: Reload config for bss 'client0' on phy 'phy0'
Thu Dec 26 20:36:00 2024 daemon.notice hostapd: Reloaded settings for phy phy0
Thu Dec 26 20:36:32 2024 daemon.err gluon-radv-filterd[12033]: Switching to 88:e6:ff:ac:20:20 (TQ=38)
Thu Dec 26 20:36:32 2024 daemon.info dnsmasq[1]: reading /tmp/resolv.conf.d/resolv.conf.auto
Thu Dec 26 20:36:32 2024 daemon.info dnsmasq[1]: using nameserver 2a00:fe0:43::158#53
Thu Dec 26 20:36:32 2024 daemon.info dnsmasq[1]: using only locally-known addresses for lan
Thu Dec 26 20:36:32 2024 user.notice firewall: Reloading firewall due to ifupdate of client (br-client)
Thu Dec 26 20:36:33 2024 user.notice firewall: Reloading firewall due to ifupdate of client (br-client)
Thu Dec 26 20:36:33 2024 daemon.err respondd[11960]: sendto failed: Operation not permitted
Thu Dec 26 20:36:49 2024 daemon.notice netifd: Network device 'lan2' link is down
Thu Dec 26 20:36:49 2024 kern.info kernel: [ 1281.415923] qca8k-ipq4019 c000000.switch lan2: Link is Down
Thu Dec 26 20:36:49 2024 kern.info kernel: [ 1281.416074] br-client: port 1(lan2) entered disabled state
Thu Dec 26 20:36:52 2024 kern.info kernel: [ 1284.536038] qca8k-ipq4019 c000000.switch lan2: Link is Up - 1Gbps/Full - flow control rx/tx
Thu Dec 26 20:36:52 2024 kern.info kernel: [ 1284.536151] br-client: port 1(lan2) entered blocking state
Thu Dec 26 20:36:52 2024 kern.info kernel: [ 1284.543340] br-client: port 1(lan2) entered forwarding state
Thu Dec 26 20:36:52 2024 daemon.notice netifd: Network device 'lan2' link is up
Thu Dec 26 20:37:10 2024 user.notice firewall: Reloading firewall due to ifupdate of client (br-client)
Thu Dec 26 20:38:00 2024 user.notice ffac-ssid-changer: SSID is FF_Offline_ffac-hg-7530, change to Freifunk
Thu Dec 26 20:38:00 2024 daemon.err micrond[2403]: ffac-ssid-changer: SSID is FF_Offline_ffac-hg-7530, change to Freifunk
Thu Dec 26 20:38:00 2024 user.notice ffac-ssid-changer: SSID is FF_Offline_ffac-hg-7530, change to Freifunk
Thu Dec 26 20:38:00 2024 daemon.err micrond[2403]: ffac-ssid-changer: SSID is FF_Offline_ffac-hg-7530, change to Freifunk
Thu Dec 26 20:38:00 2024 daemon.notice hostapd: Reload config for bss 'client1' on phy 'phy1'
Thu Dec 26 20:38:00 2024 daemon.notice netifd: Network device 'client1' link is down
Thu Dec 26 20:38:00 2024 kern.info kernel: [ 1352.295371] br-client: port 7(client1) entered disabled state
Thu Dec 26 20:38:00 2024 daemon.notice netifd: Network device 'client1' link is up
Thu Dec 26 20:38:00 2024 kern.info kernel: [ 1352.307101] br-client: port 7(client1) entered blocking state
Thu Dec 26 20:38:00 2024 kern.info kernel: [ 1352.307170] br-client: port 7(client1) entered forwarding state
Thu Dec 26 20:38:00 2024 daemon.notice hostapd: Reloaded settings for phy phy1
Thu Dec 26 20:38:00 2024 daemon.notice hostapd: Reload config for bss 'client0' on phy 'phy0'
Thu Dec 26 20:38:00 2024 daemon.notice hostapd: Reloaded settings for phy phy0
Thu Dec 26 20:43:32 2024 daemon.info pppd[12651]: No response to 5 echo-requests
Thu Dec 26 20:43:32 2024 daemon.notice pppd[12651]: Serial link appears to be disconnected.
Thu Dec 26 20:43:32 2024 daemon.info pppd[12651]: Connect time 9.6 minutes.
Thu Dec 26 20:43:32 2024 daemon.info pppd[12651]: Sent 0 bytes, received 19298070 bytes.
Thu Dec 26 20:43:32 2024 daemon.err odhcp6c[12854]: Failed to send RELEASE message to ff02::1:2 (Network unreachable)
Thu Dec 26 20:43:32 2024 daemon.notice netifd: Interface 'wan_6' is disabled
Thu Dec 26 20:43:32 2024 daemon.notice netifd: Network device 'pppoe-wan' link is down
Thu Dec 26 20:43:32 2024 daemon.notice netifd: Network alias 'pppoe-wan' link is down
Thu Dec 26 20:43:32 2024 daemon.notice netifd: Interface 'wan_6' has link connectivity loss
Thu Dec 26 20:43:32 2024 daemon.notice netifd: Interface 'wan' has lost the connection
Thu Dec 26 20:43:32 2024 daemon.info dnsmasq[1]: reading /tmp/resolv.conf.d/resolv.conf.auto
Thu Dec 26 20:43:32 2024 daemon.info dnsmasq[1]: using nameserver 2a00:fe0:43::158#53
Thu Dec 26 20:43:32 2024 daemon.info dnsmasq[1]: using only locally-known addresses for lan
Thu Dec 26 20:43:32 2024 daemon.notice netifd: wan_6 (12854): Command failed: ubus call network.interface notify_proto { "action": 0, "link-up": false, "keep": false, "interface": "wan_6" } (Permission denied)
Thu Dec 26 20:43:32 2024 daemon.err odhcp6c[12854]: Failed to send SOLICIT message to ff02::1:2 (Network unreachable)
Thu Dec 26 20:43:32 2024 daemon.notice netifd: Interface 'wan_6' is now down
Thu Dec 26 20:43:37 2024 daemon.notice netifd: Network device 'dsl0' link is down
Thu Dec 26 20:43:37 2024 daemon.notice netifd: VLAN 'dsl0.7' link is down
Thu Dec 26 20:43:37 2024 daemon.notice netifd: Interface 'wan' has link connectivity loss
Thu Dec 26 20:43:37 2024 kern.info kernel: [ 1689.171383] vrx518_tc:ptm_showtime_exit: Line[0]: show time exit!
Thu Dec 26 20:43:37 2024 kern.info kernel: [ 1689.171445] vrx518_tc:is_ptm_sl: is_ptm_sl: SINGLE
Thu Dec 26 20:43:37 2024 daemon.info pppd[12651]: Terminating on signal 15
Thu Dec 26 20:43:38 2024 daemon.notice pppd[12651]: Connection terminated.
Thu Dec 26 20:43:38 2024 daemon.info pppd[12651]: Sent PADT
Thu Dec 26 20:43:38 2024 daemon.notice pppd[12651]: Modem hangup
Thu Dec 26 20:43:38 2024 daemon.info pppd[12651]: Exit.
Thu Dec 26 20:43:38 2024 daemon.notice netifd: Interface 'wan' is now down
Thu Dec 26 20:43:38 2024 daemon.info hostapd: client1: STA e8:78:29:c4:6a:2c IEEE 802.11: authenticated
Thu Dec 26 20:43:38 2024 daemon.info hostapd: client1: STA e8:78:29:c4:6a:2c IEEE 802.11: associated (aid 1)
Thu Dec 26 20:43:38 2024 daemon.notice hostapd: client1: AP-STA-CONNECTED e8:78:29:c4:6a:2c auth_alg=open
```
</details>

required addition to `/etc/config/network`

```
config interface 'wdsl'
    option device 'dsl0.7'
    option proto 'pppoe'
    option username 'username'
    option password 'xxx'
    option ipv6 'auto'
```

This is not yet safe for `gluon-reconfigure` or sysupgrades but I think that this is an interesting feature for installations, where the sole purpose of the DSL router is to forward internet to the Freifunk Router.

Tested with a FB7520 and current gluon main.

Note: one might need to apply this patch for the fb7530:
https://github.com/openwrt/openwrt/pull/15421 (WIP) or this https://github.com/janh/openwrt/commit/59f52125178146a9dc44290c11c63e5e029e8044

This is a PR to show that this is working and add the required packages to the fb7530.

A package which persists the required configuration and exposes it to the web-config-mode is expected in the future.
Though, I think that this is more suitable for the community-packages repository, as this is a rather niche use-case.

TODO:

- [x] DSL does not receive an IPv6 prefix
- [x] check firewall rules
- [x] Community-package
- [x] web-config-mode package


<details> 
<summary>ip a</summary>

```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host proto kernel_lo 
       valid_lft forever preferred_lft forever
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether da:23:0b:5f:51:5b brd ff:ff:ff:ff:ff:ff
    inet6 fe80::d823:bff:fe5f:515b/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
3: lan1@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master br-wan state LOWERLAYERDOWN group default qlen 1000
    link/ether da:23:0b:5f:51:5b brd ff:ff:ff:ff:ff:ff
4: lan2@eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-client state UP group default qlen 1000
    link/ether da:23:0b:5f:51:5b brd ff:ff:ff:ff:ff:ff
5: lan3@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master br-client state LOWERLAYERDOWN group default qlen 1000
    link/ether da:23:0b:5f:51:5b brd ff:ff:ff:ff:ff:ff
6: lan4@eth0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue master br-client state LOWERLAYERDOWN group default qlen 1000
    link/ether da:23:0b:5f:51:5b brd ff:ff:ff:ff:ff:ff
7: dummy0: <BROADCAST,NOARP> mtu 1500 qdisc noop state DOWN group default qlen 1000
    link/ether 5e:06:b9:f2:1d:11 brd ff:ff:ff:ff:ff:ff
8: br-client: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 3c:37:12:82:cb:ab brd ff:ff:ff:ff:ff:ff
    inet6 2a03:2260:3006:220:3e37:ffff:ffff/64 scope global dynamic noprefixroute 
       valid_lft 577sec preferred_lft 277sec
    inet6 2a03:2260:3006:120:3e37:ffff:ffff/64 scope global dynamic noprefixroute 
       valid_lft 589sec preferred_lft 289sec
    inet6 fdac::3e37:12ff:ffff:ffff/64 scope global dynamic noprefixroute 
       valid_lft 86331sec preferred_lft 14331sec
    inet6 fe80::3e37:12ff:ffff:ffff/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
10: local-port@local-node: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-client state UP group default qlen 1000
    link/ether 3c:37:12:82:cb:ab brd ff:ff:ff:ff:ff:ff
11: local-node@local-port: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether ac:41:95:40:f7:dc brd ff:ff:ff:ff:ff:ff
    inet6 fdac::ac/128 scope global deprecated 
       valid_lft forever preferred_lft 0sec
    inet6 fe80::ae41:95ff:fe40:f7dc/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
12: wg_mesh: <POINTOPOINT,NOARP,UP,LOWER_UP> mtu 1406 qdisc noqueue state UNKNOWN group default qlen 1000
    link/none 
    inet6 fe80::20e:4cff:febb:35f3/128 scope link 
       valid_lft forever preferred_lft forever
13: bat0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-client state UNKNOWN group default qlen 1000
    link/ether 3c:37:12:82:cb:ab brd ff:ff:ff:ff:ff:ff
    inet6 fe80::3e37:12ff:ffff:ffff/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
14: primary0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1532 qdisc noqueue master bat0 state UNKNOWN group default qlen 1000
    link/ether 02:9b:7f:ac:9e:ab brd ff:ff:ff:ff:ff:ff
    inet6 fe80::9b:7fff:feac:9eab/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
15: mesh-vpn: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1336 qdisc noqueue master bat0 state UNKNOWN group default qlen 1000
    link/ether 5e:cb:75:ff:bf:f9 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::5ccb:75ff:feff:bff9/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
16: client1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-client state UP group default qlen 1000
    link/ether 02:9b:7f:ac:9e:ac brd ff:ff:ff:ff:ff:ff permaddr 3c:37:12:82:cb:ac
17: client0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master br-client state UP group default qlen 1000
    link/ether 02:9b:7f:ac:9e:a8 brd ff:ff:ff:ff:ff:ff permaddr 3c:37:12:82:cb:ab
18: mesh1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1532 qdisc noqueue master bat0 state UP group default qlen 1000
    link/ether 02:9b:7f:ac:9e:ad brd ff:ff:ff:ff:ff:ff
    inet6 fe80::9b:7fff:feac:9ead/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
19: mesh0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1532 qdisc noqueue master bat0 state UP group default qlen 1000
    link/ether 02:9b:7f:ac:9e:a9 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::9b:7fff:feac:9ea9/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
20: dsl0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 3c:37:12:82:cb:a6 brd ff:ff:ff:ff:ff:ff permaddr ac:9a:96:11:22:33
    inet6 fe80::3e37:12ff:fe82:cba6/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
25: br-wan: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000
    link/ether 02:9b:7f:ac:9e:a8 brd ff:ff:ff:ff:ff:ff
29: dsl0.7@dsl0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP group default qlen 1000
    link/ether 3c:37:12:82:cb:a6 brd ff:ff:ff:ff:ff:ff
    inet6 fe80::3e37:12ff:fe82:cba6/64 scope link proto kernel_ll 
       valid_lft forever preferred_lft forever
30: pppoe-wdsl: <POINTOPOINT,MULTICAST,NOARP,UP,LOWER_UP> mtu 1492 qdisc fq_codel state UNKNOWN group default qlen 3
    link/ppp 
    inet 78.153.x.x peer 78.153.x.x/32 scope global pppoe-wdsl
       valid_lft forever preferred_lft forever
    inet6 fe80::4dbc:f2e7:fbeb:a02e peer fe80::22e0:9cff:fe03:f401/128 scope link nodad 
       valid_lft forever preferred_lft forever
```

</summary>