### PR TITLE
core: Fix wl phyname

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -5,6 +5,8 @@ local util = require 'gluon.util'
 local unistd = require 'posix.unistd'
 local dirent = require 'posix.dirent'
 
+local iwinfo = require 'iwinfo'
+
 
 local M = {}
 
@@ -50,8 +52,9 @@ local function find_phy_by_macaddr(macaddr)
 end
 
 function M.find_phy(config)
-	if not config or config.type ~= 'mac80211' then
-		return nil
+	phyname = iwinfo.nl80211.phyname(config['.name'])
+	if phyname then
+		return phyname
 	elseif config.path then
 		return find_phy_by_path(config.path)
 	elseif config.macaddr then


### PR DESCRIPTION
just a shot in the dark to fix wifi for mediatek-mt7622 devices on openwrt-24.10 to fix #3332

eventually, there is a better way to adapt to the new upstream wifi behavior as seen in 
https://github.com/freifunk-gluon/gluon/pull/3332#issuecomment-2566283197