### PR TITLE
gluon-private-wifi: rename psk3 to sae as it is used in openwrt that way

### DIFF
--- a/package/gluon-private-wifi/luasrc/lib/gluon/upgrade/325-gluon-private-wifi
+++ b/package/gluon-private-wifi/luasrc/lib/gluon/upgrade/325-gluon-private-wifi
@@ -13,6 +13,11 @@ wireless.foreach_radio(uci, function(radio)
 	end
 
 	uci:set('wireless', name, 'ifname', suffix and 'wl-wan' .. suffix)
+
+	-- migrate encryption from Gluon v2023.2.x or older
+	-- remove in 2027 or on first release supporting only upgrades from >=v2025.1.x
+	local encryption = uci:get('wireless', name, 'encryption')
+	uci:set('wireless', name, 'encryption', encryption:gsub("psk3", "sae"))
 end)
 
 uci:save('wireless')

--- a/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
+++ b/package/gluon-web-private-wifi/luasrc/lib/gluon/config-mode/model/admin/privatewifi.lua
@@ -49,8 +49,8 @@ local encryption = s:option(ListValue, "encryption", translate("Encryption"))
 encryption:depends(enabled, true)
 encryption:value("psk2", translate("WPA2"))
 if wireless.device_supports_wpa3() then
-	encryption:value("psk3-mixed", translate("WPA2 / WPA3"))
-	encryption:value("psk3", translate("WPA3"))
+	encryption:value("sae-mixed", translate("WPA2 / WPA3"))
+	encryption:value("sae", translate("WPA3"))
 end
 encryption.default = uci:get('wireless', primary_iface, 'encryption') or "psk2"
 


### PR DESCRIPTION
I had a hard time finding information about psk3 in openwrt documentation as it is not mentioned here:

https://openwrt.org/docs/guide-user/network/wifi/basic#encryption_modes

I think the naming changed some time, so it makes sense to use the documented value of sae instead of psk3.

The functionality in openwrt is the same, so this does not change any functionality ~~and there is no good reason to migrate existing configs~~.
Though this helps to better find related documentation to the value set in `uci show wireless`