### PR TITLE
docs: add AP3915i to supported_devices

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -225,6 +225,10 @@ ipq40xx-generic
   - FRITZ!Box 7530 [#eva_ramboot]_ [#lan_as_wan]_
   - FRITZ!Repeater 1200 [#eva_ramboot]_
 
+* Extreme Networks
+
+  - WS-AP3915i
+
 * GL.iNet
 
   - GL-AP1300


### PR DESCRIPTION
this is a fixup to #3396 in which initial support to the Extreme Networks AP3915i was added.
In this PR the addition to the supported_devices.rst was missing.