### PR TITLE
ramips-mt76x8: Add support for Xiaomi Mi Router 4A (100M International Edition v2 - R4ACv2) - closes #3183

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -542,6 +542,7 @@ ramips-mt76x8
 
   - Xiaomi Mi Router 4A (100M Edition) - MIR4A
   - Xiaomi Mi Router 4A (100M International Edition) - R4AC
+  - Xiaomi Mi Router 4A (100M International Edition v2) - R4ACv2
   - Xiaomi Mi Router 4C - R4CM
 
 rockchip-armv8

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -540,9 +540,9 @@ ramips-mt76x8
 
 * Xiaomi
 
-  - Xiaomi Mi Router 4A (100M Edition)
-  - Xiaomi Mi Router 4A (100M International Edition)
-  - Xiaomi Mi Router 4C
+  - Xiaomi Mi Router 4A (100M Edition) - MIR4A
+  - Xiaomi Mi Router 4A (100M International Edition) - R4AC
+  - Xiaomi Mi Router 4C - R4CM
 
 rockchip-armv8
 --------------

--- a/targets/ramips-mt76x8
+++ b/targets/ramips-mt76x8
@@ -124,6 +124,10 @@ device('xiaomi-mi-router-4a-100m-international-edition', 'xiaomi_mi-router-4a-10
 	factory = false,
 })
 
+device('xiaomi-mi-router-4a-100m-international-edition-v2', 'xiaomi_mi-router-4a-100m-intl-v2', {
+	factory = false,
+})
+
 device('xiaomi-mi-router-4c', 'xiaomi_mi-router-4c', {
 	factory = false,
 })


### PR DESCRIPTION
- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [X] Other: <sysupgrade -n from OpenWRT 24.10rc5>
- [ ] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`