### PR TITLE
ramips-mt7620: Add support for Netgear EX6120

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -405,6 +405,7 @@ ramips-mt7620
 
   - EX3700
   - EX3800
+  - EX6120
   - EX6130
 
 * Nexx

--- a/targets/ramips-mt7620
+++ b/targets/ramips-mt7620
@@ -30,6 +30,10 @@ device('netgear-ex3700', 'netgear_ex3700', {
 	factory_ext = '.chk',
 })
 
+device('netgear-ex6120', 'netgear_ex6120', {
+	factory_ext = '.chk',
+})
+
 device('netgear-ex6130', 'netgear_ex6130', {
 	factory_ext = '.chk',
 })


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [x] nmrpflash
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
       ->  netgear-ex6120
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages) -> MAC-Address match eth0 and br-wan but not br-client (last digit changed)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio ->  led labeled "router" and led labeled "device" was controllable in openwrt but is off with gluon
    - [ ] Should show activity ->  led labeled "router" and led labeled "device" was controllable in openwrt but is off with gluon
    - [ ] Should map to their respective port (or switch, if only one led present) ->  no extra led
    - [ ] Should show link state and activity ->  no extra led
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`