### PR TITLE
docs: move D-Link M30, M60 to mediatek-filogic section

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -40,8 +40,6 @@ ath79-generic
 
 * D-Link
 
-  - AQUILA PRO AI M30 A1
-  - AQUILA PRO AI M60 A1
   - DAP-1330 A1 [#lan_as_wan]_
   - DAP-1365 A1 [#lan_as_wan]_
   - DAP-2660 A1 [#lan_as_wan]_
@@ -322,6 +320,11 @@ mediatek-filogic
 
   - AP3000 Outdoor (v1)
   - WR3000 (v1)
+
+* D-Link
+
+  - AQUILA PRO AI M30 A1
+  - AQUILA PRO AI M60 A1
 
 * GL.iNet
 


### PR DESCRIPTION
in `docs/user/supported_devices.rst`

(@RolandoMagico: these devices had sneaked into the ath79 section)