### PR TITLE
gluon-core: set 5GHz rssi leds to mesh1 connectivity

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -249,5 +249,10 @@ if uci:get('system', 'rssid_wlan0') then
 	uci:save('system')
 end
 
+if uci:get('system', 'rssid_wlan1') then
+	uci:set('system', 'rssid_wlan1', 'dev', 'mesh1')
+	uci:save('system')
+end
+
 uci:save('wireless')
 uci:save('network')


### PR DESCRIPTION
The RSSI LEDS on 5GHz in openwrt did not work for gluon as they were set to `wlan1` which does not exist.

For example the dap-x1860 profits from using its LEDs to show the mesh connectivity on 5GHz through the LEDs.

This of course is only limited to show the connectivity on radio1 if possible.
This might as well be misleading in situations where radio1 does not mesh and the turned off connectivity is interpreted wrongly.

Though I don't think there is a better approach than using it for mesh1 and I do think it is a nice feature and should be enabled by default :)

Tested on a DAP-X1860 in combination with a COVR-X1860 - works great to show if a neighbor on mesh1 is visible