### PR TITLE
gluon-core: fixes wifi on mediatek-mt7622 through a fallback of renamed wireless phys

### DIFF
--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -9,7 +9,11 @@ local iwinfo = require 'iwinfo'
 local M = {}
 
 function M.find_phy(config)
-	return iwinfo.nl80211.phyname(config['.name'])
+	local phyname = iwinfo.nl80211.phyname(config['.name'])
+	if not phyname then
+		phyname = iwinfo.nl80211.phyname(config['.name']:gsub("radio", "phy"))
+	end
+	return phyname
 end
 
 local function get_addresses(radio)


### PR DESCRIPTION
tested on a Netgear WAX206

though I think that backporting the commit which fixes renaming of phy devices might fix this as well:
https://github.com/openwrt/openwrt/commit/ed34e337a959919048e393f4b80d22aceffc3218
(No, the files do not exist on openwrt-24.10)

@RolandoMagico can you test my PR on your device as well?

Maybe there is a better way to do this, but this is just a quick fix to get things working again.

`iwinfo.nl80211.phyname(config['.name']:gsub("radio", "phy"))` returns phy0 again.

On my device `iwinfo phy0 htmodelist` shows correct values, while

```
root@ffac-000c43266078:~# uci show wireless
wireless.radio0=wifi-device
wireless.radio0.type='mac80211'
wireless.radio0.phy='wl0'
wireless.radio0.band='2g'
wireless.radio0.channel='11'
wireless.radio0.htmode='HT20'
wireless.radio0.country='DE'
wireless.radio0.legacy_rates='0'
wireless.radio1=wifi-device
wireless.radio1.type='mac80211'
wireless.radio1.phy='wl1'
wireless.radio1.band='5g'
wireless.radio1.channel='44'
wireless.radio1.htmode='HE20'
wireless.radio1.country='DE'
```