### PR TITLE
mediatek-mt7622: add support for netgear wax206

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -349,6 +349,10 @@ mediatek-mt7622
 
   - E8450
 
+* Netgear
+
+  - WAX206
+
 * Ubiquiti
 
   - UniFi 6 LR (v1)

--- a/targets/mediatek-mt7622
+++ b/targets/mediatek-mt7622
@@ -6,6 +6,13 @@ device('linksys-e8450-ubi', 'linksys_e8450-ubi', {
 })
 
 
+-- Netgear
+
+device('netgear-wax206', 'netgear_wax206', {
+	factory_ext = '.img',
+})
+
+
 -- Ubiquiti
 
 device('ubiquiti-unifi-6-lr-v1', 'ubnt_unifi-6-lr-v1', {


### PR DESCRIPTION
- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [ ] Must support upgrade mechanism
  - [ ] Must have working sysupgrade
    - [ ] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [ ] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [ ] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios 
  - [ ] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`

## Caveats

* on the test device, the internet wan port did not work until `ethtool --set-eee internet wan off tx-lpi off` is issued. This happens on some devices on 24.10 - see https://github.com/openwrt/openwrt/issues/17351
* the LEDs are working once https://github.com/openwrt/openwrt/pull/17694 is merged and backported
