### PR TITLE
ramips-mt7621: add support netgear eax12

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -465,6 +465,9 @@ ramips-mt7621
 
 * TP-Link
 
+  - EAX11 (v2)
+  - EAX12
+  - EAX15 (v2)
   - EAP615-Wall (v1)
   - RE500 (v1)
   - RE650 (v1)

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -67,6 +67,11 @@ device('mercusys-mr70x-v1', 'mercusys_mr70x-v1')
 
 -- NETGEAR
 
+device('netgear-eax12', 'netgear_eax12', {
+	factory_ext = '.img',
+	aliases = {'netgear-eax11-v2', 'netgear-eax15-v2'},
+})
+
 device('netgear-ex6150', 'netgear_ex6150', {
 	factory_ext = '.chk',
 })


### PR DESCRIPTION
this is the same device as the EAX 11 v2 and EAX 15 v2

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [x] Other: nmrpflash
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) `netgear-eax15`
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs - no led per radio
    - [ ] Should map to their respective radio
    - [ ] Should show activity

  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`


The three LEDS: router, client, wps are working but not enabled in any way in gluon.
Reset works fine on WPS button as well as on Reset button