### PR TITLE
gluon-setup-mode: rename phys before starting setup mode

### DIFF
--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S20network
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S20network
@@ -48,6 +48,8 @@ start_service() {
 	init_switch
 	iw reg set "$(lua -e 'print(require("gluon.site").regdom())')"
 
+    /usr/bin/lua -e 'require("gluon.setup-mode").rename_phys()'
+
 	procd_open_instance
 	procd_set_param command /sbin/netifd -c /var/gluon/setup-mode/config
 	procd_set_param respawn

--- a/package/gluon-setup-mode/luasrc/usr/lib/lua/gluon/setup-mode.lua
+++ b/package/gluon-setup-mode/luasrc/usr/lib/lua/gluon/setup-mode.lua
@@ -1,4 +1,5 @@
 local platform = require 'gluon.platform'
+local json = require 'jsonc'
 
 
 local M = {}
@@ -8,6 +9,34 @@ function M.get_status_led()
 		'glinet,gl-xe300',
 	}) then
 		return "green:wlan"
+	end
+end
+
+function M.rename_phys()
+	-- Load board data from JSON file
+	local board_data = json.load('/etc/board.json')
+	local wlan_data = board_data.wlan or {}
+
+	-- Iterate over all entries in wlan_data
+	for phyname, data in pairs(wlan_data) do
+		local path = data.path
+		if path then
+			-- Get the phyname using iwinfo
+			-- lua iwinfo does return nil by path instead
+			-- local other_phyname = iwinfo.nl80211.phyname('path=' .. path)
+
+			local f = io.popen("iwinfo nl80211 phyname path=" .. path)
+			local other_phyname = f:read("*a")
+			f:close()
+
+			-- Check if the retrieved phyname doesn't match the key
+			if other_phyname ~= "" and other_phyname ~= phyname then
+				-- Execute the command
+				os.execute(string.format("iw %s set name %s", other_phyname, phyname))
+
+				print(string.format("Renamed phy %s to %s", other_phyname, phyname))
+			end
+		end
 	end
 end
 


### PR DESCRIPTION
Works on WAX206

somehow the default_radio of openwrt is not deleted on the device..?
And I still had an issue for privatewifi, otherwise this worked on a monkeypatched wax206.

---

The `iwinfo.nl80211.phyname('path=' .. path)` behaves differently than the `iwinfo` cli command - so we use the iwinfo cli command to rename the phy as long as the networks are not up with netifd.

Outside of the setup-mode, netifd starts the interfaces correctly and does not lead to issues.
So we might want to have this patch until an upstream fix to apply the renaming before is created and backported to 24.10.

Just another attempt to fix this @neocturne @RolandoMagico @Djfe 

supersedes #3435 
supersedes #3430 