### PR TITLE
mediatek-filogic: add support for OpenWRT One

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -334,6 +334,10 @@ mediatek-filogic
 
   - WAX220
 
+* OpenWrt
+
+  - One
+
 * Ubiquiti
 
   - UniFi 6 Plus

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -1,3 +1,6 @@
+config('TARGET_ROOTFS_INITRAMFS', true)
+config('TARGET_INITRAMFS_COMPRESSION_LZMA', true)
+
 -- ASUS
 
 device('asus-tuf-ax4200', 'asus_tuf-ax4200', {
@@ -48,6 +51,13 @@ device('gl.inet-gl-mt3000', 'glinet_gl-mt3000', {
 
 device('netgear-wax220', 'netgear_wax220', {
 	factory_ext = '.img',
+})
+
+-- OpenWRT
+device('openwrt-one', 'openwrt_one',{
+	factory = '-factory',
+	factory_ext = '.ubi',
+	sysupgrade_ext = '.itb',
 })
 
 


### PR DESCRIPTION
Specification:
 - MT7981 CPU using 2.4GHz and 5GHz WiFi (both AX)
 - 1GB RAM
 - 16MB NOR
 - 128MB NAND
 - 3 LEDs (red, green, blue, white)
 - 2 buttons (reset, user defined)
 - 1 2.5Gbit WAN port (Airoha EN8811h)
 - 1 1Gbit LAN ports
 - 1 single lane M.2 SSD slot
 - 1 mikroBus socket
 - externel HW WDT (25s refresh time)
 - i2c RTC (with battery backup)

Serial Interface
 - UBS-C CDC-ACM
 - 3 Pins GND, RX, TX
 - Settings: 115200, 8N1

Test Device: https://map.chemnitz.freifunk.net/#!v:m;n:2005b6ff13f0

- [X] Must be flashable from vendor firmware
  - [X] Web interface
  - [X] TFTP
  - [X] Other: see wiki at https://openwrt.org/toh/openwrt/one
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) = openwrt-one
- [X] Reset button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - 2.5G WAN / 1G LAN 
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED - green
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`
