### PR TITLE
[v2023.2.x] ath79: Add support for Sophos AP15C

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -112,6 +112,7 @@ ath79-generic
 
 * Sophos
 
+  - AP15C
   - AP100
   - AP100c
   - AP55

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -399,6 +399,11 @@ device('sophos-ap15', 'sophos_ap15', {
 	broken = true, -- no button and no external console port
 })
 
+device('sophos-ap15c', 'sophos_ap15c', {
+	packages = ATH10K_PACKAGES_QCA9880,
+	factory = false,
+})
+
 device('sophos-ap100', 'sophos_ap100', {
 	packages = ATH10K_PACKAGES_QCA9880,
 	factory = false,


### PR DESCRIPTION
(cherry picked from commit f2aeb4629741ddf6050b0248392bfc90bdbe6086)

Supersedes #3402, which I closed by accident.