### PR TITLE
gluon-core: add hop penalty per hardif setting

### DIFF
--- a/docs/package/gluon-mesh-batman-adv.rst
+++ b/docs/package/gluon-mesh-batman-adv.rst
@@ -168,3 +168,32 @@ or to at least manually mark the port to the Gluon router as a
 Alternatively, the filtering of IGMP/MLD reports can be disabled via
 the site.conf (which is not recommended in large meshes though).
 See :ref:`site.conf mesh section <user-site-mesh>` for details.
+
+Tweaking Hop Penalty
+^^^^^^^^^^^^^^^^^^^^
+
+In general, the usage of a directly connected uplink is preferred over a faster more distant connection.
+In situations where the uplink of a device should only be used as a fallback (e.g. metered connection or slower encryption), this can be tweaked using a hop_penalty in gluon.
+Examples of this are shown below:
+
+.. code-block:: sh
+
+  # use mesh-vpn as fallback only
+  uci set gluon.mesh_vpn.batadv_hop_penalty='120'
+  # optional penalty for wired mesh
+  uci set gluon.iface_lan.batadv_hop_penalty=10
+  # optional for mesh on wan
+  uci set gluon.iface_wan.batadv_hop_penalty=10
+  # don't forget to commit changes
+  uci commit gluon
+
+To apply the changes, run the following commands:
+
+.. code-block:: sh
+
+  gluon-reconfigure
+  reboot
+
+Further documentation of the hop penalty can be found here:
+
+https://www.open-mesh.org/doc/batman-adv/Tweaking.html#hop-penalty

--- a/package/gluon-core/files/lib/netifd/proto/gluon_mesh.sh
+++ b/package/gluon-core/files/lib/netifd/proto/gluon_mesh.sh
@@ -8,14 +8,15 @@ init_proto "$@"
 
 proto_gluon_mesh_init_config() {
 	proto_config_add_boolean fixed_mtu
+	proto_config_add_int hop_penalty
 }
 
 proto_gluon_mesh_setup() {
 	export CONFIG="$1"
 	export IFNAME="$2"
 
-	local fixed_mtu
-	json_get_vars fixed_mtu
+	local fixed_mtu hop_penalty
+	json_get_vars fixed_mtu hop_penalty
 
 	export FIXED_MTU="${fixed_mtu:-0}"
 
@@ -27,6 +28,7 @@ proto_gluon_mesh_setup() {
 
 	proto_add_data
 	json_add_boolean fixed_mtu "$FIXED_MTU"
+	[ -n "${hop_penalty}" ] && json_add_int hop_penalty "${hop_penalty}"
 	[ "$IFNAME" != 'br-wan' ] && json_add_string zone 'mesh'
 	proto_close_data
 	proto_send_update "$CONFIG"

--- a/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
+++ b/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
@@ -49,8 +49,8 @@ proto_gluon_wired_setup() {
 
 	local meshif="$config"
 
-	local func vxlan vxpeer6addr
-	json_get_vars func vxlan vxpeer6addr
+	local hop_penalty func vxlan vxpeer6addr
+	json_get_vars hop_penalty func vxlan vxpeer6addr
 
 	# default args
 	[ -z "$vxlan" ] && vxlan=1
@@ -82,6 +82,7 @@ proto_gluon_wired_setup() {
 	json_add_string ifname "@${meshif}"
 	json_add_string proto 'gluon_mesh'
 	json_add_boolean fixed_mtu 1
+	[ -n "${hop_penalty}" ] && json_add_int hop_penalty "${hop_penalty}"
 	json_close_object
 	ubus call network add_dynamic "$(json_dump)"
 }

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/210-interface-mesh
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/210-interface-mesh
@@ -4,35 +4,52 @@ local site = require 'gluon.site'
 local uci = require('simple-uci').cursor()
 local util = require 'gluon.util'
 
-local mesh_interfaces = util.get_role_interfaces(uci, 'mesh')
-local uplink_interfaces = util.get_role_interfaces(uci, 'uplink')
+local mesh_interfaces = util.get_role_interfaces_with_options(uci, 'mesh', {'batadv_hop_penalty'})
+local uplink_interfaces = util.get_role_interfaces_with_options(uci, 'uplink', {})
 
 local mesh_interfaces_uplink = {}
 local mesh_interfaces_other = {}
-for _, iface in ipairs(mesh_interfaces) do
-	if util.contains(uplink_interfaces, iface) then
-		table.insert(mesh_interfaces_uplink, iface)
+for iface, options in pairs(mesh_interfaces) do
+	if uplink_interfaces[iface] ~= nil then
+		table.insert(mesh_interfaces_uplink, {iface = iface, options = options})
 	else
-		table.insert(mesh_interfaces_other, iface)
+		table.insert(mesh_interfaces_other, {iface = iface, options = options})
 	end
 end
 
+local function extract_ifaces(interfaces)
+	local ifnames = {}
+	local max_hop_penalty = 0
+	for _, iface in ipairs(interfaces) do
+		table.insert(ifnames, iface.iface)
+		local hop_penalty = tonumber(iface.options.batadv_hop_penalty) or 0
+		if max_hop_penalty < hop_penalty  then
+			max_hop_penalty = hop_penalty
+		end
+	end
+	table.sort(ifnames)
+	return max_hop_penalty, ifnames
+end
+
 if #mesh_interfaces_uplink > 0 then
+	local max_hop_penalty, _ = extract_ifaces(mesh_interfaces_uplink)
 	uci:section('network', 'interface', 'mesh_uplink', {
 		ifname = 'br-wan',
 		proto = 'gluon_wired',
 		func = 'wan',
+		hop_penalty = max_hop_penalty,
 		vxlan = site.mesh.vxlan(true),
 	})
 end
 
 if #mesh_interfaces_other > 0 then
+	local max_hop_penalty, ifnames = extract_ifaces(mesh_interfaces_other)
 	local iftype, ifname
-	if #mesh_interfaces_other == 1 then
-		ifname = mesh_interfaces_other[1]
+	if #ifnames == 1 then
+		ifname = ifnames[1]
 	else
 		iftype = 'bridge'
-		ifname = mesh_interfaces_other
+		ifname = ifnames
 
 		for _, iface in ipairs(ifname) do
 			uci:section('network', 'device', nil, {
@@ -49,6 +66,7 @@ if #mesh_interfaces_other > 0 then
 		igmp_snooping = false,
 		proto = 'gluon_wired',
 		func = 'mesh_other',
+		hop_penalty = max_hop_penalty,
 		vxlan = site.mesh.vxlan(true),
 	})
 end

--- a/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
+++ b/package/gluon-mesh-batman-adv/files/lib/netifd/proto/gluon_bat0.sh
@@ -24,21 +24,34 @@ lookup_uci() {
 	uci -q get "$path" || echo "$default"
 }
 
+handle_mesh_interface() {
+	local proto up device hop_penalty
+
+	# Enter item in the array by index
+	json_select "$2"
+
+	json_get_vars proto up device
+	json_select "data"
+	json_get_var hop_penalty hop_penalty
+	json_select ".."
+
+	if [ "$proto" = "gluon_mesh" ] && [ "$up" = 1 ]; then
+		batctl interface add "$device"
+		batctl hardif "$device" hop_penalty "${hop_penalty:-0}"
+	fi
+
+	json_select ".."
+	# exit array item at the end of the loop
+}
+
 proto_gluon_bat0_renew() {
 	local config="$1"
 
 	lock /var/lock/gluon_bat0.lock
 
-	ubus call network.interface dump | \
-		jsonfilter -e "@.interface[@.proto='static' && @.up=true]['device', 'hop_penalty']" | \
-		while read -r device
-	do
-		batctl interface add "$device"	
-		read -r hop_penalty
-		if [ -n "$hop_penalty" ]; then
-			batctl hardif "$device" hop_penalty "$hop_penalty"
-		fi
-	done
+	json_load "$(ubus call network.interface dump)"
+
+	json_for_each_item handle_mesh_interface interface
 	lock -u /var/lock/gluon_bat0.lock
 }
 

--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
@@ -12,6 +12,7 @@ uci:section('network', 'interface', 'mesh_vpn', {
 	ifname = vpn_core.get_interface(),
 	proto = 'gluon_mesh',
 	fixed_mtu = true,
+	hop_penalty = uci:get('gluon', 'mesh_vpn', 'batadv_hop_penalty'),
 	macaddr = util.generate_mac_by_name('mesh_vpn'),
 	mtu = active_vpn.mtu(),
 })


### PR DESCRIPTION
set this using

    uci set gluon.batadv_hop_penalty=batadv_hop_penalty
    uci set gluon.batadv_hop_penalty.mesh_vpn='20'
    uci set gluon.batadv_hop_penalty.mesh_radio0='20'
    uci set gluon.batadv_hop_penalty.mesh_other='20'
    uci commit gluon

run

    gluon-reconfigure
    service network restart

and check using

    batctl hardif mesh0 hop_penalty

- [x] docs are currently missing
- [ ] also documentation of `gluon.mesh_batman_adv.hop_penalty` for the general hop_penalty is not available yet
- [x] requests for improvements on the usage of uci would be cool, but I do not really know, how to do this using a list without the fuzzy string replacement

closes #2754 