### PR TITLE
labeler: update "continuous integration" label name (backport of #3152)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -25,7 +25,7 @@
     - docs/package/gluon-config-mode-*
     - package/gluon-config-mode-*/**
     - package/gluon-web*/**
-"3. topic: continous integration":
+"3. topic: continuous integration":
 - changed-files:
   - any-glob-to-any-file:
     - .github/workflows/*


### PR DESCRIPTION
The typo in the label name as been fixed, update the labeler config.

(cherry picked from commit 13dedfc234d6d505def21c66792e00a1a6c322e3)

---

With the typo fix backported to v2023.2.x and all issues relabeled a long time ago, we should be able to actually delete the old typoed label.