### PR TITLE
Fix linting for initscripts

### DIFF
--- a/package/gluon-core/files/etc/init.d/gluon-core-reconfigure
+++ b/package/gluon-core/files/etc/init.d/gluon-core-reconfigure
@@ -6,6 +6,7 @@ START=10
 start() {
 	config_load gluon
 	config_get_bool reconfigure core reconfigure 0
+	# shellcheck disable=SC2154
 	if [ "$reconfigure" = 1 ]; then
 		gluon-reconfigure
 	fi

--- a/package/gluon-ebtables-limit-arp/files/etc/init.d/gluon-arp-limiter
+++ b/package/gluon-ebtables-limit-arp/files/etc/init.d/gluon-arp-limiter
@@ -7,7 +7,7 @@ STOP=90
 start_service() {
 	procd_open_instance
 	procd_set_param command /usr/sbin/gluon-arp-limiter
-	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 
 	procd_set_param stderr 1
 	procd_close_instance

--- a/package/gluon-ebtables/files/etc/init.d/gluon-ebtables
+++ b/package/gluon-ebtables/files/etc/init.d/gluon-ebtables
@@ -15,10 +15,8 @@
 # Removing a specific rule file:
 # $ /etc/init.d/gluon-ebtables stop /lib/gluon/ebtables/100-mcast-chain
 
-
 START=19
 STOP=91
-
 
 exec_file() {
 	local file="$1"
@@ -37,12 +35,10 @@ exec_file() {
 }
 
 exec_all() {
-	local sort_arg="$1"
-
 	local old_ifs="$IFS"
 	IFS='
 '
-	for file in `find /lib/gluon/ebtables -type f | sort $sort_arg`; do
+	for file in $(find /lib/gluon/ebtables -type f | sort "$@"); do
 		exec_file "$file"
 	done
 	IFS="$old_ifs"
@@ -51,7 +47,9 @@ exec_all() {
 
 start() {
 	(
+		# shellcheck disable=SC2030,SC2031,SC2089
 		export EBTABLES_RULE='"ebtables-tiny -t " .. table .. " -A " .. command'
+		# shellcheck disable=SC2030,SC2031,SC2089
 		export EBTABLES_CHAIN='"ebtables-tiny -t " .. table .. "  -N " .. name .. " -P " .. policy'
 
 		# Contains /var/lib/ebtables/lock for '--concurrent'
@@ -59,7 +57,7 @@ start() {
 			mkdir -p /var/lib/ebtables
 
 		if [ -z "$1" ]; then
-			exec_all ''
+			exec_all
 		else
 			exec_file "$1"
 		fi
@@ -68,11 +66,13 @@ start() {
 
 stop() {
 	(
+		# shellcheck disable=SC2030,SC2031,SC2090
 		export EBTABLES_RULE='"ebtables-tiny -t " ..	table .. " -D " .. command'
+		# shellcheck disable=SC2030,SC2031,SC2090
 		export EBTABLES_CHAIN='"ebtables-tiny -t " .. table .. " -X " .. name'
 
 		if [ -z "$1" ]; then
-			exec_all '-r'
+			exec_all -r
 		else
 			exec_file "$1"
 		fi

--- a/package/gluon-l3roamd/files/etc/init.d/gluon-l3roamd
+++ b/package/gluon-l3roamd/files/etc/init.d/gluon-l3roamd
@@ -27,7 +27,7 @@ reload_service() {
 
 	for i in $(echotol3roamd "get_meshifs"| jsonfilter -e "@.mesh_interfaces[@]")
 	do
-		if ! ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device"|grep -q $i
+		if ! ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device" | grep -qxF "$i"
 		then
 			echotol3roamd "del_meshif $i"
 		fi
@@ -35,15 +35,17 @@ reload_service() {
 }
 
 start_service () {
-	local interfaces=$(
-	for dev in $(gluon-list-mesh-interfaces); do echo " -m $dev"; done
-	[ "$(ifstatus local_node | jsonfilter -e '@.up')" = 'true' ] && echo ' -i local-node'
+	local interfaces prefix4 prefix6 localip roamingprefix
+
+	interfaces=$(
+		for dev in $(gluon-list-mesh-interfaces); do echo " -m $dev"; done
+		[ "$(ifstatus local_node | jsonfilter -e '@.up')" = 'true' ] && echo ' -i local-node'
 	)
 
-	local prefix4="$(lua -e 'prefix4 = require("gluon.site").prefix4() if prefix4 then print(" -p " .. prefix4) end')"
-	local prefix6="$(lua -e 'print(" -p " .. require("gluon.site").prefix6())')"
-	local localip="$(uci get network.loopback.ip6addr | cut -d/ -f1)"
-	local roamingprefix="$(lua -e 'print(" -P " .. require("gluon.l3").node_client_prefix6())')"
+	prefix4="$(lua -e 'prefix4 = require("gluon.site").prefix4() if prefix4 then print(" -p " .. prefix4) end')"
+	prefix6="$(lua -e 'print(" -p " .. require("gluon.site").prefix6())')"
+	localip="$(uci get network.loopback.ip6addr | cut -d/ -f1)"
+	roamingprefix="$(lua -e 'print(" -P " .. require("gluon.l3").node_client_prefix6())')"
 
 	/sbin/sysctl -w net.ipv6.neigh.default.gc_thresh1=2
 	/sbin/sysctl -w net.ipv4.neigh.default.gc_thresh1=2
@@ -51,14 +53,17 @@ start_service () {
 	procd_open_instance
 	procd_set_param stdout 1
 	procd_set_param stderr 1
-	procd_set_param respawn ${respawn_threshold:-3660} ${respawn_timeout:-5} ${respawn_retry:-0}
-	procd_set_param command "$PROG" -s /var/run/l3roamd.sock $prefix4 $prefix6 $interfaces -t 254 -a $localip -b br-client $roamingprefix
+	procd_set_param respawn "${respawn_threshold:-3660}" "${respawn_timeout:-5}" "${respawn_retry:-0}"
+	# shellcheck disable=SC2086
+	procd_set_param command "$PROG" -s /var/run/l3roamd.sock "$prefix4" "$prefix6" $interfaces -t 254 -a "$localip" -b br-client "$roamingprefix"
 	procd_close_instance
 }
 
 service_triggers() {
-	local script=$(readlink "$initscript")
-	local name=$(basename "${script:-$initscript}")
+	local script name
+	# shellcheck disable=SC2154
+	script=$(readlink "$initscript")
+	name=$(basename "${script:-$initscript}")
 
 	procd_open_trigger
 	procd_add_raw_trigger 'interface.*' 0 "/etc/init.d/$name" reload

--- a/package/gluon-mmfd/files/etc/init.d/mmfd
+++ b/package/gluon-mmfd/files/etc/init.d/mmfd
@@ -15,11 +15,13 @@ waitforsocket() {
 
 
 start_service() {
-	local interfaces=$(for dev in $(gluon-list-mesh-interfaces); do echo " -i $dev"; done)
+	local interfaces
+	interfaces=$(for dev in $(gluon-list-mesh-interfaces); do echo " -i $dev"; done)
 
 	procd_open_instance
-	procd_set_param command $DAEMON -s $SOCKET $interfaces
-	procd_set_param respawn ${respawn_threshold:-60} ${respawn_timeout:-1} ${respawn_retry:-0}
+	# shellcheck disable=SC2086
+	procd_set_param command "$DAEMON" -s "$SOCKET" $interfaces
+	procd_set_param respawn "${respawn_threshold:-60}" "${respawn_timeout:-1}" "${respawn_retry:-0}"
 	procd_set_param stderr 1
 	procd_set_param stdout 1
 	procd_close_instance
@@ -30,15 +32,15 @@ mmfd_get_interfaces() {
 }
 
 mmfd_has_interface() {
-	mmfd_get_interfaces | grep -q "^$1$"
+	mmfd_get_interfaces | grep -qxF "$1"
 }
 
 addif() {
-	echo "add_meshif $@" | uc $SOCKET
+	echo "add_meshif $1" | uc $SOCKET
 }
 
 delif() {
-	echo "del_meshif $@" | uc $SOCKET
+	echo "del_meshif $1" | uc $SOCKET
 }
 
 reload_service() {
@@ -46,22 +48,24 @@ reload_service() {
 
 	for i in $(ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device")
 	do
-		if ! mmfd_has_interface $i; then
-			addif $i
+		if ! mmfd_has_interface "$i"; then
+			addif "$i"
 		fi
 	done
 
 	for i in $(mmfd_get_interfaces)
 	do
-		if ! ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device" | grep -q "^$i$"; then
-			delif $i
+		if ! ubus call network.interface dump | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device" | grep -qxF "$i"; then
+			delif "$i"
 		fi
 	done
 }
 
 service_triggers() {
-	local script=$(readlink "$initscript")
-	local name=$(basename "${script:-$initscript}")
+	local script name
+	# shellcheck disable=SC2154
+	script=$(readlink "$initscript")
+	name=$(basename "${script:-$initscript}")
 
 	procd_open_trigger
 	procd_add_raw_trigger "interface.*" 0 "/etc/init.d/$name" reload

--- a/package/gluon-radv-filterd/files/etc/init.d/gluon-radv-filterd
+++ b/package/gluon-radv-filterd/files/etc/init.d/gluon-radv-filterd
@@ -5,11 +5,12 @@ START=50
 DAEMON=/usr/sbin/gluon-radv-filterd
 
 start_service() {
-	local threshold="$(lua -e 'print(require("gluon.site").radv_filterd.threshold(20))')"
+	local threshold
+	threshold="$(lua -e 'print(require("gluon.site").radv_filterd.threshold(20))')"
 
 	procd_open_instance
-	procd_set_param command $DAEMON -i br-client -c RADV_FILTER -t $threshold
-	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	procd_set_param command "$DAEMON" -i br-client -c RADV_FILTER -t "$threshold"
+	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 	procd_set_param netdev br-client
 	procd_set_param stderr 1
 	procd_close_instance

--- a/package/gluon-radvd/files/etc/init.d/gluon-radvd
+++ b/package/gluon-radvd/files/etc/init.d/gluon-radvd
@@ -7,8 +7,9 @@ start_service() {
 	[ -x /lib/gluon/radvd/arguments ] || return 1
 
 	procd_open_instance
+	# shellcheck disable=SC2046
 	procd_set_param command /usr/sbin/uradvd $(/lib/gluon/radvd/arguments)
-	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 	procd_set_param stderr 1
 	procd_close_instance
 }

--- a/package/gluon-respondd/files/etc/init.d/gluon-respondd
+++ b/package/gluon-respondd/files/etc/init.d/gluon-respondd
@@ -7,21 +7,25 @@ DAEMON=/usr/bin/respondd
 MAXDELAY=10
 
 start_service() {
-	local ifdump="$(ubus call network.interface dump)"
+	local ifdump meshdevs clientdevs
+	ifdump="$(ubus call network.interface dump)"
 
-	local meshdevs=$(for dev in $(echo "$ifdump" | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device"); do echo " -i $dev";done;)
-	local clientdevs=$(for dev in $(echo "$ifdump" | jsonfilter -e "@.interface[@.interface='$(cat /lib/gluon/respondd/client.dev 2>/dev/null)' && @.up=true].device"); do echo " -i $dev -t $MAXDELAY";done;)
+	meshdevs=$(for dev in $(echo "$ifdump" | jsonfilter -e "@.interface[@.proto='gluon_mesh' && @.up=true].device"); do echo " -i $dev"; done)
+	clientdevs=$(for dev in $(echo "$ifdump" | jsonfilter -e "@.interface[@.interface='$(cat /lib/gluon/respondd/client.dev 2>/dev/null)' && @.up=true].device"); do echo " -i $dev -t $MAXDELAY"; done)
 
 	procd_open_instance
-	procd_set_param command $DAEMON -d /usr/lib/respondd -p 1001 -g ff02::2:1001 $meshdevs -g ff05::2:1001 $clientdevs
-	procd_set_param respawn ${respawn_threshold:-3600} ${respawn_timeout:-5} ${respawn_retry:-5}
+	# shellcheck disable=SC2086
+	procd_set_param command "$DAEMON" -d /usr/lib/respondd -p 1001 -g ff02::2:1001 $meshdevs -g ff05::2:1001 $clientdevs
+	procd_set_param respawn "${respawn_threshold:-3600}" "${respawn_timeout:-5}" "${respawn_retry:-5}"
 	procd_set_param stderr 1
 	procd_close_instance
 }
 
 service_triggers() {
-	local script=$(readlink "$initscript")
-	local name=$(basename ${script:-$initscript})
+	local script name
+	# shellcheck disable=SC2154
+	script=$(readlink "$initscript")
+	name=$(basename "${script:-$initscript}")
 
 	procd_open_trigger
 	procd_add_raw_trigger "interface.*" 0 "/etc/init.d/$name" reload

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S13urngd
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S13urngd
@@ -1,5 +1,7 @@
 #!/bin/sh /etc/rc.common
 
+# shellcheck disable=SC1091
+
 if [ -x /etc/init.d/urngd ] && /etc/init.d/urngd enabled; then
 	. /etc/init.d/urngd
 fi

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S15gluon-setup-mode
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S15gluon-setup-mode
@@ -2,15 +2,15 @@
 
 START=15
 
-
 boot() {
-	local enabled="$(uci -q get 'gluon-setup-mode.@setup_mode[0].enabled')"
-	local configured="$(uci -q get 'gluon-setup-mode.@setup_mode[0].configured')"
+	local enabled configured
+	enabled="$(uci -q get 'gluon-setup-mode.@setup_mode[0].enabled')"
+	configured="$(uci -q get 'gluon-setup-mode.@setup_mode[0].configured')"
 
 	uci set 'gluon-setup-mode.@setup_mode[0].enabled=0'
 	uci commit gluon-setup-mode
 
-	if [ "$enabled" != 1 -a "$configured" = 1 ]; then
+	if [ "$enabled" != 1 ] && [ "$configured" = 1 ]; then
 		# This can happen after an upgrade from a version before the config file was called gluon-setup-mode
 		# We'll just reboot to return to the normal mode...
 		/etc/init.d/done boot

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S50dropbear
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S50dropbear
@@ -1,5 +1,7 @@
 #!/bin/sh /etc/rc.common
 
+# shellcheck disable=SC1091
+
 USE_PROCD=1
 PROG=/usr/sbin/dropbear
 NAME=dropbear

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S96led
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S96led
@@ -1,5 +1,7 @@
 #!/bin/sh /etc/rc.common
 
+# shellcheck disable=SC1091,SC2154
+
 START=96
 
 start() {

--- a/scripts/lint-sh.sh
+++ b/scripts/lint-sh.sh
@@ -3,7 +3,7 @@
 set -e
 
 is_scriptfile() {
-	echo "$1" | grep -qE '.*\.sh$' || head -n1 "$1" | grep -qE '^#.*(sh|bash)$'
+	echo "$1" | grep -q '\.sh$' || head -n1 "$1" | grep -qE '^#!(.*\<bash|/bin/sh)$'
 }
 
 find contrib -type f | while read -r file; do

--- a/scripts/lint-sh.sh
+++ b/scripts/lint-sh.sh
@@ -6,6 +6,10 @@ is_scriptfile() {
 	echo "$1" | grep -q '\.sh$' || head -n1 "$1" | grep -qE '^#!(.*\<bash|/bin/sh)$'
 }
 
+is_initscript() {
+	head -n1 "$1" | grep -qxF '#!/bin/sh /etc/rc.common'
+}
+
 find contrib -type f | while read -r file; do
 	is_scriptfile "$file" || continue
 
@@ -14,10 +18,13 @@ find contrib -type f | while read -r file; do
 done
 
 find package -type f | while read -r file; do
-	is_scriptfile "$file" || continue
-
-	echo "Checking $file"
-	shellcheck -f gcc -x -s sh -e SC2039,SC3043,SC3037,SC3057 "$file"
+	if is_scriptfile "$file"; then
+		echo "Checking $file"
+		shellcheck -f gcc -x -s sh -e SC2039,SC3043,SC3037,SC3057 "$file"
+	elif is_initscript "$file"; then
+		echo "Checking $file (initscript)"
+		shellcheck -f gcc -x -s sh -e SC2034,SC2039,SC3043,SC3037,SC3057 "$file"
+	fi
 done
 
 find scripts -type f | while read -r file; do


### PR DESCRIPTION
We did accidentally not lint initscripts. Extend the lint script, and fix or disable warnings in initscripts.

All scripts have been tested except for radv-filterd, l3roamd and mmfd.