### PR TITLE
ath79-nand:  add support for GL.iNet E750

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
@@ -46,6 +46,7 @@ local function setup_ncm_qmi(devpath, control_type, delay)
 end
 
 if platform.match('ath79', 'nand', {
+	'glinet,gl-e750',
 	'glinet,gl-xe300',
 }) then
 	setup_ncm_qmi('/dev/cdc-wdm0', 'qmi', 15)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -82,6 +82,7 @@ end
 function M.is_cellular_device()
 	if M.match('ath79', 'nand', {
 		'zte,mf281',
+		'glinet,gl-e750',
 		'glinet,gl-xe300',
 	}) then
 		return true

--- a/targets/ath79-nand
+++ b/targets/ath79-nand
@@ -33,6 +33,12 @@ device('gl.inet-gl-ar750s-nor', 'glinet_gl-ar750s-nor', {
 	packages = ATH10K_PACKAGES_QCA9887,
 })
 
+device('gl.inet-gl-e750', 'glinet_gl-e750', {
+	broken = true, -- the display is not showing status and there are no LEDs
+	factory = false,
+	packages = ATH10K_PACKAGES_QCA9887,
+})
+
 device('gl.inet-gl-xe300', 'glinet_gl-xe300', {
 	factory = false,
 })


### PR DESCRIPTION
The gl-e750 is a portable travel router that gives you safe access to the internet while traveling.

Specifications:
- SoC: Qualcomm Atheros AR9531 (650MHz)
- RAM: 128 MB DDR2
- Flash: 16 MB SPI NOR (W25Q128FVSG) + 128 MB SPI NAND (GD5F1GQ4UFYIG)
- Ethernet: 10/100: 1xLAN
- Wireless: QCA9531 2.4GHz (bgn) + QCA9887 5GHz (ac)
- USB: 1x USB 2.0 port
- Switch: 1x switch
- Button: 1x reset button
- OLED Screen: 128*64 px

MAC addresses based on vendor firmware:
LAN *:a0 art 0x0
2.4GHz *:a1 art 0x1002
5GHz *:a2 art calculated from art 0x0 + 2

The device itself does work and needs a lot of time to boot. It takes less time to boot when the RJ45 adapter is connected to USB-C. The device itself has no LEDs, so there is no indication about the setup mode possible. I would be happy to get some feedback if I should either add the broken flag or the entry in the docs. The VPN works via WAN and WWAN.

Test Device: https://map.chemnitz.freifunk.net/#!v:m;n:9483c4204e60


- [X] Must be flashable from vendor firmware
  - [X] Web interface
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) gl.inet-gl-e750
- [X] Reset button must return device into config mode
- [X] Primary MAC address should match address on device label 
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on (Screen always shows "Booting ..." and is not configurable)
    - [] Should display config mode blink sequence (Device has no LEDs)         
  - Radio LEDs
    - Device has no LEDs only a screen which can not be configured
  - Switch port LEDs
    - Device has no LEDs only a screen which can not be configured
- Cellular devices only:
  - [X] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [X] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [ ] Added Device to `docs/user/supported_devices.rst` (not yet because of the LEDs)