### PR TITLE
gluon-mesh-layer3-common: remove deprecated node_client_prefix6 from site

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -49,17 +49,6 @@ node_prefix6
 
     node_prefix6 = 'fdca::ffee:babe:2::/64'
 
-node_client_prefix6 \: optional, deprecated
-  DEPRECATED: Don't specify it anymore, this prefix will then
-  automatically be generated from the domain_seed.
-
-  An IPv6 prefix internally used by the l3roamd protocol, used to allow
-  an efficient handover via unicast when a client roamed.
-  This is exclusively useful when running a routing mesh protocol
-  like olsr. e.g. ::
-
-    node_client_prefix6 = 'fdca::ffee:babe:3::/64'
-
 timezone
   The timezone of your community live in, e.g. ::
 

--- a/package/gluon-mesh-layer3-common/check_site.lua
+++ b/package/gluon-mesh-layer3-common/check_site.lua
@@ -1,2 +1,1 @@
 need_string_match(in_domain({'node_prefix6'}), '^[%x:]+/64$')
-need_string_match(in_domain({'node_client_prefix6'}), '^[%x:]+/64$', false)

--- a/package/gluon-mesh-layer3-common/luasrc/usr/lib/lua/gluon/l3.lua
+++ b/package/gluon-mesh-layer3-common/luasrc/usr/lib/lua/gluon/l3.lua
@@ -1,4 +1,3 @@
-local site = require("gluon.site")
 local util = require("gluon.util")
 
 local M = {}
@@ -7,14 +6,8 @@ local M = {}
 -- for l3roamd -P <node-client-prefix>
 function M.node_client_prefix6()
 	local key = "gluon-l3roamd.node_client_prefix6"
-	local prefix = site.node_client_prefix6()
-
-	if not prefix then
-		local prefix_seed = util.domain_seed_bytes(key, 7)
-		prefix = ("fd" .. prefix_seed):gsub(("(%x%x%x%x)"):rep(4), "%1:%2:%3:%4" .. "::/64")
-	end
-
-	return prefix
+	local prefix_seed = util.domain_seed_bytes(key, 7)
+	return ("fd" .. prefix_seed):gsub(("(%x%x%x%x)"):rep(4), "%1:%2:%3:%4" .. "::/64")
 end
 
 return M


### PR DESCRIPTION
This should have been removed with Babel; it was only left as deprecated to avoid breaking compatibility with existing Babel meshes. Drop support for overriding the prefix and always generate it from the domain seed.