### PR TITLE
core: remove transitive option from network interfaces

### DIFF
--- a/package/gluon-core/files/lib/netifd/proto/gluon_mesh.sh
+++ b/package/gluon-core/files/lib/netifd/proto/gluon_mesh.sh
@@ -8,18 +8,16 @@ init_proto "$@"
 
 proto_gluon_mesh_init_config() {
 	proto_config_add_boolean fixed_mtu
-	proto_config_add_boolean transitive
 }
 
 proto_gluon_mesh_setup() {
 	export CONFIG="$1"
 	export IFNAME="$2"
 
-	local fixed_mtu transitive
-	json_get_vars fixed_mtu transitive
+	local fixed_mtu
+	json_get_vars fixed_mtu
 
 	export FIXED_MTU="${fixed_mtu:-0}"
-	export TRANSITIVE="${transitive:-0}"
 
 	for script in /lib/gluon/core/mesh/setup.d/*; do
 		[ ! -x "$script" ] || "$script"
@@ -29,7 +27,6 @@ proto_gluon_mesh_setup() {
 
 	proto_add_data
 	json_add_boolean fixed_mtu "$FIXED_MTU"
-	json_add_boolean transitive "$TRANSITIVE"
 	[ "$IFNAME" != 'br-wan' ] && json_add_string zone 'mesh'
 	proto_close_data
 	proto_send_update "$CONFIG"

--- a/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
+++ b/package/gluon-core/files/lib/netifd/proto/gluon_wired.sh
@@ -7,7 +7,6 @@
 init_proto "$@"
 
 proto_gluon_wired_init_config() {
-	proto_config_add_boolean transitive
 	proto_config_add_int index
 	proto_config_add_boolean vxlan
 	proto_config_add_string vxpeer6addr
@@ -50,8 +49,8 @@ proto_gluon_wired_setup() {
 
 	local meshif="$config"
 
-	local transitive index vxlan vxpeer6addr
-	json_get_vars transitive index vxlan vxpeer6addr
+	local index vxlan vxpeer6addr
+	json_get_vars index vxlan vxpeer6addr
 
 	# default args
 	[ -z "$vxlan" ] && vxlan=1
@@ -83,7 +82,6 @@ proto_gluon_wired_setup() {
 	json_add_string ifname "@${meshif}"
 	json_add_string proto 'gluon_mesh'
 	json_add_boolean fixed_mtu 1
-	[ -n "$transitive" ] && json_add_boolean transitive "$transitive"
 	json_close_object
 	ubus call network add_dynamic "$(json_dump)"
 }

--- a/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
+++ b/package/gluon-mesh-vpn-core/luasrc/lib/gluon/upgrade/500-mesh-vpn
@@ -11,7 +11,6 @@ local _, active_vpn = vpn_core.get_active_provider()
 uci:section('network', 'interface', 'mesh_vpn', {
 	ifname = vpn_core.get_interface(),
 	proto = 'gluon_mesh',
-	transitive = true,
 	fixed_mtu = true,
 	macaddr = util.generate_mac(7),
 	mtu = active_vpn.mtu(),

--- a/package/gluon-mesh-vpn-wireguard/files/lib/netifd/proto/gluon_wireguard.sh
+++ b/package/gluon-mesh-vpn-wireguard/files/lib/netifd/proto/gluon_wireguard.sh
@@ -58,7 +58,6 @@ proto_gluon_wireguard_setup() {
 	json_add_string ifname "$ifname"
 	json_add_string proto 'wgpeerselector'
 	json_add_string unix_group 'gluon-mesh-vpn'
-	json_add_boolean transitive 1
 	json_close_object
 	ubus call network add_dynamic "$(json_dump)"
 


### PR DESCRIPTION
this removes an obsolete network interface config option "transitive"

i'm not sure, if the line in gluon-mesh-vpn-wireguard is necessary though - this was not part of the discussion back in 2020 in #2081 as there was no wireguard in Gluon back then.

closes #2081