### PR TITLE
generic: enable dnsmasq ed25519 keys regardless of target

### DIFF
--- a/targets/generic
+++ b/targets/generic
@@ -58,6 +58,10 @@ try_config('PACKAGE_dnsmasq_full_rtc', false)
 
 try_config('TARGET_SQUASHFS_BLOCK_SIZE', 256)
 
+-- OpenWrt disables ed25519 keys on SMALL_FLASH targets
+-- (e.g. ramips-mt76x8) by default.
+config('DROPBEAR_ED25519', true)
+
 config('KERNEL_PROC_STRIPPED', true)
 config('KERNEL_AIO', false)
 try_config('KERNEL_IO_URING', false)


### PR DESCRIPTION
OpenWrt disabled ed25519 SSH keys for SMALL_FLASH targets back in 2020, however this now affects ramips-mt76x8 targets.

ALways compile dnsmasq with ed25519 support. Without this patch, previously working ed25519 keys would be unusable on said devices without this patch.

Link: https://github.com/openwrt/openwrt/commit/d0f295837a03f7f52000ae6d395827bdde7996a4
Link: https://github.com/openwrt/openwrt/commit/fd46680966e9b9bc282b665282e2e6a22a27c26e