### PR TITLE
[v2023.2.x] package/gluon-respondd: add target information

### DIFF
--- a/package/gluon-respondd/src/respondd-nodeinfo.c
+++ b/package/gluon-respondd/src/respondd-nodeinfo.c
@@ -101,6 +101,9 @@ struct json_object * respondd_provider_nodeinfo(void) {
 	struct json_object *software_firmware = json_object_new_object();
 	json_object_object_add(software_firmware, "base", gluon_version());
 	json_object_object_add(software_firmware, "release", gluonutil_wrap_and_free_string(gluonutil_read_line("/lib/gluon/release")));
+	json_object_object_add(software_firmware, "target", gluonutil_wrap_string(platforminfo_get_target()));
+	json_object_object_add(software_firmware, "subtarget", gluonutil_wrap_string(platforminfo_get_subtarget()));
+	json_object_object_add(software_firmware, "image_name", gluonutil_wrap_string(platforminfo_get_image_name()));
 	json_object_object_add(software, "firmware", software_firmware);
 	json_object_object_add(ret, "software", software);
 


### PR DESCRIPTION
Backport of #3496

```console
$ ssh fd01:67c:2ed8:100d::1:1 "gluon-neighbour-info -d ::1 -p 1001 -r nodeinfo" | jq
```
```json
{
  "software": {
    "autoupdater": {
      "branch": "testing",
      "enabled": false
    },
    "batman-adv": {
      "version": "2023.1-openwrt-10",
      "compat": 15
    },
    "fastd": {
      "version": "v23",
      "enabled": true,
      "public_key": "724259408885162fb5843095d0c99c9287700e3f21ed5c2eb529e0d718bfeaf8"
    },
    "firmware": {
      "base": "gluon-v2023.2-142-gca9dcd5",
      "release": "3.0.6~20250505",
      "target": "ramips",
      "subtarget": "mt7621",
      "image_name": "xiaomi-mi-router-4a-gigabit-edition"
    }
  },
  "network": {
    "addresses": [
      "fd01:67c:2ed8:100d:3ecd:57ff:fe72:ff17",
      "fe80::3ecd:57ff:fe72:ff17"
    ],
    "mesh": {
      "bat0": {
        "interfaces": {
          "wireless": [
            "3e:cd:57:72:ff:19",
            "ca:40:f6:4a:16:a9"
          ],
          "other": [
            "ca:40:f6:4a:16:ab"
          ]
        }
      }
    },
    "mesh_vpn": {
      "bandwidth_limit": {
        "enabled": false
      },
      "provider": "fastd",
      "enabled": true
    },
    "mac": "3c:cd:57:72:ff:17"
  },
  "system": {
    "site_code": "ffda",
    "domain_code": "ffda_64673",
    "primary_domain_code": "dom13"
  },
  "node_id": "3ccd5772ff17",
  "hostname": "64625-3ccd5772ff17-Xiaomi-4a-GE",
  "hardware": {
    "model": "Xiaomi Mi Router 4A Gigabit Edition",
    "nproc": 4
  }
}
```