### PR TITLE
gluon-setup-mode: provide LED feedback for setup-mode activation

### DIFF
--- a/package/gluon-setup-mode/files/etc/hotplug.d/button/50-gluon-setup-mode
+++ b/package/gluon-setup-mode/files/etc/hotplug.d/button/50-gluon-setup-mode
@@ -6,6 +6,7 @@ wait=3
 
 wait_setup_mode() {
 	sleep $wait
+	/lib/gluon/setup-mode/led.sh confirm
 	gluon-enter-setup-mode
 }
 

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/led.sh
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/led.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# shellcheck disable=SC1091,SC2154
+
+get_setup_mode_led() {
+	. /etc/diag.sh
+	get_status_led 2> /dev/null
+
+	if [ -z "$status_led" ]; then
+		status_led="$running"
+	fi
+
+	if [ -z "$status_led" ]; then
+		status_led="$boot"
+	fi
+
+	custom_led="$(lua -e 'print(require("gluon.setup-mode").get_status_led() or "")')"
+	if [ -z "$status_led" ]; then
+		status_led="$custom_led"
+	fi
+}
+
+MODE="$1"
+case "$mode" in
+	confirm)
+		get_setup_mode_led 2> /dev/null
+		status_led_set_timer 100 100
+		;;
+	running)
+		get_setup_mode_led 2> /dev/null
+		status_led_set_timer 1000 300
+		;;
+	*)
+		echo "Usage: $0 <running|confirm>"
+		exit 1
+		;;
+esac

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S96led
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S96led
@@ -1,30 +1,8 @@
 #!/bin/sh /etc/rc.common
 
-# shellcheck disable=SC1091,SC2154
-
 START=96
 
 start() {
-	local custom_led
-
 	/etc/init.d/led start
-
-	. /etc/diag.sh
-
-	get_status_led 2> /dev/null
-
-	if [ -z "$status_led" ]; then
-		status_led="$running"
-	fi
-
-	if [ -z "$status_led" ]; then
-		status_led="$boot"
-	fi
-
-	custom_led="$(lua -e 'print(require("gluon.setup-mode").get_status_led() or "")')"
-	if [ -z "$status_led" ]; then
-		status_led="$custom_led"
-	fi
-
-	status_led_set_timer 1000 300
+	/lib/gluon/setup-mode/led.sh running
 }


### PR DESCRIPTION
This adds a fast-blink animation when Gluon started the procedure to enter setup mode.

This is helpful, as some devices might not provide feedback by the status LED on reboot.
This can lead to unwanted activation of a bootloader recovery procedure in case the reset button is not released prior.