### PR TITLE
gluon-core, gluon-web-admin: move translations for gluon-info strings to gluon-core

### DIFF
--- a/package/gluon-core/i18n/de.po
+++ b/package/gluon-core/i18n/de.po
@@ -1,0 +1,41 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2015-05-04 00:34+0200\n"
+"Last-Translator:  <mschiffer@universe-factory.net>\n"
+"Language-Team: German\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Domain"
+msgstr "Domäne"
+
+msgid "Firmware release"
+msgstr "Firmware-Release"
+
+msgid "Gluon version"
+msgstr "Gluon-Version"
+
+msgid "Hardware model"
+msgstr "Hardware-Modell"
+
+msgid "Hostname"
+msgstr "Hostname"
+
+msgid "MAC address"
+msgstr "MAC-Adresse"
+
+msgid "Public VPN key"
+msgstr "Öffentlicher VPN-Schlüssel"
+
+msgid "Site"
+msgstr "Site"
+
+msgid "Site version"
+msgstr "Site-Version"
+
+msgid "Switch type"
+msgstr "Switch Typ"

--- a/package/gluon-core/i18n/de.po
+++ b/package/gluon-core/i18n/de.po
@@ -38,4 +38,4 @@ msgid "Site version"
 msgstr "Site-Version"
 
 msgid "Switch type"
-msgstr "Switch Typ"
+msgstr "Switch-Typ"

--- a/package/gluon-core/i18n/fr.po
+++ b/package/gluon-core/i18n/fr.po
@@ -1,0 +1,41 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"PO-Revision-Date: 2015-08-19 20:20+0100\n"
+"Last-Translator: Bernot Tobias <tqbs@airmail.cc>\n"
+"Language-Team: French\n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+msgid "Domain"
+msgstr ""
+
+msgid "Firmware release"
+msgstr "Version de la firmware"
+
+msgid "Gluon version"
+msgstr "Version de Gluon"
+
+msgid "Hardware model"
+msgstr "Modèle du Matériel"
+
+msgid "Hostname"
+msgstr "Nom d'hôte"
+
+msgid "MAC address"
+msgstr "Adresse MAC"
+
+msgid "Public VPN key"
+msgstr "Clé VPN publique"
+
+msgid "Site"
+msgstr "Site"
+
+msgid "Site version"
+msgstr "Version de Site"
+
+msgid "Switch type"
+msgstr ""

--- a/package/gluon-core/i18n/gluon-core.pot
+++ b/package/gluon-core/i18n/gluon-core.pot
@@ -1,0 +1,32 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8"
+
+msgid "Domain"
+msgstr ""
+
+msgid "Firmware release"
+msgstr ""
+
+msgid "Gluon version"
+msgstr ""
+
+msgid "Hardware model"
+msgstr ""
+
+msgid "Hostname"
+msgstr ""
+
+msgid "MAC address"
+msgstr ""
+
+msgid "Public VPN key"
+msgstr ""
+
+msgid "Site"
+msgstr ""
+
+msgid "Site version"
+msgstr ""
+
+msgid "Switch type"
+msgstr ""

--- a/package/gluon-core/luasrc/usr/bin/gluon-info
+++ b/package/gluon-core/luasrc/usr/bin/gluon-info
@@ -2,7 +2,7 @@
 
 local info = require 'gluon.info'
 
-local values = info.get_info_pretty(function(str) return str end)
+local values = info.get_info_pretty()
 
 local padTo = 24
 

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/info.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/info.lua
@@ -34,7 +34,19 @@ function M.get_info()
 	}
 end
 
-function M.get_info_pretty(_)
+function M.get_info_pretty(i18n)
+	local _
+	if i18n then
+		local pkg_i18n = i18n 'gluon-core'
+		_ = function(s)
+			return pkg_i18n.translate(s)
+		end
+	else
+		_ = function(s)
+			return s
+		end
+	end
+
 	local data = M.get_info()
 
 	return {

--- a/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/info.html
+++ b/package/gluon-web-admin/files/lib/gluon/config-mode/view/admin/info.html
@@ -1,7 +1,7 @@
 <%-
 	local info = require 'gluon.info'
 
-	local values = info.get_info_pretty(translate)
+	local values = info.get_info_pretty(i18n)
 -%>
 <h2><%:Information%></h2>
 <% for _, v in ipairs(values) do %>

--- a/package/gluon-web-admin/i18n/de.po
+++ b/package/gluon-web-admin/i18n/de.po
@@ -44,26 +44,11 @@ msgstr "Unterbrich auf keinen Fall die Stromversorgung!"
 msgid "Firmware image"
 msgstr "Firmware-Datei"
 
-msgid "Firmware release"
-msgstr "Firmware-Release"
-
-msgid "Gluon version"
-msgstr "Gluon-Version"
-
-msgid "Hardware model"
-msgstr "Hardware-Modell"
-
-msgid "Hostname"
-msgstr "Hostname"
-
 msgid "Information"
 msgstr "Info"
 
 msgid "Keep settings"
 msgstr "Konfiguration behalten"
-
-msgid "MAC address"
-msgstr "MAC-Adresse"
 
 msgid "Password"
 msgstr "Passwort"
@@ -74,26 +59,11 @@ msgstr "Passwort geändert."
 msgid "Password removed."
 msgstr "Passwort gelöscht."
 
-msgid "Public VPN key"
-msgstr "Öffentlicher VPN-Schlüssel"
-
-msgid "Domain"
-msgstr "Domäne"
-
-msgid "Switch type"
-msgstr "Switch Typ"
-
 msgid "Remote access"
 msgstr "Remotezugriff"
 
 msgid "SSH keys"
 msgstr "SSH-Schlüssel"
-
-msgid "Site"
-msgstr "Site"
-
-msgid "Site version"
-msgstr "Site-Version"
 
 msgid "Size"
 msgstr "Größe"

--- a/package/gluon-web-admin/i18n/fr.po
+++ b/package/gluon-web-admin/i18n/fr.po
@@ -26,9 +26,9 @@ msgid ""
 msgstr ""
 "Alternativement, vous pouvez mettre un mot de passe pour accéder à votre "
 "nœud, Penseiz à choisir un mot de passe sûr, que vous n'utilisez nulle part "
-"ailleurs. <br><br> Si vous n'entrez pas de mot de passe, la connexion "
-"par mot de passe sera désactivée. La connexion par mot de passe est "
-"désactivée par défaut."
+"ailleurs. <br><br> Si vous n'entrez pas de mot de passe, la connexion par "
+"mot de passe sera désactivée. La connexion par mot de passe est désactivée "
+"par défaut."
 
 msgid "Cancel"
 msgstr "Annuler"
@@ -45,26 +45,11 @@ msgstr "N'interrompez en aucun cas l'alimentation!"
 msgid "Firmware image"
 msgstr "Fichier image"
 
-msgid "Firmware release"
-msgstr "Version de la firmware"
-
-msgid "Gluon version"
-msgstr "Version de Gluon"
-
-msgid "Hardware model"
-msgstr "Modèle du Matériel"
-
-msgid "Hostname"
-msgstr "Nom d'hôte"
-
 msgid "Information"
 msgstr "Informations"
 
 msgid "Keep settings"
 msgstr "Garder le paramètrage"
-
-msgid "MAC address"
-msgstr "Adresse MAC"
 
 msgid "Password"
 msgstr "Mot de passe"
@@ -75,20 +60,11 @@ msgstr "Mot de passe changé."
 msgid "Password removed."
 msgstr "Mot de passe effacé."
 
-msgid "Public VPN key"
-msgstr "Clé VPN publique"
-
 msgid "Remote access"
 msgstr "Accès à distance"
 
 msgid "SSH keys"
 msgstr "Clé SSH"
-
-msgid "Site"
-msgstr "Site"
-
-msgid "Site version"
-msgstr "Version de Site"
 
 msgid "Size"
 msgstr "Taille"

--- a/package/gluon-web-admin/i18n/gluon-web-admin.pot
+++ b/package/gluon-web-admin/i18n/gluon-web-admin.pot
@@ -31,25 +31,10 @@ msgstr ""
 msgid "Firmware image"
 msgstr ""
 
-msgid "Firmware release"
-msgstr ""
-
-msgid "Gluon version"
-msgstr ""
-
-msgid "Hardware model"
-msgstr ""
-
-msgid "Hostname"
-msgstr ""
-
 msgid "Information"
 msgstr ""
 
 msgid "Keep settings"
-msgstr ""
-
-msgid "MAC address"
 msgstr ""
 
 msgid "Password"
@@ -61,25 +46,10 @@ msgstr ""
 msgid "Password removed."
 msgstr ""
 
-msgid "Public VPN key"
-msgstr ""
-
-msgid "Domain"
-msgstr ""
-
-msgid "Switch type"
-msgstr ""
-
 msgid "Remote access"
 msgstr ""
 
 msgid "SSH keys"
-msgstr ""
-
-msgid "Site"
-msgstr ""
-
-msgid "Site version"
 msgstr ""
 
 msgid "Size"


### PR DESCRIPTION
The Lua code was moved, but the translations were not - so regenerating
POT files using i18n-scan.pl would have broken them on the next msgmerge.

Generate new POT files for both gluon-core and gluon-web-admin, msgmerge
the existing translations for both, and adjust gluon.info to request
i18n data from gluon-core.

Noticed during review of #3484.