### PR TITLE
gluon-setup-mode: execute bootcount initscript in setup-mode

### DIFF
--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S11bootcount
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/rc.d/S11bootcount
@@ -1,0 +1,7 @@
+#!/bin/sh /etc/rc.common
+
+# shellcheck disable=SC1091
+
+if [ -x /etc/init.d/bootcount ] && /etc/init.d/bootcount enabled; then
+	. /etc/init.d/bootcount
+fi


### PR DESCRIPTION
Currently Gluon does not execute the bootcount scripts when booting in setup-mode.

While this is usually not issue after the first installation ahs completed, it might lead to devices with an A/B partition layout to switch active partitions after the device has been rebooted multiple times before the initial configuration.

Fix this by executing the bootcount reset initscript.