### PR TITLE
mediatek-filogic: add Wavlink WL-WN573HX3 / 7Links WLR-1300

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -345,6 +345,10 @@ mediatek-filogic
 
   - UniFi 6 Plus
 
+* Wavlink
+
+  - WL-WN573HX3 [#lan_as_wan]_
+
 * Zyxel
 
   - NWA50AX Pro

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -65,7 +65,8 @@ function M.is_outdoor_device()
 		return true
 
 	elseif M.match('mediatek', 'filogic', {
-		'cudy,ap3000outdoor-v1'
+		'cudy,ap3000outdoor-v1',
+		'wavlink,wl-wn573hx3',
 	}) then
 		return true
 

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -80,6 +80,14 @@ device('ubiquiti-unifi-6-plus', 'ubnt_unifi-6-plus', {
 })
 
 
+-- Wavlink
+
+device('wavlink-wl-wn573hx3', 'wavlink_wl-wn573hx3', {
+	factory = false,
+	sysupgrade = '-squashfs-WN573HX3-sysupgrade',
+})
+
+
 -- Zyxel
 
 device('zyxel-nwa50ax-pro', 'zyxel_nwa50ax-pro')


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - ~TFTP~
  - ~Other: <specify>~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - ~Should map to their respective radio~
    - ~Should show activity~
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - ~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~
  - ~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`

------------------------------

This device is also known as 7Links WLR-1300, sold in Europe by Pearl (https://www.pearl.de/a-ZX5612-1131.shtml).
There is an alias set in OpenWrt, is any additonal configuration required for gluon regarding autoupdate?

OEM Web interface uses sysupgrade without the option to forget uci, which results in broken network config.
A script to address this by calling `firstboot` was rejected in OpenWrt logn time ago (https://github.com/openwrt/openwrt/pull/4174#issuecomment-842434735), but maybe we could add it downstream to improve user experience.

What is the ideal way of dealing with this, maybe we could reset uci configuration upon first boot directly, when the presence of a particular key is detected, so that no additional reboot would be required?

I'm not sure what would be the best way to implement this though, but it also affects other devices (e.g. COVR-C1200 and COVR-P2500 from the `ath79` target, presumably further new devices in the future).