### PR TITLE
scripts: Alter shebangs to /usr/bin/env bash

### DIFF
--- a/contrib/actions/free-runner-space.sh
+++ b/contrib/actions/free-runner-space.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # For a List of pre-installed packages on the runner image see
 # https://github.com/actions/runner-images/tree/main?tab=readme-ov-file#available-images

--- a/contrib/actions/show-system-info.sh
+++ b/contrib/actions/show-system-info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "-- CPU --"
 cat /proc/cpuinfo

--- a/contrib/depdot.sh
+++ b/contrib/depdot.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script to output the dependency graph of Gluon's packages
 # Limitations:

--- a/contrib/lsupgrade.sh
+++ b/contrib/lsupgrade.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 # Script to list all upgrade scripts in a clear manner

--- a/scripts/feeds.sh
+++ b/scripts/feeds.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/module_check.sh
+++ b/scripts/module_check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/scripts/patch.sh
+++ b/scripts/patch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck enable=check-unassigned-uppercase
 
 set -e

--- a/scripts/update-patches.sh
+++ b/scripts/update-patches.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck enable=check-unassigned-uppercase
 
 set -e

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
> in order to increase portability across systems where /bin/ does not contain bash.