### PR TITLE
ipq806x-generic: add Extreme Networks WS-AP3935i

### DIFF
--- a/targets/ipq806x-generic
+++ b/targets/ipq806x-generic
@@ -8,8 +8,17 @@ local QCA9984_PACKAGES = {'kmod-ath10k', '-kmod-ath10k-ct', 'ath10k-firmware-qca
 
 
 --
--- QCA9980
+-- QCA9980 / QCA9990
 --
+
+-- Extreme Networks
+
+device('extreme-networks-ap3935', 'extreme_ap3935', {
+	factory = false,
+	sysupgrade = '-squashfs-nand-sysupgrade',
+	packages = QCA9980_PACKAGES,
+	broken = true,	-- https://github.com/openwrt/openwrt/issues/17635
+})
 
 -- TP-Link
 device('tp-link-archer-c2600', 'tplink_c2600', {


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: RJ45 serial console like other Extreme Network/Enterasys devices
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN) 
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity (both mesh and client traffic lights up LED)
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present)
    - [x] Should show link state and activity
- ~~Outdoor devices only:~~
  - ~~[ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- ~~Cellular devices only:~~
  - ~~[ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - ~~[ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`


---

### LAN port numbering / assignment 

The ports at the back look like this:
```
  +---------+  +---------+  +---------+
  | Console |  |  LAN 1  |  |  LAN 2  |
  |   [ ]   |  |   [ ]   |  |   [ ]   |
  +---------+  +---------+  +---------+
```

Stock OpenWRT:
- LAN 1 = LAN
- LAN 2 = WAN

At the same time, the front has two LAN LEDs labelled "1" and "2"
- LAN "1" LED = WAN (=LAN 2)
- LAN "2" LED = LAN (=LAN 1)

Should this LAN confusion be fixed in upstream OpenWRT or as part of this PR here?