### PR TITLE
ath79-generic: disable TP-Link Archer C6 (v2 EU/RU/JP) factory image

### DIFF
--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -434,6 +434,7 @@ device('tp-link-archer-c58-v1', 'tplink_archer-c58-v1', {
 
 device('tp-link-archer-c6-v2-eu-ru-jp', 'tplink_archer-c6-v2', {
 	packages = ATH10K_PACKAGES_QCA9888,
+	factory = false,
 })
 
 device('tp-link-archer-c7-v2', 'tplink_archer-c7-v2', {


### PR DESCRIPTION
The flash is quite small and apparently building the factory will fail prior to the sysupgrade.

Disabling the factory image seems like the best course of action as installing via an OpenWrt factory image should be resonably easy to do.

Reference: https://github.com/freifunk-darmstadt/site-ffda/pull/128