### PR TITLE
docs: releases/v2023.2.5: fix typo

### DIFF
--- a/docs/releases/v2023.2.5.rst
+++ b/docs/releases/v2023.2.5.rst
@@ -24,7 +24,7 @@ Bugfixes
 
 * VXLAN encapsulated mesh traffic arriving at a client interface is now filtered and not forwarded to the mesh
 
-* Fixed a missing import in `libgluonutil` which lead to undefined behavior on 64 bit architectures
+* Fixed a missing import in `libgluonutil` which led to undefined behavior on 64 bit architectures
 
 
 Known issues


### PR DESCRIPTION
Just a small typo fix (lead -> led).

---

I think it would be nice to fix the typo before #3517.