### PR TITLE
gluon-setup-mode: ignore capacitive buttons on Pulse EX400

### DIFF
--- a/package/gluon-setup-mode/files/etc/hotplug.d/button/50-gluon-setup-mode
+++ b/package/gluon-setup-mode/files/etc/hotplug.d/button/50-gluon-setup-mode
@@ -9,6 +9,12 @@ wait_setup_mode() {
 	gluon-enter-setup-mode
 }
 
+# Special case for devices that use capacitive buttons
+case "$(board_name)" in
+genexis,pulse-ex400)
+	[ "$BUTTON" = wps ] && exit 0
+	;;
+esac
 
 if [ "$BUTTON" = wps ] || [ "$BUTTON" = reset ] || [ "$BUTTON" = phone ]; then
 	case "$ACTION" in


### PR DESCRIPTION
The Genexis Pulse EX400 has a capacitive WPS button. This button is prone to errorous presses, as it is likely to be pressed when picking up or touching the device.

The device in question has a recessed hardware reset switch for entering setup-mode. Ignore the capacitive touch button on the device in order to avoid unwanted activation of setup-mode.