### PR TITLE
gluon-mesh-layer3-common: get rid of gsub substitution count on prefix

### DIFF
--- a/package/gluon-mesh-layer3-common/luasrc/usr/lib/lua/gluon/l3.lua
+++ b/package/gluon-mesh-layer3-common/luasrc/usr/lib/lua/gluon/l3.lua
@@ -7,7 +7,7 @@ local M = {}
 function M.node_client_prefix6()
 	local key = "gluon-l3roamd.node_client_prefix6"
 	local prefix_seed = util.domain_seed_bytes(key, 7)
-	return ("fd" .. prefix_seed):gsub(("(%x%x%x%x)"):rep(4), "%1:%2:%3:%4" .. "::/64")
+	return (("fd" .. prefix_seed):gsub(("(%x%x%x%x)"):rep(4), "%1:%2:%3:%4" .. "::/64"))
 end
 
 return M


### PR DESCRIPTION
because is failed in gluon-mesh-olsrd: 360-gluon-mesh-olsrd-setup-intf on line: 132