### PR TITLE
docs: Add FAQ sections for setting retention and gluon_preserve

### DIFF
--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -25,3 +25,38 @@ interface. This DNS server must be announced in router advertisements (using
 on *batman-adv*. If your mesh does not have global IPv6 connectivity, you can setup
 your *radvd* not to announce a default route by setting the *default lifetime* to 0;
 in this case, the *radvd* is only used to announce the DNS server.
+
+.. _faq-lost-settings:
+
+Which settings are retained or migrated upon an update?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Gluon provides a :doc:`../dev/web/config-mode`, which allows the configuration via webinterface.
+Under the hood it uses UCI and sets options according to the users input.
+
+There's a recurring misconception that all UCI settings are retained and migrated across
+updates unconditionally. A settings presence does not imply this on its own.
+
+Only if a setting is either configurable via the setupmode, or explicitly referenced
+in this documentation - the wiki or other inofficial places do not count - it is supposed to
+survive the update process.
+
+All other options may be overridden, might disappear or lose functionality after a firmware update or already
+after calling gluon-reconfigure.
+
+.. _faq-gluon-preserve:
+
+How can I retain options upon updates anyway?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+For settings in the sections *network* and *system*, the option *gluon_preserve* can be set to true
+in order to preserve the sections. However, this is still at a high risk and may result in broken setups.
+
+There are two conditions that must hold:
+
+- The preserved section must not already exist after OpenWrt's and
+  Gluon's setup scripts ran. Modifying existing sections is currently
+  unsupported.
+- Preserved sections must be named, so it can be detected whether a
+  section conflicts with a preexisting one.
+
+Furthermore, this merely ensures the existence, not the functionality of a UCI setting after the update.


### PR DESCRIPTION
> At the GPN I learned a lot about others Gluon setups and how their settings would sometimes get lost after an upgrade, which was why they'd avoid them in the past.
> 
> This should clarify which settings are usually retained and migrated, and which are not.


This aims to resolve #2469.
It furthermore resolves #2159, unless @yanosz objects as I documented in that issue.


[This section](https://github.com/freifunk-gluon/gluon/pull/3530/files#diff-6eb68cf3015124e96821d08dd1dade74c4239aa8e2c39abad0d216698c4a289bR54-R58) is taken straight from @neocturne's introducing commit.