### PR TITLE
ath79: add support for Comfast CF-EW71 v2

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -30,6 +30,10 @@ ath79-generic
   - WZR-HP-G300NH (rtl8366s)
   - WZR-HP-G450H / WZR-450HP
 
+* COMFAST
+
+  - CF-EW71 (v2)
+
 * devolo
 
   - WiFi pro 1200e [#lan_as_wan]_

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -24,6 +24,7 @@ end
 
 function M.is_outdoor_device()
 	if M.match('ath79', 'generic', {
+		'comfast,cf-ew71-v2',
 		'devolo,dvl1750x',
 		'librerouter,librerouter-v1',
 		'plasmacloud,pa300',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -85,6 +85,11 @@ device('buffalo-wzr-hp-g300nh-rtl8366s', 'buffalo_wzr-hp-g300nh-s')
 
 device('buffalo-wzr-hp-g450h-wzr-450hp', 'buffalo_wzr-hp-g450h')
 
+-- COMFAST
+device('comfast-cf-ew71-v2', 'comfast_cf-ew71-v2', {
+	factory = false,
+})
+
 
 -- devolo
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) --> comfast-cf-ew71-v2
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
      Uses br-client MAC (https://map.ffmuc.net/#!/en/map/e0e1a90c7529)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
      Doesn't blink, even with vendor firmare installed
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
      Doesn't blink
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
       Partically: LAN does blink
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - ~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~
  - ~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`