### PR TITLE
Revert "ramips-mt7621: remove Edgerouter X"

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -485,6 +485,8 @@ ramips-mt7621
 
 * Ubiquiti
 
+  - EdgeRouter X
+  - EdgeRouter X-SFP
   - UniFi 6 Lite
   - UniFi nanoHD
 

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -183,3 +183,17 @@ device('zyxel-wsm20', 'zyxel_wsm20', {
 	factory = false,
 })
 
+
+-- Devices without WLAN
+
+-- Ubiquiti
+
+device('ubiquiti-edgerouter-x', 'ubnt_edgerouter-x', {
+	factory = false,
+	packages = {'-hostapd-mini'},
+})
+
+device('ubiquiti-edgerouter-x-sfp', 'ubnt_edgerouter-x-sfp', {
+	factory = false,
+	packages = {'-hostapd-mini'},
+})


### PR DESCRIPTION
This reverts commit 224d0aa784ec72a3fcfc24446992c002b4beb935.

after [Migrating to 24.10.x](https://openwrt.org/toh/ubiquiti/edgerouter_x_er-x_ka#migrating_to_2410x) the router is usable again