### PR TITLE
gluon-scheduled-domain-switch: Replace ping with gluon-state checks

### DIFF
--- a/docs/package/gluon-scheduled-domain-switch.rst
+++ b/docs/package/gluon-scheduled-domain-switch.rst
@@ -10,6 +10,9 @@ powered off while this was supposed to happen, it might not be able to acquire t
 correct time. In this case, the node will switch after it has not seen any gateway
 for a given period of time.
 
+In older versions ping was used against an array of endpoints to determine mesh-connectivity.
+Nowadays *gluon-state-check* is used for this and evaluates mesh-(VPN) connectivity and NTP states.
+
 site.conf
 ---------
 All those settings have to be defined exclusively in the domain, not the site.
@@ -21,9 +24,6 @@ domain_switch : optional (needed for domains to switch)
     - amount of time without reachable gateway to switch unconditionally
   switch_time :
     - UNIX epoch after which domain will be switched
-  connection_check_targets :
-    - array of IPv6 addresses which are probed to determine if the node is
-      connected to the mesh
 
 Example::
 
@@ -31,8 +31,4 @@ Example::
     target_domain = 'new_domain',
     switch_after_offline_mins = 120,
     switch_time = 1546344000, -- 01.01.2019 - 12:00 UTC
-    connection_check_targets = {
-      '2001:4860:4860::8888',
-      '2001:4860:4860::8844',
-    },
   },

--- a/package/gluon-autoupdater/check_site.lua
+++ b/package/gluon-autoupdater/check_site.lua
@@ -29,7 +29,7 @@ local branches = table_keys(need_table({'autoupdater', 'branches'}, function(bra
 		return good_signatures <= #pubkeys
 	end, nil, string.format('be less than or equal to the number of public keys (%d)', #pubkeys))
 
-	obsolete(in_site(extend(branch, {'probability'})), 'Use GLUON_PRIORITY in site.mk instead.')
+	obsolete(extend(branch, {'probability'}), 'Use GLUON_PRIORITY in site.mk instead.')
 end))
 
 need_one_of(in_site({'autoupdater', 'branch'}), branches, false)

--- a/package/gluon-scheduled-domain-switch/Makefile
+++ b/package/gluon-scheduled-domain-switch/Makefile
@@ -6,7 +6,7 @@ include ../gluon.mk
 
 define Package/gluon-scheduled-domain-switch
   TITLE:=Allows scheduled migrations between domains
-  DEPENDS:=+gluon-core @GLUON_MULTIDOMAIN
+  DEPENDS:=+gluon-core +gluon-state-check @GLUON_MULTIDOMAIN
 endef
 
 $(eval $(call BuildPackageGluon,gluon-scheduled-domain-switch))

--- a/package/gluon-scheduled-domain-switch/check_site.lua
+++ b/package/gluon-scheduled-domain-switch/check_site.lua
@@ -2,5 +2,6 @@ if need_table(in_domain({'domain_switch'}), nil, false) then
 	need_domain_name(in_domain({'domain_switch', 'target_domain'}))
 	need_number(in_domain({'domain_switch', 'switch_after_offline_mins'}))
 	need_number(in_domain({'domain_switch', 'switch_time'}))
-	need_string_array_match(in_domain({'domain_switch', 'connection_check_targets'}), '^[%x:]+$')
+	obsolete({'domain_switch', 'connection_check_targets'},
+	'Connections to NTP servers and gateways are used for this now.')
 end

--- a/package/gluon-scheduled-domain-switch/luasrc/usr/bin/gluon-check-connection
+++ b/package/gluon-scheduled-domain-switch/luasrc/usr/bin/gluon-check-connection
@@ -5,7 +5,14 @@ local util = require 'gluon.util'
 local site = require 'gluon.site'
 
 local offline_flag_file = "/tmp/gluon_offline"
-local is_offline = true
+
+local ntp_negative_state_file = "/var/gluon/state/has_lost_ntp_sync"
+
+
+local function is_offline()
+	return unistd.access(ntp_negative_state_file)
+end
+
 
 -- Check if domain-switch is scheduled
 if site.domain_switch() == nil then
@@ -13,16 +20,7 @@ if site.domain_switch() == nil then
 	os.exit(0)
 end
 
--- Check reachability of pre-defined targets
-for _, ip in ipairs(site.domain_switch.connection_check_targets()) do
-	local exit_code = os.execute("ping -c 1 -w 10 " .. ip)
-	if exit_code == 0 then
-		is_offline = false
-		break
-	end
-end
-
-if is_offline then
+if is_offline() then
 	-- Check if we were previously offline
 	if unistd.access(offline_flag_file) then
 		os.exit(0)


### PR DESCRIPTION
I'd like to touch a relict again, now that we've got ntp checks.

As @mweinelt put it a few days ago:

> [...] irgendeine Kombination aus den folgenden Dinge prüfen
> 
> kein ntp sync
> kein batman gateway
> keine ipv6 route


- [x] check the three above
- [x] dependency on gluon-state-check (has_default_gw6)
- [x] dependency on batman_adv (has_default_gw4)
- [x] dependency on ntpd-check (has_lost_ntp_sync)
- [x] see if there might an absence check in check_site.lua *yes, 1702 introduced the feature.*
- [x] either make sure the outdated section has been removed using check_site lua ~or warn about it during runtime~
- [x] take a look at the docs
- [x] test all the things 

This intends to resolve #2231 eventually.

This was accepted in https://github.com/freifunk-gluon/gluon/issues/2231#issuecomment-857192174.