### PR TITLE
gluon-harden-dropbear: Add package

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -69,6 +69,7 @@ Several Freifunk communities in Germany use Gluon as the foundation of their Fre
   package/gluon-ebtables-filter-ra-dhcp
   package/gluon-ebtables-limit-arp
   package/gluon-ebtables-source-filter
+  package/gluon-harden-dropbear
   package/gluon-hoodselector
   package/gluon-logging
   package/gluon-mesh-batman-adv

--- a/docs/package/gluon-harden-dropbear.rst
+++ b/docs/package/gluon-harden-dropbear.rst
@@ -1,0 +1,30 @@
+gluon-harden-dropbear
+=====================
+
+This package reduces the attack surface of dropbear, the SSH server on the router.
+
+If the root account either has no password configured or is locked,
+password authorization is disabled in dropbear's settings.
+
+If furthermore no SSH key is authorized to login, the ``dropbear`` service is disabled.
+
+Changing the password or updating authorized keys
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Via console
+"""""""""""
+
+Upon editing */etc/dropbear/authorized_keys* or changing root's password,
+a call to *gluon-reconfigure* as well as a reboot might be needed in order to have dropbear launched conditionally upon boot.
+
+.. code-block:: bash
+
+  passwd
+  gluon-reconfigure
+  reboot
+
+
+In setup-mode
+"""""""""""""
+
+As *gluon-reconfigure* is run when rebooting from the setup-mode web interface, no further steps are required.

--- a/package/gluon-harden-dropbear/Makefile
+++ b/package/gluon-harden-dropbear/Makefile
@@ -1,0 +1,16 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=gluon-harden-dropbear
+
+include ../gluon.mk
+
+define Package/gluon-harden-dropbear
+  TITLE:=Reduces dropbears exposition
+  DEPENDS:=+gluon-core +gluon-lock-password
+endef
+
+define Package/gluon-harden-dropbear/description
+	This packages disables password access if root is locked and disables dropbear if no access is configured.
+endef
+
+$(eval $(call BuildPackageGluon,gluon-harden-dropbear))

--- a/package/gluon-harden-dropbear/files/lib/gluon/upgrade/105-harden-dropbear
+++ b/package/gluon-harden-dropbear/files/lib/gluon/upgrade/105-harden-dropbear
@@ -1,0 +1,49 @@
+#!/usr/bin/lua
+
+local uci = require('simple-uci').cursor()
+local util = require('gluon.util')
+
+local function is_root_pw_unlocked()
+	for line in io.lines("/etc/shadow") do
+		if line:match("^root:!") then
+			return false
+		end
+	end
+	return true
+end
+
+local function has_authorized_keys()
+	local file = io.open("/etc/dropbear/authorized_keys", "r")
+	if not file then
+		return false
+	end
+	for line in file:lines() do
+		-- if the line is neither comments nor solely whitespaces
+		if not (line:match("^%s*#") or line:match("^%s*$")) then
+			file:close()
+			return true
+		end
+	end
+	file:close()
+	return false
+end
+
+local root_pw_is_unlocked = is_root_pw_unlocked()
+
+local password_auth = 'off'
+if root_pw_is_unlocked then
+	password_auth = 'on'
+end
+
+-- disable dropbear alltogether, if no access is configured
+local enable_dropbear = has_authorized_keys() or root_pw_is_unlocked
+
+uci:foreach('dropbear', 'dropbear', function(s)
+	uci:tset('dropbear', s['.name'], {
+		enable = enable_dropbear,
+		PasswordAuth = password_auth,
+		RootPasswordAuth = password_auth}
+	)
+end)
+
+uci:save('dropbear')


### PR DESCRIPTION
> Upon gluon-reconfigure, this package disables password-based SSH access, if the account root is locked. It furthermore disables the dropbear service if neither passwords nor authorized keys are present.

This intends to resolve #686.

I think `gluon-reconfigure` is a decent compromise between not having to fiddle with the dropbear settings manually and us definitely not wanting to patch the init script of dropbear.

I intend to take a look at also closing the firewall port if dropbear is offline.