### PR TITLE
ath79-generic: add support for GL.iNet GL-AR300M16

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -62,6 +62,7 @@ ath79-generic
   - 6416A
   - GL-AR150
   - GL-AR300M-Lite
+  - GL-AR300M16
   - GL-AR750
   - GL-USB150 (Microuter)
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -182,6 +182,10 @@ device('gl.inet-gl-ar300m-lite', 'glinet_gl-ar300m-lite', {
 	factory = false,
 })
 
+device('gl.inet-gl-ar300m16', 'glinet_gl-ar300m16', {
+	factory = false,
+})
+
 device('gl.inet-gl-ar750', 'glinet_gl-ar750', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9887,


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - ~TFTP~ **not tested**, but works according to openwrt
  - ~Other: <specify>~
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - ~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~
- Cellular devices only:
  - ~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~
  - ~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`
  
The device can be flashed using an initramfs image (OpenWrt) from uboots webinterface
and can then be sysupgraded like usual via console or web.

~Test results are welcome @fsffunk.~

> Test results won't be necessary until we come to a mutual understanding of professional cooperation and communication.

_Originally posted by @AiyionPrime in https://github.com/freifunk-gluon/gluon/issues/3544#issuecomment-3071168652_

This eventually closes #3535.