### PR TITLE
mesh-vpn-wireguard: Mark tc test as completed

### DIFF
--- a/package/gluon-mesh-vpn-wireguard/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
+++ b/package/gluon-mesh-vpn-wireguard/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
@@ -26,7 +26,6 @@ function M.active()
 end
 
 function M.set_limit(ingress_limit, egress_limit)
-	-- TODO: Test that limiting this via simple-tc here is correct!
 	uci:delete('simple-tc', 'mesh_vpn')
 	if ingress_limit ~= nil and egress_limit ~= nil then
 		uci:section('simple-tc', 'interface', 'mesh_vpn', {


### PR DESCRIPTION
> as imposing a bandwidth limit via tc does work properly.

After setting a limit of 5Mbit/s via tc and rebooting:

```console
$ speedtest-cli --simple
Ping: 19.84 ms
Download: 3.37 Mbit/s
Upload: 4.45 Mbit/s
```

After disabling the limit, but not restarting network:

```console
$ speedtest-cli --simple
Ping: 16.942 ms
Download: 3.40 Mbit/s
Upload: 4.47 Mbit/s
```

After rebooting the device afterwords:

```console
$ speedtest-cli --simple
Ping: 44.887 ms
Download: 14.19 Mbit/s
Upload: 12.68 Mbit/s
```