### PR TITLE
docs: Add install command and change debian release

### DIFF
--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -25,7 +25,7 @@ An example configuration can be found in the Gluon repository at *docs/site-exam
 Dependencies
 ------------
 To build Gluon, several packages need to be installed on the system.
-You can install the required packages with the following command:
+On Debian Bookworm, you can install the required packages with the following command:
 
 .. code-block:: sh
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -25,7 +25,7 @@ An example configuration can be found in the Gluon repository at *docs/site-exam
 Dependencies
 ------------
 To build Gluon, several packages need to be installed on the system. On a
-freshly installed Debian Bullseye system the following packages are required:
+freshly installed Debian Bookworm system the following packages are required:
 
 * `clang`
 * `git` (to get Gluon and other dependencies)
@@ -47,6 +47,12 @@ freshly installed Debian Bullseye system the following packages are required:
 * `qemu-utils`
 * `ecdsautils` (to sign firmware, see `contrib/sign.sh`)
 * `swig`
+
+You can install all these packages with this command.
+
+::
+
+  apt install clang git python3 python3-{dev,pyelftools,setuptools} build-essential gawk unzip libncurses5-dev zlib1g-dev libssl-dev libelf-dev llvm wget rsync time qemu-utils ecdsautils swig
 
 We also provide a container environment that already tracks all these dependencies. It quickly gets you up and running, if you already have either Docker or Podman installed locally.
 

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -24,35 +24,15 @@ An example configuration can be found in the Gluon repository at *docs/site-exam
 
 Dependencies
 ------------
-To build Gluon, several packages need to be installed on the system. On a
-freshly installed Debian Bookworm system the following packages are required:
+To build Gluon, several packages need to be installed on the system.
+You can install the required packages with the following command:
 
-* `clang`
-* `git` (to get Gluon and other dependencies)
-* `python3`
-* `python3-dev`
-* `python3-pyelftools`
-* `python3-setuptools`
-* `build-essential`
-* `gawk`
-* `unzip`
-* `libncurses-dev` (actually `libncurses5-dev`)
-* `libz-dev` (actually `zlib1g-dev`)
-* `libssl-dev`
-* `libelf-dev` (to build x86-64)
-* `llvm`
-* `wget`
-* `rsync`
-* `time` (built-in `time` doesn't work)
-* `qemu-utils`
-* `ecdsautils` (to sign firmware, see `contrib/sign.sh`)
-* `swig`
+.. code-block:: sh
 
-You can install all these packages with this command.
-
-::
-
-  apt install clang git python3 python3-{dev,pyelftools,setuptools} build-essential gawk unzip libncurses5-dev zlib1g-dev libssl-dev libelf-dev llvm wget rsync time qemu-utils ecdsautils swig
+  apt install clang git python3 python3-dev python3-pyelftools \
+  python3-setuptools build-essential gawk unzip libncurses5-dev \
+  zlib1g-dev libssl-dev libelf-dev llvm wget rsync time qemu-utils \
+  ecdsautils swig
 
 We also provide a container environment that already tracks all these dependencies. It quickly gets you up and running, if you already have either Docker or Podman installed locally.
 


### PR DESCRIPTION
This PR adds a copy-paste line to install the dependencies for building Gluon. It furthermore changes the Debian distribution to Bookworm since Buster is near EOL. The command is tested on Debian Bookworm. 