### PR TITLE
ath79-generic: add support for TP-Link CPE710-v2

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -136,7 +136,7 @@ ath79-generic
   - CPE210 (v1.0, v1.1, v2.0, v3.0, v3.1, v3.20)
   - CPE220 (v3.0)
   - CPE510 (v1.0, v1.1, v2.0, v3.0)
-  - CPE710 (v1.0)
+  - CPE710 (v1.0, v2.0)
   - EAP225-Outdoor (v1, v3)
   - TL-WDR3500 (v1)
   - TL-WDR3600 (v1)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -36,6 +36,7 @@ function M.is_outdoor_device()
 		'tplink,cpe510-v2',
 		'tplink,cpe510-v3',
 		'tplink,cpe710-v1',
+		'tplink,cpe710-v2',
 		'tplink,eap225-outdoor-v1',
 		'tplink,eap225-outdoor-v3',
 		'tplink,wbs210-v1',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -484,6 +484,8 @@ device('tp-link-cpe510-v3', 'tplink_cpe510-v3')
 
 device('tp-link-cpe710-v1', 'tplink_cpe710-v1')
 
+device('tp-link-cpe710-v2', 'tplink_cpe710-v2')
+
 device('tp-link-eap225-outdoor-v1', 'tplink_eap225-outdoor-v1', {
 	packages = ATH10K_PACKAGES_QCA9888,
 })


### PR DESCRIPTION
I recently got an request to create a gluon firmware for this device from a node owner of our community. I will test the whole checklist as soon as I get the device.

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [x] TFTP
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) --> tp-link-cpe710-v2
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence (uses ethernet LED)
 
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- Outdoor devices only:
  - [X] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`



TP-Link CPE710-v2 is an outdoor wireless CPE for 5 GHz with one Ethernet port based on the AP152 reference board. Compared to the CPE710-v1, the only change observed in hardware is that the mdio address of the ethernet physical changed from 0x4 to 0x0.

Specifications:
- SoC: QCA9563-AL3A MIPS 74kc @ 775MHz, AHB @ 258MHz
- RAM: 128MiB DDR2 @ 650MHz
- Flash: 16MiB SPI NOR Based on the GD25Q128
- Wi-Fi 5Ghz: ath10k chip (802.11ac for up to 867Mbps on 5GHz wireless data rate), based on the QCA9896
- Ethernet: one 1GbE port
- 23dBi high-gain directional 2×2 MIMO parabolic antenna
- Power, LAN, WLAN5G Blue LEDs
