### PR TITLE
mesh-batman-adv: Add parker-vpn to radvd config

### DIFF
--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/radvd/arguments
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/radvd/arguments
@@ -1,6 +1,34 @@
 #!/usr/bin/lua
 
 local site = require "gluon.site"
+local has_vpn, vpn = pcall(require, 'gluon.mesh-vpn')
+
+if has_vpn then
+	local provider_name, _ = vpn.get_active_provider()
+	if provider_name == "parker" then
+		-- If parker is used as vpn-provider uradvd must be started
+		-- with a different configuration than in vanilla gluon.
+		-- If parker has VPN enabled and has obtained a valid configuration
+		-- /tmp/range6 and /tmp/addr6 have been written by nodeconfig.
+
+		local f_range6 = io.open("/tmp/range6","r")
+		if f_range6 then
+			local range6 = f_range6:read('*a')
+			f_range6:close()
+
+			io.write("-i br-client -p " .. range6)
+		end
+
+		local f_addr6 = io.open("/tmp/addr6","r")
+		if f_addr6 then
+			local addr6 = f_addr6:read('*a')
+			f_addr6:close()
+
+			io.write(" --rdnss " .. addr6)
+		end
+		os.exit()
+	end
+end
 
 io.write("-i local-node -p " .. site.prefix6())
 


### PR DESCRIPTION
This PR is part of our upstreaming effort of [gluon-parker](https://github.com/ffbs/gluon-parker/) into gluon itself.
On it's own this PR does not really make sense for gluon. But we are planning on upstreaming all other missing components as well. Our roadmap / collection of work packages is [here](https://github.com/ffbs/gluon-parker/wiki/Mainlining-Roadmap).

When the parker mesh-vpn provider is used `radvd` needs to be configured in a different way compared to vanilla Gluon.

With this change the different behavior is introduced if the mesh-vpn provider is "parker".

In parker every node with an active VPN connection gets an individual IPv6 prefix (and address). This configuration is placed in `/tmp/addr6` and `/tmp/prefix6` by the configuration service.

These values are than used to announce the prefix to use and to announce the node itself as DNS server.