### PR TITLE
gluon-mesh-batman-adv: improve has_default_gw4 for parker

### DIFF
--- a/package/gluon-mesh-batman-adv/files/lib/gluon/state/check.d/has_default_gw4
+++ b/package/gluon-mesh-batman-adv/files/lib/gluon/state/check.d/has_default_gw4
@@ -1,2 +1,19 @@
 #!/bin/sh
-out=$(batctl gwl -H 2>/dev/null) && [ -n "$out" ]
+
+# shellcheck disable=SC3040
+set -o pipefail
+
+if ! out=$(batctl gwl -H 2>/dev/null); then
+	# batctl gwl command failed
+	exit 1
+fi
+
+if [ -n "$out" ]; then
+	# no batctl gw available
+	exit 2
+fi
+
+if ! batctl gw_mode | grep -qw '^server'; then
+	# server is also not in gw_mode
+	exit 3
+fi


### PR DESCRIPTION
if we have batctl gw_mode server configured, we also have a `default_gw` for it.

This does not occur for traditional setups and therefore does not change existing behavior

The motivation for this is the FFBS setup, which otherwise does not have a working `has_default_gw4`.

@SmithChart 