### PR TITLE
openwrt hostapd: disable WPS button handling

### DIFF
--- a/patches/openwrt/0009-hostapd-disable-wps-button-handling.patch
+++ b/patches/openwrt/0009-hostapd-disable-wps-button-handling.patch
@@ -1,0 +1,23 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Thu, 24 Jul 2025 20:25:22 +0200
+Subject: hostapd: disable wps button handling
+
+Pressing the WPS button when wpa-supplicant is installed for encrypted
+mesh operation triggers WPS in the wpa_supplicant process.
+
+This disables the wireless mesh completely.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/package/network/services/hostapd/files/wps-hotplug.sh b/package/network/services/hostapd/files/wps-hotplug.sh
+index 073bdd18687c53c4dd00065fbc6fab8da66410e9..104accc828c6baa520e146089a04fe1c25977424 100644
+--- a/package/network/services/hostapd/files/wps-hotplug.sh
++++ b/package/network/services/hostapd/files/wps-hotplug.sh
+@@ -1,5 +1,7 @@
+ #!/bin/sh
+ 
++exit 0
++
+ wps_catch_credentials() {
+ 	local iface ifaces ifc ifname ssid encryption key radio radios
+ 	local found=0


### PR DESCRIPTION
Pressing the WPS button when wpa-supplicant is installed for encrypted mesh operation triggers WPS in the wpa_supplicant process.

This results in a deactivation of the wireless mesh.

Disabling the WPS handling in OpenWrt to keep wireless mesh operational even when pressing the WPS key.