### PR TITLE
mediatek-filogic: add support for Xiaomi AX3000T

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -351,6 +351,10 @@ mediatek-filogic
 
   - WL-WN573HX3 [#lan_as_wan]_
 
+* Xiaomi
+
+  - Mi Router AX3000T
+
 * Zyxel
 
   - NWA50AX Pro

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -88,6 +88,13 @@ device('wavlink-wl-wn573hx3', 'wavlink_wl-wn573hx3', {
 })
 
 
+-- Xiaomi
+
+device('xiaomi-mi-router-ax3000t', 'xiaomi_mi-router-ax3000t', {
+	factory = false,
+})
+
+
 -- Zyxel
 
 device('zyxel-nwa50ax-pro', 'zyxel_nwa50ax-pro')


### PR DESCRIPTION
SoC: MediaTek MT7981B 2x A53
Flash: ESMT F50L1G41LB 128MB
RAM: NT52B128M16JR-FL 256MB
Ethernet: 4x 10/100/1000 Mbps
Switch: MediaTek MT7531AE
WiFI: MediaTek MT7976C

The initial OpenWRT install is described in the OpenWRT wiki https://openwrt.org/inbox/toh/xiaomi/ax3000t

- [x] Must be flashable from vendor firmware
  - [x] Other: install OpenWRT first like mentioned above and install gluon sysupgrade afterwards
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> xiaomi-mi-router-ax3000t

- [X] Reset button must return device into config mode (mesh button does nothing)
- [X] Primary MAC address should match address on device label
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
      - the first port should is declared as WAN, all other ports LAN (like in vanilla OpenWRT)
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED (only one LED present)
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`