### PR TITLE
openwrt: ath9k: Add RX inactivity detection and reset chip when it occurs

### DIFF
--- a/patches/openwrt/0012-ath9k-add-rx-inactivity-detection-and-reset-chip-when-it-occurs.patch
+++ b/patches/openwrt/0012-ath9k-add-rx-inactivity-detection-and-reset-chip-when-it-occurs.patch
@@ -1,0 +1,101 @@
+From: Toke Høiland-Jørgensen <toke@toke.dk>
+Date: Wed, 06 Nov 2024 13:41:44 +0100
+Subject: ath9k: Add RX inactivity detection and reset chip when it occurs
+
+diff --git a/package/kernel/mac80211/patches/ath9k/554-ath9k_add_rx_inactivity_detection_and_reset_chip_when_it_occurs.patch b/package/kernel/mac80211/patches/ath9k/554-ath9k_add_rx_inactivity_detection_and_reset_chip_when_it_occurs.patch
+new file mode 100644
+index 0000000000..e6699d99f7
+--- /dev/null
++++ b/package/kernel/mac80211/patches/ath9k/554-ath9k_add_rx_inactivity_detection_and_reset_chip_when_it_occurs.patch
+@@ -0,0 +1,91 @@
++--- a/drivers/net/wireless/ath/ath9k/ath9k.h
+++++ b/drivers/net/wireless/ath/ath9k/ath9k.h
++@@ -1016,6 +1016,8 @@ struct ath_softc {
++ 
++ 	u8 gtt_cnt;
++ 	u32 intrstatus;
+++	u32 rx_active_check_time;
+++	u32 rx_active_count;
++ 	u16 ps_flags; /* PS_* */
++ 	bool ps_enabled;
++ 	bool ps_idle;
++--- a/drivers/net/wireless/ath/ath9k/debug.c
+++++ b/drivers/net/wireless/ath/ath9k/debug.c
++@@ -765,6 +765,7 @@ static int read_file_reset(struct seq_file *file, void *data)
++ 		[RESET_TYPE_CALIBRATION] = "Calibration error",
++ 		[RESET_TX_DMA_ERROR] = "Tx DMA stop error",
++ 		[RESET_RX_DMA_ERROR] = "Rx DMA stop error",
+++		[RESET_TYPE_RX_INACTIVE] = "Rx path inactive",
++ 	};
++ 	int i;
++ 
++--- a/drivers/net/wireless/ath/ath9k/debug.h
+++++ b/drivers/net/wireless/ath/ath9k/debug.h
++@@ -52,6 +52,7 @@ enum ath_reset_type {
++ 	RESET_TYPE_CALIBRATION,
++ 	RESET_TX_DMA_ERROR,
++ 	RESET_RX_DMA_ERROR,
+++	RESET_TYPE_RX_INACTIVE,
++ 	__RESET_TYPE_MAX
++ };
++ 
++--- a/drivers/net/wireless/ath/ath9k/link.c
+++++ b/drivers/net/wireless/ath/ath9k/link.c
++@@ -50,7 +50,36 @@ static bool ath_tx_complete_check(struct ath_softc *sc)
++ 		"tx hung, resetting the chip\n");
++ 	ath9k_queue_reset(sc, RESET_TYPE_TX_HANG);
++ 	return false;
+++}
+++
+++#define RX_INACTIVE_CHECK_INTERVAL (4 * MSEC_PER_SEC)
+++
+++static bool ath_hw_rx_inactive_check(struct ath_softc *sc)
+++{
+++	struct ath_common *common = ath9k_hw_common(sc->sc_ah);
+++	u32 interval, count;
+++
+++	interval = jiffies_to_msecs(jiffies - sc->rx_active_check_time);
+++	count = sc->rx_active_count;
+++
+++	if (interval < RX_INACTIVE_CHECK_INTERVAL)
+++		return true; /* too soon to check */
++ 
+++	sc->rx_active_count = 0;
+++	sc->rx_active_check_time = jiffies;
+++
+++	/* Need at least one interrupt per second, and we should only react if
+++	 * we are within a factor two of the expected interval
+++	 */
+++	if (interval > RX_INACTIVE_CHECK_INTERVAL * 2 ||
+++	    count >= interval / MSEC_PER_SEC)
+++		return true;
+++
+++	ath_dbg(common, RESET,
+++		"RX inactivity detected. Schedule chip reset\n");
+++	ath9k_queue_reset(sc, RESET_TYPE_RX_INACTIVE);
+++
+++	return false;
++ }
++ 
++ void ath_hw_check_work(struct work_struct *work)
++@@ -58,8 +87,8 @@ void ath_hw_check_work(struct work_struct *work)
++ 	struct ath_softc *sc = container_of(work, struct ath_softc,
++ 					    hw_check_work.work);
++ 
++-	if (!ath_hw_check(sc) ||
++-	    !ath_tx_complete_check(sc))
+++	if (!ath_hw_check(sc) || !ath_tx_complete_check(sc) ||
+++	    !ath_hw_rx_inactive_check(sc))
++ 		return;
++ 
++ 	ieee80211_queue_delayed_work(sc->hw, &sc->hw_check_work,
++--- a/drivers/net/wireless/ath/ath9k/main.c
+++++ b/drivers/net/wireless/ath/ath9k/main.c
++@@ -453,6 +453,7 @@ void ath9k_tasklet(struct tasklet_struct *t)
++ 			ath_rx_tasklet(sc, 0, true);
++ 
++ 		ath_rx_tasklet(sc, 0, false);
+++		sc->rx_active_count++;
++ 	}
++ 
++ 	if (status & ATH9K_INT_TX) {


### PR DESCRIPTION
Backport of this patch:
https://github.com/torvalds/linux/commit/b5f871ab4913b2403a7cdcbcde16d39d0b071fb3