### PR TITLE
cortexa53: add support for GL.iNet GL-MV1000

### DIFF
--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -155,6 +155,16 @@
     "targets/generic",
     "targets/targets.mk"
   ],
+  "mvebu-cortexa53": [
+    "targets/mvebu-cortexa53",
+    ".github/workflows/build-gluon.yml",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk"
+  ],
   "mpc85xx-p1010": [
     "targets/mpc85xx-p1010",
     ".github/workflows/build-gluon.yml",
@@ -314,16 +324,6 @@
   ],
   "mvebu-cortexa9": [
     "targets/mvebu-cortexa9",
-    ".github/workflows/build-gluon.yml",
-    "modules",
-    "Makefile",
-    "patches/**",
-    "scripts/**",
-    "targets/generic",
-    "targets/targets.mk"
-  ],
-  "mvebu-cortexa53": [
-    "targets/mvebu-cortexa53",
     ".github/workflows/build-gluon.yml",
     "modules",
     "Makefile",

--- a/.github/filters.yml
+++ b/.github/filters.yml
@@ -321,5 +321,15 @@
     "scripts/**",
     "targets/generic",
     "targets/targets.mk"
+  ],
+  "mvebu-cortexa53": [
+    "targets/mvebu-cortexa53",
+    ".github/workflows/build-gluon.yml",
+    "modules",
+    "Makefile",
+    "patches/**",
+    "scripts/**",
+    "targets/generic",
+    "targets/targets.mk"
   ]
 }

--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -370,6 +370,13 @@ mediatek-mt7622
 
   - UniFi 6 LR (v1)
 
+mvebu-cortexa53
+---------------
+
+* GL.iNet
+
+  - GL-MV1000
+
 mpc85xx-p1010
 -------------
 

--- a/targets/mvebu-cortexa53
+++ b/targets/mvebu-cortexa53
@@ -1,4 +1,4 @@
-device('glinet-gl-mv1000', 'glinet_gl-mv1000', {
+device('gl.inet-gl-mv1000', 'glinet_gl-mv1000', {
 	factory = false,
 	sysupgrade = '-ext4-sdcard',
 	sysupgrade_ext = '.img.gz',

--- a/targets/mvebu-cortexa53
+++ b/targets/mvebu-cortexa53
@@ -1,5 +1,5 @@
 device('gl.inet-gl-mv1000', 'glinet_gl-mv1000', {
 	factory = false,
-	sysupgrade = '-ext4-sdcard',
+	sysupgrade = '-squashfs-sdcard',
 	sysupgrade_ext = '.img.gz',
 })

--- a/targets/mvebu-cortexa53
+++ b/targets/mvebu-cortexa53
@@ -1,3 +1,6 @@
 device('glinet-gl-mv1000', 'glinet_gl-mv1000', {
-	factory_ext = '.img',
+	factory = false,
+	sysupgrade = '-ext4-sdcard',
+	sysupgrade_ext = '.img.gz',
+	manifest_aliases = {'gl-inet-gl-mv1000'},
 })

--- a/targets/mvebu-cortexa53
+++ b/targets/mvebu-cortexa53
@@ -2,5 +2,4 @@ device('glinet-gl-mv1000', 'glinet_gl-mv1000', {
 	factory = false,
 	sysupgrade = '-ext4-sdcard',
 	sysupgrade_ext = '.img.gz',
-	manifest_aliases = {'gl-inet-gl-mv1000'},
 })

--- a/targets/mvebu-cortexa53
+++ b/targets/mvebu-cortexa53
@@ -1,0 +1,3 @@
+device('glinet-gl-mv1000', 'glinet_gl-mv1000', {
+	factory_ext = '.img',
+})

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -32,6 +32,5 @@ $(eval $(call GluonTarget,bcm27xx,bcm2711)) # BROKEN: No 11s support, no reset b
 $(eval $(call GluonTarget,ipq40xx,chromium)) # BROKEN: Devices cannot be flashed without opening the case
 $(eval $(call GluonTarget,kirkwood,generic)) # BROKEN: No devices with 11s support
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
-$(eval $(call GluonTarget,mvebu,cortexa53)) # BROKEN:
-
+$(eval $(call GluonTarget,mvebu,cortexa53)) # BROKEN: Untested
 endif

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -13,6 +13,7 @@ $(eval $(call GluonTarget,lantiq,xrx200_legacy))
 $(eval $(call GluonTarget,lantiq,xway))
 $(eval $(call GluonTarget,mediatek,filogic))
 $(eval $(call GluonTarget,mediatek,mt7622))
+$(eval $(call GluonTarget,mvebu,cortexa53))
 $(eval $(call GluonTarget,mpc85xx,p1010))
 $(eval $(call GluonTarget,mpc85xx,p1020))
 $(eval $(call GluonTarget,ramips,mt7620))
@@ -32,5 +33,4 @@ $(eval $(call GluonTarget,bcm27xx,bcm2711)) # BROKEN: No 11s support, no reset b
 $(eval $(call GluonTarget,ipq40xx,chromium)) # BROKEN: Devices cannot be flashed without opening the case
 $(eval $(call GluonTarget,kirkwood,generic)) # BROKEN: No devices with 11s support
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
-$(eval $(call GluonTarget,mvebu,cortexa53)) # BROKEN: Wireless untested
 endif

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -32,5 +32,5 @@ $(eval $(call GluonTarget,bcm27xx,bcm2711)) # BROKEN: No 11s support, no reset b
 $(eval $(call GluonTarget,ipq40xx,chromium)) # BROKEN: Devices cannot be flashed without opening the case
 $(eval $(call GluonTarget,kirkwood,generic)) # BROKEN: No devices with 11s support
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
-$(eval $(call GluonTarget,mvebu,cortexa53)) # BROKEN: Untested
+$(eval $(call GluonTarget,mvebu,cortexa53)) # BROKEN: Wireless untested
 endif

--- a/targets/targets.mk
+++ b/targets/targets.mk
@@ -32,4 +32,6 @@ $(eval $(call GluonTarget,bcm27xx,bcm2711)) # BROKEN: No 11s support, no reset b
 $(eval $(call GluonTarget,ipq40xx,chromium)) # BROKEN: Devices cannot be flashed without opening the case
 $(eval $(call GluonTarget,kirkwood,generic)) # BROKEN: No devices with 11s support
 $(eval $(call GluonTarget,mvebu,cortexa9)) # BROKEN: No 11s support
+$(eval $(call GluonTarget,mvebu,cortexa53)) # BROKEN:
+
 endif


### PR DESCRIPTION
We recently got an request to create a gluon firmware for this device from a node owner of our community. the node owner will test the whole checklist as soon as possible

Test Device: https://map.ffmuc.net/#!/de/map/9483c400f884
OpenWrt sites: 
https://openwrt.org/toh/hwdata/gl.inet/gl.inet_gl-mv1000_brume
https://openwrt.org/toh/gl.inet/gl-mv1000

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [x] Other: Web interface: 
	- https://forum.gl-inet.com/t/installing-openwrt-23-05-on-brume-1/33477 			
	- https://openwrt.org/toh/gl.inet/gl-mv1000#uboot_method
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
	- [x] sysupgrade keeps configuration
	- firstboot
<img width="651" height="106" alt="image" src="https://github.com/user-attachments/assets/d55edaab-ac15-4377-97fa-758ca9b5bf9f" />

  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> `gl.inet-gl-mv1000`

<img width="622" height="54" alt="image" src="https://github.com/user-attachments/assets/afb45ff0-0367-4d3a-bf3d-1783281f4625" />

- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- ~~Wireless network (if applicable)~~ we dont got a GL-MV1000W so no Wireless Features can be tested
  - [ ] ~~Association with AP must be possible on all radios~~
  - [ ] ~~Association with 802.11s mesh must work on all radios~~
  - [ ] ~~AP+mesh mode must work in parallel on all radios~~
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - ~~Radio LEDs~~
    - [ ] ~~Should map to their respective radio~~
    - [ ] ~~Should show activity~~
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
- ~~Outdoor devices only:~~
  - [ ] ~~Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- ~~Cellular devices only:~~
  - [ ] ~~Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - [ ] ~~Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`




https://github.com/freifunkMUC/site-ffm/tree/add-cortexa53