### PR TITLE
scripts: update-modules: always request git remote branch head

### DIFF
--- a/scripts/update-modules.sh
+++ b/scripts/update-modules.sh
@@ -36,7 +36,7 @@ for MODULE in "OPENWRT" ${GLUON_FEEDS}; do
 	}
 
 	# fetch the commit id for the HEAD of the module
-	REMOTE_HEAD=$(git ls-remote "${REMOTE_URL}" "${REMOTE_BRANCH}" | awk '{ print $1 }')
+	REMOTE_HEAD=$(git ls-remote --heads "${REMOTE_URL}" "${REMOTE_BRANCH}" | awk '{ print $1 }')
 
 	# skip ahead if the commit id did not change
 	[ "$LOCAL_HEAD" == "$REMOTE_HEAD" ] && continue 1


### PR DESCRIPTION
Without specifically requesting with --heads it can happen that multiple refrences
are returned:

```
$ git ls-remote https://github.com/openwrt/packages.git openwrt-24.10
d7ce96f2d2e20ced1f63e3781355d3e4acb62dc9	refs/heads/openwrt-24.10
1ddc0b1c8d9a4674fa0de4abceb66981797e5130	refs/remotes/origin/openwrt-24.10
```

We can work around this by just requesting the branch head specifically:

```
$ git ls-remote --heads https://github.com/openwrt/packages.git openwrt-24.10
d7ce96f2d2e20ced1f63e3781355d3e4acb62dc9	refs/heads/openwrt-24.10
```