### PR TITLE
gluon-mesh-batman-adv: fix has_default_gw4

### DIFF
--- a/package/gluon-mesh-batman-adv/files/lib/gluon/state/check.d/has_default_gw4
+++ b/package/gluon-mesh-batman-adv/files/lib/gluon/state/check.d/has_default_gw4
@@ -8,12 +8,8 @@ if ! out=$(batctl gwl -H 2>/dev/null); then
 	exit 1
 fi
 
-if [ -n "$out" ]; then
-	# no batctl gw available
+# node does not have any gateways listed
+# and is also not in gw_mode
+if [ -z "$out" ] && ! batctl gw_mode | grep -qw '^server'; then
 	exit 2
-fi
-
-if ! batctl gw_mode | grep -qw '^server'; then
-	# server is also not in gw_mode
-	exit 3
 fi


### PR DESCRIPTION
before, the script did land in exit 2 as $out is not empty

this fixes a bug introduced in #3556 which led to the ssid-changer always showing the offline SSID on current gluon main.

Also checking the `gw_mode` is only of interest if no `batctl gwl` exists.

And if the gw_mode is set to server, we should return with exit 0.