### PR TITLE
gluon-mesh-layer3-common: Allow lifetime configuration in site

### DIFF
--- a/package/gluon-mesh-layer3-common/luasrc/lib/gluon/radvd/arguments
+++ b/package/gluon-mesh-layer3-common/luasrc/lib/gluon/radvd/arguments
@@ -5,3 +5,11 @@ io.write("-i local-node --default-lifetime 900 -a " .. site.prefix6())
 if site.dns() and site.dns.servers() then
 	io.write(" --rdnss " .. site.next_node.ip6())
 end
+if site.uradvd() then
+	if site.uradvd.preferred_lifetime() then
+		io.write(" --preferred-lifetime " .. site.uradvd.preferred_lifetime())
+	end
+	if site.uradvd.valid_lifetime() then
+		io.write(" --valid-lifetime " .. site.uradvd.valid_lifetime())
+	end
+end


### PR DESCRIPTION
> as optional section:
> uradvd = {
>     preferred_lifetime = 14400,
>     valid_lifetime = 86400,
> },


this is currrently **blocked** by #3569.