### PR TITLE
mesh-layer3-common: Align fixes to mesh-batman-adv

### DIFF
--- a/package/gluon-mesh-layer3-common/luasrc/lib/gluon/radvd/arguments
+++ b/package/gluon-mesh-layer3-common/luasrc/lib/gluon/radvd/arguments
@@ -4,6 +4,6 @@ local site = require "gluon.site"
 
 io.write("-i local-node --default-lifetime 900 -a " .. site.prefix6())
 
-if site.dns() and site.dns.servers() and site.next_node.ip6() then
+if site.dns.servers() and site.next_node.ip6() then
 	io.write(" --rdnss " .. site.next_node.ip6())
 end

--- a/package/gluon-mesh-layer3-common/luasrc/lib/gluon/radvd/arguments
+++ b/package/gluon-mesh-layer3-common/luasrc/lib/gluon/radvd/arguments
@@ -1,7 +1,9 @@
 #!/usr/bin/lua
+
 local site = require "gluon.site"
 
 io.write("-i local-node --default-lifetime 900 -a " .. site.prefix6())
-if site.dns() and site.dns.servers() then
+
+if site.dns() and site.dns.servers() and site.next_node.ip6() then
 	io.write(" --rdnss " .. site.next_node.ip6())
 end


### PR DESCRIPTION
While working on #3570, I found two unnecessary discrepancies between the variants of the arguments file in the two mesh packages.