### PR TITLE
mesh-vpn: Remove `pubkey_privacy` setting for WireGuard

### DIFF
--- a/docs/features/multidomain.rst
+++ b/docs/features/multidomain.rst
@@ -134,7 +134,6 @@ site.conf only variables
   - setup_mode.skip
   - autoupdater.branch
   - mesh_vpn.enabled
-  - mesh_vpn.pubkey_privacy
   - mesh_vpn.bandwidth_limit
   - mesh_vpn.bandwidth_limit.enabled
   - mesh_vpn.bandwidth_limit.ingress

--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -287,6 +287,9 @@ mesh_vpn
   nodes via public respondd data. If this is of no concern in your threat model,
   this behaviour can be disabled (and thus announcing the public key be enabled) by
   setting `pubkey_privacy` to `false`.
+  As *WireGuard* is *identity hiding*, there is no need to omit the public key from
+  respondd data to prevent such correlation.
+  As such the setting is obsolete for *WireGuard*.
 
   The `fastd` section configures settings specific to the *fastd* VPN
   implementation.

--- a/package/gluon-mesh-vpn-core/check_site.lua
+++ b/package/gluon-mesh-vpn-core/check_site.lua
@@ -1,5 +1,5 @@
 need_boolean(in_site({'mesh_vpn', 'enabled'}), false)
-need_boolean(in_site({'mesh_vpn', 'pubkey_privacy'}), false)
+need_boolean({'mesh_vpn', 'pubkey_privacy'}, false)
 
 need_boolean(in_site({'mesh_vpn', 'bandwidth_limit', 'enabled'}), false)
 need_number(in_site({'mesh_vpn', 'bandwidth_limit', 'ingress'}), false)

--- a/package/gluon-mesh-vpn-wireguard/check_site.lua
+++ b/package/gluon-mesh-vpn-wireguard/check_site.lua
@@ -8,3 +8,5 @@ end
 
 need_table({'mesh_vpn', 'wireguard', 'peers'}, check_peer)
 need_number({'mesh_vpn', 'wireguard', 'mtu'})
+obsolete({'mesh_vpn', 'pubkey_privacy'},
+'WireGuard inherently doesn\'t leak the pubkey to third parties upon initiating connections.')

--- a/package/gluon-mesh-vpn-wireguard/src/respondd.c
+++ b/package/gluon-mesh-vpn-wireguard/src/respondd.c
@@ -93,37 +93,13 @@ disabled_nofree:
 	return enabled;
 }
 
-static bool get_pubkey_privacy(void) {
-	bool ret = true;
-	struct json_object *site = NULL;
-
-	site = gluonutil_load_site_config();
-	if (!site)
-		goto end;
-
-	struct json_object *mesh_vpn;
-	if (!json_object_object_get_ex(site, "mesh_vpn", &mesh_vpn))
-		goto end;
-
-	struct json_object *pubkey_privacy;
-	if (!json_object_object_get_ex(mesh_vpn, "pubkey_privacy", &pubkey_privacy))
-		goto end;
-
-	ret = json_object_get_boolean(pubkey_privacy);
-
-end:
-	json_object_put(site);
-
-	return ret;
-}
-
 static struct json_object * get_wireguard(void) {
 	bool wg_enabled = wireguard_enabled();
 
 	struct json_object *ret = json_object_new_object();
 	json_object_object_add(ret, "version", get_wireguard_version());
 	json_object_object_add(ret, "enabled", json_object_new_boolean(wg_enabled));
-	if (wg_enabled && !get_pubkey_privacy())
+	if (wg_enabled)
 		json_object_object_add(ret, "public_key", get_wireguard_public_key());
 	return ret;
 }


### PR DESCRIPTION
> which implies a usefulness for WireGuard.
> 
> Contrary to fastd WireGuard itself is identity hiding; which means: As long as neither of the two peers is compromised, the identity if the initiator will not be revealed to third parties.
> 
> The claim can be found on https://www.wireguard.com/protocol/ under 'Key Exchange and Data Packets':
> `- Identity Hiding`
> 
> The explanation of it and the whole exchange in detail can be found in this blog post:
> https://icandothese.com/docs/tech/networking/noise_and_wireguard/#identity-hiding
> 
> In order to support mixed setups, where one domain is using e.g. fastd - where the privacy setting is useful - and another domain is using WireGuard, this commit removes the limitation to only set `pubkey_privacy` in the `site.conf`.