### PR TITLE
gluon-client-bridge: owe should  correctly receive its wifi mac

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
@@ -55,7 +55,7 @@ local function configure_owe(radio, index, config, radio_name)
 		return
 	end
 
-	local macaddr = wireless.get_wlan_mac('mesh', index, radio)
+	local macaddr = wireless.get_wlan_mac('owe', index, radio)
 
 	if not ap.owe_ssid() or not macaddr then
 		return


### PR DESCRIPTION
Unfortunately, in #3539 this somehow slipped through to set the wrong MAC-Address for OWE.

Fixing this makes sure to use the MAC-Address which we reserved for OWE again.