### PR TITLE
ath79-generic: (re)add support for Buffalo WZR-HP-G450H / WZR-450HP

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -28,6 +28,7 @@ ath79-generic
 
   - WZR-HP-AG300H / WZR-600DHP
   - WZR-HP-G300NH (rtl8366s)
+  - WZR-HP-G450H / WZR-450HP
 
 * devolo
 

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -83,6 +83,8 @@ device('buffalo-wzr-600dhp', 'buffalo_wzr-600dhp')
 
 device('buffalo-wzr-hp-g300nh-rtl8366s', 'buffalo_wzr-hp-g300nh-s')
 
+device('buffalo-wzr-hp-g450h-wzr-450hp', 'buffalo_wzr-hp-g450h')
+
 
 -- devolo
 


### PR DESCRIPTION
Reference: https://forum.ffrn.de/t/support-fuer-buffalo-wzr-hp-g450h-verschwunden/3629

This device was dropped with the removal of ar71xx-generic.

This doesn't introduce the old device name `buffalo-wzr-hp-g450h` as a manifest_aliases due to the upgrade path not beeing supported from v2021.1.x.
This means a manual reinstallation is neccesary for all devices. It wasn't validated that there actually would be an issue with a direct upgrade.

## Checklist

- [ ] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [ ] Must support upgrade mechanism
  - [ ] Must have working sysupgrade
    - [ ] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [ ] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [ ] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios 
  - [ ] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [ ] Lit while the device is on
    - [ ] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- Outdoor devices only:
  - [ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [ ] Added Device to `docs/user/supported_devices.rst`

---

I'm not quite sure how "Must be flashable from vendor firmware" should be handeled. I didn't (quickly) find a vendor firmware and it's probably quite unlikely that anyone is going to flash on of those anyway. According to the Census there are only 4 devices of this model beeing used.
One idea i've got would be to disable factory image generation and leaving the factory install question open. But i'm personally also not really all that comfortable with that.

Opening this PR to get some opinios.