### PR TITLE
gluon-setup-mode: fix non-interactive dropbear sessions

### DIFF
--- a/package/gluon-setup-mode/Makefile
+++ b/package/gluon-setup-mode/Makefile
@@ -10,7 +10,7 @@ include ../gluon.mk
 define Package/gluon-setup-mode
   TITLE:=Setup mode
   DEPENDS:=+gluon-core +gluon-lock-password +ubus +dnsmasq-full \
-    +!BUSYBOX_CONFIG_NSENTER:nsenter +!BUSYBOX_CONFIG_UNSHARE:unshare
+    +!BUSYBOX_CONFIG_UNSHARE:unshare
 endef
 
 define Package/gluon-setup-mode/description
@@ -41,6 +41,8 @@ define Package/gluon-setup-mode/install
 	for link in $(init_links); do \
 		$(LN) "/etc/init.d/$$$${link:3}" "$(1)/lib/gluon/setup-mode/rc.d/$$$${link}"; \
 	done
+
+	$(INSTALL_BIN) $(PKG_BUILD_DIR)/ash-wrapper $(1)/lib/gluon/setup-mode/dropbear/ash
 endef
 
 $(eval $(call BuildPackageGluon,gluon-setup-mode))

--- a/package/gluon-setup-mode/files/lib/gluon/setup-mode/dropbear/ash
+++ b/package/gluon-setup-mode/files/lib/gluon/setup-mode/dropbear/ash
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-export SHELL=/bin/ash
-exec nsenter --target=1 --mount --wd="$PWD" "$SHELL" --login "$@"

--- a/package/gluon-setup-mode/src/Makefile
+++ b/package/gluon-setup-mode/src/Makefile
@@ -1,0 +1,8 @@
+CFLAGS += -std=c99
+
+all: ash-wrapper
+
+clean:
+	rm -f ash-wrapper
+
+.PHONY: all clean

--- a/package/gluon-setup-mode/src/ash-wrapper.c
+++ b/package/gluon-setup-mode/src/ash-wrapper.c
@@ -1,0 +1,46 @@
+// ash-wrapper:
+// a tiny wrapper around /bin/ash that joins the mount namespace of PID1, while
+// preserving the value of argv[0] (which is not possible with a script-based
+// solution because of the way shebangs work)
+
+#define _GNU_SOURCE
+
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+
+#define SHELL "/bin/ash"
+
+int main(int argc, char *argv[]) {
+	char *cwd = get_current_dir_name();
+	if (!cwd) {
+		fprintf(stderr, "get_current_dir_name: %m\n");
+		return 1;
+	}
+
+	int pid1fd = syscall(SYS_pidfd_open, 1, 0);
+	if (pid1fd < 0) {
+		fprintf(stderr, "pidfd_open: %m\n");
+		return 1;
+	}
+
+	if (setns(pid1fd, CLONE_NEWNS) < 0) {
+		fprintf(stderr, "setns: %m\n");
+		return 1;
+	}
+
+	if (chdir(cwd) < 0) {
+		fprintf(stderr, "chdir: %m\n");
+		return 1;
+	}
+
+	setenv("SHELL", SHELL, 1);
+
+	execv(SHELL, argv);
+
+	// Not reached on success
+	fprintf(stderr, "exec: %m\n");
+	return 1;
+}

--- a/targets/generic
+++ b/targets/generic
@@ -86,7 +86,6 @@ try_config('OONF_GENERIC_HTTP', true)
 config('COLLECT_KERNEL_DEBUG', true)
 
 config('BUSYBOX_CUSTOM', true)
-config('BUSYBOX_CONFIG_NSENTER', true)
 config('BUSYBOX_CONFIG_UNSHARE', true)
 
 config('TARGET_MULTI_PROFILE', true)


### PR DESCRIPTION
Our ash wrapper was passing `--login` unconditionally, however this is incorrect for non-interactive sessions - it does not only result in the OpenWrt banner to be included in the output of commands like `ssh node ... > output.log`, but also completely breaks scp.

The correct behavior is determined by the value of argv[0] set by dropbear, which is '-ash' for interactive sessions and 'ash' otherwise, and interpreted by busybox accordingly. This however poses a problem for our shell-based wrapper: argv[0] is lost due to the indirection when passing the script to its interpreter defined by the shebang.

To solve the problem, replace our shell wrapper with a tiny C program, which preserves the whole argv array when running ash.

Fixes: 18879e28fe74 ("gluon-setup-mode: namespace-based implementation for password-less login")