### PR TITLE
mediatek-filogic: Add support for Xiaomi AX3000T ubootmod

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -356,7 +356,7 @@ mediatek-filogic
 
 * Xiaomi
 
-  - Mi Router AX3000T
+  - Mi Router AX3000T (Stock, ubootmod)
 
 * Zyxel
 

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -21,14 +21,14 @@ device('asus-tuf-ax6000', 'asus_tuf-ax6000', {
 device('d-link-aquila-pro-ai-m30-a1', 'dlink_aquila-pro-ai-m30-a1', {
 	factory = false,
 	extra_images = {
-		{'-squashfs-recovery', '-recovery', '.bin'}
+		{ '-squashfs-recovery', '-recovery', '.bin' }
 	},
 })
 
 device('d-link-aquila-pro-ai-m60-a1', 'dlink_aquila-pro-ai-m60-a1', {
 	factory = false,
 	extra_images = {
-		{'-squashfs-recovery', '-recovery', '.bin'}
+		{ '-squashfs-recovery', '-recovery', '.bin' }
 	},
 })
 
@@ -66,7 +66,7 @@ device('netgear-wax220', 'netgear_wax220', {
 })
 
 -- OpenWRT
-device('openwrt-one', 'openwrt_one',{
+device('openwrt-one', 'openwrt_one', {
 	factory = '-factory',
 	factory_ext = '.ubi',
 	sysupgrade_ext = '.itb',
@@ -94,6 +94,10 @@ device('xiaomi-mi-router-ax3000t', 'xiaomi_mi-router-ax3000t', {
 	factory = false,
 })
 
+device('xiaomi-mi-router-ax3000t-openwrt-u-boot-layout', 'xiaomi_mi-router-ax3000t-ubootmod', {
+	factory = false,
+	sysupgrade_ext = '.itb',
+})
 
 -- Zyxel
 


### PR DESCRIPTION
This PR adds ubootmod support for the Xiaomi AX3000T. Support for the router was introduced in https://github.com/freifunk-gluon/gluon/pull/3559

- [x] Must be flashable from vendor firmware
  - [x] Other: install OpenWRT first and install gluon sysupgrade afterwards
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> xiaomi-mi-router-ax3000t-openwrt-u-boot-layout
- [x] Reset/WPS/... button must return device into config mode (mesh button does nothing)
- [x] Primary MAC address should match address on device label (or packaging)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - the first port is declared as WAN, all other ports LAN (like in vanilla OpenWRT)
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst` (Added ubootmod to existing entry)