### PR TITLE
ipq40xx-generic: add support for linksys-whw03v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -241,7 +241,7 @@ ipq40xx-generic
   - MR8300
   - VLP01
   - WHW01
-  - WHW03 (v2)
+  - WHW03 (v1,v2)
 
 * NETGEAR
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -119,6 +119,7 @@ local primary_addrs = {
 		{'ipq40xx', 'generic', {
 			'linksys,ea6350v3',
 			'linksys,mr8300',
+			'linksys,whw03',
 			'openmesh,a42',
 			'openmesh,a62',
 		}},

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -97,6 +97,10 @@ device('linksys-whw01', 'linksys_whw01', {
 	},
 })
 
+device('linksys-whw03-velop', 'linksys_whw03', {
+	packages = ATH10K_PACKAGES_IPQ40XX_QCA9888,
+})
+
 device('linksys-whw03-v2-velop', 'linksys_whw03v2', {
 	packages = ATH10K_PACKAGES_IPQ40XX_QCA9888,
 })


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [X] Web interface
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> linksys-whw03-velop
- [X] Reset button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN) -> left WAN, right LAN
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on (blue)
    - [X] Should display config mode blink sequence (blue slow)
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`

Test device: https://map.chemnitz.freifunk.net/#!/de/map/24f5a278428e

Hardware:
=========
SOC:             Qualcomm IPQ4019
WiFi 1:          QCA4019 IEEE 802.11b/g/n
WiFi 2:          QCA4019 IEEE 802.11a/n/ac
WiFi 3:          QCA9886 IEEE 802.11a/n/ac
Bluetooth:       Qualcomm CSR8510 (A10)
Zigbee:          Silicon Labs EM3581 NCP + Skyworks SE2432L
Ethernet:        Qualcomm Atheros QCA8072 (2-port)
Flash:           Samsung KLM4G1FEPD (4GB eMMC)
RAM (NAND):      512MB
LED Controller:  NXP PCA9633 (I2C)
Buttons:         Single reset button (GPIO).

Ethernet:
=========
The device has 2 ethernet ports, configured as follows by default:
- left port: WAN
- right port: LAN

Installation:
=============
"factory" image can be installed via the stock web UI:
1. Login to the UI.
2. Enter support mode by clicking on the "CA" link at the bottom.
3. Click "Connectivity", "Choose file", "Start", and ignore warnings.

Singed-off-by: Steffen Förster <nemesis@chemnitz.freifunk.net>
