### PR TITLE
ipq40xx-generic: add linksys-mr8300

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -238,6 +238,7 @@ ipq40xx-generic
 * Linksys
 
   - EA6350 (v3)
+  - MR8300
   - VLP01
   - WHW01
   - WHW03 (v2)

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/010-primary-mac
@@ -118,6 +118,7 @@ local primary_addrs = {
 	{interface('wan'), {
 		{'ipq40xx', 'generic', {
 			'linksys,ea6350v3',
+			'linksys,mr8300',
 			'openmesh,a42',
 			'openmesh,a62',
 		}},

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -86,6 +86,11 @@ device('gl.inet-gl-b1300', 'glinet_gl-b1300', {
 
 device('linksys-ea6350v3', 'linksys_ea6350v3')
 
+device('linksys-mr8300-dallas', 'linksys_mr8300',{
+	packages = ATH10K_PACKAGES_IPQ40XX_QCA9888,
+	factory = false,
+})
+
 device('linksys-whw01', 'linksys_whw01', {
 	aliases = {
 		'linksys-vlp01',


### PR DESCRIPTION
Thanks to @Djfe for the preparation. I got this device to try some potential triple radio devices. This PR supersedes #2769 

The installation path has multiple steps but is not too hard.

Test device: https://map.chemnitz.freifunk.net/#!/de/map/e89f80af75fb

- [X] Must be flashable from vendor firmware
  - [X] Other: via OpenWRT as described in https://openwrt.org/toh/linksys/mr8300#installation
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> linksys-mr8300-dallas
- [X] Reset and WPS buttons must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)     
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`

Hardware Highlights:

SoC: IPQ4019 at 717 MHz (4 CPUs)
RAM: 512MB RAM

SoC:	Qualcomm IPQ4019 at 717 MHz (4 CPUs)
RAM:	512M DDR3
FLASH:	256 MB NAND (Winbond W29N02GV, 8-bit parallel)
ETH:	Qualcomm QCA8075 (4x GigE LAN, 1x GigE Internet Ethernet Jacks)
BTN:	Reset and WPS
USB:	USB3.0, single port on rear with LED
SERIAL:	Serial pads internal (unpopulated)
LED:	Four status lights on top + USB LED
WIFI1:	2x2:2 QCA4019 2.4 GHz radio on ch. 1-14
WIFI2:  2x2:2 QCA4019 5 GHz radio on ch. 36-64
WIFI3:  2x2:2 QCA9888 5 GHz radio on ch. 100-165

Installation:
"Factory" images may be installed directly through the OEM GUI using
URL: https://ip-of-router/fwupdate.html (Typically 192.168.1.1)
