### PR TITLE
ipq40xx-generic: add NETGEAR SRR60/SRS60

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -247,6 +247,8 @@ ipq40xx-generic
 
   - EX6100 (v2)
   - EX6150 (v2)
+  - SRR60
+  - SRS60
 
 * OpenMesh
 

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -14,6 +14,15 @@ local ATH10K_PACKAGES_IPQ40XX_QCA9888 = {
 	'ath10k-firmware-qca9888',
 	'-ath10k-firmware-qca9888-ct',
 }
+local ATH10K_PACKAGES_IPQ40XX_QCA9984 = {
+	'kmod-ath10k',
+	'-kmod-ath10k-ct',
+	'-kmod-ath10k-ct-smallbuffers',
+	'ath10k-firmware-qca4019',
+	'-ath10k-firmware-qca4019-ct',
+	'ath10k-firmware-qca9984',
+	'-ath10k-firmware-qca9984-ct',
+}
 
 
 defaults {
@@ -127,6 +136,16 @@ device('netgear-ex6100v2', 'netgear_ex6100v2', {
 
 device('netgear-ex6150v2', 'netgear_ex6150v2', {
 	factory_ext = '.img',
+})
+
+device('netgear-srr60', 'netgear_srr60', {
+	factory_ext = '.img',
+	packages = ATH10K_PACKAGES_IPQ40XX_QCA9984,
+})
+
+device('netgear-srs60', 'netgear_srs60', {
+	factory_ext = '.img',
+	packages = ATH10K_PACKAGES_IPQ40XX_QCA9984,
 })
 
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [ ] Other: nmrpflash should work, even though it didnt with my test devices
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> `netgear-srr60` / `netgear-srs60`
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`

Even though the SRS60 has no wan port labeled, they are both configured identical, so the leftmost port is WAN on both devices.

To successfully flash the device via the vendor ui you need to enable telnet first and check on the console if the boot-part is set to 02.

To switch on partition 2 you have to enable telnet first:
 1. Go to http://<device_ip>/debug.htm and check "Enable Telnet".
 2. Connect through telent and login using admin/password.

To read the current boot_part:
artmtd -r boot_part

To write the new boot_part:
artmtd -w boot_part 02

After a reboot you can flash the factory gluon image.