### PR TITLE
mediatek-filogic: add cudy-wr3000e

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -331,6 +331,7 @@ mediatek-filogic
   - AP3000 Outdoor (v1)
   - TR3000 (v1)
   - WR3000 (v1)
+  - WR3000e (v1)
 
 * D-Link
 

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -47,6 +47,9 @@ device('cudy-wr3000-v1', 'cudy_wr3000-v1', {
 	factory = false,
 })
 
+device('cudy-wr3000e-v1', 'cudy_wr3000e-v1', {
+	factory = false,
+})
 
 -- GL.iNet
 


### PR DESCRIPTION
- [x] Must be flashable from vendor firmware
  - [x] Web interface *one needs to install a signed OWRT from cudy first*
  - [x] TFTP *needs a signed firmware*

- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [x] Should map to their respective radio
    - [x] Should show activity
  - Switch port LEDs
    - [x] Should map to their respective port (or switch, if only one led present) 
    - [x] Should show link state and activity
        *wan will both work but waits for PR* 
        *lan has one led represening 4 lan ports of which only one of them can be assigned at a time*

- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`
