### PR TITLE
ipq40xx-generic: add support for Netgear RBR50v1/RBS50v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -247,6 +247,8 @@ ipq40xx-generic
 
   - EX6100 (v2)
   - EX6150 (v2)
+  - RBR50 (v1)
+  - RBS50 (v1)
   - SRR60
   - SRS60
 

--- a/targets/ipq40xx-generic
+++ b/targets/ipq40xx-generic
@@ -142,6 +142,16 @@ device('netgear-ex6150v2', 'netgear_ex6150v2', {
 	factory_ext = '.img',
 })
 
+device('netgear-rbr50', 'netgear_rbr50', {
+	factory_ext = '.img',
+	packages = ATH10K_PACKAGES_IPQ40XX_QCA9984,
+})
+
+device('netgear-rbs50', 'netgear_rbs50', {
+	factory_ext = '.img',
+	packages = ATH10K_PACKAGES_IPQ40XX_QCA9984,
+})
+
 device('netgear-srr60', 'netgear_srr60', {
 	factory_ext = '.img',
 	packages = ATH10K_PACKAGES_IPQ40XX_QCA9984,


### PR DESCRIPTION
Even though the RBS50 has no wan port labeled, they are both configured identical, so the leftmost port is WAN on both devices.

To successfully flash the device via the vendor ui you need to enable telnet first and check on the console if the boot-part is set to 02.

To switch on partition 2 you have to enable telnet first:
 1. Go to http://<device_ip>/debug.htm and check "Enable Telnet".
 2. Connect through telent and login using admin/password.

To read the current boot_part:
artmtd -r boot_part

To write the new boot_part:
artmtd -w boot_part 02

After a reboot you can flash the factory gluon image.

Checklist
-----
- [x] Must be flashable from vendor firmware
  - [x] Web interface
- [x] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> `netgear-rbr50`, `netgear-rbs50`
- [x] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [x] should support all network ports on the device
  - [x] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [x] Association with AP must be possible on all radios
  - [x] Association with 802.11s mesh must work on all radios 
  - [x] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [x] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`