### PR TITLE
gluon-wan-dnsmasq: work around missing capabilities for libpacketmark + minor cleanup

### DIFF
--- a/package/gluon-wan-dnsmasq/files/etc/init.d/gluon-wan-dnsmasq
+++ b/package/gluon-wan-dnsmasq/files/etc/init.d/gluon-wan-dnsmasq
@@ -22,7 +22,10 @@ start_service() {
 		--keep-in-foreground \
 		--pid-file=/var/run/dnsmasq/gluon-wan-dnsmasq.pid \
 		--cache-size=0 \
+		--enable-ubus=gluon-wan-dnsmasq \
 		--resolv-file="$RESOLV_CONF"
+	# --enable-ubus must be set as a workaround to avoid dnsmasq dropping
+	# CAP_NET_RAW, which would break libpacketmark
 	procd_set_param env LD_PRELOAD=libpacketmark.so LIBPACKETMARK_MARK=1
 	procd_set_param respawn 60 5 5
 


### PR DESCRIPTION
Workaround for #3613, as a VRF-based solution is too invasive for a timely 2025.1 release.