### PR TITLE
net/l2tp: reset skb control buffer

### DIFF
--- a/patches/openwrt/0012-net-l2tp-reset-skb-control-buffer.patch
+++ b/patches/openwrt/0012-net-l2tp-reset-skb-control-buffer.patch
@@ -1,0 +1,68 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Mon, 17 Nov 2025 01:50:08 +0100
+Subject: net/l2tp: reset skb control buffer
+
+The L2TP stack did not reset the skb control buffer before handing off
+the package to the lower netdev.
+
+In a setup with an ath10k radio and batman-adv over an L2TP tunnel
+massive fragmentations happen sporadically if the L2TP tunnel is
+established over IPv4.
+
+L2TP might reset some of the fields in the IP control buffer, but L2TP
+assumes the type of the control buffer to be of an IPv4 packet, while
+due to it being Layer 2, this is not a given.
+
+Clear the entire control buffer to avoid such mishaps altogether.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+
+diff --git a/target/linux/generic/pending-6.6/985-net-l2tp-reset-skb-control-buffer.patch b/target/linux/generic/pending-6.6/985-net-l2tp-reset-skb-control-buffer.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..5c8f66300082cac7ee8637613513bd618ded5593
+--- /dev/null
++++ b/target/linux/generic/pending-6.6/985-net-l2tp-reset-skb-control-buffer.patch
+@@ -0,0 +1,43 @@
++From 6317095a52e769169ca1bd9a2d9100c0feb5e92b Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Mon, 17 Nov 2025 01:46:47 +0100
++Subject: [PATCH] net/l2tp: reset skb control buffer
++
++The L2TP stack did not reset the skb control buffer before handing off
++the package to the lower netdev.
++
++In a setup with an ath10k radio and batman-adv over an L2TP tunnel
++massive fragmentations happen sporadically if the L2TP tunnel is
++established over IPv4.
++
++L2TP might reset some of the fields in the IP control buffer, but L2TP
++assumes the type of the control buffer to be of an IPv4 packet, while
++due to it being Layer 2, this is not a given.
++
++Clear the entire control buffer to avoid such mishaps altogether.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++---
++ net/l2tp/l2tp_core.c | 6 +++---
++ 1 file changed, 3 insertions(+), 3 deletions(-)
++
++diff --git a/net/l2tp/l2tp_core.c b/net/l2tp/l2tp_core.c
++index 369a2f2e459cd..0710281dd95aa 100644
++--- a/net/l2tp/l2tp_core.c
+++++ b/net/l2tp/l2tp_core.c
++@@ -1246,9 +1246,9 @@ static int l2tp_xmit_core(struct l2tp_session *session, struct sk_buff *skb, uns
++ 	else
++ 		l2tp_build_l2tpv3_header(session, __skb_push(skb, session->hdr_len));
++ 
++-	/* Reset skb netfilter state */
++-	memset(&(IPCB(skb)->opt), 0, sizeof(IPCB(skb)->opt));
++-	IPCB(skb)->flags &= ~(IPSKB_XFRM_TUNNEL_SIZE | IPSKB_XFRM_TRANSFORMED | IPSKB_REROUTED);
+++	/* Reset control buffer */
+++	memset(skb->cb, 0, sizeof(skb->cb));
+++
++ 	nf_reset_ct(skb);
++ 
++ 	/* L2TP uses its own lockdep subclass to avoid lockdep splats caused by
++-- 
++2.51.0
++


### PR DESCRIPTION
Backport of #3614

---

The L2TP stack did not reset the skb control buffer before handing off the package to the lower netdev.

In a setup with an ath10k radio and batman-adv over an L2TP tunnel massive fragmentations happen sporadically if the L2TP tunnel is established over IPv4.

L2TP might reset some of the fields in the IP control buffer, but L2TP assumes the type of the control buffer to be of an IPv4 packet, while due to it being Layer 2, this is not a given.

Clear the entire control buffer to avoid such mishaps altogether.


(cherry picked from commit 0af1e351787aa2028bd77ed621ff4eb8f5da5e01)