### PR TITLE
gluon-core: limit size of wireless buffers

### DIFF
--- a/package/gluon-core/files/etc/hotplug.d/ieee80211/01-gluon-core-codel-memusage
+++ b/package/gluon-core/files/etc/hotplug.d/ieee80211/01-gluon-core-codel-memusage
@@ -1,8 +1,17 @@
 #!/bin/sh
 
+LIMIT=""
+
 if [ "${ACTION}" = 'add' ]; then
 	RAM=$(awk '/MemTotal/ {print $2}' /proc/meminfo)
-	if [ "$RAM" -le $((32*1024)) ]; then
-		echo 'fq_memory_limit 262144' > "/sys/kernel/debug/ieee80211/$DEVICENAME/aqm"
+	if [ "$RAM" -le $((64*1024)) ]; then
+		LIMIT=524288
+	elif [ "$RAM" -le $((128*1024)) ]; then
+		LIMIT=2097152
+	fi
+
+	if [ -n "$LIMIT" ]; then
+		echo "fq_memory_limit $LIMIT" > "/sys/kernel/debug/ieee80211/$DEVICENAME/aqm"
+		iw phy "$DEVICENAME" set txq memory_limit $LIMIT
 	fi
 fi


### PR DESCRIPTION
By default, the kernel configures the buffers for wireless PHYs to 4MB for 11n radios and 16MB for 11ac and above.

For our RAM constrained devices, this has the effect of the buffers potentially filling up to cause a OOM oops. This makes it harder to bisect issues, as non-resumed TX queues often lead to such a crash on resource-constrained boards.

Limit wireless queue size for devices with 64MB of RAM to 512kB. For 128MB RAM limit to 2MB accordingly. The 512kB was chosen to provide ~100 Mbit/s sustained traffic total to 3 clients on a more powerful board. This should totally suffice the needs of these lower-tier routers.