### PR TITLE
wifi: mt76: mt76x02: wake queues after reconfig

### DIFF
--- a/patches/openwrt/0012-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+++ b/patches/openwrt/0012-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
@@ -1,0 +1,54 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 29 Nov 2025 03:53:16 +0100
+Subject: wifi: mt76: mt76x02: wake queues after reconfig
+
+The shared reset procedure of MT7610 and MT7612 stop all queues before
+starting the reset sequence.
+
+They however never restart these like other supported mt76 chips
+do in the reconfig_complete call. This leads to TX not continuing
+after the reset.
+
+Restart queues in the reconfig_complete callback to restore
+functionality after the reset.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+Link: https://patchwork.kernel.org/project/linux-wireless/patch/20251129023904.288484-1-mail@david-bauer.net/
+
+diff --git a/package/kernel/mt76/patches/350-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch b/package/kernel/mt76/patches/350-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..8d9a2477da94d01f4f19dca7b34fb374ac13439b
+--- /dev/null
++++ b/package/kernel/mt76/patches/350-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+@@ -0,0 +1,31 @@
++From 189755ebda9163c7745be8b675672ca619f0f34e Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Sat, 29 Nov 2025 03:36:32 +0100
++Subject: [PATCH mt76] wifi: mt76: mt76x02: wake queues after reconfig
++
++The shared reset procedure of MT7610 and MT7612 stop all queues before
++starting the reset sequence.
++
++They however never restart these like other supported mt76 chips
++do in the reconfig_complete call. This leads to TX not continuing
++after the reset.
++
++Restart queues in the reconfig_complete callback to restore
++functionality after the reset.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++Link: https://patchwork.kernel.org/project/linux-wireless/patch/20251129023904.288484-1-mail@david-bauer.net/
++---
++ mt76x02_mmio.c | 1 +
++ 1 file changed, 1 insertion(+)
++
++--- a/mt76x02_mmio.c
+++++ b/mt76x02_mmio.c
++@@ -534,6 +534,7 @@ void mt76x02_reconfig_complete(struct ie
++ 		return;
++ 
++ 	clear_bit(MT76_RESTART, &dev->mphy.state);
+++	ieee80211_wake_queues(hw);
++ }
++ EXPORT_SYMBOL_GPL(mt76x02_reconfig_complete);
++ 


### PR DESCRIPTION
This is an issue i have observed for a longer time but never got around to bisect.

Looking at the graph, you can see memory usage filling up and the device subsequently reboot:

<img width="1278" height="448" alt="image" src="https://github.com/user-attachments/assets/10134f4d-36f1-4453-a011-6884e14154ce" />

This is the same for the crashes within short intervals (additionally with high client-load):

<img width="726" height="477" alt="image" src="https://github.com/user-attachments/assets/3b0213ed-dea3-4370-be97-5869a5ee9f38" />

I'll send the patch upstream, but i appreciate feedback as quite some popular devices from the lower-end (Netgear R6120 / Archer C50 / Xiaomi MiRouter 4AG) are affected.

---

The shared reset procedure of MT7610 and MT7612 stop all queues before starting the reset sequence but never restartet these like other supported mt76 chips do in the reconfig_complete call.

This leads to TX not continuing after the reset.

Restart queues in the reconfig_complete callback to restore functionality after the reset.