### PR TITLE
gluon-core: fix pubkey_privacy being in site instead of uci

### DIFF
--- a/package/gluon-mesh-vpn-core/luasrc/usr/lib/lua/gluon/mesh-vpn.lua
+++ b/package/gluon-mesh-vpn-core/luasrc/usr/lib/lua/gluon/mesh-vpn.lua
@@ -45,7 +45,7 @@ function M.get_active_provider()
 end
 
 function M.get_enabled_public_key()
-	if M.enabled() ~= true or uci:get_bool('gluon', 'mesh_vpn', 'pubkey_privacy') ~= true then
+	if M.enabled() ~= true then
 		return nil
 	end
 
@@ -53,7 +53,9 @@ function M.get_enabled_public_key()
 
 	local pubkey
 	if active_vpn ~= nil then
-		pubkey = active_vpn.public_key()
+		if not active_vpn.pubkey_privacy() then
+			pubkey = active_vpn.public_key()
+		end
 	end
 
 	return pubkey

--- a/package/gluon-mesh-vpn-fastd/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/fastd.lua
+++ b/package/gluon-mesh-vpn-fastd/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/fastd.lua
@@ -73,4 +73,8 @@ function M.mtu()
 	return site.mesh_vpn.fastd.mtu()
 end
 
+function M.pubkey_privacy()
+	return site.mesh_vpn.pubkey_privacy(true)
+end
+
 return M

--- a/package/gluon-mesh-vpn-wireguard/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
+++ b/package/gluon-mesh-vpn-wireguard/luasrc/usr/lib/lua/gluon/mesh-vpn/provider/wireguard.lua
@@ -43,4 +43,9 @@ function M.mtu()
 	return site.mesh_vpn.wireguard.mtu()
 end
 
+function M.pubkey_privacy()
+	-- WireGuard inherently doesn't leak the pubkey to third parties upon initiating connections.
+	return false
+end
+
 return M


### PR DESCRIPTION
This readds the setting for wireguard as well, to configure the behavior on the status page

The alternative - if one does not want to have this setting for wireguard at all, would be to extend the mesh-vpn provider as done in:

https://github.com/ffac/gluon/commit/7df8f6324c458950ad4b1483ada8f4789ae40eff

From my perspective, this is the cleaner solution to not add more complexity into this feature.
What do you think about this @aiyionprime

fixes #3624