### PR TITLE
contrib: fix removal of .NET

### DIFF
--- a/contrib/actions/free-runner-space.sh
+++ b/contrib/actions/free-runner-space.sh
@@ -8,7 +8,6 @@ df -h
 
 # Remove packages not required to run the Gluon build CI
 sudo apt-get -y remove \
-	dotnet-* \
 	firefox \
 	google-chrome-stable \
 	kubectl \
@@ -17,6 +16,9 @@ sudo apt-get -y remove \
 
 # Remove Android SDK tools
 sudo rm -rf /usr/local/lib/android
+
+# Remove .NET
+sudo rm -rf /usr/share/dotnet
 
 echo "Disk space after cleanup"
 df -h


### PR DESCRIPTION
Dispose of the Microsoft garbage properly after the installation method changed within the same image version.

Link: https://github.com/actions/runner-images/pull/13004