### PR TITLE
treewide: bump minimum CMake version

### DIFF
--- a/package/gluon-core/src/CMakeLists.txt
+++ b/package/gluon-core/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20)
 
 project(gluon-core C)
 

--- a/package/libgluonutil/src/CMakeLists.txt
+++ b/package/libgluonutil/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.20)
 
 project(libgluonutil C)
 


### PR DESCRIPTION
CMake 4 dropped support for CMakeList files with a minimum version less than 3.5.

Update all CMakeList files to target version 3.20 in order to build Gluon based on OpenWrt 24.10 and newer.