### PR TITLE
ramips-mt7621: add support for Cudy AP1300 Outdoor v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -488,6 +488,7 @@ ramips-mt7621
 
 * Cudy
 
+  - AP1300 Outdoor (v1)
   - WR1300 (v1)
   - WR2100
   - X6 (v1, v2)

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -76,6 +76,7 @@ function M.is_outdoor_device()
 		return true
 
 	elseif M.match('ramips', 'mt7621', {
+		'cudy,ap1300-outdoor-v1',
 		'wavlink,ws-wn572hp3-4g',
 		'zyxel,nwa55axe',
 	}) then

--- a/targets/ramips-mt7621
+++ b/targets/ramips-mt7621
@@ -12,6 +12,10 @@ device('asus-rt-ax53u', 'asus_rt-ax53u')
 
 -- Cudy
 
+device('cudy-ap1300-outdoor-v1', 'cudy_ap1300-outdoor-v1',{
+	factory = false,
+})
+
 device('cudy-wr1300-v1', 'cudy_wr1300-v1', {
 	factory = false,
 	manifest_aliases = {


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [X] Other: via intermediate firmware supplied by Cudy
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> cudy-ap1300-outdoor-v1
- [X] Reset/WPS/... button must return device into config mode
- [x] Primary MAC address should match address on device label (or packaging) -> one above the actual printed MAC
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - [X] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`


Hardware:
 - SoC: MediaTek MT7621DAT
 - Flash: 16 MiB XM25QH128C
 - RAM: 128 MiB
 - WLAN: 2.4 GHz (MT7603E, 11n), 5 GHz (MediaTek MT7613BEN, 11ac)
 - Ethernet: 1x10/100/1000 Mbps LAN
 - Buttons: 1 Reset button, 1 WPS button
 - LEDs: 5x Green
 - Serial Console: unpopulated header 115200 8n1 (silkscreen on PCB)
 - Power: POE 802.3af (37-57V DC)


