### PR TITLE
core: fix ipv6 config for cellular devices

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular
@@ -29,6 +29,7 @@ local function setup_ncm_qmi(devpath, control_type, delay)
 		disabled = not uci:get_bool('gluon', 'cellular', 'enabled'),
 		pdptype = pdptype,
 		peerdns = false,
+		ip6table = 1,
 		apn = uci:get('gluon', 'cellular', 'apn'),
 	})
 


### PR DESCRIPTION
The mark for uplink traffic from cellular to be used as wan for gluon-wan-dnsmasq and wireguard was not set.
Without this ipv6 uplink does not work for cellular devices

fixes the issue mentioned in https://github.com/freifunk-gluon/gluon/pull/3618#issuecomment-3696686621
