### PR TITLE
docs: declare effect of adjusting mcast_rate in mesh

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -142,6 +142,8 @@ wifi24 \: optional
   ``mesh`` also accepts an optional ``mcast_rate`` (kbit/s) parameter for
   setting the multicast bitrate. Increasing the default value of 1000 to something
   like 12000 is recommended.
+  Increasing this (e.g. to 24000) decreases airtime of multicast traffic, but also
+  reduces coverage as higher-quality meshes are required for a successful connection.
 
   ::
 


### PR DESCRIPTION
This was mentioned at the meetup.

As no exact values are known, it does not really make sense to give a threshold (e.g. 1000-32000 ..?) but a rough idea of possible changes and the impact is given now.