### PR TITLE
gluon-status-page: add ssid, htmode, base version and firmware target to overview

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
+++ b/package/gluon-status-page/files/lib/gluon/status-page/view/status-page.html
@@ -50,10 +50,15 @@
 
 		wireless.foreach_radio(uci, function(radio)
 			local channel = iwinfo.nl80211.channel(wireless.find_phy(radio))
+			local radio_name = radio['.name']
+			local suffix = radio_name:match('^radio(%d+)$')
+			local ssid = iwinfo.nl80211.ssid('client' .. suffix) 
 			if channel then
 				table.insert(ret, {
-					name = radio['.name'],
+					name = radio_name,
 					channel = channel,
+					ssid = ssid,
+					htmode = radio.htmode
 				})
 			end
 		end)
@@ -159,10 +164,11 @@
 							<%| nodeinfo.location.latitude %>, <%| nodeinfo.location.longitude %>
 						</a></dd>
 					<%- end %>
-					<dt><%:Model%></dt><dd><%| nodeinfo.hardware.model %></dd>
+					<dt><%:Model%></dt><dd><%| nodeinfo.hardware.model %> (<%| nodeinfo.hardware.nproc %> CPUs)</dd>
 					<dt><%:Primary MAC address%></dt><dd><%| nodeinfo.network.mac %></dd>
 					<dt><%:IP address%></dt><dd><%= pcdata(table.concat(sorted(nodeinfo.network.addresses), '\n')):gsub('\n', '<br>') %></dd>
-					<dt><%:Firmware%></dt><dd><%| nodeinfo.software.firmware.release %></dd>
+					<dt><%:Firmware%></dt><dd><%| nodeinfo.software.firmware.release %> (<%| nodeinfo.software.firmware.base %>)</dd>
+					<dd><%| nodeinfo.software.firmware.target %> (<%| nodeinfo.software.firmware.subtarget %>)</dd>
 					<% if nodeinfo.network.mesh_vpn then -%>
 						<dt><%:Mesh VPN%></dt>
 						<dd>
@@ -241,6 +247,11 @@
 								<tr>
 									<th><%| radio.name %></th>
 									<td><%| translatef('Channel %u', radio.channel) %></td>
+									<td>(<%| radio.htmode %>)</td>
+								</tr>
+								<tr>
+									<th></th>
+									<td><%| translate('SSID') %>: <%| radio.ssid %></td>
 								</tr>
 							<%- end %>
 						</tbody>


### PR DESCRIPTION
This solves the addition of:

- ssid of active client radios
- gluon base version next to firmware version
- target/imagename
- cpu core count (ncpus)

from #3645

Status page with additional information:

<img width="1077" height="904" alt="image" src="https://github.com/user-attachments/assets/8901f906-f7ab-4e73-9d8e-d4456e17a527" />
