### PR TITLE
gluon-core: add setting of htmode channel_width per radio

### DIFF
--- a/docs/user/site.rst
+++ b/docs/user/site.rst
@@ -104,6 +104,7 @@ regdom \: optional
 wifi24 \: optional
   WLAN configuration for 2.4 GHz devices.
   ``channel`` must be set to a valid wireless channel for your radio.
+  ``bandwidth`` can be specified to set a custom bandwidth per radio band in MHz. Can be 20, 40, 80 or 160.
   ``beacon_interval`` can be specified to set a custom beacon interval in
   time units (TU). A time unit is equivalent to 1024 µs.
   If not set, the default value of 100 TU (=102.4 ms) is used.

--- a/package/gluon-core/check_site.lua
+++ b/package/gluon-core/check_site.lua
@@ -35,6 +35,7 @@ for _, config in ipairs({'wifi24', 'wifi5'}) do
 	if need_table({config}, nil, false) then
 		need_string(in_site({'regdom'})) -- regdom is only required when wifi24 or wifi5 is configured
 		need_number({config, 'beacon_interval'}, false)
+		need_one_of({config, 'channel_width'}, {20, 40, 80, 160}, false)
 
 		if config == "wifi24" then
 			local channels = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -74,16 +74,37 @@ local function get_htmode(radio)
 		end
 	end
 
+	local channel_width = 20
+
+	if radio.band == '2g' then
+		channel_width = site.wifi24.channel_width(20)
+	elseif radio.band == '5g' then
+		channel_width = site.wifi5.channel_width(20)
+	end
+
 	local phy = wireless.find_phy(radio)
+	local htmode
 	if iwinfo.nl80211.hwmodelist(phy).ax then
-		return 'HE20'
+		htmode = 'HE' .. channel_width
+	elseif iwinfo.nl80211.hwmodelist(phy).ac then
+		htmode = 'VHT' .. channel_width
+	else
+		htmode = 'HT' .. channel_width
 	end
 
-	if iwinfo.nl80211.hwmodelist(phy).ac then
-		return 'VHT20'
+	local last_mode
+
+	for mode, available in pairs(iwinfo.nl80211.htmodelist(phy)) do
+		if available and mode == htmode then
+			return htmode
+		end
+
+		last_mode = mode
 	end
 
-	return 'HT20'
+	-- if preferred htmode is not available
+	-- select the last one we got
+	return last_mode
 end
 
 local function configure_mesh(radio, index, mesh_config)


### PR DESCRIPTION
allow setting a custom bandwidth per band
can be 20, 40, 80 or 160 MHz

Depends on the supported bandwidth on the device.

This can be configured to use 40MHz bandwidth for 5GHz radios as in:

```
wifi5 = {
channel_width = 40,
...
}
```

fixes #2947 