### PR TITLE
mediatek-filogic: add support for Cudy M3000 v1

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -344,6 +344,7 @@ mediatek-filogic
 * Cudy
 
   - AP3000 Outdoor (v1)
+  - M3000 (v1)
   - RE3000 (v1)
   - TR3000 (v1)
   - WR3000 (v1)

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -39,6 +39,10 @@ device('cudy-ap3000-outdoor-v1', 'cudy_ap3000outdoor-v1', {
 	factory = false,
 })
 
+device('cudy-m3000-v1', 'cudy_m3000-v1', {
+	factory = false,
+})
+
 device('cudy-re3000-v1', 'cudy_re3000-v1', {
 	factory = false,
 })


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [ ] Web interface
  - [ ] TFTP
  - [X] Other: Web Based via Intermediate Firmware. [German Instructions](https://forum.darmstadt.freifunk.net/t/installation-cudy-tr3000/1010) | [English Instructions](https://openwrt.org/toh/cudy/tr3000#oem_easy_installation) (Similar to TR3000 v1)
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [X] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [X] Reset/WPS/... button must return device into config mode
- [-] Primary MAC address should match address on device label (or packaging) (Currently off by +1)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [-] Should map to their respective radio
    - [-] Should show activity
  - Switch port LEDs
    - [-] Should map to their respective port (or switch, if only one led present) 
    - [-] Should show link state and activity
- Outdoor devices only:
  - [-] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [-] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [-] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`