### PR TITLE
ath79-generic: re add support for ubiquiti-rocket-m-xm

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -159,6 +159,7 @@ ath79-generic
   - NanoBeam M5 (XW)
   - NanoStation Loco M2/M5 (XW)
   - NanoStation M2/M5 (XW)
+  - Rocket M2/M5 (XM)
   - UniFi AC Lite
   - UniFi AC LR
   - UniFi AC Mesh

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua
@@ -46,6 +46,7 @@ function M.is_outdoor_device()
 		'ubnt,nanobeam-ac-xc',
 		'ubnt,nanostation-loco-m-xw',
 		'ubnt,nanostation-m-xw',
+		'ubnt,rocket-m',
 		'ubnt,uk-ultra',
 		'ubnt,unifi-ap-outdoor-plus',
 		'ubnt,unifiac-mesh',

--- a/targets/ath79-generic
+++ b/targets/ath79-generic
@@ -548,6 +548,8 @@ device('ubiquiti-nanostation-loco-m-xw', 'ubnt_nanostation-loco-m-xw', {
 
 device('ubiquiti-nanostation-m-xw', 'ubnt_nanostation-m-xw')
 
+device('ubiquiti-rocket-m-xm', 'ubnt_rocket-m')
+
 device('ubiquiti-unifi-ac-lite', 'ubnt_unifiac-lite', {
 	factory = false,
 	packages = ATH10K_PACKAGES_QCA9880,


### PR DESCRIPTION
This device comes in 3 differenct configurations:
* dual-band (M XM)
* 2.4 G only (M2 XM)
* 5 GHz only (M5 XM)

Was removed in #2925
Since then, devices affected by the read-only issue were added in #3141

More information in https://forum.freifunk.net/t/ubiquiti-rocket-m2-m5-xm-besitzer-gesucht/23762/79

Tested by  murxmaster from forum.freifunk.net

## Checklist

- [X] Must be flashable from vendor firmware
  - [X] Web interface
  - [ ] TFTP
  - [ ] Other: <specify>
- [X] Must support upgrade mechanism
  - [x] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
      
  - [X] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
        ubiquiti-rocket-m-xm
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
- [x] When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [x] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
          No. Last RSSI-LED has blink sequence
          maurerle: this is fine
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Outdoor devices only:
  - [x] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
- Cellular devices only:
  - [ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`
  - [ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`

