### PR TITLE
mediatek-filogic: add support for Cudy WR3000S

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -343,6 +343,7 @@ mediatek-filogic
   - TR3000 (v1)
   - WR3000 (v1)
   - WR3000e (v1)
+  - WR3000s (v1)
 
 * D-Link
 

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -55,6 +55,10 @@ device('cudy-wr3000e-v1', 'cudy_wr3000e-v1', {
 	factory = false,
 })
 
+device('cudy-wr3000s-v1', 'cudy_wr3000s-v1', {
+	factory = false,
+})
+
 -- GL.iNet
 
 device('gl.inet-gl-mt2500', 'glinet_gl-mt2500', {


### PR DESCRIPTION
- [X] Must be flashable from vendor firmware
  - [X] Other: intermediate OpenWRT image
- [X] Must support upgrade mechanism
  - [X] Must have working sysupgrade
    - [x] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [x] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`) -> cudy-wr3000s-v1
- [X] Reset/WPS/... button must return device into config mode
- [X] Primary MAC address should match address on device label (or packaging)
- Wired network
  - [X] should support all network ports on the device
  - [X] must have correct port assignment (WAN/LAN)
- Wireless network (if applicable)
  - [X] Association with AP must be possible on all radios
  - [X] Association with 802.11s mesh must work on all radios 
  - [X] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [X] Lit while the device is on
    - [X] Should display config mode blink sequence 
  - Radio LEDs
    - [X] Should map to their respective radio
    - [X] Should show activity
  - Switch port LEDs
    - [X] Should map to their respective port (or switch, if only one led present) 
    - [X] Should show link state and activity
- Docs:
  - [X] Added Device to `docs/user/supported_devices.rst`

Test Device: https://map.chemnitz.freifunk.net/#!/de/map/80afca6b320a


Hardware
--------
MediaTek MT7981 WiSoC
256MB DDR3 RAM
128MB SPI-NAND (XMC XM25QH128C)
MediaTek MT7981 2x2 DBDC 802.11ax 2T2R (2.4 / 5)

Installation
--------
Via OpenWRT intermediate Firmware supplied by Cudy