### PR TITLE
[v2023.2.x] wifi: mt76: mt76x02: wake queues after reconfig

### DIFF
--- a/patches/openwrt/0013-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+++ b/patches/openwrt/0013-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
@@ -1,0 +1,54 @@
+From: David Bauer <mail@david-bauer.net>
+Date: Sat, 29 Nov 2025 03:53:16 +0100
+Subject: wifi: mt76: mt76x02: wake queues after reconfig
+
+The shared reset procedure of MT7610 and MT7612 stop all queues before
+starting the reset sequence.
+
+They however never restart these like other supported mt76 chips
+do in the reconfig_complete call. This leads to TX not continuing
+after the reset.
+
+Restart queues in the reconfig_complete callback to restore
+functionality after the reset.
+
+Signed-off-by: David Bauer <mail@david-bauer.net>
+Link: https://patchwork.kernel.org/project/linux-wireless/patch/20251129023904.288484-1-mail@david-bauer.net/
+
+diff --git a/package/kernel/mt76/patches/350-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch b/package/kernel/mt76/patches/350-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+new file mode 100644
+index 0000000000000000000000000000000000000000..8d9a2477da94d01f4f19dca7b34fb374ac13439b
+--- /dev/null
++++ b/package/kernel/mt76/patches/350-wifi-mt76-mt76x02-wake-queues-after-reconfig.patch
+@@ -0,0 +1,31 @@
++From 189755ebda9163c7745be8b675672ca619f0f34e Mon Sep 17 00:00:00 2001
++From: David Bauer <mail@david-bauer.net>
++Date: Sat, 29 Nov 2025 03:36:32 +0100
++Subject: [PATCH mt76] wifi: mt76: mt76x02: wake queues after reconfig
++
++The shared reset procedure of MT7610 and MT7612 stop all queues before
++starting the reset sequence.
++
++They however never restart these like other supported mt76 chips
++do in the reconfig_complete call. This leads to TX not continuing
++after the reset.
++
++Restart queues in the reconfig_complete callback to restore
++functionality after the reset.
++
++Signed-off-by: David Bauer <mail@david-bauer.net>
++Link: https://patchwork.kernel.org/project/linux-wireless/patch/20251129023904.288484-1-mail@david-bauer.net/
++---
++ mt76x02_mmio.c | 1 +
++ 1 file changed, 1 insertion(+)
++
++--- a/mt76x02_mmio.c
+++++ b/mt76x02_mmio.c
++@@ -534,6 +534,7 @@ void mt76x02_reconfig_complete(struct ie
++ 		return;
++ 
++ 	clear_bit(MT76_RESTART, &dev->mphy.state);
+++	ieee80211_wake_queues(hw);
++ }
++ EXPORT_SYMBOL_GPL(mt76x02_reconfig_complete);
++ 


### PR DESCRIPTION
This patch is applied to v2025.1.x as well as master. It has been recently accepted upstream, which makes it sensible to apply to v2023.2.x too.

As stated in the last PR, it fixes routers with MT7612 / MT7610 chip becoming unusable on the 5GHz band after the firmware has been restarted.

---

The shared reset procedure of MT7610 and MT7612 stop all queues before starting the reset sequence.

They however never restart these like other supported mt76 chips do in the reconfig_complete call. This leads to TX not continuing after the reset.

Restart queues in the reconfig_complete callback to restore functionality after the reset.

Link: https://patchwork.kernel.org/project/linux-wireless/patch/20251129023904.288484-1-mail@david-bauer.net/


(cherry picked from commit f8ff0a210e410e59cda61b5a4cc1d965d690dc5e)