### PR TITLE
Add support for CreatLentem CLT-R30B1 / EDUP RT2980 / Dragonglass DGX21 / Livinet Li228

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -341,6 +341,10 @@ mediatek-filogic
   - TUF AX4200
   - TUF AX6000
 
+* CreatLentem / EDUP / Dragonglass / Livinet
+  - CreatLentem CLT-R30B1 / EDUP RT2980 / Dragonglass DGX21 / Livinet Li228
+  - CreatLentem CLT-R30B1 112M / EDUP RT2980 112M / Dragonglass DGX21 112M / Livinet Li228 112M
+
 * Cudy
 
   - AP3000 Outdoor (v1)

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -16,20 +16,14 @@ device('asus-tuf-ax6000', 'asus_tuf-ax6000', {
 })
 
 
--- D-Link
+-- CreatLentem / EDUP / Dragonglass / Livinet
 
-device('d-link-aquila-pro-ai-m30-a1', 'dlink_aquila-pro-ai-m30-a1', {
+device('creatlentem-clt-r30b1', 'creatlentem_clt-r30b1', {
 	factory = false,
-	extra_images = {
-		{ '-squashfs-recovery', '-recovery', '.bin' }
-	},
 })
 
-device('d-link-aquila-pro-ai-m60-a1', 'dlink_aquila-pro-ai-m60-a1', {
+device('creatlentem-clt-r30b1-112m', 'creatlentem_clt-r30b1-112m', {
 	factory = false,
-	extra_images = {
-		{ '-squashfs-recovery', '-recovery', '.bin' }
-	},
 })
 
 
@@ -65,6 +59,22 @@ device('cudy-wr3000h-v1', 'cudy_wr3000h-v1', {
 
 device('cudy-wr3000s-v1', 'cudy_wr3000s-v1', {
 	factory = false,
+})
+
+-- D-Link
+
+device('d-link-aquila-pro-ai-m30-a1', 'dlink_aquila-pro-ai-m30-a1', {
+	factory = false,
+	extra_images = {
+		{ '-squashfs-recovery', '-recovery', '.bin' }
+	},
+})
+
+device('d-link-aquila-pro-ai-m60-a1', 'dlink_aquila-pro-ai-m60-a1', {
+	factory = false,
+	extra_images = {
+		{ '-squashfs-recovery', '-recovery', '.bin' }
+	},
 })
 
 -- GL.iNet


### PR DESCRIPTION
This device is supported by OpenWRT 25.12.x and above.

- [x] Must be flashable from vendor firmware
  - [x] Web interface
  - [ ] TFTP
  - [x] Other: U-Boot webinterface can also be used in case a faulty image has been flashed
- [ ] Must support upgrade mechanism
  - [ ] Must have working sysupgrade
    - [ ] Must keep/forget configuration (`sysupgrade [-n]`, `firstboot`)
  - [ ] Gluon profile name matches autoupdater image name
        (`lua -e 'print(require("platform_info").get_image_name())'`)
- [ ] Reset/WPS/... button must return device into config mode
- [ ] Primary MAC address should match address on device label (or packaging)
      (https://gluon.readthedocs.io/en/latest/dev/hardware.html#hardware-support-in-packages)
  - When re-adding a device that was supported by an earlier version of Gluon, a
    factory reset must be performed before checking the primary MAC address, as
    the setting from the old version is not reset otherwise.
- Wired network
  - [ ] should support all network ports on the device
  - [ ] must have correct port assignment (WAN/LAN)
    - if there are multiple ports but no WAN port:
      - the PoE input should be WAN, all other ports LAN
      - otherwise the first port should be declared as WAN, all other ports LAN
- Wireless network (if applicable)
  - [ ] Association with AP must be possible on all radios
  - [ ] Association with 802.11s mesh must work on all radios 
  - [ ] AP+mesh mode must work in parallel on all radios
- LED mapping
  - Power/system LED
    - [ ] Lit while the device is on
    - [ ] Should display config mode blink sequence 
          (https://gluon.readthedocs.io/en/latest/features/configmode.html)
  - Radio LEDs
    - [ ] Should map to their respective radio
    - [ ] Should show activity
  - Switch port LEDs
    - [ ] Should map to their respective port (or switch, if only one led present) 
    - [ ] Should show link state and activity
- ~~Outdoor devices only:~~
  - ~~[ ] Added board name to `is_outdoor_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
- ~~Cellular devices only:~~
  - ~~[ ] Added board name to `is_cellular_device` function in `package/gluon-core/luasrc/usr/lib/lua/gluon/platform.lua`~~
  - ~~[ ] Added board name with modem setup function `setup_ncm_qmi` to `package/gluon-core/luasrc/lib/gluon/upgrade/250-cellular`~~
- Docs:
  - [x] Added Device to `docs/user/supported_devices.rst`