### PR TITLE
gluon-core: add common USB drivers to previous load order migration

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/019-migrate-interface-order
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/019-migrate-interface-order
@@ -36,7 +36,7 @@ end
 
 -- v2023.2.x load order (/proc/modules) - Ethernet drivers only
 -- (x86-64; should be accurate enough for x64-generic as well)
--- Does not account for site-specific driver additions
+-- It includes some common site-specific usb-net drivers.
 local prev_load_order = {
 	'tg3',
 	'igb',
@@ -54,15 +54,28 @@ local prev_load_order = {
 	'e100',
 	'e1000e',
 	'forcedeth',
+	'hso',
 	'igc',
+	'ipheth',
 	'ne2k_pci',
 	'pcnet32',
+	'pegasus',
+	'r8152',
 	'r8169',
 	'sis900',
 	'sky2',
 	'tulip',
 	'via_rhine',
 	'via_velocity',
+	'asix',
+	'ax88179_178a',
+	'cdc_eem',
+	'cdc_ether',
+	'cdc_subset',
+	'dm9601',
+	'mcs7830',
+	'rndis_host',
+	'smsc95xx',
 }
 
 local prev_load_index = {}


### PR DESCRIPTION
The previous list did not take into account common USB drivers.

This could result in interface order changes when a firmware includes those and then such a driver is used ([#3576](https://github.com/freifunk-gluon/gluon/issues/3576#issuecomment-3801420891)).

Used the following command to get the order on a x86-64 device running v2023.2.4:

```
grep -oi -E '^(tg3|igb|fsl_mph_dr_of|ena|natsemi|amd_xgbe|e1000|ixgbe|3c59x|8139cp|8139too|8390|bnx2|e100|e1000e|forcedeth|igc|ne2k_pci|pcnet32|r8169|sis900|sky2|tulip|via_rhine|via_velocity|asix|ax88179_178a|cdc_eem|cdc_ether|cdc_subset|dm9601|hso|ipheth|mcs7830|pegasus|rndis_host|r8152|smsc95xx)' /proc/modules
```

This still isn't a perfect solution and if there are further additions done during a build this still could cause problems but it hopefully covers a lot of cases.

Tested it with the x86-64 image on an FUJITSU SIEMENS FUTRO S550 with asix USB-NIC. Without this patch the interfaces are reversed, with it they stay the same.