### PR TITLE
[v2021.1.x] Backport build-container action

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@b4bedf8053341df3b5a9f9e0f2cf4e79e27360c6
+        if: ${{ github.repository_owner == 'freifunk-gluon' }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -34,6 +35,6 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: ./contrib/docker
-          push: true
+          push: ${{ github.repository_owner == 'freifunk-gluon' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'next'
       - 'v202[0-9].[0-9].x'
     tags:
       - 'v*'

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -1,0 +1,42 @@
+# Based on the example from https://docs.github.com/en/actions/publishing-packages/publishing-docker-images
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'master'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: gluon-build
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/freifunk-gluon/${{ env.IMAGE_NAME }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: ./contrib/docker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -20,7 +20,11 @@ jobs:
     permissions: write-all
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       - name: Log in to the Container registry
         uses: docker/login-action@b4bedf8053341df3b5a9f9e0f2cf4e79e27360c6
         if: ${{ github.repository_owner == 'freifunk-gluon' && github.event_name == 'push' }}
@@ -38,5 +42,6 @@ jobs:
         with:
           context: ./contrib/docker
           push: ${{ github.repository_owner == 'freifunk-gluon' && github.event_name == 'push' }}
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: gluon-build
+  IMAGE_NAME: ${{ github.repository }}-build
 
 jobs:
   build-and-push-image:
@@ -36,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/freifunk-gluon/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -8,6 +8,7 @@ on:
       - 'v202[0-9].[0-9].x'
     tags:
       - 'v*'
+  pull_request:
 
 env:
   REGISTRY: ghcr.io
@@ -22,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Log in to the Container registry
         uses: docker/login-action@b4bedf8053341df3b5a9f9e0f2cf4e79e27360c6
-        if: ${{ github.repository_owner == 'freifunk-gluon' }}
+        if: ${{ github.repository_owner == 'freifunk-gluon' && github.event_name == 'push' }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -36,6 +37,6 @@ jobs:
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: ./contrib/docker
-          push: ${{ github.repository_owner == 'freifunk-gluon' }}
+          push: ${{ github.repository_owner == 'freifunk-gluon' && github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -4,7 +4,7 @@ name: Create and publish a Docker image
 on:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'next'
       - 'v202[0-9].[0-9].x'
     tags:
@@ -17,17 +17,17 @@ env:
 
 jobs:
   build-and-push-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions: write-all
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
-        uses: docker/login-action@b4bedf8053341df3b5a9f9e0f2cf4e79e27360c6
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         if: ${{ github.repository_owner == 'freifunk-gluon' && github.event_name == 'push' }}
         with:
           registry: ${{ env.REGISTRY }}
@@ -35,11 +35,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
       - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
         with:
           context: ./contrib/docker
           push: ${{ github.repository_owner == 'freifunk-gluon' && github.event_name == 'push' }}

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -7,9 +7,6 @@ on:
       - 'master'
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - 'master'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - 'master'
+      - 'v202[0-9].[0-9].x'
     tags:
       - 'v*'
 

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian/eol:buster-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This backports the build-container action to v2021.1.x so that there is an compatible image to build v2021.1.x images with a container from the the registry.

I'm somewhat torn with this PR. I currently "need" such a container so there is that and others could probably also find it helpful down the line as well. But the Release is certainly EoL and there is a good argument to be made that it shouldn't be touched.
Since i'm doing the work anyway i thought hoewer i might as well open the PR and hear what others have to say.

Unfortunately i can't just use one of the existing images because dependencies differ.

Note: The build-container action builds and publishes as expected from my testing. I haven't looked at the other actions of the branch but i also don't think they should be touched this far down the line without a very good reason. This PR therefore doesn't get a green tick from the CI. And neither would the merged commit.