### PR TITLE
[v2023.2.x] docs: releases: add v2023.2.6 release notes

### DIFF
--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -5,6 +5,7 @@ Release Notes
   :caption: Gluon 2023.2
   :maxdepth: 2
 
+  v2023.2.6
   v2023.2.5
   v2023.2.4
   v2023.2.3

--- a/docs/releases/v2023.2.6.rst
+++ b/docs/releases/v2023.2.6.rst
@@ -1,0 +1,62 @@
+Gluon 2023.2.6
+==============
+
+Added hardware support
+----------------------
+
+ath79-generic
+~~~~~~~~~~~~~
+
+- Ubiquiti
+
+  - NanoBeam 5AC 19 (XC)
+  - NanoBeam M5 (XW)
+  - NanoStation Loco M2/M5 (XW)
+  - NanoStation M2/M5 (XW)
+  - Rocket M2/M5 (XM)
+
+mediatek-filogic
+~~~~~~~~~~~~~~~~
+
+- Cudy
+
+  - RE3000 (v1)
+
+
+Bugfixes
+--------
+
+.. _#3705: https://github.com/freifunk-gluon/gluon/issues/3705
+
+- Fix hang at sysupgrade when using BATMAN_V (`#3705`_)
+
+Known issues
+------------
+
+.. _#94: https://github.com/freifunk-gluon/gluon/issues/94
+.. _#496: https://github.com/freifunk-gluon/gluon/issues/496
+.. _#1726: https://github.com/freifunk-gluon/gluon/issues/1726
+.. _#1728: https://github.com/freifunk-gluon/gluon/issues/1728
+.. _#3154: https://github.com/freifunk-gluon/gluon/issues/3154
+
+* Unstable wireless with certain MediaTek devices (`#3154`_)
+
+- The integration of the BATMAN_V routing algorithm is incomplete.
+
+  - Mesh neighbors don't appear on the status page (`#1726`_)
+
+    Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new
+    throughput metric.
+  - Throughput values are not correctly acquired for different interface types (`#1728`_)
+
+    This affects virtual interface types like bridges and VXLAN.
+
+- Default TX power on many Ubiquiti devices is too high, correct offsets are unknown (`#94`_)
+
+  Reducing the TX power in the Advanced Settings is recommended.
+
+- In configurations without VXLAN, the MAC address of the WAN interface is modified even when
+  Mesh-on-WAN is disabled (`#496`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when
+  promiscuous mode is disallowed).

--- a/docs/releases/v2023.2.6.rst
+++ b/docs/releases/v2023.2.6.rst
@@ -28,7 +28,7 @@ Bugfixes
 
 .. _#3705: https://github.com/freifunk-gluon/gluon/issues/3705
 
-- Fix hang at sysupgrade when using BATMAN_V (`#3705`_)
+- Fix the hang that occurs during sysupgrade when using BATMAN_V (`#3705`_)
 
 Known issues
 ------------


### PR DESCRIPTION
this releases the latest changes on v2023.2.x branch.

~~maybe add MT76 fix..? The current one can not be easily backported. The upcoming one is not merged~~
