### PR TITLE
scripts: update-modules: use git worktree for generating changelog

### DIFF
--- a/.github/workflows/bump-gluon.yml
+++ b/.github/workflows/bump-gluon.yml
@@ -30,7 +30,10 @@ jobs:
 
       - name: Link example Site
         run: ln -s docs/site-example site
-      
+
+      - name: Clone modules
+        run: make update
+
       - name: Invoke update-modules
         run: make update-modules
       

--- a/scripts/update-modules.sh
+++ b/scripts/update-modules.sh
@@ -9,65 +9,98 @@ cd "$(dirname "$0")/.." || exit 1
 # shellcheck source=./modules
 source ./modules
 
-git diff --quiet ./modules || {
-	1>&2 echo "Your modules file is dirty, aborting."
-	exit 1
+function switch_to_branch() {
+	local BRANCH="$1"
+	git switch -c "${BRANCH}" || git switch "${BRANCH}"
 }
 
-LOCAL_BRANCH=$(git branch --show-current)
-[[ $LOCAL_BRANCH != *-updates ]] && LOCAL_BRANCH+=-updates
+function get_default_branch() {
+	local REPO_URL="$1"
+	git ls-remote --symref "${REPO_URL}" HEAD | awk '/^ref:/ { sub(/refs\/heads\//, "", $2); print $2 }'
+}
 
-for MODULE in "OPENWRT" ${GLUON_FEEDS}; do
-	if [[ $MODULE != "OPENWRT" ]]; then
-		MODULE=PACKAGES_${MODULE^^}
-	fi
+function get_module_info() {
+	local MODULE_NAME=$1
+	local MODULE_DATA=$2
 
-	_REMOTE_URL=${MODULE}_REPO
-	_REMOTE_BRANCH=${MODULE}_BRANCH
-	_LOCAL_HEAD=${MODULE}_COMMIT
+	_DATA_KEY=${MODULE_NAME^^}_${MODULE_DATA}
+	echo "${!_DATA_KEY}"
+}
 
-	REMOTE_URL="${!_REMOTE_URL}"
-	REMOTE_BRANCH="${!_REMOTE_BRANCH}"
-	LOCAL_HEAD="${!_LOCAL_HEAD}"
-
-	# get default branch name if none is set
-	[ -z "${REMOTE_BRANCH}" ] && {
-		REMOTE_BRANCH=$(git ls-remote --symref "${REMOTE_URL}" HEAD | awk '/^ref:/ { sub(/refs\/heads\//, "", $2); print $2 }')
-	}
-
-	# fetch the commit id for the HEAD of the module
-	REMOTE_HEAD=$(git ls-remote --heads "${REMOTE_URL}" "${REMOTE_BRANCH}" | awk '{ print $1 }')
-
-	# skip ahead if the commit id did not change
-	[ "$LOCAL_HEAD" == "$REMOTE_HEAD" ] && continue 1
-
-	# switch to local working branch, if we found changes
-	[ "$(git branch --show-current)" != "${LOCAL_BRANCH}" ] && {
-		git switch -c "${LOCAL_BRANCH}" || git switch "${LOCAL_BRANCH}"
-	}
-
-	CHECKOUT=$(mktemp -d)
-
-	# clone the target branch
-	git clone --bare "${REMOTE_URL}" --branch="${REMOTE_BRANCH}" "${CHECKOUT}"
+function get_commit_message() {
+	local MODULE_NAME="$1"
+	local MODULE_PATH="$2"
+	local LOCAL_HEAD="$3"
+	local REMOTE_HEAD="$4"
 
 	# prepare the commit message
 	# shellcheck disable=SC2001
-	MODULE=$(echo "${MODULE,,}" | sed 's/packages_//')
+	MODULE=$(echo "${MODULE_NAME,,}" | sed 's/packages_//')
 	TITLE="modules: update ${MODULE}"
 	MESSAGE="$(mktemp)"
 	{
 		echo "${TITLE}"
 		printf '\n\n'
-		git -C "${CHECKOUT}" log --oneline --no-decorate --no-merges "${LOCAL_HEAD}..${REMOTE_HEAD}" | cat
+		git -C "${MODULE_PATH}" log --oneline --no-decorate --no-merges "${LOCAL_HEAD}..${REMOTE_HEAD}" | cat
 	} > "$MESSAGE"
+
+	cat "$MESSAGE"
+}
+
+function update_module() {
+	local MODULE_NAME="$1"
+	local MODULE_PATH="$2"
+
+	local COMMIT_MESSAGE
+	local LOCAL_HEAD
+	local REMOTE_URL
+	local REMOTE_BRANCH
+	local REMOTE_HEAD
+
+	REMOTE_URL="$(get_module_info "${MODULE_NAME}" "REPO")"
+	REMOTE_BRANCH="$(get_module_info "${MODULE_NAME}" "BRANCH")"
+	LOCAL_HEAD="$(get_module_info "${MODULE_NAME}" "COMMIT")"
+
+	if [ "${REMOTE_BRANCH}" ]; then
+		REMOTE_REF="refs/heads/${REMOTE_BRANCH}"
+	else
+		REMOTE_REF="HEAD"
+	fi
+
+	# fetch the commit id for the HEAD of the module
+	REMOTE_HEAD="$(git ls-remote "${REMOTE_URL}" "${REMOTE_REF}" | awk '{ print $1 }')"
+
+	# skip ahead if the commit id did not change
+	[ "$LOCAL_HEAD" = "$REMOTE_HEAD" ] && return 0
+
+	# switch to local working branch, if we found changes
+	[ "$(git branch --show-current)" != "${LOCAL_BRANCH}" ] && switch_to_branch "${LOCAL_BRANCH}"
+
+	# fetch branch from remote
+	git -C "${MODULE_PATH}" fetch "${REMOTE_URL}" "${REMOTE_REF}"
+
+	# get the commit message
+	COMMIT_MESSAGE="$(get_commit_message "${MODULE_NAME}" "${MODULE_PATH}" "${LOCAL_HEAD}" "${REMOTE_HEAD}")"
 
 	# modify modules file
 	sed -i "s/${LOCAL_HEAD}/${REMOTE_HEAD}/" ./modules
-	git add ./modules
 
-	git commit -F "${MESSAGE}"
+	# commit the changes
+	git commit -F - -- ./modules <<<"${COMMIT_MESSAGE}"
+}
 
-	# remove the checkout
-	rm -fr "${CHECKOUT}"
+git diff --quiet ./modules || {
+	1>&2 echo "Your modules file is dirty, aborting."
+	exit 1
+}
+
+# Checkout update branch, create if it does not exist
+CURRENT_DATE=$(date +%Y%m%d-%H%M%S)
+LOCAL_BRANCH=$(git branch --show-current)
+[[ $LOCAL_BRANCH != *-updates-${CURRENT_DATE} ]] && LOCAL_BRANCH+=-updates-${CURRENT_DATE}
+
+update_module "openwrt" "./openwrt"
+
+for MODULE in ${GLUON_FEEDS}; do
+	update_module "PACKAGES_${MODULE}" "packages/${MODULE,,}"
 done

--- a/scripts/update-modules.sh
+++ b/scripts/update-modules.sh
@@ -9,65 +9,99 @@ cd "$(dirname "$0")/.." || exit 1
 # shellcheck source=./modules
 source ./modules
 
-git diff --quiet ./modules || {
-	1>&2 echo "Your modules file is dirty, aborting."
-	exit 1
+function switch_to_branch() {
+	local BRANCH="$1"
+	git switch -c "${BRANCH}" || git switch "${BRANCH}"
 }
 
-LOCAL_BRANCH=$(git branch --show-current)
-[[ $LOCAL_BRANCH != *-updates ]] && LOCAL_BRANCH+=-updates
+function get_default_branch() {
+	local REPO_URL="$1"
+	git ls-remote --symref "${REPO_URL}" HEAD | awk '/^ref:/ { sub(/refs\/heads\//, "", $2); print $2 }'
+}
 
-for MODULE in "OPENWRT" ${GLUON_FEEDS}; do
-	if [[ $MODULE != "OPENWRT" ]]; then
-		MODULE=PACKAGES_${MODULE^^}
-	fi
+function get_module_info() {
+	local MODULE_NAME=$1
+	local MODULE_DATA=$2
 
-	_REMOTE_URL=${MODULE}_REPO
-	_REMOTE_BRANCH=${MODULE}_BRANCH
-	_LOCAL_HEAD=${MODULE}_COMMIT
+	local _DATA_KEY=${MODULE_NAME}_${MODULE_DATA}
+	echo "${!_DATA_KEY}"
+}
 
-	REMOTE_URL="${!_REMOTE_URL}"
-	REMOTE_BRANCH="${!_REMOTE_BRANCH}"
-	LOCAL_HEAD="${!_LOCAL_HEAD}"
-
-	# get default branch name if none is set
-	[ -z "${REMOTE_BRANCH}" ] && {
-		REMOTE_BRANCH=$(git ls-remote --symref "${REMOTE_URL}" HEAD | awk '/^ref:/ { sub(/refs\/heads\//, "", $2); print $2 }')
-	}
-
-	# fetch the commit id for the HEAD of the module
-	REMOTE_HEAD=$(git ls-remote --heads "${REMOTE_URL}" "${REMOTE_BRANCH}" | awk '{ print $1 }')
-
-	# skip ahead if the commit id did not change
-	[ "$LOCAL_HEAD" == "$REMOTE_HEAD" ] && continue 1
-
-	# switch to local working branch, if we found changes
-	[ "$(git branch --show-current)" != "${LOCAL_BRANCH}" ] && {
-		git switch -c "${LOCAL_BRANCH}" || git switch "${LOCAL_BRANCH}"
-	}
-
-	CHECKOUT=$(mktemp -d)
-
-	# clone the target branch
-	git clone --bare "${REMOTE_URL}" --branch="${REMOTE_BRANCH}" "${CHECKOUT}"
+function get_commit_message() {
+	local MODULE_NAME="$1"
+	local MODULE_PATH="$2"
+	local LOCAL_HEAD="$3"
+	local REMOTE_HEAD="$4"
 
 	# prepare the commit message
 	# shellcheck disable=SC2001
-	MODULE=$(echo "${MODULE,,}" | sed 's/packages_//')
+	MODULE=$(echo "${MODULE_NAME}" | sed 's/packages_//')
 	TITLE="modules: update ${MODULE}"
 	MESSAGE="$(mktemp)"
 	{
 		echo "${TITLE}"
 		printf '\n\n'
-		git -C "${CHECKOUT}" log --oneline --no-decorate --no-merges "${LOCAL_HEAD}..${REMOTE_HEAD}" | cat
+		git -C "${MODULE_PATH}" log --oneline --no-decorate --no-merges "${LOCAL_HEAD}..${REMOTE_HEAD}" | cat
 	} > "$MESSAGE"
+
+	cat "$MESSAGE"
+}
+
+function update_module() {
+	local MODULE_NAME="$1"
+	local MODULE_DATA_PREFIX="$2"
+	local MODULE_PATH="$3"
+
+	local COMMIT_MESSAGE
+	local LOCAL_HEAD
+	local REMOTE_URL
+	local REMOTE_BRANCH
+	local REMOTE_HEAD
+
+	REMOTE_URL="$(get_module_info "${MODULE_DATA_PREFIX}" "REPO")"
+	REMOTE_BRANCH="$(get_module_info "${MODULE_DATA_PREFIX}" "BRANCH")"
+	LOCAL_HEAD="$(get_module_info "${MODULE_DATA_PREFIX}" "COMMIT")"
+
+	if [ "${REMOTE_BRANCH}" ]; then
+		REMOTE_REF="refs/heads/${REMOTE_BRANCH}"
+	else
+		REMOTE_REF="HEAD"
+	fi
+
+	# fetch the commit id for the HEAD of the module
+	REMOTE_HEAD="$(git ls-remote "${REMOTE_URL}" "${REMOTE_REF}" | awk '{ print $1 }')"
+
+	# skip ahead if the commit id did not change
+	[ "$LOCAL_HEAD" = "$REMOTE_HEAD" ] && return 0
+
+	# switch to local working branch, if we found changes
+	[ "$(git branch --show-current)" != "${LOCAL_BRANCH}" ] && switch_to_branch "${LOCAL_BRANCH}"
+
+	# fetch branch from remote
+	git -C "${MODULE_PATH}" fetch "${REMOTE_URL}" "${REMOTE_REF}"
+
+	# get the commit message
+	COMMIT_MESSAGE="$(get_commit_message "${MODULE_NAME}" "${MODULE_PATH}" "${LOCAL_HEAD}" "${REMOTE_HEAD}")"
 
 	# modify modules file
 	sed -i "s/${LOCAL_HEAD}/${REMOTE_HEAD}/" ./modules
-	git add ./modules
 
-	git commit -F "${MESSAGE}"
+	# commit the changes
+	git commit -F - -- ./modules <<<"${COMMIT_MESSAGE}"
+}
 
-	# remove the checkout
-	rm -fr "${CHECKOUT}"
+git diff --quiet ./modules || {
+	1>&2 echo "Your modules file is dirty, aborting."
+	exit 1
+}
+
+# Checkout update branch, create if it does not exist
+CURRENT_DATE=$(date +%Y%m%d-%H%M%S)
+LOCAL_BRANCH=$(git branch --show-current)
+[[ $LOCAL_BRANCH != *-updates-${CURRENT_DATE} ]] && LOCAL_BRANCH+=-updates-${CURRENT_DATE}
+
+update_module "openwrt" "OPENWRT" "./openwrt"
+
+for MODULE in ${GLUON_FEEDS}; do
+	update_module "$MODULE" "PACKAGES_${MODULE^^}" "packages/${MODULE}"
 done


### PR DESCRIPTION
Use a git worktree with the already cloned modules.

This avoids re-cloning all the modules for every bump, substantially speeding up the process.