### PR TITLE
gluon-core: set global DHCPv6 DUID

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/015-dhcp-duid
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/015-dhcp-duid
@@ -1,0 +1,18 @@
+#!/usr/bin/lua
+
+-- Configure global DUID for DHCPv4/DHCPv6 based on the primary MAC address.
+-- OpenWrt generates the DUID randomly based on a UUID. As we regenerate the configuration
+-- for every "gluon-reconfigure" run, we need to ensure the DUID remains identical across reconfigurations.
+
+-- In the past (OpenWrt 25.12) DUID was based on the interface MAC address, so this was not necessary.
+
+-- Even though DUID is IPv6 specific, the set value from UCI is also used as the client-id for DHCPv4.
+
+local uci = require('simple-uci').cursor()
+local sysconfig = require 'gluon.sysconfig'
+
+local primary_mac = sysconfig.primary_mac
+local duid = '0003' .. primary_mac:gsub(':', ''):lower()
+
+uci:set('network', 'globals', 'dhcp_default_duid', duid)
+uci:save('network')


### PR DESCRIPTION
Upstream requires a global DUID option to be set for DHCPv4 and DHCPv6. This option shall be stable for a given device. As Gluon resets the network uci configuration, this id gets lost.

Set the DUID based on the primary MAC-address on every reconfigure.

Fixes: https://github.com/freifunk-gluon/gluon/issues/3707

---

Strictly this is only required when switching to `next`. No impact for the current OpenWrt base as this key is not used anywhere.