### PR TITLE
contrib: update dockerfile to debian trixie

### DIFF
--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm-slim
+FROM debian:trixie-slim
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -35,7 +35,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir /tmp/ec &&\
-    wget -O /tmp/ec/ec-${TARGETOS}-${TARGETARCH}.tar.gz https://github.com/editorconfig-checker/editorconfig-checker/releases/download/2.7.0/ec-${TARGETOS}-${TARGETARCH}.tar.gz &&\
+    wget -O /tmp/ec/ec-${TARGETOS}-${TARGETARCH}.tar.gz https://github.com/editorconfig-checker/editorconfig-checker/releases/download/v3.6.1/ec-${TARGETOS}-${TARGETARCH}.tar.gz &&\
     tar -xvzf /tmp/ec/ec-${TARGETOS}-${TARGETARCH}.tar.gz &&\
     mv bin/ec-${TARGETOS}-${TARGETARCH} /usr/local/bin/editorconfig-checker &&\
     rm -rf /tmp/ec

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -25,7 +25,7 @@ An example configuration can be found in the Gluon repository at *docs/site-exam
 Dependencies
 ------------
 To build Gluon, several packages need to be installed on the system.
-On Debian Bookworm, you can install the required packages with the following command:
+On Debian Trixie, you can install the required packages with the following command:
 
 .. code-block:: sh
 


### PR DESCRIPTION
This updates the docker container to use Debian Trixie as a base.
While at it, updates the editorconfig-checker release as well.

Fixes #3693 