### PR TITLE
[v2025.1.x] mediatek-mt7622: re-add Xiaomi AX3200 / Redmi AX6S (Backport)

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -405,6 +405,10 @@ mediatek-mt7622
 
   - UniFi 6 LR (v1, v2, v3)
 
+* Xiaomi
+
+  - AX3200 / Redmi AX6S
+
 mvebu-cortexa53
 ---------------
 

--- a/targets/mediatek-mt7622
+++ b/targets/mediatek-mt7622
@@ -27,3 +27,11 @@ device('ubiquiti-unifi-6-lr-v2', 'ubnt_unifi-6-lr-v2', {
 device('ubiquiti-unifi-6-lr-v3', 'ubnt_unifi-6-lr-v3', {
 	factory = false,
 })
+
+
+-- Xiaomi
+
+device('xiaomi-redmi-router-ax6s', 'xiaomi_redmi-router-ax6s', {
+	sysupgrade_ext = '.itb',
+	factory = '-factory',
+})


### PR DESCRIPTION
Backport of #3738 