### PR TITLE
[v2025.1.x] patches: add openwrt patch to improve phy path migration order

### DIFF
--- a/patches/openwrt/0013-base-files-move-config_generate-to-preinit.patch
+++ b/patches/openwrt/0013-base-files-move-config_generate-to-preinit.patch
@@ -1,0 +1,104 @@
+From: Florian Eckert <fe@dev.tdt.de>
+Date: Mon, 2 Sep 2024 15:22:41 +0200
+Subject: base-files: move config_generate to preinit
+
+The mutex file via '/tmp/.config_pending' should prevent the command
+'/sbin/wifi config' from being called in the ieee80211 hotplug when loading
+the kernel modules [1]. Since the file '/etc/board.json' does not yet exist
+and could be incomplete.
+
+The '/etc/board.json' file is modified in the '/sbin/wifi config' script.
+This is only generated during the first boot when '/bin/config_generate' is
+called.
+
+This whole handling is unclean. Therefore the creation of the default
+configuration '/etc/config/network', '/etc/config/system' and
+'/etc/board.json' via '/sbin/config_generate' is moved to the preinint
+after the rootfile system has been mounted
+
+The advantage now is that on an ieee80211 hotplug event, the
+'/etc/board.json' is already present which simplifies the whole thing.
+
+[1] https://github.com/openwrt/openwrt/blob/main/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect
+
+Fixes: b993a00b82b1 ("base-files: fix duplicate wifi radio sections when using phy renaming")
+
+Signed-off-by: Florian Eckert <fe@dev.tdt.de>
+
+diff --git a/package/base-files/files/etc/init.d/boot b/package/base-files/files/etc/init.d/boot
+index a26d4886b2873bc09995e50fc8d5931a3f238275..98a74b7b544c3865548d20ed24ed7d5479d261bc 100755
+--- a/package/base-files/files/etc/init.d/boot
++++ b/package/base-files/files/etc/init.d/boot
+@@ -40,22 +40,15 @@ boot() {
+ 	grep -q pstore /proc/filesystems && /bin/mount -o nosuid,nodev,noexec,noatime -t pstore pstore /sys/fs/pstore
+ 	[ "$FAILSAFE" = "true" ] && touch /tmp/.failsafe
+ 
+-	touch /tmp/.config_pending
+-	/sbin/kmodloader
++	# update wifi config before additional ieee80211 hotplug events
++	# get executed because of '/sbin/kmodloader' kmod loading.
++	[ -f /etc/board.json ] && /sbin/wifi config
+ 
+-	[ ! -f /etc/config/wireless ] && {
+-		# compat for bcm47xx and mvebu
+-		sleep 1
+-	}
++	/sbin/kmodloader
+ 
+-	mkdir -p /tmp/.uci
+-	[ -f /etc/uci-defaults/30_uboot-envtools ] && (. /etc/uci-defaults/30_uboot-envtools)
+-	/bin/config_generate
+-	rm -f /tmp/.config_pending
+-	/sbin/wifi config
+ 	uci_apply_defaults
+ 	sync
+-	
++
+ 	# temporary hack until configd exists
+ 	/sbin/reload_config
+ }
+diff --git a/package/base-files/files/lib/preinit/82_config_generate b/package/base-files/files/lib/preinit/82_config_generate
+new file mode 100644
+index 0000000000000000000000000000000000000000..e40448d10f65b50cd7ef0dbe8eaa0890a38ee9c7
+--- /dev/null
++++ b/package/base-files/files/lib/preinit/82_config_generate
+@@ -0,0 +1,16 @@
++do_config_generate() {
++	[ -f /etc/board.json ] || {
++		# This allows /etc/board.d/* scripts to use values from the uboot environment
++		mkdir -p /tmp/.uci
++		[ -f /etc/uci-defaults/30_uboot-envtools ] && (. /etc/uci-defaults/30_uboot-envtools)
++
++		echo "- generating board file -"
++		/bin/board_detect /tmp/board.json
++		mv /tmp/board.json /etc/board.json
++
++		/bin/config_generate > /dev/null
++	}
++}
++
++boot_hook_add preinit_main do_config_generate
++boot_hook_add initramfs do_config_generate
+diff --git a/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect b/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect
+index b86555266138a814ee56ad9ddb4c2dd12d5018dc..7db5ac5555598257ae0127b007bc4ccd0e023c96 100644
+--- a/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect
++++ b/package/network/config/wifi-scripts/files/etc/hotplug.d/ieee80211/10-wifi-detect
+@@ -1,5 +1,5 @@
+ #!/bin/sh
+ 
+-[ "${ACTION}" = "add" ] && {
++[ "${ACTION}" = "add" ] && [ -f /etc/board.json ] && {
+ 	/sbin/wifi config
+ }
+diff --git a/package/network/config/wifi-scripts/files/sbin/wifi b/package/network/config/wifi-scripts/files/sbin/wifi
+index c70723560b767d5ca5d43f901d79421983887cf5..67a3ec7b40557be6338a5ef3f925b8ee3ece7731 100755
+--- a/package/network/config/wifi-scripts/files/sbin/wifi
++++ b/package/network/config/wifi-scripts/files/sbin/wifi
+@@ -62,7 +62,6 @@ wifi_detect_notice() {
+ }
+ 
+ wifi_config() {
+-	[ -e /tmp/.config_pending ] && return
+ 	ucode /usr/share/hostap/wifi-detect.uc
+ 	[ ! -f /etc/config/wireless ] && touch /etc/config/wireless
+ 	ucode /lib/wifi/mac80211.uc | uci -q batch


### PR DESCRIPTION
Backport of #3735