### PR TITLE
docs: forward port v2025.1.1 release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the future development of Gluon.
 
 Please refrain from using the `main` branch for anything else but development purposes!
 Use the most recent release instead. You can list all releases by running `git tag`
-and switch to one by running `git checkout v2025.1 && make update`.
+and switch to one by running `git checkout v2025.1.1 && make update`.
 
 If you're using the autoupdater, do not autoupdate nodes with anything but releases.
 If you upgrade using random main commits the nodes *might break* eventually.

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -5,6 +5,7 @@ Release Notes
   :caption: Gluon 2025.1
   :maxdepth: 2
 
+  v2025.1.1
   v2025.1
 
 .. toctree::

--- a/docs/releases/v2025.1.1.rst
+++ b/docs/releases/v2025.1.1.rst
@@ -1,0 +1,138 @@
+Gluon 2025.1.1
+==============
+
+Added hardware support
+----------------------
+
+ath79-generic
+~~~~~~~~~~~~~
+
+- Ubiquiti
+
+  - Rocket M2/M5 (XM) [#readded]_
+
+ipq40xx-generic
+~~~~~~~~~~~~~~~
+
+- ASUS
+
+  - Lyra MAP-AC2200
+
+mediatek-filogic
+~~~~~~~~~~~~~~~~
+
+- Cudy
+
+  - RE3000 (v1)
+  - M3000 (v1)
+  - WR3000s
+  - WR3000h (v1)
+
+- Mercusys
+
+  - MR90X (v1)
+
+ramips-mt7621
+~~~~~~~~~~~~~
+
+- Totolink
+
+  - X5000R
+
+- Xiaomi
+
+  - Mi Router AC2100
+  - Redmi Router AC2100
+
+ramips-mt7622
+~~~~~~~~~~~~~
+
+- Ubiquiti
+
+  - UniFi 6 LR (v2, v3)
+
+- Xiaomi
+
+  - AX3200 / Redmi AX6S [#readded]_
+
+qualcommax-ipq807x
+~~~~~~~~~~~~~~~~~~
+
+* Linksys
+
+  - MX5300
+
+.. [#readded]
+  This previously supported device had been removed in an earlier release and was reintroduced in
+  v2025.1.1.
+
+New Features
+------------
+
+Configuration of channel_width per band in site configuration (`#3659`_)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _#3659: https://github.com/freifunk-gluon/gluon/pull/3659
+
+The default channel width can be set in the site configuration.
+This uses the highest MCS (HT/VHT/HE/...) available and combines it with the selected channel width in MHz.
+The following example increases the width to 40MHz for all 5GHz radios.
+
+.. code-block:: lua
+
+    wifi5 = {
+      channel_width = 40,
+      ...
+    }
+
+Additional information on status page (`#3654`_)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _#3654: https://github.com/freifunk-gluon/gluon/pull/3654
+
+Add more information to the status page, including:
+
+- number of cores (nproc) of the device
+- base version
+- firmware target
+- currently active ssid
+- configured htmode
+
+Bugfixes
+--------
+
+.. _#3576: https://github.com/freifunk-gluon/gluon/issues/3576
+.. _#3705: https://github.com/freifunk-gluon/gluon/issues/3705
+.. _#3735: https://github.com/freifunk-gluon/gluon/issues/3735
+
+- Fix phy path migration timing on some devices (like WR3000), which led to a broken wifi configuration (`#3735`_)
+- Improve migration for x86 Ethernet driver load order change to also cover typical USB drivers (`#3576`_)
+- Fix hang at sysupgrade when using BATMAN_V (`#3705`_)
+
+Known issues
+------------
+
+.. _#94: https://github.com/freifunk-gluon/gluon/issues/94
+.. _#496: https://github.com/freifunk-gluon/gluon/issues/496
+.. _#1726: https://github.com/freifunk-gluon/gluon/issues/1726
+.. _#1728: https://github.com/freifunk-gluon/gluon/issues/1728
+
+- The integration of the BATMAN_V routing algorithm is incomplete.
+
+  - Mesh neighbors don't appear on the status page (`#1726`_)
+
+    Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new
+    throughput metric.
+  - Throughput values are not correctly acquired for different interface types (`#1728`_)
+
+    This affects virtual interface types like bridges and VXLAN.
+
+- Default TX power on many Ubiquiti devices is too high, correct offsets are unknown (`#94`_)
+
+  Reducing the TX power in the Advanced Settings is recommended.
+
+- In configurations without VXLAN, the MAC address of the WAN interface is modified even when
+  Mesh-on-WAN is disabled (`#496`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when
+  promiscuous mode is disallowed).

--- a/docs/releases/v2025.1.rst
+++ b/docs/releases/v2025.1.rst
@@ -406,6 +406,15 @@ Known issues
 .. _#496: https://github.com/freifunk-gluon/gluon/issues/496
 .. _#1726: https://github.com/freifunk-gluon/gluon/issues/1726
 .. _#1728: https://github.com/freifunk-gluon/gluon/issues/1728
+.. _#3576: https://github.com/freifunk-gluon/gluon/issues/3576
+.. _#3699: https://github.com/freifunk-gluon/gluon/pull/3699
+.. _#3704: https://github.com/freifunk-gluon/gluon/issues/3704
+
+- The phy path migration happening on some devices (like WR3000) can happen at the wrong time, leading to a broken wifi configuration (`#3704`_)
+  
+- Devices hang randomly at sysupgrade until power cycled due to a bug in BATMAN_V (`#3699`_)
+
+- Devices using additional USB network drivers of the community config switch the interface order (`#3576`_)
 
 - The integration of the BATMAN_V routing algorithm is incomplete.
 

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2025.1
+-- This is an example site configuration for Gluon v2025.1.1
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -8,7 +8,7 @@ Gluon's releases are managed using `Git tags`_. If you are just getting
 started with Gluon we recommend to use the latest stable release of Gluon.
 
 Take a look at the `list of gluon releases`_ and notice the latest release,
-e.g. *v2025.1*. Always get Gluon using git and don't try to download it
+e.g. *v2025.1.1*. Always get Gluon using git and don't try to download it
 as a Zip archive as the archive will be missing version information.
 
 Please keep in mind that there is no "default Gluon" build; a site configuration
@@ -44,7 +44,7 @@ Building the images
 -------------------
 
 To build Gluon, first check out the repository. Replace *RELEASE* with the
-version you'd like to checkout, e.g. *v2025.1*.
+version you'd like to checkout, e.g. *v2025.1.1*.
 
 ::
 


### PR DESCRIPTION
This forward ports the v2025.1.1 release notes to also land on the main/latest branch of the docs.