### PR TITLE
docs: update minor release to v2025.1.1 in docs as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the future development of Gluon.
 
 Please refrain from using the `main` branch for anything else but development purposes!
 Use the most recent release instead. You can list all releases by running `git tag`
-and switch to one by running `git checkout v2025.1 && make update`.
+and switch to one by running `git checkout v2025.1.1 && make update`.
 
 If you're using the autoupdater, do not autoupdate nodes with anything but releases.
 If you upgrade using random main commits the nodes *might break* eventually.

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2025.1
+-- This is an example site configuration for Gluon v2025.1.1
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -8,7 +8,7 @@ Gluon's releases are managed using `Git tags`_. If you are just getting
 started with Gluon we recommend to use the latest stable release of Gluon.
 
 Take a look at the `list of gluon releases`_ and notice the latest release,
-e.g. *v2025.1*. Always get Gluon using git and don't try to download it
+e.g. *v2025.1.1*. Always get Gluon using git and don't try to download it
 as a Zip archive as the archive will be missing version information.
 
 Please keep in mind that there is no "default Gluon" build; a site configuration
@@ -44,7 +44,7 @@ Building the images
 -------------------
 
 To build Gluon, first check out the repository. Replace *RELEASE* with the
-version you'd like to checkout, e.g. *v2025.1*.
+version you'd like to checkout, e.g. *v2025.1.1*.
 
 ::
 


### PR DESCRIPTION
The docs change was missing from: https://github.com/freifunk-gluon/gluon/wiki/Release-Process unfortunately.