### PR TITLE
gluon-core: fix htmode on devices with channel widths < site ch-width

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -98,11 +98,13 @@ local function get_htmode(radio)
 	local last_mode
 
 	for mode, available in pairs(iwinfo.nl80211.htmodelist(phy)) do
-		if available and mode == htmode then
-			return htmode
-		end
+		if available then
+			if mode == htmode then
+				return htmode
+			end
 
-		last_mode = mode
+			last_mode = mode
+		end
 	end
 
 	-- if preferred htmode is not available

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -88,28 +88,33 @@ local function get_htmode(radio)
 	local phy = wireless.find_phy(radio)
 	local htmode
 	if iwinfo.nl80211.hwmodelist(phy).ax then
-		htmode = 'HE' .. channel_width
+		htmode = 'HE'
 	elseif iwinfo.nl80211.hwmodelist(phy).ac then
-		htmode = 'VHT' .. channel_width
+		htmode = 'VHT'
 	else
-		htmode = 'HT' .. channel_width
+		htmode = 'HT'
 	end
 
-	local last_mode
+	local last_width
 
 	for mode, available in pairs(iwinfo.nl80211.htmodelist(phy)) do
 		if available then
-			if mode == htmode then
-				return htmode
-			end
+			local hwmode = mode:match("%a+")
+			local width = mode:match("%d+")
 
-			last_mode = mode
+			if hwmode .. width == mode and hwmode == htmode then
+				if width == channel_width then
+					return hwmode .. width
+				end
+
+				if not last_width or width > last_width then
+					last_width = width
+				end
+			end
 		end
 	end
 
-	-- if preferred htmode is not available
-	-- select the last one we got
-	return last_mode
+	return htmode .. last_width
 end
 
 local function configure_mesh(radio, index, mesh_config)


### PR DESCRIPTION
On a TP-Link TL-WDR3600 v1 running Gluon v2025.1.1 with an 80MHz channel width in the site config for the 5GHz radio it was observed that the 5GHz radio would not be created anymore since the addition of the channel width setting. The issue could be narrowed down to the UCI htmode setting wrongly being set to HE40 instead of HT40.

```
$ uci get wireless.radio1.htmode
HE40
```

HE40 is not available on this 802.11n/Wi-Fi 4/5GHz radio though:

```
$ iwinfo phy1 htmodelist
HT20 HT40
```

Further investigation showed that in the get_htmode() function it would eventually find and set the "last_mode = HT40". However unless it is not exactly matching the site.conf channel width then it would overwrite it again and finally return the last htmode it checked, even if it was not available on the radio. The order in which get_htmode() checked modes: HE80+80, HE20, VHT20, EHT80, EHT160, HE80, NOHT, HT20, HT40, VHT40, VHT160, EHT20, VHT80+80, EHT320, EHT80+80, VHT80, EHT40, HE160, HE40. Resulting in the last item, HE40 being picked.

Fixing this by only overwriting the last found, chosen mode if the new one is available on this hardware for one thing. For another ensure to select the widest channel width allowed by site config, as the output of iwinfo.nl80211.htmodelist(phy), as can be seen above, is not ensured to be sorted by channel width.