### PR TITLE
[v2025.1.x] ipq806x-generic: remove broken flag for Extreme Networks WS-AP3935i

### DIFF
--- a/docs/user/supported_devices.rst
+++ b/docs/user/supported_devices.rst
@@ -295,6 +295,10 @@ ipq40xx-mikrotik
 ipq806x-generic
 ---------------
 
+* Extreme Networks
+
+  - WS-AP3935i
+
 * NETGEAR
 
   - R7800

--- a/targets/ipq806x-generic
+++ b/targets/ipq806x-generic
@@ -17,7 +17,6 @@ device('extreme-networks-ap3935', 'extreme_ap3935', {
 	factory = false,
 	sysupgrade = '-squashfs-nand-sysupgrade',
 	packages = QCA9980_PACKAGES,
-	broken = true,	-- https://github.com/openwrt/openwrt/issues/17635
 })
 
 -- TP-Link


### PR DESCRIPTION
Commit 0d7f2b1ec8b04a07dac7eb40a93a837f02ca0018 updated OpenWrt with the included fix for LAN1:

8c3c253692 ipq806x: ap3935: disable hibernation on LAN1