### PR TITLE
gluon-ebtables-filter-multicast: allow meshtastic

### DIFF
--- a/package/gluon-ebtables-filter-multicast/luasrc/lib/gluon/ebtables/110-mcast-allow-meshtastic
+++ b/package/gluon-ebtables-filter-multicast/luasrc/lib/gluon/ebtables/110-mcast-allow-meshtastic
@@ -1,0 +1,1 @@
+rule 'MULTICAST_OUT -p IPv4 --ip-destination 224.0.0.69 --ip-protocol udp --ip-destination-port 4403 -j RETURN'


### PR DESCRIPTION
Meshtastic has gotten support to also mesh and message over WLAN via IPv4 multicast: https://github.com/meshtastic/firmware/pull/5779

While it would have been nicer for us if meshtastic were supporting IPv6 multicast, so that batman-adv could use optimized paths for it and it would then have just worked out of the box with Gluon, this might be a bit more tricky e.g. due to disabled/no IPv6 support due to size constaints on the ESP32: https://github.com/meshtastic/firmware/issues/7951

So instead allow the IPv4 multicast packets of meshtastic for now. They are transmitted via UDP to IP:port 224.0.0.69:4403.

Even though flooding doesn't scale that well, as LoRa is very low throughput anyway the burden on our Freifunk mesh networks should be low, too.