### PR TITLE
docs: add "wireless" to sections supported by "gluon_preserve"

### DIFF
--- a/docs/user/faq.rst
+++ b/docs/user/faq.rst
@@ -48,7 +48,7 @@ after calling gluon-reconfigure.
 
 How can I retain options upon updates anyway?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-For settings in the sections *network* and *system*, the option *gluon_preserve* can be set to true
+For settings in the sections *network*, *system* and *wireless*, the option *gluon_preserve* can be set to true
 in order to preserve the sections. However, this is still at a high risk and may result in broken setups.
 
 There are two conditions that must hold:


### PR DESCRIPTION
Support for the "gluon_preserve" UCI option was added for wireless sections in 462e6a4da834 ("gluon-core: allow configuration of additional wireless settings using gluon_preserve"). Update the FAQ documentation accordingly.