### PR TITLE
gluon-ebtables-filter-multicast: add new meshtastic address

### DIFF
--- a/package/gluon-ebtables-filter-multicast/luasrc/lib/gluon/ebtables/110-mcast-allow-meshtastic
+++ b/package/gluon-ebtables-filter-multicast/luasrc/lib/gluon/ebtables/110-mcast-allow-meshtastic
@@ -1,1 +1,2 @@
 rule 'MULTICAST_OUT -p IPv4 --ip-destination 224.0.0.69 --ip-protocol udp --ip-destination-port 4403 -j RETURN'
+rule 'MULTICAST_OUT -p IPv4 --ip-destination 239.0.0.69 --ip-protocol udp --ip-destination-port 4403 -j RETURN'


### PR DESCRIPTION
Yesterday the IPv4 multicast address for Meshtastic was changed from 224.0.0.69 to 239.0.0.69: https://github.com/meshtastic/firmware/pull/8612. Allow the new multicast address to pass our firewall as well.