### PR TITLE
add v2025.1.2 release notes to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ the future development of Gluon.
 
 Please refrain from using the `main` branch for anything else but development purposes!
 Use the most recent release instead. You can list all releases by running `git tag`
-and switch to one by running `git checkout v2025.1.1 && make update`.
+and switch to one by running `git checkout v2025.1.2 && make update`.
 
 If you're using the autoupdater, do not autoupdate nodes with anything but releases.
 If you upgrade using random main commits the nodes *might break* eventually.

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -5,6 +5,7 @@ Release Notes
   :caption: Gluon 2025.1
   :maxdepth: 2
 
+  v2025.1.2
   v2025.1.1
   v2025.1
 

--- a/docs/releases/v2025.1.2.rst
+++ b/docs/releases/v2025.1.2.rst
@@ -1,0 +1,56 @@
+Gluon 2025.1.2
+==============
+
+Important notes
+---------------
+
+The OpenWrt Base of Gluon has been updated to the latest version of openwrt-24.10
+introducing various security related bugfixes.
+
+Added hardware support
+----------------------
+
+ipq806x-generic
+~~~~~~~~~~~~~~~
+
+- Extreme Networks
+
+  - WS-AP3935i
+
+Bugfixes
+--------
+
+.. _#3797: https://github.com/freifunk-gluon/gluon/pull/3797
+.. _#3802: https://github.com/freifunk-gluon/gluon/pull/3802
+
+- Fix wireless htmode selection on devices with channel widths smaller than the site configuration (`#3797`_)
+- Fix wireless bandwidth selection logic sometimes prioritizing lower rates (`#3797`_)
+- Adapt sysctl parameters for 64M RAM devices to improve performance and stability (`#3802`_)
+
+Known issues
+------------
+
+.. _#94: https://github.com/freifunk-gluon/gluon/issues/94
+.. _#496: https://github.com/freifunk-gluon/gluon/issues/496
+.. _#1726: https://github.com/freifunk-gluon/gluon/issues/1726
+.. _#1728: https://github.com/freifunk-gluon/gluon/issues/1728
+
+- The integration of the BATMAN_V routing algorithm is incomplete.
+
+  - Mesh neighbors don't appear on the status page (`#1726`_)
+
+    Many tools have the BATMAN_IV metric hardcoded, these need to be updated to account for the new
+    throughput metric.
+  - Throughput values are not correctly acquired for different interface types (`#1728`_)
+
+    This affects virtual interface types like bridges and VXLAN.
+
+- Default TX power on many Ubiquiti devices is too high, correct offsets are unknown (`#94`_)
+
+  Reducing the TX power in the Advanced Settings is recommended.
+
+- In configurations without VXLAN, the MAC address of the WAN interface is modified even when
+  Mesh-on-WAN is disabled (`#496`_)
+
+  This may lead to issues in environments where a fixed MAC address is expected (like VMware when
+  promiscuous mode is disallowed).

--- a/docs/site-example/site.conf
+++ b/docs/site-example/site.conf
@@ -1,4 +1,4 @@
--- This is an example site configuration for Gluon v2025.1.1
+-- This is an example site configuration for Gluon v2025.1.2
 --
 -- Take a look at the documentation located at
 -- https://gluon.readthedocs.io/ for details.

--- a/docs/user/getting_started.rst
+++ b/docs/user/getting_started.rst
@@ -8,7 +8,7 @@ Gluon's releases are managed using `Git tags`_. If you are just getting
 started with Gluon we recommend to use the latest stable release of Gluon.
 
 Take a look at the `list of gluon releases`_ and notice the latest release,
-e.g. *v2025.1.1*. Always get Gluon using git and don't try to download it
+e.g. *v2025.1.2*. Always get Gluon using git and don't try to download it
 as a Zip archive as the archive will be missing version information.
 
 Please keep in mind that there is no "default Gluon" build; a site configuration
@@ -65,7 +65,7 @@ Building the images
 -------------------
 
 To build Gluon, first check out the repository. Replace *RELEASE* with the
-version you'd like to checkout, e.g. *v2025.1.1*.
+version you'd like to checkout, e.g. *v2025.1.2*.
 
 ::
 


### PR DESCRIPTION
This PR forward ports the release notes of v2025.1.2 to the main branch.