### PR TITLE
gluon-core: fix mistyped channel-width comparison

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -103,7 +103,7 @@ local function get_htmode(radio)
 			local width = mode:match("%d+")
 
 			if hwmode .. width == mode and hwmode == htmode then
-				if width == channel_width then
+				if width == tostring(channel_width) then
 					return hwmode .. width
 				end
 


### PR DESCRIPTION
The channel-width returned by string matching is of Lua type string while the value from site is a number.

Convert the value read from the site to a string. Make it this way, as i do not have a 80+80 device at hand and avoid resolving split channel htmodes, as they are not currently proper supported by OpenWrt.

Fixes: e734119eb808 ("gluon-core: fix potentially too low channel_bandwidth")

---

How this manifests: For me all devices do select a 80 MHz HTMode even as 20 MHz are configured in the site. With this fix applied, the expected behavior of selecting a 20 MHz mode is realized.