### PR TITLE
Fix channel_width selection

### DIFF
--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -100,7 +100,7 @@ local function get_htmode(radio)
 	for mode, available in pairs(iwinfo.nl80211.htmodelist(phy)) do
 		if available then
 			local hwmode = mode:match("%a+")
-			local width = mode:match("%d+")
+			local width = tonumber(mode:match("%d+"))
 
 			if hwmode .. width == mode and hwmode == htmode then
 				if width == channel_width then


### PR DESCRIPTION
Regression from e734119e, shipped in v2025.1.2.

get_htmode() compares a string (from mode:match) against a number (from
site config), so the exact-match branch is dead and every radio takes the
fallback path. The fallback's max comparison is also string-based, so
"80" > "160".

This hits sites that never set channel_width too, since the default of 20
takes the same path.

Noticed in the Freifunk Innsbruck community while upgrading, currently
shipping a patched release.