### PR TITLE
gluon-core: extract wireless helpers (radio_roles, is_outdoor)

### DIFF
--- a/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
+++ b/package/gluon-client-bridge/luasrc/lib/gluon/upgrade/320-gluon-client-bridge-wireless
@@ -19,7 +19,7 @@ end)
 local function is_disabled(radio, config)
 	-- now we assign radios to roles
 	local band = radio.band
-	local roles = uci:get_list('gluon', 'band_' .. band, 'role')
+	local roles = wireless.radio_roles(uci, radio)
 	-- if there is a radio which does not support the mesh channel, we can configure it on a different channel
 	-- in this case, the other radio on the same band supporting the channel turns off its client radio and is mesh only
 	local disable_client = wireless.supports_channel(radio, config.channel()) and client_only_radio['band_' .. band] > 0

--- a/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
+++ b/package/gluon-config-mode-outdoor/luasrc/lib/gluon/config-mode/wizard/0250-outdoor.lua
@@ -19,7 +19,7 @@ return function(form, uci)
 		.. "to comply with local frequency regulations."
 	))
 
-	local outdoor_mode = uci:get_bool('gluon', 'wireless', 'outdoor')
+	local outdoor_mode = wireless.is_outdoor(uci)
 	local outdoor = section:option(Flag, 'outdoor', pkg_i18n.translate("Node will be installed outdoors"))
 	outdoor.default = outdoor_mode
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/022-wireless-roles
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/022-wireless-roles
@@ -94,13 +94,9 @@ for band, _ in pairs(default_wifi_roles) do
 end
 
 
-local function is_outdoor()
-	return uci:get_bool('gluon', 'wireless', 'outdoor')
-end
-
 -- Remove 5ghz mesh role configuration for outdoor
 local roles_5g = uci:get_list('gluon', 'band_5g', 'role')
-if util.contains(roles_5g, 'mesh') and is_outdoor() then
+if util.contains(roles_5g, 'mesh') and wireless.is_outdoor(uci) then
 	util.remove_from_set(roles_5g, 'mesh')
 	uci:set_list('gluon', 'band_5g', 'role', roles_5g)
 end

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -52,12 +52,8 @@ wireless.foreach_radio(uci, function(radio)
 	end
 end)
 
-local function is_outdoor()
-	return uci:get_bool('gluon', 'wireless', 'outdoor')
-end
-
 local function get_channel(radio, config)
-	if (radio.band == '5g' and is_outdoor()) or not wireless.supports_channel(radio, config.channel()) then
+	if (radio.band == '5g' and wireless.is_outdoor(uci)) or not wireless.supports_channel(radio, config.channel()) then
 		-- actual channel will be picked and probed from chanlist
 		return 'auto'
 	end
@@ -70,7 +66,7 @@ local function get_htmode(radio)
 		return radio.htmode
 	end
 
-	if radio.band == '5g' and is_outdoor() then
+	if radio.band == '5g' and wireless.is_outdoor(uci) then
 		local outdoor_htmode = uci:get('gluon', 'wireless', 'outdoor_' .. radio['.name'] .. '_htmode')
 		if outdoor_htmode ~= nil then
 			return outdoor_htmode
@@ -165,7 +161,7 @@ local function set_channels(radio, radio_name, config)
 	uci:set('wireless', radio_name, 'channel', channel)
 
 	local chanlist
-	if radio.band == '5g' and is_outdoor() then
+	if radio.band == '5g' and wireless.is_outdoor(uci) then
 		chanlist = config.outdoor_chanlist()
 	end
 	uci:set('wireless', radio_name, 'channels', chanlist)
@@ -212,7 +208,7 @@ wireless.foreach_radio(uci, function(radio, index, config)
 			configure_mesh(radio, index, config.mesh())
 		end
 	elseif band == '5g' then
-		if is_outdoor() then
+		if wireless.is_outdoor(uci) then
 			-- enforce outdoor channels by filtering the regdom for outdoor channels
 			uci:set('wireless', radio_name, 'country3', '0x4f')
 		else

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -199,7 +199,7 @@ wireless.foreach_radio(uci, function(radio, index, config)
 
 	local band = radio.band
 	-- now we assign radios to roles
-	local roles = uci:get_list('gluon', 'band_' .. band, 'role')
+	local roles = wireless.radio_roles(uci, radio)
 	local enable_mesh = wireless.supports_channel(radio, config.channel()) and util.contains(roles, 'mesh')
 
 	if band == '2g' then

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -148,4 +148,8 @@ function M.device_uses_band(uci, band)
 	return ret
 end
 
+function M.radio_roles(uci, radio)
+	return uci:get_list('gluon', 'band_' .. radio.band, 'role')
+end
+
 return M

--- a/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
+++ b/package/gluon-core/luasrc/usr/lib/lua/gluon/wireless.lua
@@ -152,4 +152,8 @@ function M.radio_roles(uci, radio)
 	return uci:get_list('gluon', 'band_' .. radio.band, 'role')
 end
 
+function M.is_outdoor(uci)
+	return uci:get_bool('gluon', 'wireless', 'outdoor')
+end
+
 return M

--- a/package/gluon-private-wifi/luasrc/lib/gluon/upgrade/325-gluon-private-wifi
+++ b/package/gluon-private-wifi/luasrc/lib/gluon/upgrade/325-gluon-private-wifi
@@ -42,7 +42,7 @@ local function configure_private_wifi(radio, index)
 end
 
 wireless.foreach_radio(uci, function(radio, index)
-	local roles = uci:get_list('gluon', 'band_' .. radio.band, 'role')
+	local roles = wireless.radio_roles(uci, radio)
 
 	if util.contains(roles, 'private') then
 		configure_private_wifi(radio, index)

--- a/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
+++ b/package/gluon-web-wifi-config/luasrc/lib/gluon/config-mode/model/admin/wifi-config.lua
@@ -130,7 +130,7 @@ if wireless.device_uses_band(uci, '5g') and not wireless.preserve_channels(uci) 
 	))
 
 	local outdoor = r:option(Flag, 'outdoor', translate("Node will be installed outdoors"))
-	outdoor.default = uci:get_bool('gluon', 'wireless', 'outdoor')
+	outdoor.default = wireless.is_outdoor(uci)
 
 	for _, mesh_vif in ipairs(mesh_vifs_5ghz) do
 		mesh_vif:depends(outdoor, false)


### PR DESCRIPTION
Extracts two small, behavior-neutral helpers into `gluon.wireless`,
consolidating duplicated expressions across packages.

## `radio_roles(uci, radio)`
Returns `uci:get_list('gluon', 'band_' .. radio.band, 'role')`.
Replaces the identical inline expression at three call sites

## `is_outdoor(uci)`
Returns `uci:get_bool('gluon', 'wireless', 'outdoor')`. The same local
was defined identically in both `200-wireless` and `022-wireless-roles`;
hoisted into `wireless.is_outdoor` and all seven call sites repointed.

## Behavior
Both are pure refactors. byte-equivalent substitutions, no behavior change.
No new dependencies (`wireless` already imported at all affected sites).

## Context
Split out from #3601 (per-radio htmode/txpower overrides), which bundles
several independent concerns and is currently blocked on the radio-identity
decision (indexed `wradioN` vs path-keyed sections). This PR isolates the
uncontroversial, behavior-neutral helper extractions so they can land
independently and shrink the surface of the larger effort.

Builds on the `wireless_band`/roles migration from #3563 and is compatible
with the `channel_width` site option from #3659.