### PR TITLE
gluon-mesh-batman-adv: move wireless hop_penalty handling from gluon-core

### DIFF
--- a/docs/package/gluon-mesh-batman-adv.rst
+++ b/docs/package/gluon-mesh-batman-adv.rst
@@ -197,6 +197,8 @@ Examples of this are shown below:
   uci set gluon.iface_lan.batadv_hop_penalty=10
   # optional for mesh on wan
   uci set gluon.iface_wan.batadv_hop_penalty=10
+  # optional penalty for wireless mesh per band
+  uci set gluon.band_5g.batadv_hop_penalty=10
   # don't forget to commit changes
   uci commit gluon
 

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/200-wireless
@@ -134,11 +134,8 @@ local function configure_mesh(radio, index, mesh_config)
 		return
 	end
 
-	local batadv_hop_penalty = uci:get('gluon', 'band_' .. radio.band, 'batadv_hop_penalty') or 0
-
 	uci:section('network', 'interface', name, {
 		proto = 'gluon_mesh',
-		hop_penalty = batadv_hop_penalty,
 	})
 
 	uci:section('wireless', 'wifi-iface', name, {

--- a/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/305-gluon-mesh-batman-adv-hop-penalty
+++ b/package/gluon-mesh-batman-adv/luasrc/lib/gluon/upgrade/305-gluon-mesh-batman-adv-hop-penalty
@@ -1,0 +1,21 @@
+#!/usr/bin/lua
+
+local wireless = require 'gluon.wireless'
+
+local uci = require('simple-uci').cursor()
+
+
+wireless.foreach_radio(uci, function(radio)
+	local name = 'mesh_' .. radio['.name']
+
+	if not uci:get('network', name) then
+		return
+	end
+
+	local hop_penalty = uci:get('gluon', 'band_' .. radio.band, 'batadv_hop_penalty')
+	if hop_penalty ~= nil then
+		uci:set('network', name, 'hop_penalty', hop_penalty)
+	end
+end)
+
+uci:save('network')


### PR DESCRIPTION
The `batadv_hop_penalty` option for wireless mesh interfaces was read
in `gluon-core`'s `200-wireless`, mixing the batman-adv-specific option
name into the generic wireless configurator. Move the read into a new
`gluon-mesh-batman-adv` upgrade script (`305`) that runs after
`200-wireless` has created the `mesh_<radio>` network interfaces.

## Changes
- **New** `305-gluon-mesh-batman-adv-hop-penalty`: iterates radios,
  reads `gluon.band_X.batadv_hop_penalty`, and sets `hop_penalty` on
  existing `network.mesh_<radio>` sections (skipping radios where mesh
  is not enabled).
- **Removed** the `batadv_hop_penalty` read from `200-wireless`
  (`gluon-core`).
- **Documented** the wireless band-scoped `batadv_hop_penalty` in
  `gluon-mesh-batman-adv.rst` alongside the existing wired/VPN variants.

## Behavior
Preserved. When `gluon.band_X.batadv_hop_penalty` is set, `hop_penalty`
is applied to `network.mesh_<radio>`; when unset, it is left absent and
`gluon_bat0.sh` defaults it to `0` at runtime — equivalent to the
previous `or 0` fallback in `200-wireless`.

## Background
Introduced in `17f59562` ("gluon-core: add hop_penalty support for mesh
interfaces"), which extended wired/VPN hop_penalty support to wireless
but placed the read in `gluon-core`. This PR completes the separation
noted by @neocturne in #3601: the `batadv` string should not appear in
`gluon-core`.