### PR TITLE
gluon-core: fix silent failure of gluon-reconfigure on missing config

### DIFF
--- a/package/gluon-core/files/usr/bin/gluon-reconfigure
+++ b/package/gluon-core/files/usr/bin/gluon-reconfigure
@@ -2,6 +2,14 @@
 
 cd /lib/gluon/upgrade || exit 1
 
+touch /etc/config/gluon
+if ! uci -q get gluon.core >/dev/null; then
+	uci add gluon core >/dev/null
+	uci rename gluon.@core[-1]=core
+	uci commit gluon
+fi
+
+
 err=0
 
 for script in *; do

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/005-set-domain
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/005-set-domain
@@ -43,6 +43,6 @@ if not domain then
 
 end
 
-uci:set('gluon', 'core', 'domain', domain)
+assert(uci:set('gluon', 'core', 'domain', domain))
 uci:delete('gluon', 'core', 'switch_domain')
-uci:save('gluon')
+assert(uci:save('gluon'))

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/110-network
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/110-network
@@ -74,7 +74,7 @@ uci:section('network', 'route6', 'wan6_unreachable', {
 	metric = 65535,
 })
 
-uci:save('network')
+assert(uci:save('network'))
 
 
 uci:section('firewall', 'rule', 'wan_igmp', {
@@ -95,4 +95,4 @@ uci:section('firewall', 'rule', 'wan_mld', {
 	target = 'ACCEPT',
 })
 
-uci:save('firewall')
+assert(uci:save('firewall'))

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/300-firewall-rules
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/300-firewall-rules
@@ -110,4 +110,4 @@ for _, zone in ipairs({'wired_mesh', 'wan'}) do
 end
 
 
-uci:save('firewall')
+assert(uci:save('firewall'))

--- a/package/gluon-harden-dropbear/files/lib/gluon/upgrade/105-harden-dropbear
+++ b/package/gluon-harden-dropbear/files/lib/gluon/upgrade/105-harden-dropbear
@@ -46,4 +46,4 @@ uci:foreach('dropbear', 'dropbear', function(s)
 	)
 end)
 
-uci:save('dropbear')
+assert(uci:save('dropbear'))


### PR DESCRIPTION
When a user deletes a configuration file (like /etc/config/gluon, dropbear, or firewall) to reset its state, lua-simple-uci silently ignores uci:set() and uci:save() failures. This causes gluon-reconfigure to falsely report success without actually applying the necessary configuration.

This commit addresses the issue by:
1. Ensuring /etc/config/gluon is reliably recreated in gluon-reconfigure, so that deleting it intentionally acts as a proper reset.
2. Wrapping critical uci:set() and uci:save() calls in the upgrade scripts for gluon, dropbear, firewall, and network with lua's assert(). This forces these scripts to fail loudly on unexpected UCI errors (like missing files or read-only filesystems), causing gluon-reconfigure to report the failure properly.

This makes sure that gluon-reconfigure hints and configs which are misconfigured or missing