### PR TITLE
contrib: ci: drop batman-only ebtables features from olsr site

### DIFF
--- a/contrib/ci/olsr-site/image-customization.lua
+++ b/contrib/ci/olsr-site/image-customization.lua
@@ -1,8 +1,5 @@
 features {
 	'autoupdater',
-	'ebtables-filter-multicast',
-	'ebtables-filter-ra-dhcp',
-	'ebtables-limit-arp',
 	'mesh-olsrd',
 	'mesh-vpn-fastd',
 	'respondd',

--- a/contrib/ci/olsr-site/site.conf
+++ b/contrib/ci/olsr-site/site.conf
@@ -24,6 +24,7 @@
   -- prefix6 is required, prefix4 can be omitted if next_node.ip4
   -- is not set.
   prefix6 = 'fdff:cafe:cafe:cafe::/64',
+  prefix4 = '10.0.0.0/20',
 
   -- Prefixes used by nodes within the mesh
   node_prefix6 = 'fdff:cafe:cafe:cafe::/64',


### PR DESCRIPTION
This makes the site config build again