### PR TITLE
 mediatek-filogic: remove recovery image for D-Link AQUILA PRO AI M30+M60 A1

### DIFF
--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -27,9 +27,6 @@ device('asus-tuf-ax6000', 'asus_tuf-ax6000', {
 
 device('d-link-aquila-pro-ai-m30-a1', 'dlink_aquila-pro-ai-m30-a1', {
 	factory = false,
-	extra_images = {
-		{ '-squashfs-recovery', '-recovery', '.bin' }
-	},
 })
 
 device('d-link-aquila-pro-ai-m60-a1', 'dlink_aquila-pro-ai-m60-a1', {

--- a/targets/mediatek-filogic
+++ b/targets/mediatek-filogic
@@ -31,9 +31,6 @@ device('d-link-aquila-pro-ai-m30-a1', 'dlink_aquila-pro-ai-m30-a1', {
 
 device('d-link-aquila-pro-ai-m60-a1', 'dlink_aquila-pro-ai-m60-a1', {
 	factory = false,
-	extra_images = {
-		{ '-squashfs-recovery', '-recovery', '.bin' }
-	},
 })
 
 


### PR DESCRIPTION
There have been two (as far as i can tell) independent reports both at FFMUC and [FFRN](https://forum.ffrn.de/t/d-link-m30-flashen-geht-nicht/3645) yesterday that the recovery image for the M30 A1 isn't working to install a new device. At FFAC they apparently noticed it before and removed that image from their firmware selector.

I also wouldn't expect it to work since the install is a two step process with first installing the recovery (an initramfs image) and then sysupgrading the gluon image.

- https://openwrt.org/toh/d-link/aquila_pro_ai_m30_a1#flash_procedure

Using an OpenWrt recovery image and then sysupgrading the gluon image seems like the correct approach here.

The recovery image was added together with the device support in #3153 (and #3407 for the M60).

I also propose dropping the M60 recovery image, as it seems to be a similar situation.

This should be backported to v2025.1.x if merged.