### PR TITLE
gluon-status-page: export manifest file

### DIFF
--- a/package/gluon-autoupdater/files/lib/upgrade/keep.d/autoupdater
+++ b/package/gluon-autoupdater/files/lib/upgrade/keep.d/autoupdater
@@ -1,0 +1,1 @@
+/lib/gluon/core/sysupgrade/

--- a/package/gluon-autoupdater/files/usr/lib/autoupdater/upgrade.d/90gluon-autoupdater
+++ b/package/gluon-autoupdater/files/usr/lib/autoupdater/upgrade.d/90gluon-autoupdater
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+OUTDIR="/lib/gluon/core/sysupgrade"
+
+if [ -f /tmp/manifest.txt ]; then
+	# ignore errors, the sysupgrade is more important
+	if ! [ -d "$OUTDIR" ]; then
+		mkdir "$OUTDIR" || true
+	fi
+
+	cp /tmp/manifest.txt "$OUTDIR/manifest.txt.new" || true
+fi

--- a/package/gluon-autoupdater/luasrc/lib/gluon/upgrade/500-autoupdater
+++ b/package/gluon-autoupdater/luasrc/lib/gluon/upgrade/500-autoupdater
@@ -86,3 +86,6 @@ local f = io.open('/usr/lib/micron.d/autoupdater', 'w')
 f:write(string.format('%i 4 * * * /usr/sbin/autoupdater\n', minute))
 f:write(string.format('%i 0-3,5-23 * * * /usr/sbin/autoupdater --fallback\n', minute))
 f:close()
+
+os.remove("/lib/gluon/core/sysupgrade/manifest.txt")
+os.rename("/lib/gluon/core/sysupgrade/manifest.txt.new", "/lib/gluon/core/sysupgrade/manifest.txt")

--- a/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/firmware
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/firmware
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+MANIFEST_FILE="/lib/gluon/core/sysupgrade/manifest.txt"
+
+notfound() {
+	echo 'Status: 404 Not Found'
+	echo
+	exit 1
+}
+
+list_directory() {
+	local branch="$1"
+
+	echo
+
+	cat <<EOF
+<html>
+<head>
+<title>Directory listing for /cgi-bin/firmware/</title>
+</head>
+<body>
+<h1>Directory listing for /cgi-bin/firmware/</h1>
+<hr>
+<ul>
+EOF
+
+	if [ -f "$MANIFEST_FILE" ]; then
+		echo "<li><a href=\"/cgi-bin/firmware/manifest.txt\">manifest.txt</a></li>"
+
+		if [ -n "$branch" ]; then
+			echo "<li><a href=\"/cgi-bin/firmware/$branch.manifest\">$branch.manifest@</a></li>"
+		fi
+	fi
+
+	cat <<EOF
+</ul>
+<hr>
+</body>
+</html>
+EOF
+}
+
+manifest_response() {
+	if [ -f "$MANIFEST_FILE" ]; then
+		echo "Content-Type: text/plain"
+		echo
+		cat "$MANIFEST_FILE"
+	else
+		notfound
+	fi
+}
+
+manifest_redirect() {
+	local branch="$1"
+
+	echo "Status: 307 Temporary Redirect"
+	echo "Location: /cgi-bin/firmware/$branch.manifest"
+	echo
+}
+
+
+BRANCH="$(sed -n "s/^BRANCH=//p;q" "$MANIFEST_FILE")"
+
+if [ -z "$PATH_INFO" ]; then
+	list_directory "$BRANCH"
+elif [ "$PATH_INFO" = "/manifest.txt" ]; then
+	if [ -z "$BRANCH" ]; then
+		manifest_response
+	else
+		manifest_redirect "$BRANCH"
+	fi
+else
+	if [ -z "$BRANCH" ]; then
+		notfound
+	fi
+
+	if [ "/$BRANCH.manifest" = "$PATH_INFO" ]; then
+		manifest_response
+	else
+		notfound
+	fi
+fi


### PR DESCRIPTION
This makes the manifest file from the last autoupdate available under /cgi-bin/firmware/manifest.txt and /cgi-bin/firmware/$branch.manifest.
    
This is useful to later check which signed manifest file the currently running firmware is (supposedly) based on.
    
The directory structure exported to an HTTP client is purposefully in an autoupdater mirror compatible structure to potentially allow node-to-node autoupdates later.

---

This change is only useful after https://github.com/freifunk-gluon/packages/pull/285