### PR TITLE
gluon-status-page: allow update via HTTP POST'ed manifest file

### DIFF
--- a/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/firmware-upload
+++ b/package/gluon-status-page/files/lib/gluon/status-page/www/cgi-bin/firmware-upload
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+badrequest() {
+	echo 'Status: 400 Bad Request'
+	echo
+	exit 1
+}
+
+case "${REQUEST_METHOD}" in
+	POST)
+		;;
+	*)
+		badrequest
+		;;
+esac
+
+if ! [ -e /usr/sbin/autoupdater ]; then
+	badrequest
+fi
+
+echo ""
+
+logger -t autoupdater "Receiving manifest via HTTP POST, starting autoupdater"
+exec autoupdater - > /dev/null 2>&1


### PR DESCRIPTION
Allow uploading an autoupdater manifest file via HTTP POST and running the autoupdater on it. For instance via curl like this:

```
  $ curl --data-binary "@/tmp/experimental.manifest" \
        "http://<gluon-node-ipv6-addr>/cgi-bin/firmware-upload"
```

The autoupdater is still performing the usual signature checks etc. on the manifest file.

The advantage of this are the following two: In more complicated, incompatible update scenarios it might useful to be able to perform node updates in a more curated order. Simply using curl and pushing the update to specific nodes should be easier than updating filters on an autoupdater mirror and waiting for a node's micron to trigger.

The second advantage is that this avoids the issue of being unable to update if an autoupdater server becomes inaccessible to signers and/or nodes. Technically the autoupdater server side, including its DNS can currently have a separate governance. And has the power to overrule or disrupt any democratic decisions from the signers, challenging their souvereignity. In the worst case a single person running the autoupdater HTTP server and/or its DNS entries can overrule the signers collective decision. Also due to a misconfiguration or hardware failure an autoupdater server might accidentally become unreachable.

However the primary security promise is supposed to lie in a signed manifest file. And its n-of-m signatures approach to facilitate a democratic security architecture.

---

This PR requires https://github.com/freifunk-gluon/packages/pull/289.

Also posting this as draft for now as I'm wondering if some sort of rate-limiting or similar should be added to avoid a random person potentially blocking legitimate autoupdater processes by continuously sending bogus manifest files.