### PR TITLE
gluon-core: fix sysctl customization for 64MB boards

### DIFF
--- a/package/gluon-core/files/lib/gluon/sysctl/memory-64m.conf
+++ b/package/gluon-core/files/lib/gluon/sysctl/memory-64m.conf
@@ -1,0 +1,7 @@
+vm.min_free_kbytes=2048
+net.ipv4.ipfrag_low_thresh=393216
+net.ipv4.ipfrag_high_thresh=524288
+net.ipv6.ip6frag_low_thresh=393216
+net.ipv6.ip6frag_high_thresh=524288
+net.netfilter.nf_conntrack_frag6_low_thresh=393216
+net.netfilter.nf_conntrack_frag6_high_thresh=524288

--- a/package/gluon-core/files/lib/gluon/sysctl/memory-64m.sysctl
+++ b/package/gluon-core/files/lib/gluon/sysctl/memory-64m.sysctl
@@ -1,7 +1,0 @@
-vm.min_free_kbytes="2048"
-net.ipv4.ipfrag_low_thresh="393216"
-net.ipv4.ipfrag_high_thresh="524288"
-net.ipv6.ip6frag_low_thresh="393216"
-net.ipv6.ip6frag_high_thresh="524288"
-net.netfilter.nf_conntrack_frag6_low_thresh="393216"
-net.netfilter.nf_conntrack_frag6_high_thresh="524288"

--- a/package/gluon-core/luasrc/lib/gluon/upgrade/550-sysctl
+++ b/package/gluon-core/luasrc/lib/gluon/upgrade/550-sysctl
@@ -3,11 +3,11 @@
 local util = require "gluon.util"
 local unistd = require "posix.unistd"
 
-if util.get_mem_total() >= 64 * 1024 * 1024 then
+if util.get_mem_total() >= 64 * 1024 then
 	return
 end
 
 unistd.link(
-	"/lib/gluon/sysctl/memory-64m.sysctl",
-	"/etc/sysctl.d/35-gluon-memory-64m.sysctl",
+	"/lib/gluon/sysctl/memory-64m.conf",
+	"/etc/sysctl.d/35-gluon-memory-64m.conf",
 	true)


### PR DESCRIPTION
The original PR contained an outdated fix which was broken.

 - File extension did not match the expectation of the sysctl init-file
 - Quotation marks broke sysctl application

Fix both issues to ensure the application works as expected.

Fixes: a505f767ab86 ("gluon-core: adapt sysctl for 64M RAM (#3801)")